### PR TITLE
refactor: unify insert API to match remove operation pattern

### DIFF
--- a/src/orm/queryset.cppm
+++ b/src/orm/queryset.cppm
@@ -50,12 +50,13 @@ export namespace storm {
 
         // Insert operations
         std::expected<int64_t, Error> insert(const T& obj) {
-            return execute_insert(obj);
+            return execute_insert(std::span<const T>{&obj, 1})
+                .transform([](const auto& ids) { return ids[0]; });
         }
 
         // Bulk insert operations
         std::expected<std::vector<int64_t>, Error> insert(std::span<const T> objects) {
-            return execute_insert_batch(objects);
+            return execute_insert(objects);
         }
 
         // Static methods for connection management
@@ -100,13 +101,8 @@ export namespace storm {
             return orm::statements::RemoveStatement<T, ConnType>(conn_).execute(objects);
         }
 
-        [[nodiscard]] std::expected<int64_t, Error> execute_insert(const T& obj) const noexcept {
-            // Use optimized single insert path to avoid .and_then() overhead
-            return orm::statements::InsertStatement<T, ConnType>(conn_).execute_single(obj);
-        }
-
         [[nodiscard]] std::expected<std::vector<int64_t>, Error>
-        execute_insert_batch(std::span<const T> objects) const noexcept {
+        execute_insert(std::span<const T> objects) const noexcept {
             return orm::statements::InsertStatement<T, ConnType>(conn_).execute(objects);
         }
 

--- a/src/orm/statements/insert.cppm
+++ b/src/orm/statements/insert.cppm
@@ -190,8 +190,26 @@ export namespace storm::orm::statements {
       public:
         explicit InsertStatement(Connection& conn) : conn_(conn) {}
 
-        // Single insert operation - optimized fast path for single object
-        [[nodiscard]] auto execute_single(const T& obj) noexcept -> std::expected<int64_t, Error> {
+        // Unified insert operation - handles both single and batch operations
+        [[nodiscard]] auto execute(std::span<const T> objects) noexcept -> std::expected<std::vector<int64_t>, Error> {
+            if (objects.empty()) {
+                return std::vector<int64_t>{};
+            }
+
+            // Fast path for single object
+            if (objects.size() == 1) {
+                return execute_single_optimized(objects[0]).transform([](int64_t id) {
+                    return std::vector<int64_t>{id};
+                });
+            }
+
+            // Batch path
+            return Base::execute_standard_batch(*this, objects, Base::field_count_);
+        }
+
+      private:
+        // Private optimized implementation for single insert
+        [[nodiscard]] auto execute_single_optimized(const T& obj) noexcept -> std::expected<int64_t, Error> {
             // Fast path: directly prepare and execute for single object
             const auto& sql = get_insert_sql();
 
@@ -212,11 +230,6 @@ export namespace storm::orm::statements {
                         return conn_.last_insert_rowid();
                     }
             );
-        }
-
-        // Batch insert operation with optimization strategies
-        [[nodiscard]] auto execute(std::span<const T> objects) noexcept -> std::expected<std::vector<int64_t>, Error> {
-            return Base::execute_standard_batch(*this, objects, Base::field_count_);
         }
 
       protected: // Changed to protected so BaseStatement can access


### PR DESCRIPTION
Standardize InsertStatement and QuerySet to use unified execute() pattern:
- InsertStatement: Single execute(span) method handles both single and batch
- QuerySet: Unified execute_insert(span) replaces split execute_insert/execute_insert_batch
- Simplified insert(const T&) to use .transform() for extracting single ID

This makes insert operations consistent with remove operations, which already used this unified pattern. All tests pass, performance maintained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)