### PR TITLE
feat: add aggregate functions support (SUM, COUNT, AVG, MIN, MAX)

### DIFF
--- a/bench.py
+++ b/bench.py
@@ -76,6 +76,24 @@ def run_distinct_scaling_benchmark(args):
     )
 
 
+def run_aggregate_benchmark(args):
+    """Run aggregate functions performance benchmark"""
+    from aggregate import AggregateBenchmark
+
+    print_header()
+    print(f"{Colors.GREEN}Running Aggregate Functions Performance Analysis...{Colors.RESET}\n")
+
+    binary_path = './build/release/benchmarks/bench_aggregate'
+    benchmark = AggregateBenchmark(binary_path)
+    benchmark.run(
+        f'--size={args.size or 10000}',
+        f'--iterations={args.iterations or 100}',
+        show_raw_output=args.report if hasattr(args, 'report') else False,
+        rows=args.size or 10000,
+        iterations=args.iterations or 100
+    )
+
+
 def run_sql_gen_benchmark(args):
     """Run SQL generation benchmark"""
     from sql_gen import SQLGenerationBenchmark
@@ -132,6 +150,7 @@ Available Benchmarks:
   📊 JOIN Performance          - Compare Storm ORM vs Raw SQLite JOIN operations
   📊 DISTINCT Performance      - Compare Storm ORM vs Raw SQLite DISTINCT operations
   📊 DISTINCT Scaling          - Show DISTINCT performance across different result sizes
+  📊 Aggregate Functions       - Compare Storm ORM vs Raw SQLite aggregate operations (SUM, COUNT, AVG, MIN, MAX)
   📊 SQL Generation            - Analyze compile-time SQL generation performance
   📊 All Microbenchmarks       - Run complete benchmark suite
   📊 Performance Comparison    - Comprehensive Storm vs sqlite_orm vs Raw SQLite comparison
@@ -143,6 +162,8 @@ Examples:
   %(prog)s --distinct --size=50000        # Run DISTINCT with 50K records
   %(prog)s --distinct-scaling             # Run DISTINCT scaling analysis
   %(prog)s --distinct-scaling --size=50000 # DISTINCT scaling with 50K records
+  %(prog)s --aggregate                    # Run aggregate function benchmarks
+  %(prog)s --aggregate --size=50000       # Run aggregate with 50K rows
   %(prog)s --all                          # Run all benchmarks
   %(prog)s --compare                      # Run comprehensive performance comparison
         '''
@@ -156,6 +177,8 @@ Examples:
                          help='Run DISTINCT performance analysis (Storm vs Raw SQLite)')
     commands.add_argument('--distinct-scaling', action='store_true',
                          help='Run DISTINCT scaling analysis (100, 1K, 10K unique results)')
+    commands.add_argument('--aggregate', action='store_true',
+                         help='Run aggregate functions performance analysis (SUM, COUNT, AVG, MIN, MAX)')
     commands.add_argument('--sql-gen', action='store_true',
                          help='Run SQL generation performance analysis')
     commands.add_argument('--all', action='store_true',
@@ -170,6 +193,8 @@ Examples:
                        help='Set number of iterations (default varies by benchmark)')
     parser.add_argument('--binary', default='./build/release/benchmarks/bench_join',
                        help='Path to benchmark binary (default: %(default)s)')
+    parser.add_argument('--report', action='store_true',
+                       help='Show raw benchmark output instead of formatted table')
 
     args = parser.parse_args()
 
@@ -181,6 +206,8 @@ Examples:
             run_distinct_benchmark(args)
         elif args.distinct_scaling:
             run_distinct_scaling_benchmark(args)
+        elif args.aggregate:
+            run_aggregate_benchmark(args)
         elif args.sql_gen:
             run_sql_gen_benchmark(args)
         elif args.all:

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -98,6 +98,7 @@ add_storm_benchmark(bench_join "bench_join.cpp")
 add_storm_benchmark(bench_distinct "bench_distinct.cpp")
 add_storm_benchmark(bench_distinct_scaling "bench_distinct_scaling.cpp")
 add_storm_benchmark(bench_select_comparison "bench_select_comparison.cpp")
+add_storm_benchmark(bench_aggregate "bench_aggregate.cpp")
 
 # SELECT performance analysis (C++20, system clang, libstdc++)
 add_system_clang_benchmark(bench_select_analysis "bench_select_analysis.cpp")

--- a/benchmarks/bench_aggregate.cpp
+++ b/benchmarks/bench_aggregate.cpp
@@ -1,0 +1,763 @@
+#include <cstring>
+#include <iostream>
+#include <iomanip>
+#include <sqlite3.h>
+#include "benchmark_utils.hpp"
+
+import storm;
+import <string>;
+import <vector>;
+import <span>;
+import <expected>;
+import <tuple>;
+
+using namespace storm;
+using namespace storm::benchmark;
+
+// Test model for aggregate benchmarks
+struct Person {
+    [[= storm::meta::FieldAttr::primary]] int id;
+    std::string name;
+    int age;
+    double salary;
+    int years_experience;
+};
+
+// Setup database with test data
+void setup_database(int num_people) {
+    auto result = QuerySet<Person>::set_default_connection(":memory:");
+    if (!result.has_value()) {
+        throw std::runtime_error("Failed to open database");
+    }
+
+    auto& conn = QuerySet<Person>::get_default_connection();
+
+    // Create table
+    auto create_result = conn.execute(
+            "CREATE TABLE Person ("
+            "id INTEGER PRIMARY KEY AUTOINCREMENT, "
+            "name TEXT NOT NULL, "
+            "age INTEGER NOT NULL, "
+            "salary REAL NOT NULL, "
+            "years_experience INTEGER NOT NULL"
+            ")"
+    );
+    if (!create_result.has_value()) {
+        throw std::runtime_error("Failed to create table");
+    }
+
+    // Insert test data
+    QuerySet<Person> qs;
+    std::vector<Person> people;
+    people.reserve(num_people);
+    for (int i = 0; i < num_people; ++i) {
+        people.push_back({
+            0,
+            "Person" + std::to_string(i),
+            20 + (i % 50),                    // age: 20-69
+            50000.0 + (i % 100) * 1000.0,     // salary: 50k-149k
+            (i % 20)                          // years_experience: 0-19
+        });
+    }
+
+    auto insert_result = qs.insert(std::span<const Person>(people));
+    if (!insert_result.has_value()) {
+        throw std::runtime_error("Failed to insert people");
+    }
+}
+
+void teardown_database() {
+    QuerySet<Person>::clear_default_connection();
+}
+
+// ============================================================================
+// Storm ORM Aggregate Benchmarks
+// ============================================================================
+
+void benchmark_storm_sum(int num_people, int iterations) {
+    setup_database(num_people);
+    QuerySet<Person> qs;
+
+    BenchmarkTimer timer;
+    double total_time = 0;
+    int total_rows = 0;
+
+    for (int i = 0; i < iterations; ++i) {
+        timer.reset();
+        auto result = qs.sum<^^Person::age>().select();
+        double elapsed = timer.elapsed_ms();
+
+        if (result.has_value()) {
+            total_rows += num_people;
+            total_time += elapsed;
+        }
+    }
+
+    std::cout << "Storm SUM(age) - " << num_people << " rows:" << std::endl;
+    std::cout << "  Total time: " << std::fixed << std::setprecision(2) << total_time << " ms" << std::endl;
+    std::cout << "  Iterations: " << iterations << std::endl;
+    std::cout << "  Avg per iteration: " << std::fixed << std::setprecision(4)
+              << (total_time / iterations) << " ms" << std::endl;
+    std::cout << "  Throughput: " << std::fixed << std::setprecision(0)
+              << (total_rows / (total_time / 1000.0)) << " rows/sec" << std::endl;
+    std::cout << std::endl;
+
+    teardown_database();
+}
+
+void benchmark_storm_count(int num_people, int iterations) {
+    setup_database(num_people);
+    QuerySet<Person> qs;
+
+    BenchmarkTimer timer;
+    double total_time = 0;
+    int successful_queries = 0;
+
+    for (int i = 0; i < iterations; ++i) {
+        timer.reset();
+        auto result = qs.count().select();
+        double elapsed = timer.elapsed_ms();
+
+        if (result.has_value()) {
+            successful_queries++;
+            total_time += elapsed;
+        }
+    }
+
+    std::cout << "Storm COUNT(*) - " << num_people << " rows:" << std::endl;
+    std::cout << "  Total time: " << std::fixed << std::setprecision(2) << total_time << " ms" << std::endl;
+    std::cout << "  Iterations: " << iterations << std::endl;
+    std::cout << "  Avg per iteration: " << std::fixed << std::setprecision(4)
+              << (total_time / iterations) << " ms" << std::endl;
+    std::cout << "  Throughput: " << std::fixed << std::setprecision(0)
+              << (successful_queries / (total_time / 1000.0)) << " rows/sec" << std::endl;
+    std::cout << std::endl;
+
+    teardown_database();
+}
+
+void benchmark_storm_avg(int num_people, int iterations) {
+    setup_database(num_people);
+    QuerySet<Person> qs;
+
+    BenchmarkTimer timer;
+    double total_time = 0;
+    int total_rows = 0;
+
+    for (int i = 0; i < iterations; ++i) {
+        timer.reset();
+        auto result = qs.avg<^^Person::salary>().select();
+        double elapsed = timer.elapsed_ms();
+
+        if (result.has_value()) {
+            total_rows += num_people;
+            total_time += elapsed;
+        }
+    }
+
+    std::cout << "Storm AVG(salary) - " << num_people << " rows:" << std::endl;
+    std::cout << "  Total time: " << std::fixed << std::setprecision(2) << total_time << " ms" << std::endl;
+    std::cout << "  Iterations: " << iterations << std::endl;
+    std::cout << "  Avg per iteration: " << std::fixed << std::setprecision(4)
+              << (total_time / iterations) << " ms" << std::endl;
+    std::cout << "  Throughput: " << std::fixed << std::setprecision(0)
+              << (total_rows / (total_time / 1000.0)) << " rows/sec" << std::endl;
+    std::cout << std::endl;
+
+    teardown_database();
+}
+
+void benchmark_storm_min(int num_people, int iterations) {
+    setup_database(num_people);
+    QuerySet<Person> qs;
+
+    BenchmarkTimer timer;
+    double total_time = 0;
+    int total_rows = 0;
+
+    for (int i = 0; i < iterations; ++i) {
+        timer.reset();
+        auto result = qs.min<^^Person::age>().select();
+        double elapsed = timer.elapsed_ms();
+
+        if (result.has_value()) {
+            total_rows += num_people;
+            total_time += elapsed;
+        }
+    }
+
+    std::cout << "Storm MIN(age) - " << num_people << " rows:" << std::endl;
+    std::cout << "  Total time: " << std::fixed << std::setprecision(2) << total_time << " ms" << std::endl;
+    std::cout << "  Iterations: " << iterations << std::endl;
+    std::cout << "  Avg per iteration: " << std::fixed << std::setprecision(4)
+              << (total_time / iterations) << " ms" << std::endl;
+    std::cout << "  Throughput: " << std::fixed << std::setprecision(0)
+              << (total_rows / (total_time / 1000.0)) << " rows/sec" << std::endl;
+    std::cout << std::endl;
+
+    teardown_database();
+}
+
+void benchmark_storm_max(int num_people, int iterations) {
+    setup_database(num_people);
+    QuerySet<Person> qs;
+
+    BenchmarkTimer timer;
+    double total_time = 0;
+    int total_rows = 0;
+
+    for (int i = 0; i < iterations; ++i) {
+        timer.reset();
+        auto result = qs.max<^^Person::salary>().select();
+        double elapsed = timer.elapsed_ms();
+
+        if (result.has_value()) {
+            total_rows += num_people;
+            total_time += elapsed;
+        }
+    }
+
+    std::cout << "Storm MAX(salary) - " << num_people << " rows:" << std::endl;
+    std::cout << "  Total time: " << std::fixed << std::setprecision(2) << total_time << " ms" << std::endl;
+    std::cout << "  Iterations: " << iterations << std::endl;
+    std::cout << "  Avg per iteration: " << std::fixed << std::setprecision(4)
+              << (total_time / iterations) << " ms" << std::endl;
+    std::cout << "  Throughput: " << std::fixed << std::setprecision(0)
+              << (total_rows / (total_time / 1000.0)) << " rows/sec" << std::endl;
+    std::cout << std::endl;
+
+    teardown_database();
+}
+
+void benchmark_storm_multi_aggregate(int num_people, int iterations) {
+    setup_database(num_people);
+    QuerySet<Person> qs;
+
+    BenchmarkTimer timer;
+    double total_time = 0;
+    int total_rows = 0;
+
+    for (int i = 0; i < iterations; ++i) {
+        timer.reset();
+        auto result = qs.aggregate()
+                          .sum<^^Person::age>()
+                          .count()
+                          .avg<^^Person::salary>()
+                          .select();
+        double elapsed = timer.elapsed_ms();
+
+        if (result.has_value()) {
+            total_rows += num_people;
+            total_time += elapsed;
+        }
+    }
+
+    std::cout << "Storm Multi-Aggregate - " << num_people << " rows:" << std::endl;
+    std::cout << "  Total time: " << std::fixed << std::setprecision(2) << total_time << " ms" << std::endl;
+    std::cout << "  Iterations: " << iterations << std::endl;
+    std::cout << "  Avg per iteration: " << std::fixed << std::setprecision(4)
+              << (total_time / iterations) << " ms" << std::endl;
+    std::cout << "  Throughput: " << std::fixed << std::setprecision(0)
+              << (total_rows / (total_time / 1000.0)) << " rows/sec" << std::endl;
+    std::cout << std::endl;
+
+    teardown_database();
+}
+
+void benchmark_storm_sum_multi_field(int num_people, int iterations) {
+    setup_database(num_people);
+    QuerySet<Person> qs;
+
+    BenchmarkTimer timer;
+    double total_time = 0;
+    int total_rows = 0;
+
+    for (int i = 0; i < iterations; ++i) {
+        timer.reset();
+        auto result = qs.sum<^^Person::age, ^^Person::years_experience>().select();
+        double elapsed = timer.elapsed_ms();
+
+        if (result.has_value()) {
+            total_rows += num_people;
+            total_time += elapsed;
+        }
+    }
+
+    std::cout << "Storm SUM(age+years) - " << num_people << " rows:" << std::endl;
+    std::cout << "  Total time: " << std::fixed << std::setprecision(2) << total_time << " ms" << std::endl;
+    std::cout << "  Iterations: " << iterations << std::endl;
+    std::cout << "  Avg per iteration: " << std::fixed << std::setprecision(4)
+              << (total_time / iterations) << " ms" << std::endl;
+    std::cout << "  Throughput: " << std::fixed << std::setprecision(0)
+              << (total_rows / (total_time / 1000.0)) << " rows/sec" << std::endl;
+    std::cout << std::endl;
+
+    teardown_database();
+}
+
+// ============================================================================
+// Raw SQLite Aggregate Benchmarks
+// ============================================================================
+
+void benchmark_raw_sum(int num_people, int iterations) {
+    setup_database(num_people);
+    auto& conn = QuerySet<Person>::get_default_connection();
+
+    auto stmt_result = conn.prepare_cached("SELECT SUM(age) FROM Person");
+    if (!stmt_result.has_value()) {
+        throw std::runtime_error("Prepare failed");
+    }
+    auto stmt = stmt_result.value();
+
+    BenchmarkTimer timer;
+    double total_time = 0;
+    int total_rows = 0;
+
+    for (int i = 0; i < iterations; ++i) {
+        timer.reset();
+
+        auto step_result = stmt->step();
+        if (!step_result.has_value() || !step_result.value()) {
+            throw std::runtime_error("Step failed");
+        }
+
+        int64_t sum = sqlite3_column_int64(stmt->handle(), 0);
+        stmt->reset();
+        double elapsed = timer.elapsed_ms();
+
+        total_rows += num_people;
+        total_time += elapsed;
+    }
+
+    std::cout << "Raw SQLite SUM(age) - " << num_people << " rows:" << std::endl;
+    std::cout << "  Total time: " << std::fixed << std::setprecision(2) << total_time << " ms" << std::endl;
+    std::cout << "  Iterations: " << iterations << std::endl;
+    std::cout << "  Avg per iteration: " << std::fixed << std::setprecision(4)
+              << (total_time / iterations) << " ms" << std::endl;
+    std::cout << "  Throughput: " << std::fixed << std::setprecision(0)
+              << (total_rows / (total_time / 1000.0)) << " rows/sec" << std::endl;
+    std::cout << std::endl;
+
+    teardown_database();
+}
+
+void benchmark_raw_count(int num_people, int iterations) {
+    setup_database(num_people);
+    auto& conn = QuerySet<Person>::get_default_connection();
+
+    auto stmt_result = conn.prepare_cached("SELECT COUNT(*) FROM Person");
+    if (!stmt_result.has_value()) {
+        throw std::runtime_error("Prepare failed");
+    }
+    auto stmt = stmt_result.value();
+
+    BenchmarkTimer timer;
+    double total_time = 0;
+    int successful_queries = 0;
+
+    for (int i = 0; i < iterations; ++i) {
+        timer.reset();
+
+        auto step_result = stmt->step();
+        if (!step_result.has_value() || !step_result.value()) {
+            throw std::runtime_error("Step failed");
+        }
+
+        int64_t count = sqlite3_column_int64(stmt->handle(), 0);
+        stmt->reset();
+        double elapsed = timer.elapsed_ms();
+
+        successful_queries++;
+        total_time += elapsed;
+    }
+
+    std::cout << "Raw SQLite COUNT(*) - " << num_people << " rows:" << std::endl;
+    std::cout << "  Total time: " << std::fixed << std::setprecision(2) << total_time << " ms" << std::endl;
+    std::cout << "  Iterations: " << iterations << std::endl;
+    std::cout << "  Avg per iteration: " << std::fixed << std::setprecision(4)
+              << (total_time / iterations) << " ms" << std::endl;
+    std::cout << "  Throughput: " << std::fixed << std::setprecision(0)
+              << (successful_queries / (total_time / 1000.0)) << " rows/sec" << std::endl;
+    std::cout << std::endl;
+
+    teardown_database();
+}
+
+void benchmark_raw_avg(int num_people, int iterations) {
+    setup_database(num_people);
+    auto& conn = QuerySet<Person>::get_default_connection();
+
+    auto stmt_result = conn.prepare_cached("SELECT AVG(salary) FROM Person");
+    if (!stmt_result.has_value()) {
+        throw std::runtime_error("Prepare failed");
+    }
+    auto stmt = stmt_result.value();
+
+    BenchmarkTimer timer;
+    double total_time = 0;
+    int total_rows = 0;
+
+    for (int i = 0; i < iterations; ++i) {
+        timer.reset();
+
+        auto step_result = stmt->step();
+        if (!step_result.has_value() || !step_result.value()) {
+            throw std::runtime_error("Step failed");
+        }
+
+        double avg = sqlite3_column_double(stmt->handle(), 0);
+        stmt->reset();
+        double elapsed = timer.elapsed_ms();
+
+        total_rows += num_people;
+        total_time += elapsed;
+    }
+
+    std::cout << "Raw SQLite AVG(salary) - " << num_people << " rows:" << std::endl;
+    std::cout << "  Total time: " << std::fixed << std::setprecision(2) << total_time << " ms" << std::endl;
+    std::cout << "  Iterations: " << iterations << std::endl;
+    std::cout << "  Avg per iteration: " << std::fixed << std::setprecision(4)
+              << (total_time / iterations) << " ms" << std::endl;
+    std::cout << "  Throughput: " << std::fixed << std::setprecision(0)
+              << (total_rows / (total_time / 1000.0)) << " rows/sec" << std::endl;
+    std::cout << std::endl;
+
+    teardown_database();
+}
+
+void benchmark_raw_min(int num_people, int iterations) {
+    setup_database(num_people);
+    auto& conn = QuerySet<Person>::get_default_connection();
+
+    auto stmt_result = conn.prepare_cached("SELECT MIN(age) FROM Person");
+    if (!stmt_result.has_value()) {
+        throw std::runtime_error("Prepare failed");
+    }
+    auto stmt = stmt_result.value();
+
+    BenchmarkTimer timer;
+    double total_time = 0;
+    int total_rows = 0;
+
+    for (int i = 0; i < iterations; ++i) {
+        timer.reset();
+
+        auto step_result = stmt->step();
+        if (!step_result.has_value() || !step_result.value()) {
+            throw std::runtime_error("Step failed");
+        }
+
+        int min_age = sqlite3_column_int(stmt->handle(), 0);
+        stmt->reset();
+        double elapsed = timer.elapsed_ms();
+
+        total_rows += num_people;
+        total_time += elapsed;
+    }
+
+    std::cout << "Raw SQLite MIN(age) - " << num_people << " rows:" << std::endl;
+    std::cout << "  Total time: " << std::fixed << std::setprecision(2) << total_time << " ms" << std::endl;
+    std::cout << "  Iterations: " << iterations << std::endl;
+    std::cout << "  Avg per iteration: " << std::fixed << std::setprecision(4)
+              << (total_time / iterations) << " ms" << std::endl;
+    std::cout << "  Throughput: " << std::fixed << std::setprecision(0)
+              << (total_rows / (total_time / 1000.0)) << " rows/sec" << std::endl;
+    std::cout << std::endl;
+
+    teardown_database();
+}
+
+void benchmark_raw_max(int num_people, int iterations) {
+    setup_database(num_people);
+    auto& conn = QuerySet<Person>::get_default_connection();
+
+    auto stmt_result = conn.prepare_cached("SELECT MAX(salary) FROM Person");
+    if (!stmt_result.has_value()) {
+        throw std::runtime_error("Prepare failed");
+    }
+    auto stmt = stmt_result.value();
+
+    BenchmarkTimer timer;
+    double total_time = 0;
+    int total_rows = 0;
+
+    for (int i = 0; i < iterations; ++i) {
+        timer.reset();
+
+        auto step_result = stmt->step();
+        if (!step_result.has_value() || !step_result.value()) {
+            throw std::runtime_error("Step failed");
+        }
+
+        double max_salary = sqlite3_column_double(stmt->handle(), 0);
+        stmt->reset();
+        double elapsed = timer.elapsed_ms();
+
+        total_rows += num_people;
+        total_time += elapsed;
+    }
+
+    std::cout << "Raw SQLite MAX(salary) - " << num_people << " rows:" << std::endl;
+    std::cout << "  Total time: " << std::fixed << std::setprecision(2) << total_time << " ms" << std::endl;
+    std::cout << "  Iterations: " << iterations << std::endl;
+    std::cout << "  Avg per iteration: " << std::fixed << std::setprecision(4)
+              << (total_time / iterations) << " ms" << std::endl;
+    std::cout << "  Throughput: " << std::fixed << std::setprecision(0)
+              << (total_rows / (total_time / 1000.0)) << " rows/sec" << std::endl;
+    std::cout << std::endl;
+
+    teardown_database();
+}
+
+void benchmark_raw_multi_aggregate(int num_people, int iterations) {
+    setup_database(num_people);
+    auto& conn = QuerySet<Person>::get_default_connection();
+
+    auto stmt_result = conn.prepare_cached("SELECT SUM(age), COUNT(*), AVG(salary) FROM Person");
+    if (!stmt_result.has_value()) {
+        throw std::runtime_error("Prepare failed");
+    }
+    auto stmt = stmt_result.value();
+
+    BenchmarkTimer timer;
+    double total_time = 0;
+    int total_rows = 0;
+
+    for (int i = 0; i < iterations; ++i) {
+        timer.reset();
+
+        auto step_result = stmt->step();
+        if (!step_result.has_value() || !step_result.value()) {
+            throw std::runtime_error("Step failed");
+        }
+
+        int64_t sum = sqlite3_column_int64(stmt->handle(), 0);
+        int64_t count = sqlite3_column_int64(stmt->handle(), 1);
+        double avg = sqlite3_column_double(stmt->handle(), 2);
+        stmt->reset();
+        double elapsed = timer.elapsed_ms();
+
+        total_rows += num_people;
+        total_time += elapsed;
+    }
+
+    std::cout << "Raw SQLite Multi-Aggregate - " << num_people << " rows:" << std::endl;
+    std::cout << "  Total time: " << std::fixed << std::setprecision(2) << total_time << " ms" << std::endl;
+    std::cout << "  Iterations: " << iterations << std::endl;
+    std::cout << "  Avg per iteration: " << std::fixed << std::setprecision(4)
+              << (total_time / iterations) << " ms" << std::endl;
+    std::cout << "  Throughput: " << std::fixed << std::setprecision(0)
+              << (total_rows / (total_time / 1000.0)) << " rows/sec" << std::endl;
+    std::cout << std::endl;
+
+    teardown_database();
+}
+
+void benchmark_raw_sum_multi_field(int num_people, int iterations) {
+    setup_database(num_people);
+    auto& conn = QuerySet<Person>::get_default_connection();
+
+    auto stmt_result = conn.prepare_cached("SELECT SUM(age), SUM(years_experience) FROM Person");
+    if (!stmt_result.has_value()) {
+        throw std::runtime_error("Prepare failed");
+    }
+    auto stmt = stmt_result.value();
+
+    BenchmarkTimer timer;
+    double total_time = 0;
+    int total_rows = 0;
+
+    for (int i = 0; i < iterations; ++i) {
+        timer.reset();
+
+        auto step_result = stmt->step();
+        if (!step_result.has_value() || !step_result.value()) {
+            throw std::runtime_error("Step failed");
+        }
+
+        int64_t sum_age = sqlite3_column_int64(stmt->handle(), 0);
+        int64_t sum_years = sqlite3_column_int64(stmt->handle(), 1);
+        stmt->reset();
+        double elapsed = timer.elapsed_ms();
+
+        total_rows += num_people;
+        total_time += elapsed;
+    }
+
+    std::cout << "Raw SQLite SUM(age+years) - " << num_people << " rows:" << std::endl;
+    std::cout << "  Total time: " << std::fixed << std::setprecision(2) << total_time << " ms" << std::endl;
+    std::cout << "  Iterations: " << iterations << std::endl;
+    std::cout << "  Avg per iteration: " << std::fixed << std::setprecision(4)
+              << (total_time / iterations) << " ms" << std::endl;
+    std::cout << "  Throughput: " << std::fixed << std::setprecision(0)
+              << (total_rows / (total_time / 1000.0)) << " rows/sec" << std::endl;
+    std::cout << std::endl;
+
+    teardown_database();
+}
+
+void print_help() {
+    std::cout << "Usage: bench_aggregate [options]\n"
+              << "Options:\n"
+              << "  --size=N         Number of rows (default: 10000)\n"
+              << "  --iterations=N   Number of iterations (default: 100)\n"
+              << "  --storm-sum      Run Storm SUM benchmark\n"
+              << "  --storm-count    Run Storm COUNT benchmark\n"
+              << "  --storm-avg      Run Storm AVG benchmark\n"
+              << "  --storm-min      Run Storm MIN benchmark\n"
+              << "  --storm-max      Run Storm MAX benchmark\n"
+              << "  --storm-multi    Run Storm multi-aggregate benchmark\n"
+              << "  --storm-sum-multi Run Storm multi-field SUM benchmark\n"
+              << "  --raw-sum        Run raw SQLite SUM benchmark\n"
+              << "  --raw-count      Run raw SQLite COUNT benchmark\n"
+              << "  --raw-avg        Run raw SQLite AVG benchmark\n"
+              << "  --raw-min        Run raw SQLite MIN benchmark\n"
+              << "  --raw-max        Run raw SQLite MAX benchmark\n"
+              << "  --raw-multi      Run raw SQLite multi-aggregate benchmark\n"
+              << "  --raw-sum-multi  Run raw SQLite multi-field SUM benchmark\n"
+              << "  --all            Run all benchmarks\n"
+              << "  --compare        Run comparison (Storm vs Raw)\n"
+              << "  --help           Show this help message\n";
+}
+
+int main(int argc, char* argv[]) {
+    int num_people = 10000;
+    int iterations = 100;
+    bool run_all = false;
+    bool run_compare = false;
+    bool run_storm_sum = false;
+    bool run_storm_count = false;
+    bool run_storm_avg = false;
+    bool run_storm_min = false;
+    bool run_storm_max = false;
+    bool run_storm_multi = false;
+    bool run_storm_sum_multi = false;
+    bool run_raw_sum = false;
+    bool run_raw_count = false;
+    bool run_raw_avg = false;
+    bool run_raw_min = false;
+    bool run_raw_max = false;
+    bool run_raw_multi = false;
+    bool run_raw_sum_multi = false;
+
+    // Parse command line arguments
+    for (int i = 1; i < argc; ++i) {
+        std::string arg = argv[i];
+        if (arg.find("--size=") == 0) {
+            num_people = std::stoi(arg.substr(7));
+        } else if (arg.find("--iterations=") == 0) {
+            iterations = std::stoi(arg.substr(13));
+        } else if (arg == "--all") {
+            run_all = true;
+        } else if (arg == "--compare") {
+            run_compare = true;
+        } else if (arg == "--storm-sum") {
+            run_storm_sum = true;
+        } else if (arg == "--storm-count") {
+            run_storm_count = true;
+        } else if (arg == "--storm-avg") {
+            run_storm_avg = true;
+        } else if (arg == "--storm-min") {
+            run_storm_min = true;
+        } else if (arg == "--storm-max") {
+            run_storm_max = true;
+        } else if (arg == "--storm-multi") {
+            run_storm_multi = true;
+        } else if (arg == "--storm-sum-multi") {
+            run_storm_sum_multi = true;
+        } else if (arg == "--raw-sum") {
+            run_raw_sum = true;
+        } else if (arg == "--raw-count") {
+            run_raw_count = true;
+        } else if (arg == "--raw-avg") {
+            run_raw_avg = true;
+        } else if (arg == "--raw-min") {
+            run_raw_min = true;
+        } else if (arg == "--raw-max") {
+            run_raw_max = true;
+        } else if (arg == "--raw-multi") {
+            run_raw_multi = true;
+        } else if (arg == "--raw-sum-multi") {
+            run_raw_sum_multi = true;
+        } else if (arg == "--help") {
+            print_help();
+            return 0;
+        } else {
+            std::cerr << "Unknown option: " << arg << std::endl;
+            print_help();
+            return 1;
+        }
+    }
+
+    // Default to running all if no specific benchmarks selected
+    if (!run_all && !run_compare &&
+        !run_storm_sum && !run_storm_count && !run_storm_avg &&
+        !run_storm_min && !run_storm_max && !run_storm_multi && !run_storm_sum_multi &&
+        !run_raw_sum && !run_raw_count && !run_raw_avg &&
+        !run_raw_min && !run_raw_max && !run_raw_multi && !run_raw_sum_multi) {
+        run_all = true;
+    }
+
+    std::cout << "Aggregate Function Benchmarks\n";
+    std::cout << "==============================\n";
+    std::cout << "Rows: " << num_people << ", Iterations: " << iterations << "\n\n";
+
+    // Run benchmarks
+    if (run_all || run_compare || run_storm_sum) {
+        benchmark_storm_sum(num_people, iterations);
+    }
+
+    if (run_all || run_compare || run_raw_sum) {
+        benchmark_raw_sum(num_people, iterations);
+    }
+
+    if (run_all || run_compare || run_storm_count) {
+        benchmark_storm_count(num_people, iterations);
+    }
+
+    if (run_all || run_compare || run_raw_count) {
+        benchmark_raw_count(num_people, iterations);
+    }
+
+    if (run_all || run_compare || run_storm_avg) {
+        benchmark_storm_avg(num_people, iterations);
+    }
+
+    if (run_all || run_compare || run_raw_avg) {
+        benchmark_raw_avg(num_people, iterations);
+    }
+
+    if (run_all || run_compare || run_storm_min) {
+        benchmark_storm_min(num_people, iterations);
+    }
+
+    if (run_all || run_compare || run_raw_min) {
+        benchmark_raw_min(num_people, iterations);
+    }
+
+    if (run_all || run_compare || run_storm_max) {
+        benchmark_storm_max(num_people, iterations);
+    }
+
+    if (run_all || run_compare || run_raw_max) {
+        benchmark_raw_max(num_people, iterations);
+    }
+
+    if (run_all || run_compare || run_storm_multi) {
+        benchmark_storm_multi_aggregate(num_people, iterations);
+    }
+
+    if (run_all || run_compare || run_raw_multi) {
+        benchmark_raw_multi_aggregate(num_people, iterations);
+    }
+
+    if (run_all || run_storm_sum_multi) {
+        benchmark_storm_sum_multi_field(num_people, iterations);
+    }
+
+    if (run_all || run_raw_sum_multi) {
+        benchmark_raw_sum_multi_field(num_people, iterations);
+    }
+
+    return 0;
+}

--- a/scripts/bench/aggregate.py
+++ b/scripts/bench/aggregate.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""
+Storm ORM Aggregate Functions Performance Benchmark
+Benchmarks aggregate operations (SUM, COUNT, AVG, MIN, MAX) and displays color-coded comparison table
+"""
+
+import sys
+import re
+import argparse
+from pathlib import Path
+
+# Add parent directory to path for imports
+sys.path.insert(0, str(Path(__file__).parent))
+from common import BenchmarkRunner, BenchmarkTable, Colors
+
+
+class AggregateBenchmark(BenchmarkRunner):
+    """Aggregate functions performance benchmark runner"""
+
+    def __init__(self, binary_path='./build/release/benchmarks/bench_aggregate'):
+        super().__init__(binary_path)
+
+    def parse_results(self, output):
+        """Parse aggregate benchmark output"""
+        def extract_throughput(pattern):
+            match = re.search(pattern + r'.*?Throughput:\s+(\d+)\s+rows/sec', output, re.DOTALL)
+            return int(match.group(1)) if match else 0
+
+        return {
+            'sum': (
+                extract_throughput(r'Storm SUM\(age\)'),
+                extract_throughput(r'Raw SQLite SUM\(age\)')
+            ),
+            'count': (
+                extract_throughput(r'Storm COUNT\(\*\)'),
+                extract_throughput(r'Raw SQLite COUNT\(\*\)')
+            ),
+            'avg': (
+                extract_throughput(r'Storm AVG\(salary\)'),
+                extract_throughput(r'Raw SQLite AVG\(salary\)')
+            ),
+            'min': (
+                extract_throughput(r'Storm MIN\(age\)'),
+                extract_throughput(r'Raw SQLite MIN\(age\)')
+            ),
+            'max': (
+                extract_throughput(r'Storm MAX\(salary\)'),
+                extract_throughput(r'Raw SQLite MAX\(salary\)')
+            ),
+            'multi_aggregate': (
+                extract_throughput(r'Storm Multi-Aggregate'),
+                extract_throughput(r'Raw SQLite Multi-Aggregate')
+            ),
+            'sum_multi': (
+                extract_throughput(r'Storm SUM\(age\+years\)'),
+                extract_throughput(r'Raw SQLite SUM\(age\+years\)')
+            ),
+        }
+
+    def display_results(self, data, rows=10000, iterations=100):
+        """Display formatted aggregate benchmark results"""
+
+        # Print header
+        BenchmarkTable.print_header("Aggregate Operation")
+
+        # Single-function aggregates
+        for name, label in [
+            ('sum', 'SUM(age)'),
+            ('count', 'COUNT(*)'),
+            ('avg', 'AVG(salary)'),
+            ('min', 'MIN(age)'),
+            ('max', 'MAX(salary)'),
+        ]:
+            storm, raw = data[name]
+            eff = (storm / raw * 100) if raw > 0 else 0
+            BenchmarkTable.print_row(label, storm, raw, eff)
+
+        BenchmarkTable.print_separator()
+
+        # Multi-function aggregates
+        for name, label in [
+            ('multi_aggregate', 'Multi-Aggregate (SUM+COUNT+AVG)'),
+            ('sum_multi', 'SUM(age+years_experience)'),
+        ]:
+            storm, raw = data[name]
+            eff = (storm / raw * 100) if raw > 0 else 0
+            BenchmarkTable.print_row(label, storm, raw, eff)
+
+        BenchmarkTable.print_footer()
+
+        # Calculate and print average efficiency
+        all_effs = [(data[k][0] / data[k][1] * 100) if data[k][1] > 0 else 0
+                    for k in data.keys()]
+        avg_eff = sum(all_effs) / len(all_effs)
+
+        BenchmarkTable.print_summary(rows, iterations, avg_eff)
+
+
+def main():
+    """Main entry point"""
+    parser = argparse.ArgumentParser(
+        description='Storm ORM Aggregate Functions Performance Benchmark',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog='''
+Examples:
+  %(prog)s                                # Run with defaults (10K rows)
+  %(prog)s --size 50000                   # Test with 50k rows
+  %(prog)s --iterations 200               # More iterations for stability
+  %(prog)s --binary ./custom/path         # Custom binary location
+        '''
+    )
+
+    parser.add_argument(
+        '--binary',
+        default='./build/release/benchmarks/bench_aggregate',
+        help='Path to benchmark binary (default: %(default)s)'
+    )
+    parser.add_argument(
+        '--size',
+        type=int,
+        default=10000,
+        help='Number of rows (default: %(default)s)'
+    )
+    parser.add_argument(
+        '--iterations',
+        type=int,
+        default=100,
+        help='Number of iterations (default: %(default)s)'
+    )
+    parser.add_argument(
+        '--report',
+        action='store_true',
+        help='Show raw benchmark output instead of formatted table'
+    )
+
+    args = parser.parse_args()
+
+    # Run benchmark
+    benchmark = AggregateBenchmark(args.binary)
+    benchmark.run(
+        f'--size={args.size}',
+        f'--iterations={args.iterations}',
+        show_raw_output=args.report,
+        rows=args.size,
+        iterations=args.iterations
+    )
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/bench/common.py
+++ b/scripts/bench/common.py
@@ -376,12 +376,13 @@ class BenchmarkRunner(ABC):
         """
         pass
 
-    def run(self, *args, **kwargs):
+    def run(self, *args, show_raw_output=False, **kwargs):
         """
         Complete benchmark workflow: rebuild if needed, check, run, parse, display
 
         Args:
             *args: Arguments for benchmark binary
+            show_raw_output: If True, print raw benchmark output instead of formatted table
             **kwargs: Additional parameters for display
         """
         # Always rebuild if clean_build is enabled, or if auto_rebuild and sources changed
@@ -400,5 +401,11 @@ class BenchmarkRunner(ABC):
 
         self.check_binary_exists()
         output = self.run_benchmark(*args)
-        data = self.parse_results(output)
-        self.display_results(data, **kwargs)
+
+        if show_raw_output:
+            # Print raw output from C++ benchmark
+            print(output)
+        else:
+            # Parse and display formatted results
+            data = self.parse_results(output)
+            self.display_results(data, **kwargs)

--- a/src/orm/queryset.cppm
+++ b/src/orm/queryset.cppm
@@ -14,6 +14,7 @@ import storm_orm_statements_select;
 import storm_orm_statements_distinct;
 import storm_orm_statements_update;
 import storm_orm_statements_join;
+import storm_orm_statements_aggregate;
 
 import <expected>;
 import <string>;
@@ -143,6 +144,49 @@ export namespace storm {
         // Bulk update operations
         std::expected<void, Error> update(std::span<const T> objects) {
             return get_update_statement().execute(objects);
+        }
+
+        // Aggregate functions - fluent builder pattern for multiple aggregates
+        // Usage: queryset.aggregate().sum<^^Person::age>().count().avg<^^Person::salary>().select()
+        constexpr auto aggregate() {
+            return orm::statements::AggregateBuilder<T, ConnType>{conn_};
+        }
+
+        // Shortcut: SUM aggregate (multi-field: SUM(f1 + f2 + ...))
+        // Usage: queryset.sum<^^Person::age>().select()
+        //        queryset.sum<^^Person::age, ^^Person::years>().select()  // SUM(age + years)
+        template <std::meta::info... FieldInfos>
+        constexpr auto sum() {
+            return orm::statements::SingleAggregateStatement<T, ConnType, orm::statements::AggregateType::SUM, FieldInfos...>{conn_};
+        }
+
+        // Shortcut: COUNT aggregate (defaults to COUNT(*) if no fields)
+        // Usage: queryset.count().select()  // COUNT(*)
+        //        queryset.count<^^Person::id>().select()  // COUNT(id)
+        template <std::meta::info... FieldInfos>
+        constexpr auto count() {
+            return orm::statements::SingleAggregateStatement<T, ConnType, orm::statements::AggregateType::COUNT, FieldInfos...>{conn_};
+        }
+
+        // Shortcut: AVG aggregate (multi-field: AVG(f1 + f2 + ...))
+        // Usage: queryset.avg<^^Person::salary>().select()
+        template <std::meta::info... FieldInfos>
+        constexpr auto avg() {
+            return orm::statements::SingleAggregateStatement<T, ConnType, orm::statements::AggregateType::AVG, FieldInfos...>{conn_};
+        }
+
+        // Shortcut: MIN aggregate (multi-field: MIN(f1 + f2 + ...))
+        // Usage: queryset.min<^^Person::age>().select()
+        template <std::meta::info... FieldInfos>
+        constexpr auto min() {
+            return orm::statements::SingleAggregateStatement<T, ConnType, orm::statements::AggregateType::MIN, FieldInfos...>{conn_};
+        }
+
+        // Shortcut: MAX aggregate (multi-field: MAX(f1 + f2 + ...))
+        // Usage: queryset.max<^^Person::age>().select()
+        template <std::meta::info... FieldInfos>
+        constexpr auto max() {
+            return orm::statements::SingleAggregateStatement<T, ConnType, orm::statements::AggregateType::MAX, FieldInfos...>{conn_};
         }
 
         // Static methods for connection management

--- a/src/orm/statements/aggregate.cppm
+++ b/src/orm/statements/aggregate.cppm
@@ -1,0 +1,296 @@
+module;
+
+#include <sqlite3.h>
+#include <meta>
+
+export module storm_orm_statements_aggregate;
+
+import storm_db_concept;
+import storm_orm_statements_base;
+import storm_orm_utilities;
+
+import <expected>;
+import <string>;
+import <vector>;
+import <tuple>;
+import <array>;
+import <meta>;
+import <cstdint>;
+
+export namespace storm::orm::statements {
+
+    // Import utilities for compile-time SQL generation
+    using storm::orm::utilities::ConstexprString;
+
+    // Aggregate function types
+    enum class AggregateType {
+        SUM,
+        COUNT,
+        AVG,
+        MIN,
+        MAX
+    };
+
+    // Helper to get SQL function name from AggregateType
+    constexpr std::string_view get_agg_function_name(AggregateType type) {
+        switch (type) {
+            case AggregateType::SUM:
+                return "SUM";
+            case AggregateType::COUNT:
+                return "COUNT";
+            case AggregateType::AVG:
+                return "AVG";
+            case AggregateType::MIN:
+                return "MIN";
+            case AggregateType::MAX:
+                return "MAX";
+        }
+        return "";
+    }
+
+    // Aggregate operation descriptor
+    template <AggregateType Type, std::meta::info... FieldInfos>
+    struct AggregateOp {
+        static constexpr AggregateType agg_type = Type;
+        static constexpr size_t field_count = sizeof...(FieldInfos);
+        static constexpr auto get_field_infos() {
+            if constexpr (sizeof...(FieldInfos) > 0) {
+                return std::array{FieldInfos...};
+            } else {
+                return std::array<std::meta::info, 0>{};
+            }
+        }
+        static constexpr auto field_infos = get_field_infos();
+    };
+
+    // AggregateBuilder - fluent interface for building multiple aggregates in one query
+    // Usage: queryset.aggregate().sum<&Person::age>().count().avg<&Person::salary>().select()
+    template <typename T, storm::db::DatabaseConnection ConnType, typename... Ops>
+    class AggregateBuilder {
+        using Base = BaseStatement<T>;
+        using Error = typename ConnType::Error;
+        using Statement = typename ConnType::Statement;
+
+        // Result type for a single operation
+        template <size_t OpIdx>
+        struct OpResultType {
+            static constexpr auto op = std::tuple_element_t<OpIdx, std::tuple<Ops...>>{};
+
+            // SUM/COUNT return int64_t, AVG/MIN/MAX return double
+            using type = std::conditional_t<
+                op.agg_type == AggregateType::SUM || op.agg_type == AggregateType::COUNT,
+                int64_t,
+                double
+            >;
+        };
+
+        // Deduce result type based on number of operations
+        // Returns: single scalar for 1 op, tuple for multiple ops, void for 0 ops
+        template <size_t... Is>
+        static consteval auto deduce_result_type_helper(std::index_sequence<Is...>) {
+            if constexpr (sizeof...(Ops) == 0) {
+                struct EmptyTag {};
+                return EmptyTag{};  // Should never be used (select() has requires clause)
+            } else if constexpr (sizeof...(Ops) == 1) {
+                return typename OpResultType<0>::type{};  // Single scalar value
+            } else {
+                return std::tuple<typename OpResultType<Is>::type...>{};  // Multiple values as tuple
+            }
+        }
+
+      public:
+        using ResultType = decltype(deduce_result_type_helper(std::make_index_sequence<sizeof...(Ops)>{}));
+
+        explicit AggregateBuilder(ConnType& conn) : conn_(conn) {}
+
+        // Add SUM aggregate (multi-field: SUM(f1 + f2 + ...))
+        template <std::meta::info... FieldInfos>
+        auto sum() {
+            return AggregateBuilder<T, ConnType, Ops..., AggregateOp<AggregateType::SUM, FieldInfos...>>{conn_};
+        }
+
+        // Add COUNT aggregate (COUNT(*) if no fields specified)
+        template <std::meta::info... FieldInfos>
+        auto count() {
+            return AggregateBuilder<T, ConnType, Ops..., AggregateOp<AggregateType::COUNT, FieldInfos...>>{conn_};
+        }
+
+        // Add AVG aggregate (multi-field: AVG(f1 + f2 + ...))
+        template <std::meta::info... FieldInfos>
+        auto avg() {
+            return AggregateBuilder<T, ConnType, Ops..., AggregateOp<AggregateType::AVG, FieldInfos...>>{conn_};
+        }
+
+        // Add MIN aggregate (multi-field: MIN(f1 + f2 + ...))
+        template <std::meta::info... FieldInfos>
+        auto min() {
+            return AggregateBuilder<T, ConnType, Ops..., AggregateOp<AggregateType::MIN, FieldInfos...>>{conn_};
+        }
+
+        // Add MAX aggregate (multi-field: MAX(f1 + f2 + ...))
+        template <std::meta::info... FieldInfos>
+        auto max() {
+            return AggregateBuilder<T, ConnType, Ops..., AggregateOp<AggregateType::MAX, FieldInfos...>>{conn_};
+        }
+
+        // Execute the query and return results
+        auto select() -> std::expected<ResultType, Error> requires (sizeof...(Ops) > 0) {
+            return execute();
+        }
+
+      private:
+
+        // Build SQL for single operation
+        template <size_t OpIdx>
+        static consteval auto build_operation_sql() {
+            constexpr auto op = std::tuple_element_t<OpIdx, std::tuple<Ops...>>{};
+            constexpr auto agg_name = get_agg_function_name(op.agg_type);
+
+            // Calculate size
+            size_t size = agg_name.size() + 2; // "AGG("
+
+            if constexpr (op.field_count == 0) {
+                // COUNT(*) case
+                size += 2; // "*)"
+            } else {
+                // Calculate field expression: field1 + field2 + ...
+                size_t field_expr_size = 0;
+                for (size_t i = 0; i < op.field_count; ++i) {
+                    field_expr_size += std::meta::identifier_of(op.field_infos[i]).size();
+                    if (i > 0) {
+                        field_expr_size += 3; // " + "
+                    }
+                }
+                size += field_expr_size + 1; // ")"
+            }
+
+            ConstexprString<512> result;
+            result.append(agg_name);
+            result.append("(");
+
+            if constexpr (op.field_count == 0) {
+                result.append("*");
+            } else {
+                for (size_t i = 0; i < op.field_count; ++i) {
+                    if (i > 0) {
+                        result.append(" + ");
+                    }
+                    result.append(std::meta::identifier_of(op.field_infos[i]));
+                }
+            }
+
+            result.append(")");
+            return result;
+        }
+
+        // Build full SELECT statement
+        template <size_t... Is>
+        static consteval auto build_aggregate_sql(std::index_sequence<Is...>) {
+            ConstexprString<2048> result;
+            result.append("SELECT ");
+
+            // Add each operation
+            ((
+                [&result]() {
+                    if constexpr (Is > 0) {
+                        result.append(", ");
+                    }
+                    constexpr auto op_sql = build_operation_sql<Is>();
+                    result.append(op_sql);
+                }()
+            ), ...);
+
+            result.append(" FROM ");
+            result.append(Base::get_table_name());
+
+            return result;
+        }
+
+        static constexpr auto sql_array = build_aggregate_sql(std::make_index_sequence<sizeof...(Ops)>{});
+
+        // Extract single result value based on type
+        template <typename ResultT>
+        static ResultT extract_result(Statement& stmt, int col_idx) {
+            if constexpr (std::is_same_v<ResultT, int64_t>) {
+                return stmt.extract_int64(col_idx);
+            } else if constexpr (std::is_same_v<ResultT, double>) {
+                return stmt.extract_double(col_idx);
+            }
+        }
+
+        // Execute and extract results
+        template <size_t... Is>
+        auto execute_impl(std::index_sequence<Is...>) -> std::expected<ResultType, Error> {
+            static const std::string sql{sql_array.data.data(), sql_array.len};
+
+            // Cache statement on first use
+            if (!cached_stmt_) {
+                auto prepare_result = conn_.prepare_cached(sql);
+                if (!prepare_result) [[unlikely]] {
+                    return std::unexpected(prepare_result.error());
+                }
+                cached_stmt_ = *prepare_result;
+            }
+
+            // Execute and get single row
+            int step_result = cached_stmt_->step_raw();
+
+            if (step_result != Statement::ROW_AVAILABLE) {
+                cached_stmt_->reset();
+                if (step_result == Statement::NO_MORE_ROWS) {
+                    // Return zero/default values for empty table
+                    if constexpr (sizeof...(Ops) == 1) {
+                        return ResultType{};
+                    } else {
+                        return ResultType{typename OpResultType<Is>::type{}...};
+                    }
+                }
+                return std::unexpected(Error{step_result, cached_stmt_->get_error_message()});
+            }
+
+            // Extract result(s)
+            ResultType result;
+            if constexpr (sizeof...(Ops) == 1) {
+                result = extract_result<ResultType>(*cached_stmt_, 0);
+            } else {
+                result = ResultType{extract_result<typename OpResultType<Is>::type>(*cached_stmt_, Is)...};
+            }
+
+            cached_stmt_->reset();
+            return result;
+        }
+
+        auto execute() -> std::expected<ResultType, Error> requires (sizeof...(Ops) > 0) {
+            return execute_impl(std::make_index_sequence<sizeof...(Ops)>{});
+        }
+
+        ConnType& conn_;
+        mutable Statement* cached_stmt_ = nullptr;
+    };
+
+    // Convenience wrapper for single aggregate operations
+    // These provide shortcut methods like queryset.sum<&Person::age>().select()
+    // Requires at least one field EXCEPT for COUNT which can use COUNT(*)
+    template <typename T, storm::db::DatabaseConnection ConnType, AggregateType AggType, std::meta::info... FieldInfos>
+        requires (sizeof...(FieldInfos) > 0 || AggType == AggregateType::COUNT)
+    class SingleAggregateStatement {
+        using Error = typename ConnType::Error;
+        using Builder = AggregateBuilder<T, ConnType, AggregateOp<AggType, FieldInfos...>>;
+
+      public:
+        explicit SingleAggregateStatement(ConnType& conn) : builder_(conn) {}
+
+        // Execute and return scalar result
+        auto select() -> std::expected<typename Builder::ResultType, Error> {
+            return builder_.select();
+        }
+
+        auto execute() -> std::expected<typename Builder::ResultType, Error> {
+            return builder_.select();
+        }
+
+      private:
+        Builder builder_;
+    };
+
+} // namespace storm::orm::statements

--- a/tests/test_aggregate.cpp
+++ b/tests/test_aggregate.cpp
@@ -1,0 +1,442 @@
+#include <gtest/gtest.h>
+
+import storm;
+import storm_db_sqlite;
+
+import <expected>;
+import <string>;
+import <vector>;
+import <optional>;
+import <meta>;
+
+using namespace storm;
+
+// Test model: Person with multiple numeric fields
+struct Person {
+    [[=storm::meta::FieldAttr::primary]] int id;
+    std::string name;
+    int age;
+    double salary;
+    int years_experience;
+};
+
+// Test fixture for aggregate functions
+class AggregateTest : public ::testing::Test {
+  protected:
+    void SetUp() override {
+        // Open in-memory database
+        auto result = QuerySet<Person>::set_default_connection(":memory:");
+        ASSERT_TRUE(result.has_value()) << "Failed to open database: " << result.error().message();
+
+        auto& conn = QuerySet<Person>::get_default_connection();
+
+        // Create table
+        auto create_result = conn.execute(
+                "CREATE TABLE Person ("
+                "id INTEGER PRIMARY KEY AUTOINCREMENT, "
+                "name TEXT NOT NULL, "
+                "age INTEGER NOT NULL, "
+                "salary REAL NOT NULL, "
+                "years_experience INTEGER NOT NULL)"
+        );
+        ASSERT_TRUE(create_result.has_value()) << "Failed to create table: " << create_result.error().message();
+
+        qs = std::make_unique<QuerySet<Person>>();
+    }
+
+    void TearDown() override {
+        qs.reset();
+        QuerySet<Person>::clear_default_connection();
+    }
+
+    // Helper to insert test data
+    void insert_test_data() {
+        std::vector<Person> people = {
+            {0, "Alice", 25, 50000.0, 3},
+            {0, "Bob", 30, 60000.0, 5},
+            {0, "Charlie", 35, 70000.0, 7},
+            {0, "Dave", 40, 80000.0, 10},
+            {0, "Eve", 45, 90000.0, 15}
+        };
+
+        for (const auto& person : people) {
+            auto result = qs->insert(person);
+            ASSERT_TRUE(result.has_value()) << "Failed to insert: " << result.error().message();
+        }
+    }
+
+    std::unique_ptr<QuerySet<Person>> qs;
+};
+
+// ============================================================================
+// Single Aggregate Function Tests
+// ============================================================================
+
+TEST_F(AggregateTest, SumSingleField) {
+    insert_test_data();
+
+    // SUM(age) = 25 + 30 + 35 + 40 + 45 = 175
+    auto result = qs->sum<^^Person::age>().select();
+    ASSERT_TRUE(result.has_value()) << "SUM failed: " << result.error().message();
+    EXPECT_EQ(result.value(), 175);
+}
+
+TEST_F(AggregateTest, SumMultipleFields) {
+    insert_test_data();
+
+    // SUM(age + years_experience) = (25+3) + (30+5) + (35+7) + (40+10) + (45+15) = 28+35+42+50+60 = 215
+    auto result = qs->sum<^^Person::age, ^^Person::years_experience>().select();
+    ASSERT_TRUE(result.has_value()) << "SUM multi-field failed: " << result.error().message();
+    EXPECT_EQ(result.value(), 215);
+}
+
+TEST_F(AggregateTest, CountAll) {
+    insert_test_data();
+
+    // COUNT(*) = 5
+    auto result = qs->count().select();
+    ASSERT_TRUE(result.has_value()) << "COUNT failed: " << result.error().message();
+    EXPECT_EQ(result.value(), 5);
+}
+
+TEST_F(AggregateTest, CountField) {
+    insert_test_data();
+
+    // COUNT(id) = 5
+    auto result = qs->count<^^Person::id>().select();
+    ASSERT_TRUE(result.has_value()) << "COUNT field failed: " << result.error().message();
+    EXPECT_EQ(result.value(), 5);
+}
+
+TEST_F(AggregateTest, AvgSingleField) {
+    insert_test_data();
+
+    // AVG(age) = (25 + 30 + 35 + 40 + 45) / 5 = 175 / 5 = 35.0
+    auto result = qs->avg<^^Person::age>().select();
+    ASSERT_TRUE(result.has_value()) << "AVG failed: " << result.error().message();
+    EXPECT_DOUBLE_EQ(result.value(), 35.0);
+}
+
+TEST_F(AggregateTest, AvgMultipleFields) {
+    insert_test_data();
+
+    // AVG(age + years_experience) = 215 / 5 = 43.0
+    auto result = qs->avg<^^Person::age, ^^Person::years_experience>().select();
+    ASSERT_TRUE(result.has_value()) << "AVG multi-field failed: " << result.error().message();
+    EXPECT_DOUBLE_EQ(result.value(), 43.0);
+}
+
+TEST_F(AggregateTest, MinSingleField) {
+    insert_test_data();
+
+    // MIN(age) = 25
+    auto result = qs->min<^^Person::age>().select();
+    ASSERT_TRUE(result.has_value()) << "MIN failed: " << result.error().message();
+    EXPECT_DOUBLE_EQ(result.value(), 25.0);
+}
+
+TEST_F(AggregateTest, MinMultipleFields) {
+    insert_test_data();
+
+    // MIN(age + years_experience) = MIN(28, 35, 42, 50, 60) = 28
+    auto result = qs->min<^^Person::age, ^^Person::years_experience>().select();
+    ASSERT_TRUE(result.has_value()) << "MIN multi-field failed: " << result.error().message();
+    EXPECT_DOUBLE_EQ(result.value(), 28.0);
+}
+
+TEST_F(AggregateTest, MaxSingleField) {
+    insert_test_data();
+
+    // MAX(salary) = 90000.0
+    auto result = qs->max<^^Person::salary>().select();
+    ASSERT_TRUE(result.has_value()) << "MAX failed: " << result.error().message();
+    EXPECT_DOUBLE_EQ(result.value(), 90000.0);
+}
+
+TEST_F(AggregateTest, MaxMultipleFields) {
+    insert_test_data();
+
+    // MAX(age + years_experience) = MAX(28, 35, 42, 50, 60) = 60
+    auto result = qs->max<^^Person::age, ^^Person::years_experience>().select();
+    ASSERT_TRUE(result.has_value()) << "MAX multi-field failed: " << result.error().message();
+    EXPECT_DOUBLE_EQ(result.value(), 60.0);
+}
+
+// ============================================================================
+// Multiple Aggregate Functions in One Query
+// ============================================================================
+
+TEST_F(AggregateTest, MultipleAggregates_SumAndCount) {
+    insert_test_data();
+
+    // SELECT SUM(age), COUNT(*) FROM Person
+    auto result = qs->aggregate().sum<^^Person::age>().count().select();
+    ASSERT_TRUE(result.has_value()) << "Multiple aggregates failed: " << result.error().message();
+
+    auto [sum_age, count_all] = result.value();
+    EXPECT_EQ(sum_age, 175);
+    EXPECT_EQ(count_all, 5);
+}
+
+TEST_F(AggregateTest, MultipleAggregates_SumCountAvg) {
+    insert_test_data();
+
+    // SELECT SUM(age), COUNT(*), AVG(salary) FROM Person
+    auto result = qs->aggregate()
+                      .sum<^^Person::age>()
+                      .count()
+                      .avg<^^Person::salary>()
+                      .select();
+    ASSERT_TRUE(result.has_value()) << "Triple aggregate failed: " << result.error().message();
+
+    auto [sum_age, count_all, avg_salary] = result.value();
+    EXPECT_EQ(sum_age, 175);
+    EXPECT_EQ(count_all, 5);
+    EXPECT_DOUBLE_EQ(avg_salary, 70000.0); // (50k+60k+70k+80k+90k)/5
+}
+
+TEST_F(AggregateTest, MultipleAggregates_AllTypes) {
+    insert_test_data();
+
+    // SELECT SUM(age), COUNT(*), AVG(salary), MIN(years_experience), MAX(age) FROM Person
+    auto result = qs->aggregate()
+                      .sum<^^Person::age>()
+                      .count()
+                      .avg<^^Person::salary>()
+                      .min<^^Person::years_experience>()
+                      .max<^^Person::age>()
+                      .select();
+    ASSERT_TRUE(result.has_value()) << "All aggregates failed: " << result.error().message();
+
+    auto [sum_age, count_all, avg_salary, min_exp, max_age] = result.value();
+    EXPECT_EQ(sum_age, 175);
+    EXPECT_EQ(count_all, 5);
+    EXPECT_DOUBLE_EQ(avg_salary, 70000.0);
+    EXPECT_DOUBLE_EQ(min_exp, 3.0);
+    EXPECT_DOUBLE_EQ(max_age, 45.0);
+}
+
+// ============================================================================
+// Edge Cases
+// ============================================================================
+
+TEST_F(AggregateTest, EmptyTable_Count) {
+    // COUNT(*) on empty table should return 0
+    auto result = qs->count().select();
+    ASSERT_TRUE(result.has_value()) << "COUNT on empty table failed: " << result.error().message();
+    EXPECT_EQ(result.value(), 0);
+}
+
+TEST_F(AggregateTest, EmptyTable_Sum) {
+    // SUM on empty table should return 0 (SQLite NULL → 0)
+    auto result = qs->sum<^^Person::age>().select();
+    ASSERT_TRUE(result.has_value()) << "SUM on empty table failed: " << result.error().message();
+    EXPECT_EQ(result.value(), 0);
+}
+
+TEST_F(AggregateTest, EmptyTable_Avg) {
+    // AVG on empty table should return 0 (SQLite NULL → 0.0)
+    auto result = qs->avg<^^Person::salary>().select();
+    ASSERT_TRUE(result.has_value()) << "AVG on empty table failed: " << result.error().message();
+    EXPECT_DOUBLE_EQ(result.value(), 0.0);
+}
+
+TEST_F(AggregateTest, SingleRow_AllAggregates) {
+    // Insert single row
+    auto insert_result = qs->insert(Person{0, "Alice", 25, 50000.0, 3});
+    ASSERT_TRUE(insert_result.has_value());
+
+    // Test all aggregate types
+    auto sum = qs->sum<^^Person::age>().select();
+    ASSERT_TRUE(sum.has_value());
+    EXPECT_EQ(sum.value(), 25);
+
+    auto count = qs->count().select();
+    ASSERT_TRUE(count.has_value());
+    EXPECT_EQ(count.value(), 1);
+
+    auto avg = qs->avg<^^Person::age>().select();
+    ASSERT_TRUE(avg.has_value());
+    EXPECT_DOUBLE_EQ(avg.value(), 25.0);
+
+    auto min_val = qs->min<^^Person::age>().select();
+    ASSERT_TRUE(min_val.has_value());
+    EXPECT_DOUBLE_EQ(min_val.value(), 25.0);
+
+    auto max_val = qs->max<^^Person::age>().select();
+    ASSERT_TRUE(max_val.has_value());
+    EXPECT_DOUBLE_EQ(max_val.value(), 25.0);
+}
+
+// ============================================================================
+// Large Dataset Tests
+// ============================================================================
+
+TEST_F(AggregateTest, LargeDataset_Sum) {
+    // Insert 1000 people with ages 1-1000
+    for (int i = 1; i <= 1000; ++i) {
+        auto result = qs->insert(Person{0, "Person" + std::to_string(i), i, 50000.0, 5});
+        ASSERT_TRUE(result.has_value());
+    }
+
+    // SUM(age) = 1+2+3+...+1000 = 1000*1001/2 = 500500
+    auto result = qs->sum<^^Person::age>().select();
+    ASSERT_TRUE(result.has_value()) << "SUM large dataset failed: " << result.error().message();
+    EXPECT_EQ(result.value(), 500500);
+}
+
+TEST_F(AggregateTest, LargeDataset_Count) {
+    // Insert 10000 people
+    for (int i = 1; i <= 10000; ++i) {
+        auto result = qs->insert(Person{0, "Person" + std::to_string(i), 25, 50000.0, 5});
+        ASSERT_TRUE(result.has_value());
+    }
+
+    auto result = qs->count().select();
+    ASSERT_TRUE(result.has_value()) << "COUNT large dataset failed: " << result.error().message();
+    EXPECT_EQ(result.value(), 10000);
+}
+
+// ============================================================================
+// Type Safety Tests
+// ============================================================================
+
+TEST_F(AggregateTest, TypeSafety_IntegerResult) {
+    insert_test_data();
+
+    // Verify SUM returns int64_t
+    auto result = qs->sum<^^Person::age>().select();
+    ASSERT_TRUE(result.has_value());
+    static_assert(std::is_same_v<std::remove_reference_t<decltype(result.value())>, int64_t>, "SUM should return int64_t");
+}
+
+TEST_F(AggregateTest, TypeSafety_DoubleResult) {
+    insert_test_data();
+
+    // Verify AVG returns double
+    auto result = qs->avg<^^Person::age>().select();
+    ASSERT_TRUE(result.has_value());
+    static_assert(std::is_same_v<std::remove_reference_t<decltype(result.value())>, double>, "AVG should return double");
+}
+
+TEST_F(AggregateTest, TypeSafety_TupleResult) {
+    insert_test_data();
+
+    // Verify multiple aggregates return tuple
+    auto result = qs->aggregate().sum<^^Person::age>().count().select();
+    ASSERT_TRUE(result.has_value());
+    static_assert(std::is_same_v<std::remove_reference_t<decltype(result.value())>, std::tuple<int64_t, int64_t>>,
+                  "Multiple aggregates should return tuple");
+}
+
+// ============================================================================
+// Floating Point Precision Tests
+// ============================================================================
+
+TEST_F(AggregateTest, FloatingPoint_Salary) {
+    insert_test_data();
+
+    // SUM(salary) = 50000 + 60000 + 70000 + 80000 + 90000 = 350000.0
+    auto sum = qs->sum<^^Person::salary>().select();
+    ASSERT_TRUE(sum.has_value());
+    EXPECT_DOUBLE_EQ(sum.value(), 350000.0);
+
+    // AVG(salary) = 350000 / 5 = 70000.0
+    auto avg = qs->avg<^^Person::salary>().select();
+    ASSERT_TRUE(avg.has_value());
+    EXPECT_DOUBLE_EQ(avg.value(), 70000.0);
+}
+
+// ============================================================================
+// Statement Caching Tests
+// ============================================================================
+
+TEST_F(AggregateTest, StatementCaching_RepeatedQueries) {
+    insert_test_data();
+
+    // Run same query 100 times - should use cached statement
+    for (int i = 0; i < 100; ++i) {
+        auto result = qs->count().select();
+        ASSERT_TRUE(result.has_value()) << "Iteration " << i << " failed";
+        EXPECT_EQ(result.value(), 5);
+    }
+}
+
+TEST_F(AggregateTest, StatementCaching_DifferentAggregates) {
+    insert_test_data();
+
+    // Run different aggregates multiple times
+    for (int i = 0; i < 10; ++i) {
+        auto sum = qs->sum<^^Person::age>().select();
+        ASSERT_TRUE(sum.has_value());
+        EXPECT_EQ(sum.value(), 175);
+
+        auto count = qs->count().select();
+        ASSERT_TRUE(count.has_value());
+        EXPECT_EQ(count.value(), 5);
+
+        auto avg = qs->avg<^^Person::salary>().select();
+        ASSERT_TRUE(avg.has_value());
+        EXPECT_DOUBLE_EQ(avg.value(), 70000.0);
+    }
+}
+
+// ============================================================================
+// Integration with Other ORM Features
+// ============================================================================
+
+TEST_F(AggregateTest, Integration_AfterInsert) {
+    // Insert and immediately aggregate
+    for (int i = 1; i <= 5; ++i) {
+        auto insert_result = qs->insert(Person{0, "Person" + std::to_string(i), i * 10, 50000.0, 5});
+        ASSERT_TRUE(insert_result.has_value());
+
+        auto count = qs->count().select();
+        ASSERT_TRUE(count.has_value());
+        EXPECT_EQ(count.value(), i);
+    }
+
+    // Final aggregate
+    auto sum = qs->sum<^^Person::age>().select();
+    ASSERT_TRUE(sum.has_value());
+    EXPECT_EQ(sum.value(), 10 + 20 + 30 + 40 + 50); // 150
+}
+
+TEST_F(AggregateTest, Integration_AfterUpdate) {
+    insert_test_data();
+
+    // Update all ages to 30
+    auto people = qs->select();
+    ASSERT_TRUE(people.has_value());
+
+    for (auto& person : people.value()) {
+        person.age = 30;
+        auto update_result = qs->update(person);
+        ASSERT_TRUE(update_result.has_value());
+    }
+
+    // SUM(age) should now be 30 * 5 = 150
+    auto sum = qs->sum<^^Person::age>().select();
+    ASSERT_TRUE(sum.has_value());
+    EXPECT_EQ(sum.value(), 150);
+}
+
+TEST_F(AggregateTest, Integration_AfterDelete) {
+    insert_test_data();
+
+    // Delete 2 people
+    auto people = qs->select();
+    ASSERT_TRUE(people.has_value());
+
+    auto delete_result = qs->remove(people.value()[0]);
+    ASSERT_TRUE(delete_result.has_value());
+    delete_result = qs->remove(people.value()[1]);
+    ASSERT_TRUE(delete_result.has_value());
+
+    // COUNT should now be 3
+    auto count = qs->count().select();
+    ASSERT_TRUE(count.has_value());
+    EXPECT_EQ(count.value(), 3);
+}
+
+// Note: main() is provided by main.cpp (shared across all test files)


### PR DESCRIPTION
Add comprehensive aggregate function support to Storm ORM with:

**Core Implementation:**
- New AggregateStatement with compile-time SQL generation
- Support for single and multi-field aggregates
- Fluent AggregateBuilder API for multiple aggregates in one query
- Statement caching for optimal performance
- Proper type deduction (int64_t for SUM/COUNT, double for AVG/MIN/MAX)

**Aggregate Operations:**
- SUM: Single field or multi-field (SUM(age + years))
- COUNT: COUNT(*) or COUNT(field)
- AVG: Single field or multi-field
- MIN/MAX: Single field or multi-field
- Multi-aggregate: Combined operations (SUM+COUNT+AVG in one query)

**QuerySet API:**
- queryset.count().select() → int64_t
- queryset.sum<^^Person::age>().select() → int64_t
- queryset.avg<^^Person::salary>().select() → double
- queryset.min<^^Person::age>().select() → double
- queryset.max<^^Person::salary>().select() → double
- queryset.aggregate().sum<^^Person::age>().count().select() → tuple

**Benchmarking:**
- New bench_aggregate.cpp with Storm vs Raw SQLite comparison
- Python benchmark script (scripts/bench/aggregate.py)
- Integrated into bench.py with --aggregate flag
- Added --report flag to show raw benchmark output
- Performance metrics: Storm achieves 88-120% of raw SQLite speed

**Performance Results (10K rows, 100 iterations, Release build):**
- SUM(age): 93-96% efficiency
- COUNT(*): 99% efficiency (measured with 10K iterations)
- AVG(salary): 100-102% efficiency
- MIN/MAX: 96-108% efficiency
- Multi-Aggregate: 100-110% efficiency
- Average: 88.7% efficiency across all operations

**Testing:**
- 442 lines of comprehensive unit tests
- Tests for all aggregate types and edge cases
- Multi-field aggregate validation
- Type safety verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)