### PR TITLE
feat: add .to_sql() SQL inspection API for all ORM operations

### DIFF
--- a/benchmarks/operations/aggregate.hpp
+++ b/benchmarks/operations/aggregate.hpp
@@ -161,7 +161,7 @@ namespace storm::benchmark {
       public:
         // For compatibility with execute_with_filters
         int execute_iteration() {
-            auto result = create_aggregate_stmt().select();
+            auto result = create_aggregate_stmt().select().execute();
             return (result.has_value() && result.value() >= 0) ? 1 : 0;
         }
 

--- a/benchmarks/operations/base.hpp
+++ b/benchmarks/operations/base.hpp
@@ -164,14 +164,14 @@ namespace storm::benchmark {
             prepare(iterations);
 
             // 3. INSERT data
-            auto insert_result = qs().insert(data());
+            auto insert_result = qs().insert(data()).execute();
             if (!insert_result.has_value()) {
                 std::cerr << "Failed to insert test data for benchmark\n";
                 return;
             }
 
             // 4. SELECT back to get the auto-generated IDs
-            auto select_result = qs().select();
+            auto select_result = qs().select().execute();
             if (!select_result.has_value()) {
                 std::cerr << "Failed to select test data for benchmark\n";
                 return;
@@ -207,12 +207,12 @@ namespace storm::benchmark {
             int total = 0;
             if (batch_size_ == 1) {
                 for (int i = 0; i < iterations; i++) {
-                    OperationDispatcher<Op>::call(qs(), data()[i]);
+                    OperationDispatcher<Op>::call(qs(), data()[i]).execute();
                     total++;
                 }
             } else {
                 for (int i = 0; i < iterations; i++) {
-                    OperationDispatcher<Op>::call(qs(), data());
+                    OperationDispatcher<Op>::call(qs(), data()).execute();
                     total += data().size();
                 }
             }

--- a/benchmarks/operations/delete.hpp
+++ b/benchmarks/operations/delete.hpp
@@ -49,14 +49,14 @@ namespace storm::benchmark {
             if (Base::batch_size() == 1) {
                 // Single-row: delete one row per iteration (standard behavior)
                 for (int i = 0; i < iterations; i++) {
-                    Base::qs().remove(Base::data()[i]);
+                    Base::qs().remove(Base::data()[i]).execute();
                     total++;
                 }
             } else {
                 // Batch: must re-insert before each DELETE iteration
                 for (int i = 0; i < iterations; i++) {
                     reinsert_data();
-                    Base::qs().remove(Base::data());
+                    Base::qs().remove(Base::data()).execute();
                     total += Base::data().size();
                 }
             }
@@ -188,13 +188,13 @@ namespace storm::benchmark {
 
         // Helper: Re-insert data using Storm ORM (not timed - just setup)
         void reinsert_data() {
-            auto insert_result = Base::qs().insert(Base::data());
+            auto insert_result = Base::qs().insert(Base::data()).execute();
             if (!insert_result.has_value()) {
                 return;
             }
 
             // SELECT back to get the auto-generated IDs
-            auto select_result = Base::qs().select();
+            auto select_result = Base::qs().select().execute();
             if (!select_result.has_value()) {
                 return;
             }

--- a/benchmarks/operations/first_get.hpp
+++ b/benchmarks/operations/first_get.hpp
@@ -51,7 +51,7 @@ namespace storm::benchmark {
         }
 
         int execute_iteration() {
-            auto result = Base::qs().first();
+            auto result = Base::qs().first().execute();
             return (result.has_value() && result.value().has_value()) ? 1 : 0;
         }
 
@@ -145,7 +145,7 @@ namespace storm::benchmark {
         }
 
         int execute_iteration() {
-            auto result = Base::qs().get();
+            auto result = Base::qs().get().execute();
             return result.has_value() ? 1 : 0;
         }
 

--- a/benchmarks/operations/select.hpp
+++ b/benchmarks/operations/select.hpp
@@ -161,7 +161,7 @@ namespace storm::benchmark {
         // execute - Storm ORM SELECT using base class helpers
         // ====================================================================
         int execute_iteration() {
-            auto results = Base::qs().select();
+            auto results = Base::qs().select().execute();
             return results.value().size();
         }
 
@@ -458,7 +458,7 @@ namespace storm::benchmark {
             constexpr bool asc2 = (Dir2 == OrderDirection::ASC);
 
             Base::qs().template order_by<OrderByFieldInfo1, asc1, OrderByFieldInfo2, asc2>();
-            auto results = Base::qs().select();
+            auto results = Base::qs().select().execute();
             Base::qs().reset();
             return results.value().size();
         }
@@ -578,7 +578,7 @@ namespace storm::benchmark {
 
         int execute_iteration() {
             Base::qs().template group_by<GroupByFieldInfos...>();
-            auto results = Base::qs().select();
+            auto results = Base::qs().select().execute();
             Base::qs().reset();
             return results.value().size();
         }
@@ -1052,14 +1052,14 @@ namespace storm::benchmark {
                 users.push_back(RelatedModel{.id = 0, .name = std::format("User{}", i + 1), .age = 20 + (i % 50)});
             }
 
-            auto user_result = related_qs_.insert(users);
+            auto user_result = related_qs_.insert(users).execute();
             if (!user_result.has_value()) {
                 std::cerr << "Failed to insert users for benchmark\n";
                 return;
             }
 
             // SELECT back to get the auto-generated user IDs
-            auto user_select = related_qs_.select();
+            auto user_select = related_qs_.select().execute();
             if (!user_select.has_value()) {
                 std::cerr << "Failed to select users for benchmark\n";
                 return;
@@ -1086,7 +1086,7 @@ namespace storm::benchmark {
                 );
             }
 
-            auto msg_result = qs_.insert(messages);
+            auto msg_result = qs_.insert(messages).execute();
             if (!msg_result.has_value()) {
                 std::cerr << "Failed to insert messages for benchmark\n";
             }
@@ -1098,7 +1098,7 @@ namespace storm::benchmark {
 
             int total = 0;
             for (int i = 0; i < iterations; i++) {
-                auto results = qs_.select();
+                auto results = qs_.select().execute();
                 total += results.value().size();
             }
             qs_.reset();

--- a/benchmarks/operations/select_query_base.hpp
+++ b/benchmarks/operations/select_query_base.hpp
@@ -422,14 +422,14 @@ namespace storm::benchmark {
                     users.push_back(RelatedModel{.id = 0, .name = std::format("User{}", i + 1), .age = 20 + (i % 50)});
                 }
 
-                auto user_result = related_qs_.insert(users);
+                auto user_result = related_qs_.insert(users).execute();
                 if (!user_result.has_value()) {
                     std::cerr << "Failed to insert users for benchmark\n";
                     return;
                 }
 
                 // SELECT back to get the auto-generated user IDs
-                auto user_select = related_qs_.select();
+                auto user_select = related_qs_.select().execute();
                 if (!user_select.has_value()) {
                     std::cerr << "Failed to select users for benchmark\n";
                     return;
@@ -459,7 +459,7 @@ namespace storm::benchmark {
                     );
                 }
 
-                auto msg_result = Base::qs().insert(messages);
+                auto msg_result = Base::qs().insert(messages).execute();
                 if (!msg_result.has_value()) {
                     std::cerr << "Failed to insert messages for benchmark\n";
                 }

--- a/benchmarks/operations/where_operators.hpp
+++ b/benchmarks/operations/where_operators.hpp
@@ -57,7 +57,7 @@ namespace storm::benchmark {
 
             int total = 0;
             for (int i = 0; i < iterations; i++) {
-                auto result = Base::qs().select();
+                auto result = Base::qs().select().execute();
                 if (result.has_value()) {
                     total += result.value().size();
                 }
@@ -148,7 +148,7 @@ namespace storm::benchmark {
 
             int total = 0;
             for (int i = 0; i < iterations; i++) {
-                auto result = Base::qs().select();
+                auto result = Base::qs().select().execute();
                 if (result.has_value()) {
                     total += result.value().size();
                 }
@@ -253,7 +253,7 @@ namespace storm::benchmark {
 
             int total = 0;
             for (int i = 0; i < iterations; i++) {
-                auto result = Base::qs().select();
+                auto result = Base::qs().select().execute();
                 if (result.has_value()) {
                     total += result.value().size();
                 }
@@ -388,7 +388,7 @@ namespace storm::benchmark {
 
             int total = 0;
             for (int i = 0; i < iterations; i++) {
-                auto result = Base::qs().select();
+                auto result = Base::qs().select().execute();
                 if (result.has_value()) {
                     total += result.value().size();
                 }

--- a/src/db/postgresql.cppm
+++ b/src/db/postgresql.cppm
@@ -54,6 +54,7 @@ export namespace storm::db::postgresql {
         Statement(Statement&& other) noexcept
             : conn_(other.conn_)
             , stmt_name_(std::move(other.stmt_name_))
+            , original_sql_(std::move(other.original_sql_))
             , result_(other.result_)
             , current_row_(other.current_row_)
             , total_rows_(other.total_rows_)
@@ -78,6 +79,7 @@ export namespace storm::db::postgresql {
                 clear_result();
                 conn_              = other.conn_;
                 stmt_name_         = std::move(other.stmt_name_);
+                original_sql_      = std::move(other.original_sql_);
                 result_            = other.result_;
                 current_row_       = other.current_row_;
                 total_rows_        = other.total_rows_;
@@ -263,6 +265,55 @@ export namespace storm::db::postgresql {
             return result_;
         }
 
+        // Returns SQL string with all bound parameters inlined (for debugging / SQL inspection)
+        // Substitutes ? placeholders with quoted param_values_ strings
+        template <typename = void> [[nodiscard]] auto expanded_sql() const -> std::string {
+            std::string result;
+            result.reserve(original_sql_.size() + param_count_ * 8);
+            int  param_idx       = 0;
+            bool in_single_quote = false;
+            bool in_double_quote = false;
+            for (size_t i = 0; i < original_sql_.size(); ++i) {
+                const char ch = original_sql_[i];
+                if (ch == '\'' && !in_double_quote) {
+                    in_single_quote = !in_single_quote;
+                    result += ch;
+                } else if (ch == '"' && !in_single_quote) {
+                    in_double_quote = !in_double_quote;
+                    result += ch;
+                } else if (ch == '?' && !in_single_quote && !in_double_quote) {
+                    if (param_idx < param_count_) {
+                        const auto idx = static_cast<size_t>(param_idx);
+                        if (param_ptrs_[idx] == nullptr) {
+                            result += "NULL";
+                        } else {
+                            // Quote the value as a SQL string literal
+                            result += '\'';
+                            for (const char c : param_values_[idx]) {
+                                if (c == '\'') {
+                                    result += "''"; // Escape single quotes
+                                } else {
+                                    result += c;
+                                }
+                            }
+                            result += '\'';
+                        }
+                        ++param_idx;
+                    } else {
+                        result += ch; // No param for this ?, leave as-is
+                    }
+                } else {
+                    result += ch;
+                }
+            }
+            return result;
+        }
+
+        // Store original SQL (with ? placeholders) for expanded_sql()
+        auto set_original_sql(std::string sql) -> void {
+            original_sql_ = std::move(sql);
+        }
+
         // Column extraction methods
         template <typename = void>
         [[nodiscard]] __attribute__((always_inline)) auto extract_int(int col_index) const noexcept -> int {
@@ -426,6 +477,7 @@ export namespace storm::db::postgresql {
 
         PGconn*     conn_ = nullptr; // Borrowed reference
         std::string stmt_name_;
+        std::string original_sql_; // Original SQL with ? placeholders (for expanded_sql())
         PGresult*   result_      = nullptr;
         int         current_row_ = -1;
         int         total_rows_  = 0;
@@ -580,8 +632,9 @@ export namespace storm::db::postgresql {
             }
 
             PQclear(res);
-            auto [inserted_it, inserted] =
-                    statement_cache_.emplace(std::string(sql), Statement{conn_.get(), stmt_name});
+            Statement new_stmt{conn_.get(), stmt_name};
+            new_stmt.set_original_sql(std::string(sql)); // Store original SQL for expanded_sql()
+            auto [inserted_it, inserted] = statement_cache_.emplace(std::string(sql), std::move(new_stmt));
             (void)inserted; // Always true: find() above confirmed key absence
             return &inserted_it->second;
         }

--- a/src/db/sqlite.cppm
+++ b/src/db/sqlite.cppm
@@ -243,6 +243,20 @@ export namespace storm::db::sqlite {
             return sqlite3_errmsg(sqlite3_db_handle(raw_));
         }
 
+        // Returns SQL string with all bound parameters inlined (for debugging / SQL inspection)
+        // Uses sqlite3_expanded_sql() which substitutes ? placeholders with actual bound values
+        template <typename = void> [[nodiscard]] auto expanded_sql() const -> std::string {
+            char* expanded = sqlite3_expanded_sql(raw_);
+            // LCOV_EXCL_START — sqlite3_expanded_sql returns null only on OOM, untestable via mock
+            if (expanded == nullptr) {
+                return {};
+            }
+            // LCOV_EXCL_STOP
+            std::string result(expanded);
+            sqlite3_free(expanded);
+            return result;
+        }
+
         // Constants for return codes (make them constexpr for compile-time checks)
         static constexpr int  ROW_AVAILABLE      = SQLITE_ROW;
         static constexpr int  NO_MORE_ROWS       = SQLITE_DONE;

--- a/src/orm/queryset.cppm
+++ b/src/orm/queryset.cppm
@@ -52,30 +52,30 @@ export namespace storm {
         // Default constructor using default connection
         QuerySet() : conn_(get_default_connection()) {}
 
-        auto remove(const T& obj) -> std::expected<void, Error> {
-            // Use cached RemoveStatement instance for optimal performance
-            return get_remove_statement().execute_one(obj);
+        // Remove single object - returns proxy with .execute() and .to_sql()
+        auto remove(const T& obj) {
+            return get_remove_statement().query(obj);
         }
 
-        // Bulk remove operations
-        auto remove(std::span<const T> objects) -> std::expected<void, Error> {
-            return get_remove_statement().execute(objects);
+        // Bulk remove - returns proxy with .execute() and .to_sql()
+        auto remove(std::span<const T> objects) {
+            return get_remove_statement().query(objects);
         }
 
-        // Insert single object - returns the auto-generated ID
+        // Insert single object - returns proxy with .execute() and .to_sql()
+        // .execute() returns the auto-generated ID
         // (SFINAE: only accept T, not span/container)
         template <typename U = T>
             requires std::same_as<std::remove_cvref_t<U>, T>
-        auto insert(const U& obj) -> std::expected<int64_t, Error> {
-            return get_insert_statement().execute_single_optimized(obj, true);
+        auto insert(const U& obj) {
+            return get_insert_statement().query(obj);
         }
 
-        // Bulk insert (span overload)
+        // Bulk insert - returns proxy with .execute() and .to_sql()
         // NOTE: Returns void because SQLite's last_insert_rowid() only gives the last ID,
         // and assuming consecutive IDs is unreliable (triggers, gaps, etc.)
-        auto insert(std::span<const T> objects, std::optional<orm::statements::InsertOptions> opts = std::nullopt)
-                -> std::expected<void, Error> {
-            return execute_insert(objects, opts);
+        auto insert(std::span<const T> objects, std::optional<orm::statements::InsertOptions> opts = std::nullopt) {
+            return get_insert_statement().query(objects, opts);
         }
 
         // WHERE clause support - builder pattern with method chaining using type-safe expressions
@@ -141,39 +141,32 @@ export namespace storm {
             return std::forward<decltype(self)>(self);
         }
 
-        // Select operations - returns all rows (optimized with statement caching)
+        // Select - returns proxy with .execute() and .to_sql()
         // NOTE: WHERE and JOIN state is preserved after select() for query reusability.
         // Call reset() to clear state when needed.
-        [[nodiscard]] __attribute__((hot)) auto select() -> std::expected<plf::hive<T>, Error> {
+        [[nodiscard]] __attribute__((hot)) auto select() {
             return get_select_statement()
-                    .execute(join_stmt_, where_expr_, limit_value_, offset_value_, order_by_wrapper_);
+                    .query(join_stmt_, where_expr_, limit_value_, offset_value_, order_by_wrapper_);
         }
 
-        // Returns first matching row or std::nullopt if no rows match
+        // First - returns proxy with .execute() and .to_sql()
         // Automatically applies LIMIT 1 to the query for optimal performance
-        // Usage: auto result = queryset.where(age > 30).first();
-        //        if (result.has_value() && result.value().has_value()) { ... }
-        [[nodiscard]] __attribute__((hot)) auto first() -> std::expected<std::optional<T>, Error> {
-            // Fast path: no modifiers — zero-parameter call avoids all checks + parameter passing
-            if (!where_expr_ && !join_stmt_ && !order_by_wrapper_ && !offset_value_) {
-                return get_select_statement().execute_one_fast();
-            }
+        // Usage: auto result = queryset.where(age > 30).first().execute();
+        [[nodiscard]] __attribute__((hot)) auto first() {
+            const bool fast = !where_expr_ && !join_stmt_ && !order_by_wrapper_ && !offset_value_;
             return get_select_statement()
-                    .execute_one(join_stmt_, where_expr_, limit_value_, offset_value_, order_by_wrapper_);
+                    .query_first(join_stmt_, where_expr_, limit_value_, offset_value_, order_by_wrapper_, fast);
         }
 
+        // Get - returns proxy with .execute() and .to_sql()
         // Returns exactly one matching row, or an error if 0 or >1 rows match
         // Does NOT apply LIMIT — validates uniqueness of the result (like Django's get())
         // Uses LIMIT 2 internally for efficient duplicate detection without plf::hive allocation
-        // Usage: auto result = queryset.where(id == 42).get();
-        //        if (result.has_value()) { auto& person = result.value(); }
-        [[nodiscard]] __attribute__((hot)) auto get() -> std::expected<T, Error> {
-            // Fast path: no modifiers — zero-parameter call avoids all checks + parameter passing
-            if (!where_expr_ && !join_stmt_ && !order_by_wrapper_ && !offset_value_) {
-                return get_select_statement().execute_get_fast();
-            }
+        // Usage: auto result = queryset.where(id == 42).get().execute();
+        [[nodiscard]] __attribute__((hot)) auto get() {
+            const bool fast = !where_expr_ && !join_stmt_ && !order_by_wrapper_ && !offset_value_;
             return get_select_statement()
-                    .execute_get(join_stmt_, where_expr_, limit_value_, offset_value_, order_by_wrapper_);
+                    .query_get(join_stmt_, where_expr_, limit_value_, offset_value_, order_by_wrapper_, fast);
         }
 
         // Field-specific DISTINCT support using reflection
@@ -251,17 +244,17 @@ export namespace storm {
             return std::forward<decltype(self)>(self);
         }
 
-        // Update operations (SFINAE: only accept T, not span/container)
+        // Update single object - returns proxy with .execute() and .to_sql()
+        // (SFINAE: only accept T, not span/container)
         template <typename U = T>
             requires std::same_as<std::remove_cvref_t<U>, T>
-        auto update(const U& obj) -> std::expected<void, Error> {
-            // Use cached UpdateStatement instance for optimal performance
-            return get_update_statement().execute_single_optimized(obj);
+        auto update(const U& obj) {
+            return get_update_statement().query(obj);
         }
 
-        // Bulk update operations
-        auto update(std::span<const T> objects) -> std::expected<void, Error> {
-            return get_update_statement().execute(objects);
+        // Bulk update - returns proxy with .execute() and .to_sql()
+        auto update(std::span<const T> objects) {
+            return get_update_statement().query(objects);
         }
 
         // Reset WHERE, JOIN, LIMIT, and OFFSET state
@@ -424,12 +417,6 @@ export namespace storm {
                 insert_stmt_ = std::make_unique<orm::statements::InsertStatement<T, ConnType>>(conn_);
             }
             return *insert_stmt_;
-        }
-
-        [[nodiscard]] auto execute_insert(
-                std::span<const T> objects, std::optional<orm::statements::InsertOptions> opts = std::nullopt
-        ) const noexcept -> std::expected<void, Error> {
-            return get_insert_statement().execute(objects, opts);
         }
 
         // Lazy-initialize and return cached RemoveStatement for optimal performance

--- a/src/orm/statements/base.cppm
+++ b/src/orm/statements/base.cppm
@@ -392,6 +392,43 @@ export namespace storm::orm::statements {
             }
         }
 
+        // =====================================================================
+        // COLUMN EXTRACTION HELPERS - Moved here from SelectStatement so that
+        // constexpr access to all_members_[Index] happens in base.cppm context
+        // (avoids P2996 experimental compiler limitation in select.cppm module)
+        // =====================================================================
+
+        // Extract single column into obj at compile-time index
+        // Statement is deduced from stmt pointer; all_members_[Index] is valid here
+        template <size_t Index, typename Statement>
+        __attribute__((always_inline)) static void extract_column_fast(Statement* stmt, T& obj) noexcept {
+            if constexpr (Index < field_count_) {
+                constexpr auto member = all_members_[Index];
+                using FieldType       = std::remove_cvref_t<decltype(obj.[:member:])>;
+                if constexpr (is_fk_field(member)) {
+                    obj.[:member:]                  = FieldType{};
+                    constexpr auto fk_pk_member     = find_fk_primary_key<FieldType>();
+                    using PKType                    = std::remove_cvref_t<decltype(obj.[:member:].[:fk_pk_member:])>;
+                    obj.[:member:].[:fk_pk_member:] = extract_column_value<PKType>(stmt, Index);
+                } else {
+                    obj.[:member:] = extract_column_value<FieldType>(stmt, Index);
+                }
+            }
+        }
+
+        // Expand index sequence and extract each column
+        template <typename Statement, size_t... Is>
+        __attribute__((always_inline)) static void
+        extract_all_columns_impl(Statement* stmt, T& obj, std::index_sequence<Is...> /*unused*/) noexcept {
+            ((extract_column_fast<Is>(stmt, obj)), ...);
+        }
+
+        // Entry point: extract all columns into obj using field_indices_t
+        template <typename Statement>
+        __attribute__((always_inline)) static void extract_all_columns(Statement* stmt, T& obj) noexcept {
+            extract_all_columns_impl(stmt, obj, field_indices_t{});
+        }
+
         // Transaction management utilities
         template <typename ConnType>
         [[nodiscard]] static auto begin_transaction(ConnType& conn) noexcept

--- a/src/orm/statements/insert.cppm
+++ b/src/orm/statements/insert.cppm
@@ -218,6 +218,87 @@ export namespace storm::orm::statements {
       public:
         explicit InsertStatement(std::shared_ptr<ConnType> conn) : conn_(std::move(conn)) {}
 
+        struct SingleQuery {
+            InsertStatement&   stmt;
+            const T&           obj;
+            [[nodiscard]] auto execute() -> std::expected<int64_t, Error> {
+                return stmt.execute_single_optimized(obj, true);
+            }
+            [[nodiscard]] auto to_sql() -> std::expected<std::string, Error> {
+                return stmt.to_sql(obj);
+            }
+        };
+
+        struct BulkQuery {
+            InsertStatement&             stmt;
+            std::span<const T>           objects;
+            std::optional<InsertOptions> opts;
+            [[nodiscard]] auto           execute() -> std::expected<void, Error> {
+                return stmt.execute(objects, opts);
+            }
+            [[nodiscard]] auto to_sql() -> std::expected<std::string, Error> {
+                return stmt.to_sql(objects);
+            }
+        };
+
+        auto query(const T& obj) -> SingleQuery {
+            return {*this, obj};
+        }
+        auto query(std::span<const T> objects, std::optional<InsertOptions> opts = std::nullopt) -> BulkQuery {
+            return {*this, objects, opts};
+        }
+
+        // Returns SQL string with bound parameters inlined for a single INSERT (for debugging)
+        [[nodiscard]] auto to_sql(const T& obj) -> std::expected<std::string, Error> {
+            if constexpr (ConnType::supports_returning) {
+                auto stmt_result = conn_->prepare_cached(insert_returning_sql_string);
+                if (!stmt_result) {
+                    return std::unexpected(stmt_result.error());
+                }
+                auto* stmt        = *stmt_result;
+                auto  bind_result = Base::template bind_non_pk_fields_impl<ConnType, Statement>(
+                        *stmt, obj, typename Base::field_indices_t()
+                );
+                if (!bind_result) {
+                    return std::unexpected(bind_result.error());
+                }
+                return stmt->expanded_sql();
+            } else {
+                auto stmt_result = conn_->prepare_cached(get_insert_sql());
+                if (!stmt_result) {
+                    return std::unexpected(stmt_result.error());
+                }
+                auto* stmt        = *stmt_result;
+                auto  bind_result = Base::template bind_non_pk_fields_impl<ConnType, Statement>(
+                        *stmt, obj, typename Base::field_indices_t()
+                );
+                if (!bind_result) {
+                    return std::unexpected(bind_result.error());
+                }
+                return stmt->expanded_sql();
+            }
+        }
+
+        // Returns SQL string with bound parameters inlined for a bulk INSERT (for debugging)
+        [[nodiscard]] auto to_sql(std::span<const T> objects) -> std::expected<std::string, Error> {
+            if (objects.empty()) {
+                return std::string{};
+            }
+            const auto& sql      = get_bulk_insert_sql(objects.size());
+            auto        stmt_res = conn_->prepare_cached(sql);
+            if (!stmt_res) {
+                return std::unexpected(stmt_res.error());
+            }
+            auto* stmt        = *stmt_res;
+            auto  bind_result = Base::template bind_non_pk_objects_bulk_impl<ConnType, Statement>(
+                    *stmt, objects, typename Base::field_indices_t()
+            );
+            if (!bind_result) {
+                return std::unexpected(bind_result.error());
+            }
+            return stmt->expanded_sql();
+        }
+
         // Batch insert operation with optional configuration
         // NOTE: Returns void because SQLite's last_insert_rowid() only gives the last ID,
         // and assuming consecutive IDs is unreliable (triggers, gaps, etc.)

--- a/src/orm/statements/remove.cppm
+++ b/src/orm/statements/remove.cppm
@@ -179,6 +179,71 @@ export namespace storm::orm::statements {
       public:
         explicit RemoveStatement(std::shared_ptr<ConnType> conn) : conn_(std::move(conn)) {}
 
+        struct SingleQuery {
+            RemoveStatement&   stmt;
+            const T&           obj;
+            [[nodiscard]] auto execute() -> std::expected<void, Error> {
+                return stmt.execute_one(obj);
+            }
+            [[nodiscard]] auto to_sql() -> std::expected<std::string, Error> {
+                return stmt.to_sql(obj);
+            }
+        };
+
+        struct BulkQuery {
+            RemoveStatement&   stmt;
+            std::span<const T> objects;
+            [[nodiscard]] auto execute() -> std::expected<void, Error> {
+                return stmt.execute(objects);
+            }
+            [[nodiscard]] auto to_sql() -> std::expected<std::string, Error> {
+                return stmt.to_sql(objects);
+            }
+        };
+
+        auto query(const T& obj) -> SingleQuery {
+            return {*this, obj};
+        }
+        auto query(std::span<const T> objects) -> BulkQuery {
+            return {*this, objects};
+        }
+
+        // Returns SQL string with bound parameters inlined for a single DELETE (for debugging)
+        [[nodiscard]] auto to_sql(const T& obj) -> std::expected<std::string, Error> {
+            auto stmt_result = conn_->prepare_cached(get_single_delete_sql());
+            if (!stmt_result) {
+                return std::unexpected(stmt_result.error());
+            }
+            auto* stmt = *stmt_result;
+            stmt->reset();
+            if (auto bind_result = bind_pk_at(*stmt, obj, 1); !bind_result) {
+                return std::unexpected(bind_result.error());
+            }
+            return stmt->expanded_sql();
+        }
+
+        // Returns SQL string with bound parameters inlined for a bulk DELETE (for debugging)
+        [[nodiscard]] auto to_sql(std::span<const T> objects) -> std::expected<std::string, Error> {
+            if (objects.empty()) {
+                return std::string{};
+            }
+            const auto& bulk_sql = get_bulk_delete_sql(objects.size());
+            auto        stmt_res = conn_->prepare_cached(bulk_sql);
+            if (!stmt_res) {
+                return std::unexpected(stmt_res.error());
+            }
+            auto* stmt = *stmt_res;
+            stmt->reset();
+            int param_index = 1;
+            for (const auto& obj : objects) {
+                if (auto result = bind_pk_at(*stmt, obj, param_index); !result) {
+                    return std::unexpected(result.error());
+                }
+                ++param_index;
+            }
+            return stmt->expanded_sql();
+        }
+
         [[nodiscard]] auto execute(std::span<const T> objects) -> std::expected<void, Error> {
             if (objects.empty()) {
                 return {};

--- a/src/orm/statements/select.cppm
+++ b/src/orm/statements/select.cppm
@@ -77,6 +77,160 @@ export namespace storm::orm::statements {
       public:
         explicit SelectStatement(std::shared_ptr<ConnType> conn) : conn_(std::move(conn)) {}
 
+        // Returns the SQL that would be executed by select()
+        [[nodiscard]] auto
+        to_sql(std::optional<JoinStatementWrapper>     join_wrapper     = std::nullopt,
+               const orm::where::ExpressionVariantPtr& where_expr       = nullptr,
+               const std::optional<int>&               limit            = std::nullopt,
+               const std::optional<int>&               offset           = std::nullopt,
+               const std::optional<OrderByWrapper>&    order_by_wrapper = std::nullopt)
+                -> std::expected<std::string, Error> {
+            std::string sql = join_wrapper ? join_wrapper->get_complete_sql() : std::string(get_select_sql());
+            if (where_expr) {
+                sql += " WHERE ";
+                sql += orm::where::to_sql(*where_expr);
+            }
+            Base::template append_order_by<ConnType>(sql, order_by_wrapper);
+            Base::template append_limit_offset<ConnType>(sql, limit, offset);
+
+            auto stmt_result = conn_->prepare_cached(sql);
+            if (!stmt_result) {
+                return std::unexpected(stmt_result.error());
+            }
+            auto* stmt_ptr = *stmt_result;
+            stmt_ptr->reset();
+            if (where_expr) {
+                auto bind_result = Base::template bind_where_params<Statement, Error>(stmt_ptr, where_expr);
+                if (!bind_result) {
+                    return std::unexpected(bind_result.error());
+                }
+            }
+            return stmt_ptr->expanded_sql();
+        }
+
+        // Returns the SQL that would be executed by first() (with LIMIT 1)
+        [[nodiscard]] auto to_sql_first(
+                std::optional<JoinStatementWrapper>     join_wrapper     = std::nullopt,
+                const orm::where::ExpressionVariantPtr& where_expr       = nullptr,
+                const std::optional<int>&               offset           = std::nullopt,
+                const std::optional<OrderByWrapper>&    order_by_wrapper = std::nullopt
+        ) -> std::expected<std::string, Error> {
+            std::optional<int> const limit_one = 1;
+            return to_sql(std::move(join_wrapper), where_expr, limit_one, offset, order_by_wrapper);
+        }
+
+        // Returns the SQL that would be executed by get() (with LIMIT 2)
+        [[nodiscard]] auto to_sql_get(
+                std::optional<JoinStatementWrapper>     join_wrapper     = std::nullopt,
+                const orm::where::ExpressionVariantPtr& where_expr       = nullptr,
+                const std::optional<int>&               offset           = std::nullopt,
+                const std::optional<OrderByWrapper>&    order_by_wrapper = std::nullopt
+        ) -> std::expected<std::string, Error> {
+            std::optional<int> const limit_two = 2;
+            return to_sql(std::move(join_wrapper), where_expr, limit_two, offset, order_by_wrapper);
+        }
+
+        // Proxy types returned by factory methods (used by QuerySet one-liner delegations)
+        struct QueryBase {
+            SelectStatement&                    stmt;
+            std::optional<JoinStatementWrapper> join_wrapper;
+            orm::where::ExpressionVariantPtr    where_expr;
+            std::optional<int>                  limit_value;
+            std::optional<int>                  offset_value;
+            std::optional<OrderByWrapper>       order_by_wrapper;
+        };
+
+        struct Query : QueryBase {
+            [[nodiscard]] auto execute() -> std::expected<plf::hive<T>, Error> {
+                return this->stmt.execute(
+                        this->join_wrapper,
+                        this->where_expr,
+                        this->limit_value,
+                        this->offset_value,
+                        this->order_by_wrapper
+                );
+            }
+            [[nodiscard]] auto to_sql() -> std::expected<std::string, Error> {
+                return this->stmt
+                        .to_sql(this->join_wrapper,
+                                this->where_expr,
+                                this->limit_value,
+                                this->offset_value,
+                                this->order_by_wrapper);
+            }
+        };
+
+        struct FirstQuery : QueryBase {
+            bool               fast_path;
+            [[nodiscard]] auto execute() -> std::expected<std::optional<T>, Error> {
+                if (fast_path) {
+                    return this->stmt.execute_one_fast();
+                }
+                return this->stmt.execute_one(
+                        this->join_wrapper,
+                        this->where_expr,
+                        this->limit_value,
+                        this->offset_value,
+                        this->order_by_wrapper
+                );
+            }
+            [[nodiscard]] auto to_sql() -> std::expected<std::string, Error> {
+                return this->stmt
+                        .to_sql_first(this->join_wrapper, this->where_expr, this->offset_value, this->order_by_wrapper);
+            }
+        };
+
+        struct GetQuery : QueryBase {
+            bool               fast_path;
+            [[nodiscard]] auto execute() -> std::expected<T, Error> {
+                if (fast_path) {
+                    return this->stmt.execute_get_fast();
+                }
+                return this->stmt.execute_get(
+                        this->join_wrapper,
+                        this->where_expr,
+                        this->limit_value,
+                        this->offset_value,
+                        this->order_by_wrapper
+                );
+            }
+            [[nodiscard]] auto to_sql() -> std::expected<std::string, Error> {
+                return this->stmt
+                        .to_sql_get(this->join_wrapper, this->where_expr, this->offset_value, this->order_by_wrapper);
+            }
+        };
+
+        auto
+        query(std::optional<JoinStatementWrapper>     jw,
+              const orm::where::ExpressionVariantPtr& we,
+              const std::optional<int>&               lv,
+              const std::optional<int>&               ov,
+              const std::optional<OrderByWrapper>&    ob) -> Query {
+            return {*this, jw, we, lv, ov, ob};
+        }
+
+        auto query_first(
+                std::optional<JoinStatementWrapper>     jw,
+                const orm::where::ExpressionVariantPtr& we,
+                const std::optional<int>&               lv,
+                const std::optional<int>&               ov,
+                const std::optional<OrderByWrapper>&    ob,
+                bool                                    fast
+        ) -> FirstQuery {
+            return {*this, jw, we, lv, ov, ob, fast};
+        }
+
+        auto query_get(
+                std::optional<JoinStatementWrapper>     jw,
+                const orm::where::ExpressionVariantPtr& we,
+                const std::optional<int>&               lv,
+                const std::optional<int>&               ov,
+                const std::optional<OrderByWrapper>&    ob,
+                bool                                    fast
+        ) -> GetQuery {
+            return {*this, jw, we, lv, ov, ob, fast};
+        }
+
         // Invalidate dynamic query cache
         // Call this when QuerySet::reset() is invoked to ensure fresh query on next execute
         auto invalidate_cache() noexcept -> void {
@@ -108,7 +262,7 @@ export namespace storm::orm::statements {
                 });
             }
             return execute_query_loop(stmt_ptr, [](Statement* stmt, T& obj) -> void {
-                extract_all_columns(stmt, obj);
+                Base::extract_all_columns(stmt, obj);
             });
         }
 
@@ -124,7 +278,7 @@ export namespace storm::orm::statements {
                 cached_first_stmt_ = *prepare_result;
             }
             return execute_single_row(cached_first_stmt_, [](Statement* stmt, T& obj) -> void {
-                extract_all_columns(stmt, obj);
+                Base::extract_all_columns(stmt, obj);
             });
         }
 
@@ -148,7 +302,7 @@ export namespace storm::orm::statements {
                 });
             }
             return execute_single_row(stmt_ptr, [](Statement* stmt, T& obj) -> void {
-                extract_all_columns(stmt, obj);
+                Base::extract_all_columns(stmt, obj);
             });
         }
 
@@ -163,7 +317,7 @@ export namespace storm::orm::statements {
                 cached_get_stmt_ = *prepare_result;
             }
             return execute_exact_one(cached_get_stmt_, [](Statement* stmt, T& obj) -> void {
-                extract_all_columns(stmt, obj);
+                Base::extract_all_columns(stmt, obj);
             });
         }
 
@@ -186,7 +340,9 @@ export namespace storm::orm::statements {
                     join_wrapper->extract_row(stmt, &obj);
                 });
             }
-            return execute_exact_one(stmt_ptr, [](Statement* stmt, T& obj) -> void { extract_all_columns(stmt, obj); });
+            return execute_exact_one(stmt_ptr, [](Statement* stmt, T& obj) -> void {
+                Base::extract_all_columns(stmt, obj);
+            });
         }
 
       private:
@@ -267,37 +423,6 @@ export namespace storm::orm::statements {
             cached_where_addr_ = where_addr;
 
             return cached_stmt_;
-        }
-
-        // Extract single column using Statement (database-agnostic)
-        template <size_t Index>
-        __attribute__((always_inline)) static void extract_column_fast(Statement* stmt, T& obj) noexcept {
-            if constexpr (Index < Base::field_count_) {
-                constexpr auto member = Base::all_members_[Index];
-                using FieldType       = std::remove_cvref_t<decltype(obj.[:member:])>;
-
-                // Handle FK fields - populate only the primary key
-                if constexpr (Base::is_fk_field(member)) {
-                    obj.[:member:]                  = FieldType{};
-                    constexpr auto fk_pk_member     = Base::template find_fk_primary_key<FieldType>();
-                    using PKType                    = std::remove_cvref_t<decltype(obj.[:member:].[:fk_pk_member:])>;
-                    obj.[:member:].[:fk_pk_member:] = Base::template extract_column_value<PKType>(stmt, Index);
-                } else {
-                    obj.[:member:] = Base::template extract_column_value<FieldType>(stmt, Index);
-                }
-            }
-        }
-
-        // Extract all columns using Statement with fold expression
-        template <size_t... Is>
-        __attribute__((always_inline)) static void
-        extract_all_columns_impl(Statement* stmt, T& obj, std::index_sequence<Is...> /*unused*/) noexcept {
-            ((extract_column_fast<Is>(stmt, obj)), ...);
-        }
-
-        // Fast extraction entry point using Statement (database-agnostic)
-        __attribute__((always_inline)) static void extract_all_columns(Statement* stmt, T& obj) noexcept {
-            extract_all_columns_impl(stmt, obj, typename Base::field_indices_t{});
         }
 
         // =====================================================================

--- a/src/orm/statements/update.cppm
+++ b/src/orm/statements/update.cppm
@@ -133,6 +133,58 @@ export namespace storm::orm::statements {
       public:
         explicit UpdateStatement(std::shared_ptr<ConnType> conn) : conn_(std::move(conn)) {}
 
+        struct SingleQuery {
+            UpdateStatement&   stmt;
+            const T&           obj;
+            [[nodiscard]] auto execute() -> std::expected<void, Error> {
+                return stmt.execute_single_optimized(obj);
+            }
+            [[nodiscard]] auto to_sql() -> std::expected<std::string, Error> {
+                return stmt.to_sql(obj);
+            }
+        };
+
+        struct BulkQuery {
+            UpdateStatement&   stmt;
+            std::span<const T> objects;
+            [[nodiscard]] auto execute() -> std::expected<void, Error> {
+                return stmt.execute(objects);
+            }
+            [[nodiscard]] auto to_sql() -> std::expected<std::string, Error> {
+                return stmt.to_sql(objects);
+            }
+        };
+
+        auto query(const T& obj) -> SingleQuery {
+            return {*this, obj};
+        }
+        auto query(std::span<const T> objects) -> BulkQuery {
+            return {*this, objects};
+        }
+
+        // Returns SQL string with bound parameters inlined for a single UPDATE (for debugging)
+        [[nodiscard]] auto to_sql(const T& obj) -> std::expected<std::string, Error> {
+            auto stmt_result = conn_->prepare_cached(get_update_sql());
+            if (!stmt_result) {
+                return std::unexpected(stmt_result.error());
+            }
+            auto* stmt        = *stmt_result;
+            auto  bind_result = inline_bind_all_fields(stmt, obj, typename Base::field_indices_t{});
+            if (!bind_result) {
+                return std::unexpected(bind_result.error());
+            }
+            return stmt->expanded_sql();
+        }
+
+        // Returns SQL strings for bulk UPDATE (one SQL per object, for debugging)
+        [[nodiscard]] auto to_sql(std::span<const T> objects) -> std::expected<std::string, Error> {
+            if (objects.empty()) {
+                return std::string{};
+            }
+            // For bulk, just show the first UPDATE SQL as representative
+            return to_sql(objects[0]);
+        }
+
         // Optimized batch execute - flattened, no nested lambdas
         [[nodiscard]] __attribute__((hot)) auto execute(std::span<const T> objects) noexcept
                 -> std::expected<void, Error> {

--- a/tests/mock_libpq/test_orm_pg_mock_errors.cpp
+++ b/tests/mock_libpq/test_orm_pg_mock_errors.cpp
@@ -726,6 +726,74 @@ namespace {
     }
 
     // ============================================================================
+    // expanded_sql() edge case tests (postgresql.cppm lines 279-288, 303-304)
+    // ============================================================================
+
+    TEST_F(PgStatementErrorTest, ExpandedSqlWithSingleQuote) {
+        // SQL with single-quoted literal exercises the ' branch (lines 279-280)
+        auto conn_result = PgConnection::open("host=localhost");
+        ASSERT_TRUE(conn_result.has_value());
+
+        auto stmt_result = conn_result->prepare_cached("SELECT 'literal' FROM t WHERE id = ?");
+        ASSERT_TRUE(stmt_result.has_value());
+
+        auto* stmt = *stmt_result;
+        (void)stmt->bind_int(1, 42);
+
+        std::string sql = stmt->expanded_sql();
+        EXPECT_FALSE(sql.empty());
+        EXPECT_NE(sql.find("'literal'"), std::string::npos);
+    }
+
+    TEST_F(PgStatementErrorTest, ExpandedSqlWithDoubleQuote) {
+        // SQL with double-quoted identifier exercises the " branch (lines 282-283)
+        auto conn_result = PgConnection::open("host=localhost");
+        ASSERT_TRUE(conn_result.has_value());
+
+        auto stmt_result = conn_result->prepare_cached("SELECT \"col\" FROM t WHERE id = ?");
+        ASSERT_TRUE(stmt_result.has_value());
+
+        auto* stmt = *stmt_result;
+        (void)stmt->bind_int(1, 42);
+
+        std::string sql = stmt->expanded_sql();
+        EXPECT_FALSE(sql.empty());
+        EXPECT_NE(sql.find("\"col\""), std::string::npos);
+    }
+
+    TEST_F(PgStatementErrorTest, ExpandedSqlWithNullParam) {
+        // NULL-bound parameter exercises the null branch (line 288)
+        auto conn_result = PgConnection::open("host=localhost");
+        ASSERT_TRUE(conn_result.has_value());
+
+        auto stmt_result = conn_result->prepare_cached("SELECT ? FROM t");
+        ASSERT_TRUE(stmt_result.has_value());
+
+        auto* stmt = *stmt_result;
+        (void)stmt->bind_null(1);
+
+        std::string sql = stmt->expanded_sql();
+        EXPECT_NE(sql.find("NULL"), std::string::npos);
+    }
+
+    TEST_F(PgStatementErrorTest, ExpandedSqlWithExtraPlaceholder) {
+        // More ? in SQL than bound params exercises the unmatched-? branch (lines 303-304)
+        auto conn_result = PgConnection::open("host=localhost");
+        ASSERT_TRUE(conn_result.has_value());
+
+        // SQL has 2 ? but we only bind 1
+        auto stmt_result = conn_result->prepare_cached("SELECT ? FROM t WHERE id = ?");
+        ASSERT_TRUE(stmt_result.has_value());
+
+        auto* stmt = *stmt_result;
+        (void)stmt->bind_int(1, 42); // Only bind first parameter
+
+        std::string sql = stmt->expanded_sql();
+        // Second ? should remain as-is
+        EXPECT_NE(sql.find('?'), std::string::npos);
+    }
+
+    // ============================================================================
     // Column extraction method tests
     // ============================================================================
 
@@ -1013,7 +1081,7 @@ namespace {
         PgQuerySet         qs;
         MockPgPerson const person{.id = 0, .name = "Alice", .age = 30};
 
-        auto result = qs.insert(person);
+        auto result = qs.insert(person).execute();
         ASSERT_TRUE(result.has_value());
         EXPECT_EQ(result.value(), 42);
     }
@@ -1025,7 +1093,7 @@ namespace {
         PgQuerySet         qs;
         MockPgPerson const person{.id = 0, .name = "Bob", .age = 25};
 
-        auto result = qs.insert(person);
+        auto result = qs.insert(person).execute();
         ASSERT_FALSE(result.has_value());
     }
 
@@ -1036,7 +1104,18 @@ namespace {
         PgQuerySet         qs;
         MockPgPerson const person{.id = 0, .name = "Charlie", .age = 35};
 
-        auto result = qs.insert(person);
+        auto result = qs.insert(person).execute();
+        ASSERT_FALSE(result.has_value());
+    }
+
+    // Covers insert.cppm lines 256-257: to_sql() prepare failure in PG branch
+    TEST_F(PgOrmInsertReturningTest, InsertToSqlPrepareError) {
+        MockPqConfig::prepare_returns_null();
+
+        PgQuerySet         qs;
+        MockPgPerson const person{.id = 0, .name = "Alice", .age = 30};
+
+        auto result = qs.insert(person).to_sql();
         ASSERT_FALSE(result.has_value());
     }
 
@@ -1046,7 +1125,7 @@ namespace {
         MockPqConfig::exec_prepared_ntuples(0);
 
         PgQuerySet qs;
-        auto       results = qs.offset(5).select();
+        auto       results = qs.offset(5).select().execute();
         ASSERT_TRUE(results.has_value());
         EXPECT_TRUE(results.value().empty());
     }
@@ -1173,6 +1252,10 @@ namespace {
             return "mock error";
         }
 
+        template <typename = void> [[nodiscard]] auto expanded_sql() const noexcept -> std::string {
+            return {};
+        }
+
         auto set_fail(bool fail) noexcept -> void {
             fail_ = fail;
         }
@@ -1264,10 +1347,25 @@ namespace {
         BindFailQuerySet   qs;
         MockPgPerson const person{.id = 0, .name = "Alice", .age = 30};
 
-        auto result = qs.insert(person);
+        auto result = qs.insert(person).execute();
         ASSERT_FALSE(result.has_value());
         EXPECT_EQ(result.error().code(), -1);
         EXPECT_EQ(result.error().message(), "mock bind failure");
+    }
+
+    // Covers insert.cppm lines 263-264: to_sql() bind failure in PG branch
+    TEST(PgInsertReturningBindErrorTest, InsertToSqlBindFailureReturnsError) {
+        (void)BindFailQuerySet::set_default_connection("mock");
+
+        auto conn = BindFailQuerySet::get_default_connection();
+        conn->set_fail_binds(true);
+
+        BindFailQuerySet   qs;
+        MockPgPerson const person{.id = 0, .name = "Alice", .age = 30};
+
+        auto result = qs.insert(person).to_sql();
+        ASSERT_FALSE(result.has_value());
+        EXPECT_EQ(result.error().code(), -1);
     }
 
 } // namespace

--- a/tests/mock_sqlite/test_orm_mock_errors.cpp
+++ b/tests/mock_sqlite/test_orm_mock_errors.cpp
@@ -81,7 +81,7 @@ namespace {
         QuerySet<MockPerson> qs;
         MockPerson const     person{.id = 0, .name = "Alice", .age = 30};
 
-        auto result = qs.insert(person);
+        auto result = qs.insert(person).execute();
 
         ASSERT_FALSE(result.has_value());
         EXPECT_EQ(result.error().code(), SQLITE_ERROR);
@@ -95,7 +95,7 @@ namespace {
         QuerySet<MockPerson> qs;
         MockPerson const     person{.id = 0, .name = "Alice", .age = 30};
 
-        auto result = qs.insert(person);
+        auto result = qs.insert(person).execute();
 
         // The ORM may handle bind errors internally - verify behavior
         if (!result.has_value()) {
@@ -115,7 +115,7 @@ namespace {
         QuerySet<MockPerson> qs;
         MockPerson const     person{.id = 0, .name = "Alice", .age = 30};
 
-        auto result = qs.insert(person);
+        auto result = qs.insert(person).execute();
 
         ASSERT_FALSE(result.has_value());
         EXPECT_EQ(result.error().code(), SQLITE_IOERR);
@@ -127,7 +127,7 @@ namespace {
         QuerySet<MockPerson> qs;
         MockPerson const     person{.id = 0, .name = "Alice", .age = 30};
 
-        auto result = qs.insert(person);
+        auto result = qs.insert(person).execute();
 
         ASSERT_FALSE(result.has_value());
         EXPECT_EQ(result.error().code(), SQLITE_CORRUPT);
@@ -141,7 +141,7 @@ namespace {
         MockSqlite3Config::prepare_returns(SQLITE_ERROR);
 
         QuerySet<MockPerson> qs;
-        auto                 result = qs.select();
+        auto                 result = qs.select().execute();
 
         ASSERT_FALSE(result.has_value());
         EXPECT_EQ(result.error().code(), SQLITE_ERROR);
@@ -153,7 +153,7 @@ namespace {
         MockSqlite3Config::step_fails_on_call(3, SQLITE_CORRUPT);
 
         QuerySet<MockPerson> qs;
-        auto                 result = qs.select();
+        auto                 result = qs.select().execute();
 
         // The exact behavior depends on when the failure occurs
         // It should either fail or return an error
@@ -172,7 +172,7 @@ namespace {
         QuerySet<MockPerson> qs;
         MockPerson const     person{.id = 1, .name = "Updated", .age = 35};
 
-        auto result = qs.update(person);
+        auto result = qs.update(person).execute();
 
         ASSERT_FALSE(result.has_value());
         EXPECT_EQ(result.error().code(), SQLITE_ERROR);
@@ -184,7 +184,7 @@ namespace {
         QuerySet<MockPerson> qs;
         MockPerson const     person{.id = 1, .name = "Updated", .age = 35};
 
-        auto result = qs.update(person);
+        auto result = qs.update(person).execute();
 
         ASSERT_FALSE(result.has_value());
         EXPECT_EQ(result.error().code(), SQLITE_NOMEM);
@@ -196,7 +196,7 @@ namespace {
         QuerySet<MockPerson> qs;
         MockPerson const     person{.id = 1, .name = "Updated", .age = 35};
 
-        auto result = qs.update(person);
+        auto result = qs.update(person).execute();
 
         ASSERT_FALSE(result.has_value());
         EXPECT_EQ(result.error().code(), SQLITE_BUSY);
@@ -212,7 +212,7 @@ namespace {
         QuerySet<MockPerson> qs;
         MockPerson const     person{.id = 1, .name = "ToDelete", .age = 25};
 
-        auto result = qs.remove(person);
+        auto result = qs.remove(person).execute();
 
         ASSERT_FALSE(result.has_value());
         EXPECT_EQ(result.error().code(), SQLITE_ERROR);
@@ -224,7 +224,7 @@ namespace {
         QuerySet<MockPerson> qs;
         MockPerson const     person{.id = 1, .name = "ToDelete", .age = 25};
 
-        auto result = qs.remove(person);
+        auto result = qs.remove(person).execute();
 
         ASSERT_FALSE(result.has_value());
         EXPECT_EQ(result.error().code(), SQLITE_LOCKED);
@@ -280,7 +280,7 @@ namespace {
                 {.id = 0, .name = "Bob", .age = 25},
         };
 
-        auto result = qs.insert(std::span{people});
+        auto result = qs.insert(std::span{people}).execute();
 
         // The ORM may not use exec() for transactions, or may handle the error differently
         if (!result.has_value()) {
@@ -371,7 +371,7 @@ namespace {
         QuerySet<MockPerson> qs;
         MockPerson const     person{.id = 0, .name = "Alice", .age = 30};
 
-        auto result = qs.insert(person);
+        auto result = qs.insert(person).execute();
 
         // Verify bind error is propagated (error code may vary in ORM layer)
         // Key behavior: operation should fail when bind fails
@@ -397,7 +397,7 @@ namespace {
         QuerySet<MockPersonWithDouble> qs;
         MockPersonWithDouble const     person{.id = 0, .name = "Alice", .salary = 50000.0};
 
-        auto result = qs.insert(person);
+        auto result = qs.insert(person).execute();
 
         // Verify bind error is propagated (error code may vary in ORM layer)
         if (!result.has_value()) {
@@ -420,7 +420,7 @@ namespace {
         QuerySet<MockPersonWithBlob> qs;
         MockPersonWithBlob const     person{.id = 0, .name = "Alice", .data = {0x01, 0x02, 0x03}};
 
-        auto result = qs.insert(person);
+        auto result = qs.insert(person).execute();
 
         // Verify bind error is propagated (error code may vary in ORM layer)
         if (!result.has_value()) {
@@ -436,7 +436,7 @@ namespace {
         QuerySet<MockPersonOptional> qs;
         MockPersonOptional const     person{.id = 0, .name = std::nullopt, .age = std::nullopt};
 
-        auto result = qs.insert(person);
+        auto result = qs.insert(person).execute();
 
         // Verify bind error is propagated (error code may vary in ORM layer)
         if (!result.has_value()) {
@@ -456,7 +456,7 @@ namespace {
         QuerySet<MockPerson> qs;
         MockPerson const     person{.id = 0, .name = "Alice", .age = 30};
 
-        auto result = qs.insert(person);
+        auto result = qs.insert(person).execute();
 
         ASSERT_FALSE(result.has_value());
         EXPECT_EQ(result.error().code(), SQLITE_FULL);
@@ -469,7 +469,7 @@ namespace {
         QuerySet<MockPerson> qs;
         MockPerson const     person{.id = 0, .name = "Alice", .age = 30};
 
-        auto result = qs.insert(person);
+        auto result = qs.insert(person).execute();
 
         ASSERT_FALSE(result.has_value());
         EXPECT_EQ(result.error().code(), SQLITE_READONLY);
@@ -482,7 +482,7 @@ namespace {
         QuerySet<MockPerson> qs;
         MockPerson const     person{.id = 0, .name = "Alice", .age = 30};
 
-        auto result = qs.insert(person);
+        auto result = qs.insert(person).execute();
 
         ASSERT_FALSE(result.has_value());
         EXPECT_EQ(result.error().code(), SQLITE_TOOBIG);
@@ -493,7 +493,7 @@ namespace {
         MockSqlite3Config::step_returns(SQLITE_SCHEMA);
 
         QuerySet<MockPerson> qs;
-        auto                 result = qs.select();
+        auto                 result = qs.select().execute();
 
         ASSERT_FALSE(result.has_value());
         EXPECT_EQ(result.error().code(), SQLITE_SCHEMA);
@@ -504,7 +504,7 @@ namespace {
         MockSqlite3Config::step_returns(SQLITE_INTERRUPT);
 
         QuerySet<MockPerson> qs;
-        auto                 result = qs.select();
+        auto                 result = qs.select().execute();
 
         ASSERT_FALSE(result.has_value());
         EXPECT_EQ(result.error().code(), SQLITE_INTERRUPT);
@@ -517,7 +517,7 @@ namespace {
         QuerySet<MockPerson> qs;
         MockPerson const     person{.id = 1, .name = "Updated", .age = 35};
 
-        auto result = qs.update(person);
+        auto result = qs.update(person).execute();
 
         ASSERT_FALSE(result.has_value());
         EXPECT_EQ(result.error().code(), SQLITE_ABORT);
@@ -583,7 +583,7 @@ namespace {
                 {.id = 0, .name = "Charlie", .age = 35},
         };
 
-        auto result = qs.insert(std::span{people});
+        auto result = qs.insert(std::span{people}).execute();
 
         // The batch should fail when the second insert fails
         if (!result.has_value()) {
@@ -601,7 +601,7 @@ namespace {
                 {.id = 0, .name = "Bob", .age = 25},
         };
 
-        auto result = qs.insert(std::span{people});
+        auto result = qs.insert(std::span{people}).execute();
 
         // If ORM propagates bind errors, it should fail
         if (!result.has_value()) {
@@ -618,7 +618,7 @@ namespace {
                 {.id = 2, .name = "Bob Updated", .age = 26},
         };
 
-        auto result = qs.update(std::span{people});
+        auto result = qs.update(std::span{people}).execute();
 
         if (!result.has_value()) {
             EXPECT_EQ(result.error().code(), SQLITE_BUSY);
@@ -634,7 +634,7 @@ namespace {
                 {.id = 2, .name = "Bob", .age = 25},
         };
 
-        auto result = qs.remove(std::span{people});
+        auto result = qs.remove(std::span{people}).execute();
 
         if (!result.has_value()) {
             EXPECT_EQ(result.error().code(), SQLITE_LOCKED);
@@ -651,7 +651,7 @@ namespace {
 
         QuerySet<MockPerson> qs;
         auto                 age    = storm::orm::where::Field<^^MockPerson::age>{};
-        auto                 result = qs.where(age > 25).select();
+        auto                 result = qs.where(age > 25).select().execute();
 
         // WHERE condition binding should fail
         if (!result.has_value()) {
@@ -664,7 +664,7 @@ namespace {
 
         QuerySet<MockPerson> qs;
         auto                 name   = storm::orm::where::Field<^^MockPerson::name>{};
-        auto                 result = qs.where(name == "Alice").select();
+        auto                 result = qs.where(name == "Alice").select().execute();
 
         if (!result.has_value()) {
             EXPECT_EQ(result.error().code(), SQLITE_NOMEM);
@@ -752,7 +752,7 @@ namespace {
         MockSqlite3Config::prepare_returns(SQLITE_ERROR);
 
         QuerySet<MockPerson> qs;
-        auto                 result = qs.order_by<^^MockPerson::age>().select();
+        auto                 result = qs.order_by<^^MockPerson::age>().select().execute();
 
         // Verify prepare error is propagated (error code may differ at ORM layer)
         ASSERT_FALSE(result.has_value());
@@ -763,7 +763,7 @@ namespace {
         MockSqlite3Config::prepare_returns(SQLITE_ERROR);
 
         QuerySet<MockPerson> qs;
-        auto                 result = qs.limit(10).select();
+        auto                 result = qs.limit(10).select().execute();
 
         // Verify prepare error is propagated
         ASSERT_FALSE(result.has_value());
@@ -774,7 +774,7 @@ namespace {
         MockSqlite3Config::prepare_returns(SQLITE_ERROR);
 
         QuerySet<MockPerson> qs;
-        auto                 result = qs.offset(5).select();
+        auto                 result = qs.offset(5).select().execute();
 
         // Verify prepare error is propagated
         ASSERT_FALSE(result.has_value());
@@ -785,8 +785,8 @@ namespace {
         MockSqlite3Config::step_returns(SQLITE_IOERR);
 
         QuerySet<MockPerson> qs;
-        auto                 age    = storm::orm::where::Field<^^MockPerson::age>{};
-        auto                 result = qs.where(age > 25).order_by<^^MockPerson::name>().limit(10).offset(5).select();
+        auto                 age = storm::orm::where::Field<^^MockPerson::age>{};
+        auto result = qs.where(age > 25).order_by<^^MockPerson::name>().limit(10).offset(5).select().execute();
 
         ASSERT_FALSE(result.has_value());
         EXPECT_EQ(result.error().code(), SQLITE_IOERR);
@@ -821,7 +821,7 @@ namespace {
         MockSqlite3Config::step_returns(SQLITE_INTERNAL);
 
         QuerySet<MockPerson> qs;
-        auto                 result = qs.select();
+        auto                 result = qs.select().execute();
 
         ASSERT_FALSE(result.has_value());
         EXPECT_EQ(result.error().code(), SQLITE_INTERNAL);
@@ -832,7 +832,7 @@ namespace {
         MockSqlite3Config::step_returns(SQLITE_NOTADB);
 
         QuerySet<MockPerson> qs;
-        auto                 result = qs.select();
+        auto                 result = qs.select().execute();
 
         ASSERT_FALSE(result.has_value());
         EXPECT_EQ(result.error().code(), SQLITE_NOTADB);
@@ -848,7 +848,7 @@ namespace {
         MockSqlite3Config::step_returns_sequence({SQLITE_ROW, SQLITE_ROW, SQLITE_CORRUPT});
 
         QuerySet<MockPerson> qs;
-        auto                 result = qs.select();
+        auto                 result = qs.select().execute();
 
         ASSERT_FALSE(result.has_value());
         EXPECT_EQ(result.error().code(), SQLITE_CORRUPT);
@@ -874,7 +874,7 @@ namespace {
         QuerySet<MockPerson> qs;
         MockPerson const     person{.id = 1, .name = "Updated", .age = 35};
 
-        auto result = qs.update(person);
+        auto result = qs.update(person).execute();
 
         if (!result.has_value()) {
             EXPECT_EQ(result.error().code(), SQLITE_NOMEM);
@@ -887,7 +887,7 @@ namespace {
         QuerySet<MockPerson> qs;
         MockPerson const     person{.id = 1, .name = "Updated", .age = 35};
 
-        auto result = qs.update(person);
+        auto result = qs.update(person).execute();
 
         if (!result.has_value()) {
             EXPECT_EQ(result.error().code(), SQLITE_NOMEM);
@@ -904,7 +904,7 @@ namespace {
         QuerySet<MockPerson> qs;
         MockPerson const     person{.id = 1, .name = "ToDelete", .age = 25};
 
-        auto result = qs.remove(person);
+        auto result = qs.remove(person).execute();
 
         if (!result.has_value()) {
             EXPECT_EQ(result.error().code(), SQLITE_NOMEM);
@@ -983,7 +983,7 @@ namespace {
         QuerySet<MockPerson> qs;
         MockPerson const     person{.id = 0, .name = "Alice", .age = 30};
 
-        auto result = qs.insert(person);
+        auto result = qs.insert(person).execute();
 
         // INSERT uses execute() which expects DONE, so ROW is an error
         ASSERT_FALSE(result.has_value());
@@ -1010,7 +1010,7 @@ namespace {
 
         QuerySet<MockPerson> qs;
         MockPerson const     person{.id = 0, .name = "Alice", .age = 30};
-        (void)qs.insert(person);
+        (void)qs.insert(person).execute();
 
         // At least one more prepare call for INSERT
         EXPECT_GT(MockSqlite3Config::get_prepare_call_count(), after_setup_count);
@@ -1025,8 +1025,8 @@ namespace {
         MockSqlite3Config::step_returns(SQLITE_CORRUPT);
 
         QuerySet<MockPerson> qs;
-        auto                 age    = storm::orm::where::Field<^^MockPerson::age>{};
-        auto                 result = qs.where(age > 25).order_by<^^MockPerson::name>().limit(10).offset(5).select();
+        auto                 age = storm::orm::where::Field<^^MockPerson::age>{};
+        auto result = qs.where(age > 25).order_by<^^MockPerson::name>().limit(10).offset(5).select().execute();
 
         ASSERT_FALSE(result.has_value());
         EXPECT_EQ(result.error().code(), SQLITE_CORRUPT);
@@ -1075,7 +1075,7 @@ namespace {
         MockSqlite3Config::prepare_returns(SQLITE_ERROR);
 
         QuerySet<MockMessage> qs;
-        auto                  result = qs.join<&MockMessage::sender>().select();
+        auto                  result = qs.join<&MockMessage::sender>().select().execute();
 
         // Verify prepare error is propagated (error code may differ at ORM layer)
         ASSERT_FALSE(result.has_value());
@@ -1086,7 +1086,7 @@ namespace {
         MockSqlite3Config::step_returns(SQLITE_CORRUPT);
 
         QuerySet<MockMessage> qs;
-        auto                  result = qs.join<&MockMessage::sender>().select();
+        auto                  result = qs.join<&MockMessage::sender>().select().execute();
 
         ASSERT_FALSE(result.has_value());
         EXPECT_EQ(result.error().code(), SQLITE_CORRUPT);
@@ -1097,7 +1097,7 @@ namespace {
 
         QuerySet<MockMessage> qs;
         auto                  id     = storm::orm::where::Field<^^MockMessage::id>{};
-        auto                  result = qs.where(id > 5).join<&MockMessage::sender>().select();
+        auto                  result = qs.where(id > 5).join<&MockMessage::sender>().select().execute();
 
         if (!result.has_value()) {
             EXPECT_EQ(result.error().code(), SQLITE_NOMEM);
@@ -1108,7 +1108,7 @@ namespace {
         MockSqlite3Config::step_returns(SQLITE_IOERR);
 
         QuerySet<MockMessage> qs;
-        auto                  result = qs.join<&MockMessage::sender>().order_by<^^MockMessage::id>().select();
+        auto                  result = qs.join<&MockMessage::sender>().order_by<^^MockMessage::id>().select().execute();
 
         ASSERT_FALSE(result.has_value());
         EXPECT_EQ(result.error().code(), SQLITE_IOERR);
@@ -1126,7 +1126,7 @@ namespace {
         MockUser const        sender{.id = 1, .name = "Sender", .age = 30};
         MockMessage const     message{.id = 1, .sender = sender, .text = "Hello"};
 
-        auto result = qs.update(message);
+        auto result = qs.update(message).execute();
 
         ASSERT_FALSE(result.has_value()) << "Update should fail when FK field bind fails";
         EXPECT_EQ(result.error().code(), SQLITE_NOMEM);
@@ -1167,7 +1167,7 @@ namespace {
         MockSqlite3Config::step_returns(SQLITE_PROTOCOL);
 
         QuerySet<MockPerson> qs;
-        auto                 result = qs.select();
+        auto                 result = qs.select().execute();
 
         ASSERT_FALSE(result.has_value());
         EXPECT_EQ(result.error().code(), SQLITE_PROTOCOL);
@@ -1179,7 +1179,7 @@ namespace {
         QuerySet<MockPerson> qs;
         MockPerson const     person{.id = 0, .name = "Alice", .age = 30};
 
-        auto result = qs.insert(person);
+        auto result = qs.insert(person).execute();
 
         ASSERT_FALSE(result.has_value());
         EXPECT_EQ(result.error().code(), SQLITE_PERM);
@@ -1191,7 +1191,7 @@ namespace {
         QuerySet<MockPerson> qs;
         MockPerson const     person{.id = 1, .name = "Updated", .age = 35};
 
-        auto result = qs.update(person);
+        auto result = qs.update(person).execute();
 
         ASSERT_FALSE(result.has_value());
         EXPECT_EQ(result.error().code(), SQLITE_AUTH);
@@ -1221,13 +1221,13 @@ namespace {
 
         // First call succeeds (caches the statement)
         MockSqlite3Config::step_returns(SQLITE_DONE);
-        auto first_result = qs.select();
+        auto first_result = qs.select().execute();
         // Note: DONE means no rows, which is valid for empty table
         EXPECT_TRUE(first_result.has_value());
 
         // Second call uses cached statement but step fails
         MockSqlite3Config::step_returns(SQLITE_CORRUPT);
-        auto second_result = qs.select();
+        auto second_result = qs.select().execute();
 
         ASSERT_FALSE(second_result.has_value());
         EXPECT_EQ(second_result.error().code(), SQLITE_CORRUPT);
@@ -1248,7 +1248,7 @@ namespace {
 
         QuerySet<MockPerson> qs;
         MockPerson const     person{.id = 0, .name = "Test", .age = 25};
-        (void)qs.insert(person);
+        (void)qs.insert(person).execute();
 
         // Should have called bind_int (for age) and bind_text (for name)
         EXPECT_GE(MockSqlite3Config::get_bind_int_call_count(), 0); // Implementation may vary
@@ -1270,7 +1270,7 @@ namespace {
         QuerySet<MockPerson> qs;
         MockPerson const     person{.id = 1, .name = "Updated", .age = 35};
 
-        auto result = qs.update(person);
+        auto result = qs.update(person).execute();
 
         ASSERT_FALSE(result.has_value()) << "Update should fail when PK bind fails";
         EXPECT_EQ(result.error().code(), SQLITE_NOMEM);
@@ -1284,7 +1284,7 @@ namespace {
         QuerySet<MockPerson> qs;
         MockPerson const     person{.id = 1, .name = "Updated", .age = 35};
 
-        auto result = qs.update(person);
+        auto result = qs.update(person).execute();
 
         ASSERT_FALSE(result.has_value()) << "Update should fail when field bind fails";
         EXPECT_EQ(result.error().code(), SQLITE_IOERR);
@@ -1297,7 +1297,7 @@ namespace {
         QuerySet<MockPerson> qs;
         MockPerson const     person{.id = 1, .name = "Updated", .age = 35};
 
-        auto result = qs.update(person);
+        auto result = qs.update(person).execute();
 
         ASSERT_FALSE(result.has_value()) << "Update should fail when second field bind fails";
         EXPECT_EQ(result.error().code(), SQLITE_CORRUPT);
@@ -1314,7 +1314,7 @@ namespace {
                 {.id = 2, .name = "Second", .age = 25}, // This one should fail
         };
 
-        auto result = qs.update(std::span{people});
+        auto result = qs.update(std::span{people}).execute();
 
         ASSERT_FALSE(result.has_value()) << "Batch update should fail on second row bind error";
         EXPECT_EQ(result.error().code(), SQLITE_NOMEM);
@@ -1331,7 +1331,7 @@ namespace {
         QuerySet<MockPerson>    qs;
         std::vector<MockPerson> single = {{.id = 1, .name = "SingleSpan", .age = 30}};
 
-        auto result = qs.update(std::span{single});
+        auto result = qs.update(std::span{single}).execute();
 
         // Should succeed (mock returns DONE by default)
         EXPECT_TRUE(result.has_value()) << "Span-of-one update should succeed";
@@ -1344,7 +1344,7 @@ namespace {
         QuerySet<MockPerson>    qs;
         std::vector<MockPerson> single = {{.id = 1, .name = "SingleSpan", .age = 30}};
 
-        auto result = qs.update(std::span{single});
+        auto result = qs.update(std::span{single}).execute();
 
         ASSERT_FALSE(result.has_value()) << "Span-of-one update should fail on bind error";
         EXPECT_EQ(result.error().code(), SQLITE_NOMEM);
@@ -1357,7 +1357,7 @@ namespace {
         QuerySet<MockPerson>    qs;
         std::vector<MockPerson> single = {{.id = 1, .name = "SingleSpan", .age = 30}};
 
-        auto result = qs.update(std::span{single});
+        auto result = qs.update(std::span{single}).execute();
 
         ASSERT_FALSE(result.has_value()) << "Span-of-one update should fail on exec error";
         EXPECT_EQ(result.error().code(), SQLITE_BUSY);
@@ -1368,7 +1368,7 @@ namespace {
         QuerySet<MockPerson>    qs;
         std::vector<MockPerson> empty;
 
-        auto result = qs.update(std::span{empty});
+        auto result = qs.update(std::span{empty}).execute();
 
         EXPECT_TRUE(result.has_value()) << "Empty span update should succeed immediately";
     }
@@ -1384,7 +1384,7 @@ namespace {
                 {.id = 2, .name = "Second", .age = 25},
         };
 
-        auto result = qs.update(std::span{people});
+        auto result = qs.update(std::span{people}).execute();
 
         ASSERT_FALSE(result.has_value()) << "Batch update should fail on prepare error";
         EXPECT_EQ(result.error().code(), SQLITE_ERROR);
@@ -1408,7 +1408,7 @@ namespace {
                 {.id = 2, .name = "Second", .age = 25},
         };
 
-        auto result = qs.update(std::span{people});
+        auto result = qs.update(std::span{people}).execute();
 
         // Transaction begin failure should propagate
         ASSERT_FALSE(result.has_value()) << "Batch update should fail when transaction begin fails";
@@ -1424,7 +1424,7 @@ namespace {
                 {.id = 2, .name = "Second", .age = 25},
         };
 
-        auto result = qs.update(std::span{people});
+        auto result = qs.update(std::span{people}).execute();
 
         // Mock returns DONE by default, so this should succeed
         EXPECT_TRUE(result.has_value()) << "Batch update should succeed and commit";
@@ -1603,7 +1603,7 @@ namespace {
             large_batch.push_back({.id = i, .name = "Person" + std::to_string(i), .age = 20 + (i % 50)});
         }
 
-        auto result = qs.remove(std::span{large_batch});
+        auto result = qs.remove(std::span{large_batch}).execute();
 
         // Should fail on transaction begin
         if (!result.has_value()) {
@@ -1623,7 +1623,7 @@ namespace {
             large_batch.push_back({.id = i, .name = "Person" + std::to_string(i), .age = 20 + (i % 50)});
         }
 
-        auto result = qs.remove(std::span{large_batch});
+        auto result = qs.remove(std::span{large_batch}).execute();
 
         ASSERT_FALSE(result.has_value()) << "Chunked remove should fail when max bulk prepare fails";
         EXPECT_EQ(result.error().code(), SQLITE_NOMEM);
@@ -1640,7 +1640,7 @@ namespace {
             large_batch.push_back({.id = i, .name = "Person" + std::to_string(i), .age = 20 + (i % 50)});
         }
 
-        auto result = qs.remove(std::span{large_batch});
+        auto result = qs.remove(std::span{large_batch}).execute();
 
         ASSERT_FALSE(result.has_value()) << "Chunked remove should fail when remainder prepare fails";
         EXPECT_EQ(result.error().code(), SQLITE_IOERR);
@@ -1658,7 +1658,7 @@ namespace {
             large_batch.push_back({.id = i, .name = "Person" + std::to_string(i), .age = 20 + (i % 50)});
         }
 
-        auto result = qs.remove(std::span{large_batch});
+        auto result = qs.remove(std::span{large_batch}).execute();
 
         ASSERT_FALSE(result.has_value()) << "Chunked remove should fail when full chunk exec fails";
         EXPECT_EQ(result.error().code(), SQLITE_CORRUPT);
@@ -1675,7 +1675,7 @@ namespace {
             large_batch.push_back({.id = i, .name = "Person" + std::to_string(i), .age = 20 + (i % 50)});
         }
 
-        auto result = qs.remove(std::span{large_batch});
+        auto result = qs.remove(std::span{large_batch}).execute();
 
         ASSERT_FALSE(result.has_value()) << "Chunked remove should fail when remainder exec fails";
         EXPECT_EQ(result.error().code(), SQLITE_IOERR);
@@ -1695,7 +1695,7 @@ namespace {
             large_batch.push_back({.id = i, .name = "Person" + std::to_string(i), .age = 20 + (i % 50)});
         }
 
-        auto result = qs.update(std::span{large_batch});
+        auto result = qs.update(std::span{large_batch}).execute();
 
         // Should fail on transaction begin
         if (!result.has_value()) {
@@ -1715,7 +1715,7 @@ namespace {
             large_batch.push_back({.id = i, .name = "Person" + std::to_string(i), .age = 20 + (i % 50)});
         }
 
-        auto result = qs.update(std::span{large_batch});
+        auto result = qs.update(std::span{large_batch}).execute();
 
         // Should fail during second chunk processing
         if (!result.has_value()) {
@@ -1736,7 +1736,7 @@ namespace {
             large_batch.push_back({.id = 0, .name = "Person" + std::to_string(i), .age = 20 + (i % 50)});
         }
 
-        auto result = qs.insert(std::span{large_batch});
+        auto result = qs.insert(std::span{large_batch}).execute();
 
         if (!result.has_value()) {
             EXPECT_EQ(result.error().code(), SQLITE_BUSY);
@@ -1802,7 +1802,7 @@ namespace {
         QuerySet<MockPerson>    qs;
         std::vector<MockPerson> single = {{.id = 1, .name = "ToDelete", .age = 30}};
 
-        auto result = qs.remove(std::span{single});
+        auto result = qs.remove(std::span{single}).execute();
 
         // Mock returns DONE by default
         EXPECT_TRUE(result.has_value()) << "Span-of-one remove should succeed";
@@ -1815,7 +1815,7 @@ namespace {
         QuerySet<MockPerson>    qs;
         std::vector<MockPerson> single = {{.id = 1, .name = "ToDelete", .age = 30}};
 
-        auto result = qs.remove(std::span{single});
+        auto result = qs.remove(std::span{single}).execute();
 
         ASSERT_FALSE(result.has_value()) << "Span-of-one remove should fail on step error";
         EXPECT_EQ(result.error().code(), SQLITE_LOCKED);
@@ -1831,7 +1831,7 @@ namespace {
                 {.id = 2, .name = "Second", .age = 25},
         };
 
-        auto result = qs.remove(std::span{people});
+        auto result = qs.remove(std::span{people}).execute();
 
         ASSERT_FALSE(result.has_value()) << "Bulk remove should fail on prepare error";
         EXPECT_EQ(result.error().code(), SQLITE_ERROR);
@@ -1847,7 +1847,7 @@ namespace {
                 {.id = 2, .name = "Second", .age = 25},
         };
 
-        auto result = qs.remove(std::span{people});
+        auto result = qs.remove(std::span{people}).execute();
 
         if (!result.has_value()) {
             EXPECT_EQ(result.error().code(), SQLITE_NOMEM);
@@ -1864,7 +1864,7 @@ namespace {
                 {.id = 2, .name = "Second", .age = 25},
         };
 
-        auto result = qs.remove(std::span{people});
+        auto result = qs.remove(std::span{people}).execute();
 
         ASSERT_FALSE(result.has_value()) << "Bulk remove should fail on exec error";
         EXPECT_EQ(result.error().code(), SQLITE_BUSY);
@@ -1875,7 +1875,7 @@ namespace {
         QuerySet<MockPerson>    qs;
         std::vector<MockPerson> empty;
 
-        auto result = qs.remove(std::span{empty});
+        auto result = qs.remove(std::span{empty}).execute();
 
         EXPECT_TRUE(result.has_value()) << "Empty span remove should succeed immediately";
     }
@@ -1893,7 +1893,7 @@ namespace {
                 {.id = 0, .name = "Second", .age = 25},
         };
 
-        auto result = qs.insert(std::span{people});
+        auto result = qs.insert(std::span{people}).execute();
 
         ASSERT_FALSE(result.has_value()) << "Batch insert should fail on prepare error";
         EXPECT_EQ(result.error().code(), SQLITE_ERROR);
@@ -1910,7 +1910,7 @@ namespace {
                 {.id = 0, .name = "Second", .age = 25},
         };
 
-        auto result = qs.insert(std::span{people});
+        auto result = qs.insert(std::span{people}).execute();
 
         // Either fails with expected error, or succeeds (bind_text might not be called for batch)
         if (!result.has_value()) {
@@ -1929,7 +1929,7 @@ namespace {
                 {.id = 0, .name = "Second", .age = 25},
         };
 
-        auto result = qs.insert(std::span{people});
+        auto result = qs.insert(std::span{people}).execute();
 
         ASSERT_FALSE(result.has_value()) << "Batch insert should fail on step error";
         EXPECT_EQ(result.error().code(), SQLITE_CONSTRAINT);
@@ -2014,7 +2014,7 @@ namespace {
 
         QuerySet<MockPerson> qs;
         auto                 age    = storm::orm::where::Field<^^MockPerson::age>{};
-        auto                 result = qs.where(age.between(20, 40)).select();
+        auto                 result = qs.where(age.between(20, 40)).select().execute();
 
         if (!result.has_value()) {
             EXPECT_EQ(result.error().code(), SQLITE_NOMEM);
@@ -2027,7 +2027,7 @@ namespace {
 
         QuerySet<MockPerson> qs;
         auto                 age    = storm::orm::where::Field<^^MockPerson::age>{};
-        auto                 result = qs.where(age.in(25, 30, 35)).select();
+        auto                 result = qs.where(age.in(25, 30, 35)).select().execute();
 
         if (!result.has_value()) {
             EXPECT_EQ(result.error().code(), SQLITE_NOMEM);
@@ -2041,7 +2041,7 @@ namespace {
         QuerySet<MockPerson> qs;
         auto                 age = storm::orm::where::Field<^^MockPerson::age>{};
         // The left child (age > 25) will fail to bind because bind_int returns NOMEM
-        auto result = qs.where(age > 25 && age < 40).select();
+        auto result = qs.where(age > 25 && age < 40).select().execute();
 
         if (!result.has_value()) {
             EXPECT_EQ(result.error().code(), SQLITE_NOMEM);
@@ -2056,7 +2056,7 @@ namespace {
         MockSqlite3Config::prepare_returns(SQLITE_ERROR);
 
         QuerySet<MockPerson> qs;
-        auto                 result = qs.first();
+        auto                 result = qs.first().execute();
 
         ASSERT_FALSE(result.has_value());
         EXPECT_EQ(result.error().code(), SQLITE_ERROR);
@@ -2066,7 +2066,7 @@ namespace {
         MockSqlite3Config::step_returns(SQLITE_CORRUPT);
 
         QuerySet<MockPerson> qs;
-        auto                 result = qs.first();
+        auto                 result = qs.first().execute();
 
         ASSERT_FALSE(result.has_value());
         EXPECT_EQ(result.error().code(), SQLITE_CORRUPT);
@@ -2076,7 +2076,7 @@ namespace {
         MockSqlite3Config::prepare_returns(SQLITE_ERROR);
 
         QuerySet<MockPerson> qs;
-        auto                 result = qs.get();
+        auto                 result = qs.get().execute();
 
         ASSERT_FALSE(result.has_value());
         EXPECT_EQ(result.error().code(), SQLITE_ERROR);
@@ -2086,7 +2086,7 @@ namespace {
         MockSqlite3Config::step_returns(SQLITE_CORRUPT);
 
         QuerySet<MockPerson> qs;
-        auto                 result = qs.get();
+        auto                 result = qs.get().execute();
 
         ASSERT_FALSE(result.has_value());
         // get() maps NO_MORE_ROWS to error code -1, but SQLITE_CORRUPT is a real step error
@@ -2097,7 +2097,7 @@ namespace {
         MockSqlite3Config::prepare_returns(SQLITE_ERROR);
 
         QuerySet<MockMessage> qs;
-        auto                  result = qs.join<&MockMessage::sender>().first();
+        auto                  result = qs.join<&MockMessage::sender>().first().execute();
 
         ASSERT_FALSE(result.has_value());
     }
@@ -2106,7 +2106,7 @@ namespace {
         MockSqlite3Config::prepare_returns(SQLITE_ERROR);
 
         QuerySet<MockMessage> qs;
-        auto                  result = qs.join<&MockMessage::sender>().get();
+        auto                  result = qs.join<&MockMessage::sender>().get().execute();
 
         ASSERT_FALSE(result.has_value());
     }
@@ -2115,7 +2115,7 @@ namespace {
         MockSqlite3Config::step_returns(SQLITE_CORRUPT);
 
         QuerySet<MockMessage> qs;
-        auto                  result = qs.join<&MockMessage::sender>().first();
+        auto                  result = qs.join<&MockMessage::sender>().first().execute();
 
         ASSERT_FALSE(result.has_value());
         EXPECT_EQ(result.error().code(), SQLITE_CORRUPT);
@@ -2126,7 +2126,7 @@ namespace {
         MockSqlite3Config::step_returns_sequence({SQLITE_ROW, SQLITE_DONE});
 
         QuerySet<MockMessage> qs;
-        auto                  result = qs.join<&MockMessage::sender>().first();
+        auto                  result = qs.join<&MockMessage::sender>().first().execute();
 
         // Mock returns zeroed data, but the path is exercised
         ASSERT_TRUE(result.has_value());
@@ -2137,7 +2137,7 @@ namespace {
         MockSqlite3Config::step_returns(SQLITE_CORRUPT);
 
         QuerySet<MockMessage> qs;
-        auto                  result = qs.join<&MockMessage::sender>().get();
+        auto                  result = qs.join<&MockMessage::sender>().get().execute();
 
         ASSERT_FALSE(result.has_value());
         EXPECT_EQ(result.error().code(), SQLITE_CORRUPT);
@@ -2148,10 +2148,153 @@ namespace {
         MockSqlite3Config::step_returns_sequence({SQLITE_ROW, SQLITE_DONE});
 
         QuerySet<MockMessage> qs;
-        auto                  result = qs.join<&MockMessage::sender>().get();
+        auto                  result = qs.join<&MockMessage::sender>().get().execute();
 
         // Mock returns zeroed data, but the path is exercised
         ASSERT_TRUE(result.has_value());
+    }
+
+    // ============================================================================
+    // to_sql() error path tests — SELECT
+    // ============================================================================
+
+    TEST_F(ORMMockErrorTest, ToSqlSelectFailsOnPrepare) {
+        MockSqlite3Config::prepare_returns(SQLITE_ERROR);
+
+        QuerySet<MockPerson> qs;
+        auto                 result = qs.select().to_sql();
+
+        ASSERT_FALSE(result.has_value());
+    }
+
+    TEST_F(ORMMockErrorTest, ToSqlSelectWithWhereFailsOnBind) {
+        MockSqlite3Config::bind_int_returns(SQLITE_NOMEM);
+
+        QuerySet<MockPerson> qs;
+        auto                 age    = storm::orm::where::Field<^^MockPerson::age>{};
+        auto                 result = qs.where(age > 25).select().to_sql();
+
+        ASSERT_FALSE(result.has_value());
+    }
+
+    // ============================================================================
+    // to_sql() error path tests — INSERT (single)
+    // ============================================================================
+
+    TEST_F(ORMMockErrorTest, ToSqlInsertFailsOnPrepare) {
+        MockSqlite3Config::prepare_returns(SQLITE_ERROR);
+
+        QuerySet<MockPerson> qs;
+        MockPerson const     person{.id = 0, .name = "Alice", .age = 30};
+        auto                 result = qs.insert(person).to_sql();
+
+        ASSERT_FALSE(result.has_value());
+    }
+
+    TEST_F(ORMMockErrorTest, ToSqlInsertFailsOnBind) {
+        MockSqlite3Config::bind_text_returns(SQLITE_NOMEM);
+
+        QuerySet<MockPerson> qs;
+        MockPerson const     person{.id = 0, .name = "Alice", .age = 30};
+        auto                 result = qs.insert(person).to_sql();
+
+        ASSERT_FALSE(result.has_value());
+    }
+
+    // ============================================================================
+    // to_sql() error path tests — INSERT (bulk)
+    // ============================================================================
+
+    TEST_F(ORMMockErrorTest, ToSqlBulkInsertFailsOnPrepare) {
+        MockSqlite3Config::prepare_returns(SQLITE_ERROR);
+
+        QuerySet<MockPerson>    qs;
+        std::vector<MockPerson> people = {MockPerson{.id = 0, .name = "Alice", .age = 30}};
+        auto                    result = qs.insert(std::span<const MockPerson>(people)).to_sql();
+
+        ASSERT_FALSE(result.has_value());
+    }
+
+    TEST_F(ORMMockErrorTest, ToSqlBulkInsertFailsOnBind) {
+        MockSqlite3Config::bind_text_returns(SQLITE_NOMEM);
+
+        QuerySet<MockPerson>    qs;
+        std::vector<MockPerson> people = {MockPerson{.id = 0, .name = "Alice", .age = 30}};
+        auto                    result = qs.insert(std::span<const MockPerson>(people)).to_sql();
+
+        ASSERT_FALSE(result.has_value());
+    }
+
+    // ============================================================================
+    // to_sql() error path tests — REMOVE (single)
+    // ============================================================================
+
+    TEST_F(ORMMockErrorTest, ToSqlRemoveFailsOnPrepare) {
+        MockSqlite3Config::prepare_returns(SQLITE_ERROR);
+
+        QuerySet<MockPerson> qs;
+        MockPerson const     person{.id = 1, .name = "Alice", .age = 30};
+        auto                 result = qs.remove(person).to_sql();
+
+        ASSERT_FALSE(result.has_value());
+    }
+
+    TEST_F(ORMMockErrorTest, ToSqlRemoveFailsOnBind) {
+        MockSqlite3Config::bind_int64_returns(SQLITE_NOMEM);
+
+        QuerySet<MockPerson> qs;
+        MockPerson const     person{.id = 1, .name = "Alice", .age = 30};
+        auto                 result = qs.remove(person).to_sql();
+
+        ASSERT_FALSE(result.has_value());
+    }
+
+    // ============================================================================
+    // to_sql() error path tests — REMOVE (bulk)
+    // ============================================================================
+
+    TEST_F(ORMMockErrorTest, ToSqlBulkRemoveFailsOnPrepare) {
+        MockSqlite3Config::prepare_returns(SQLITE_ERROR);
+
+        QuerySet<MockPerson>    qs;
+        std::vector<MockPerson> people = {MockPerson{.id = 1, .name = "Alice", .age = 30}};
+        auto                    result = qs.remove(std::span<const MockPerson>(people)).to_sql();
+
+        ASSERT_FALSE(result.has_value());
+    }
+
+    TEST_F(ORMMockErrorTest, ToSqlBulkRemoveFailsOnBind) {
+        MockSqlite3Config::bind_int64_returns(SQLITE_NOMEM);
+
+        QuerySet<MockPerson>    qs;
+        std::vector<MockPerson> people = {MockPerson{.id = 1, .name = "Alice", .age = 30}};
+        auto                    result = qs.remove(std::span<const MockPerson>(people)).to_sql();
+
+        ASSERT_FALSE(result.has_value());
+    }
+
+    // ============================================================================
+    // to_sql() error path tests — UPDATE (single)
+    // ============================================================================
+
+    TEST_F(ORMMockErrorTest, ToSqlUpdateFailsOnPrepare) {
+        MockSqlite3Config::prepare_returns(SQLITE_ERROR);
+
+        QuerySet<MockPerson> qs;
+        MockPerson const     person{.id = 1, .name = "Alice", .age = 30};
+        auto                 result = qs.update(person).to_sql();
+
+        ASSERT_FALSE(result.has_value());
+    }
+
+    TEST_F(ORMMockErrorTest, ToSqlUpdateFailsOnBind) {
+        MockSqlite3Config::bind_text_returns(SQLITE_NOMEM);
+
+        QuerySet<MockPerson> qs;
+        MockPerson const     person{.id = 1, .name = "Alice", .age = 30};
+        auto                 result = qs.update(person).to_sql();
+
+        ASSERT_FALSE(result.has_value());
     }
 
 } // namespace

--- a/tests/test_aggregate.cpp
+++ b/tests/test_aggregate.cpp
@@ -111,7 +111,7 @@ template <typename ConnType> class AggregateTest : public ::testing::Test {
                  {0, "Eve", 45, 90000.0, 15}};
 
         for (const auto& person : people) {
-            auto result = qs->insert(person);
+            auto result = qs->insert(person).execute();
             ASSERT_TRUE(result.has_value()) << "Failed to insert: " << result.error().message();
         }
     }
@@ -448,9 +448,13 @@ TYPED_TEST(AggregateTest, SingleAggregates_WithWhereAndJoin) {
 
 TYPED_TEST(AggregateTest, SingleRow_AllAggregates) {
     // Insert single row
-    auto insert_result = this->qs->insert(
-            AggregatePerson{.id = 0, .name = "Alice", .age = 25, .salary = 50000.0, .years_experience = 3}
-    );
+    auto insert_result =
+            this->qs->insert(
+                            AggregatePerson{
+                                    .id = 0, .name = "Alice", .age = 25, .salary = 50000.0, .years_experience = 3
+                            }
+            )
+                    .execute();
     ASSERT_TRUE(insert_result.has_value());
 
     // Test all aggregate types
@@ -483,14 +487,15 @@ TYPED_TEST(AggregateTest, LargeDataset_Sum) {
     // Insert 1000 people with ages 1-1000
     for (int i = 1; i <= 1000; ++i) {
         auto result = this->qs->insert(
-                AggregatePerson{
-                        .id               = 0,
-                        .name             = "AggregatePerson" + std::to_string(i),
-                        .age              = i,
-                        .salary           = 50000.0,
-                        .years_experience = 5
-                }
-        );
+                                      AggregatePerson{
+                                              .id               = 0,
+                                              .name             = "AggregatePerson" + std::to_string(i),
+                                              .age              = i,
+                                              .salary           = 50000.0,
+                                              .years_experience = 5
+                                      }
+        )
+                              .execute();
         ASSERT_TRUE(result.has_value());
     }
 
@@ -515,7 +520,7 @@ TYPED_TEST(AggregateTest, LargeDataset_Count) {
                 }
         );
     }
-    auto insert_result = this->qs->insert(std::span<const AggregatePerson>(people));
+    auto insert_result = this->qs->insert(std::span<const AggregatePerson>(people)).execute();
     ASSERT_TRUE(insert_result.has_value()) << "Batch insert failed: " << insert_result.error().message();
 
     auto result = this->qs->count().get();
@@ -611,14 +616,15 @@ TYPED_TEST(AggregateTest, Integration_AfterInsert) {
     // Insert and immediately aggregate
     for (int i = 1; i <= 5; ++i) {
         auto insert_result = this->qs->insert(
-                AggregatePerson{
-                        .id               = 0,
-                        .name             = "AggregatePerson" + std::to_string(i),
-                        .age              = i * 10,
-                        .salary           = 50000.0,
-                        .years_experience = 5
-                }
-        );
+                                             AggregatePerson{
+                                                     .id               = 0,
+                                                     .name             = "AggregatePerson" + std::to_string(i),
+                                                     .age              = i * 10,
+                                                     .salary           = 50000.0,
+                                                     .years_experience = 5
+                                             }
+        )
+                                     .execute();
         ASSERT_TRUE(insert_result.has_value());
 
         auto count = this->qs->count().get();
@@ -636,12 +642,12 @@ TYPED_TEST(AggregateTest, Integration_AfterUpdate) {
     this->insert_test_data();
 
     // Update all ages to 30
-    auto people = this->qs->select();
+    auto people = this->qs->select().execute();
     ASSERT_TRUE(people.has_value());
 
     for (auto& person : people.value()) {
         person.age         = 30;
-        auto update_result = this->qs->update(person);
+        auto update_result = this->qs->update(person).execute();
         ASSERT_TRUE(update_result.has_value());
     }
 
@@ -655,14 +661,14 @@ TYPED_TEST(AggregateTest, Integration_AfterDelete) {
     this->insert_test_data();
 
     // Delete 2 people
-    auto people = this->qs->select();
+    auto people = this->qs->select().execute();
     ASSERT_TRUE(people.has_value());
 
     auto it            = people.value().begin();
-    auto delete_result = this->qs->remove(*it);
+    auto delete_result = this->qs->remove(*it).execute();
     ASSERT_TRUE(delete_result.has_value());
     ++it;
-    delete_result = this->qs->remove(*it);
+    delete_result = this->qs->remove(*it).execute();
     ASSERT_TRUE(delete_result.has_value());
 
     // COUNT should now be 3
@@ -1258,20 +1264,35 @@ TYPED_TEST(AggregateTest, CountDistinctAge) {
 TYPED_TEST(AggregateTest, CountDistinctWithDuplicates) {
     // Insert data with duplicate ages
     std::ignore = this->qs->insert(
-            AggregatePerson{.id = 0, .name = "Alice", .age = 30, .salary = 50000.0, .years_experience = 3}
-    );
+                                  AggregatePerson{
+                                          .id = 0, .name = "Alice", .age = 30, .salary = 50000.0, .years_experience = 3
+                                  }
+    )
+                          .execute();
+    std::ignore =
+            this->qs->insert(
+                            AggregatePerson{.id = 0, .name = "Bob", .age = 30, .salary = 60000.0, .years_experience = 5}
+            )
+                    .execute(); // Same age as Alice
+    std::ignore =
+            this->qs->insert(
+                            AggregatePerson{
+                                    .id = 0, .name = "Charlie", .age = 35, .salary = 70000.0, .years_experience = 7
+                            }
+            )
+                    .execute();
     std::ignore = this->qs->insert(
-            AggregatePerson{.id = 0, .name = "Bob", .age = 30, .salary = 60000.0, .years_experience = 5}
-    ); // Same age as Alice
+                                  AggregatePerson{
+                                          .id = 0, .name = "Dave", .age = 30, .salary = 80000.0, .years_experience = 10
+                                  }
+    )
+                          .execute(); // Same age as Alice and Bob
     std::ignore = this->qs->insert(
-            AggregatePerson{.id = 0, .name = "Charlie", .age = 35, .salary = 70000.0, .years_experience = 7}
-    );
-    std::ignore = this->qs->insert(
-            AggregatePerson{.id = 0, .name = "Dave", .age = 30, .salary = 80000.0, .years_experience = 10}
-    ); // Same age as Alice and Bob
-    std::ignore = this->qs->insert(
-            AggregatePerson{.id = 0, .name = "Eve", .age = 35, .salary = 90000.0, .years_experience = 15}
-    ); // Same age as Charlie
+                                  AggregatePerson{
+                                          .id = 0, .name = "Eve", .age = 35, .salary = 90000.0, .years_experience = 15
+                                  }
+    )
+                          .execute(); // Same age as Charlie
 
     auto result = this->qs->template count_distinct<^^AggregatePerson::age>().get();
     ASSERT_TRUE(result.has_value()) << "COUNT(DISTINCT) with duplicates failed";
@@ -1378,14 +1399,13 @@ TYPED_TEST_SUITE(OptionalAggregateTest, DatabaseTypes);
 
 TYPED_TEST(OptionalAggregateTest, CountWithNullValues) {
     // Insert with NULL ages
-    std::ignore = this->qs->insert(AggOptionalPerson{.id = 0, .name = "Alice", .age = 25, .salary = 50000.0});
-    std::ignore = this->qs->insert(
-            AggOptionalPerson{.id = 0, .name = "Bob", .age = std::nullopt, .salary = 60000.0}
-    ); // NULL age
-    std::ignore = this->qs->insert(AggOptionalPerson{.id = 0, .name = "Charlie", .age = 35, .salary = 70000.0});
-    std::ignore = this->qs->insert(
-            AggOptionalPerson{.id = 0, .name = "Dave", .age = std::nullopt, .salary = 80000.0}
-    ); // NULL age
+    std::ignore = this->qs->insert(AggOptionalPerson{.id = 0, .name = "Alice", .age = 25, .salary = 50000.0}).execute();
+    std::ignore = this->qs->insert(AggOptionalPerson{.id = 0, .name = "Bob", .age = std::nullopt, .salary = 60000.0})
+                          .execute(); // NULL age
+    std::ignore =
+            this->qs->insert(AggOptionalPerson{.id = 0, .name = "Charlie", .age = 35, .salary = 70000.0}).execute();
+    std::ignore = this->qs->insert(AggOptionalPerson{.id = 0, .name = "Dave", .age = std::nullopt, .salary = 80000.0})
+                          .execute(); // NULL age
 
     // COUNT(*) includes all rows
     auto count_all = this->qs->count().get();
@@ -1399,11 +1419,11 @@ TYPED_TEST(OptionalAggregateTest, CountWithNullValues) {
 }
 
 TYPED_TEST(OptionalAggregateTest, SumWithNullValues) {
-    std::ignore = this->qs->insert(AggOptionalPerson{.id = 0, .name = "Alice", .age = 25, .salary = 50000.0});
-    std::ignore = this->qs->insert(
-            AggOptionalPerson{.id = 0, .name = "Bob", .age = std::nullopt, .salary = 60000.0}
-    ); // NULL age
-    std::ignore = this->qs->insert(AggOptionalPerson{.id = 0, .name = "Charlie", .age = 35, .salary = 70000.0});
+    std::ignore = this->qs->insert(AggOptionalPerson{.id = 0, .name = "Alice", .age = 25, .salary = 50000.0}).execute();
+    std::ignore = this->qs->insert(AggOptionalPerson{.id = 0, .name = "Bob", .age = std::nullopt, .salary = 60000.0})
+                          .execute(); // NULL age
+    std::ignore =
+            this->qs->insert(AggOptionalPerson{.id = 0, .name = "Charlie", .age = 35, .salary = 70000.0}).execute();
 
     auto sum = this->qs->template sum<^^AggOptionalPerson::age>().get();
     ASSERT_TRUE(sum.has_value());
@@ -1411,11 +1431,11 @@ TYPED_TEST(OptionalAggregateTest, SumWithNullValues) {
 }
 
 TYPED_TEST(OptionalAggregateTest, AvgWithNullValues) {
-    std::ignore = this->qs->insert(AggOptionalPerson{.id = 0, .name = "Alice", .age = 20, .salary = 50000.0});
-    std::ignore = this->qs->insert(
-            AggOptionalPerson{.id = 0, .name = "Bob", .age = std::nullopt, .salary = 60000.0}
-    ); // NULL age
-    std::ignore = this->qs->insert(AggOptionalPerson{.id = 0, .name = "Charlie", .age = 40, .salary = 70000.0});
+    std::ignore = this->qs->insert(AggOptionalPerson{.id = 0, .name = "Alice", .age = 20, .salary = 50000.0}).execute();
+    std::ignore = this->qs->insert(AggOptionalPerson{.id = 0, .name = "Bob", .age = std::nullopt, .salary = 60000.0})
+                          .execute(); // NULL age
+    std::ignore =
+            this->qs->insert(AggOptionalPerson{.id = 0, .name = "Charlie", .age = 40, .salary = 70000.0}).execute();
 
     auto avg = this->qs->template avg<^^AggOptionalPerson::age>().get();
     ASSERT_TRUE(avg.has_value());
@@ -1423,14 +1443,13 @@ TYPED_TEST(OptionalAggregateTest, AvgWithNullValues) {
 }
 
 TYPED_TEST(OptionalAggregateTest, MinMaxWithNullValues) {
-    std::ignore = this->qs->insert(AggOptionalPerson{.id = 0, .name = "Alice", .age = 25, .salary = 50000.0});
-    std::ignore = this->qs->insert(
-            AggOptionalPerson{.id = 0, .name = "Bob", .age = std::nullopt, .salary = 60000.0}
-    ); // NULL age
-    std::ignore = this->qs->insert(AggOptionalPerson{.id = 0, .name = "Charlie", .age = 45, .salary = 70000.0});
-    std::ignore = this->qs->insert(
-            AggOptionalPerson{.id = 0, .name = "Dave", .age = std::nullopt, .salary = 80000.0}
-    ); // NULL age
+    std::ignore = this->qs->insert(AggOptionalPerson{.id = 0, .name = "Alice", .age = 25, .salary = 50000.0}).execute();
+    std::ignore = this->qs->insert(AggOptionalPerson{.id = 0, .name = "Bob", .age = std::nullopt, .salary = 60000.0})
+                          .execute(); // NULL age
+    std::ignore =
+            this->qs->insert(AggOptionalPerson{.id = 0, .name = "Charlie", .age = 45, .salary = 70000.0}).execute();
+    std::ignore = this->qs->insert(AggOptionalPerson{.id = 0, .name = "Dave", .age = std::nullopt, .salary = 80000.0})
+                          .execute(); // NULL age
 
     auto min_val = this->qs->template min<^^AggOptionalPerson::age>().get();
     ASSERT_TRUE(min_val.has_value());
@@ -1442,17 +1461,14 @@ TYPED_TEST(OptionalAggregateTest, MinMaxWithNullValues) {
 }
 
 TYPED_TEST(OptionalAggregateTest, CountDistinctWithNullValues) {
-    std::ignore = this->qs->insert(AggOptionalPerson{.id = 0, .name = "Alice", .age = 30, .salary = 50000.0});
-    std::ignore = this->qs->insert(
-            AggOptionalPerson{.id = 0, .name = "Bob", .age = std::nullopt, .salary = 60000.0}
-    ); // NULL age
-    std::ignore = this->qs->insert(
-            AggOptionalPerson{.id = 0, .name = "Charlie", .age = 30, .salary = 70000.0}
-    ); // Same as Alice
-    std::ignore = this->qs->insert(
-            AggOptionalPerson{.id = 0, .name = "Dave", .age = std::nullopt, .salary = 80000.0}
-    ); // NULL age
-    std::ignore = this->qs->insert(AggOptionalPerson{.id = 0, .name = "Eve", .age = 40, .salary = 90000.0});
+    std::ignore = this->qs->insert(AggOptionalPerson{.id = 0, .name = "Alice", .age = 30, .salary = 50000.0}).execute();
+    std::ignore = this->qs->insert(AggOptionalPerson{.id = 0, .name = "Bob", .age = std::nullopt, .salary = 60000.0})
+                          .execute(); // NULL age
+    std::ignore = this->qs->insert(AggOptionalPerson{.id = 0, .name = "Charlie", .age = 30, .salary = 70000.0})
+                          .execute(); // Same as Alice
+    std::ignore = this->qs->insert(AggOptionalPerson{.id = 0, .name = "Dave", .age = std::nullopt, .salary = 80000.0})
+                          .execute(); // NULL age
+    std::ignore = this->qs->insert(AggOptionalPerson{.id = 0, .name = "Eve", .age = 40, .salary = 90000.0}).execute();
 
     // COUNT(DISTINCT age) - NULL excluded, should count 2 (30, 40)
     auto result = this->qs->template count_distinct<^^AggOptionalPerson::age>().get();
@@ -1462,10 +1478,13 @@ TYPED_TEST(OptionalAggregateTest, CountDistinctWithNullValues) {
 
 TYPED_TEST(OptionalAggregateTest, GroupByWithAllNullValuesInGroupColumn) {
     // Insert rows where all ages are NULL
-    std::ignore = this->qs->insert(AggOptionalPerson{.id = 0, .name = "Alice", .age = std::nullopt, .salary = 50000.0});
-    std::ignore = this->qs->insert(AggOptionalPerson{.id = 0, .name = "Bob", .age = std::nullopt, .salary = 60000.0});
+    std::ignore = this->qs->insert(AggOptionalPerson{.id = 0, .name = "Alice", .age = std::nullopt, .salary = 50000.0})
+                          .execute();
+    std::ignore = this->qs->insert(AggOptionalPerson{.id = 0, .name = "Bob", .age = std::nullopt, .salary = 60000.0})
+                          .execute();
     std::ignore =
-            this->qs->insert(AggOptionalPerson{.id = 0, .name = "Charlie", .age = std::nullopt, .salary = 70000.0});
+            this->qs->insert(AggOptionalPerson{.id = 0, .name = "Charlie", .age = std::nullopt, .salary = 70000.0})
+                    .execute();
 
     // GROUP BY on age (all NULL) - should produce one group with NULL key
     // SQLite treats NULL as a distinct group key in GROUP BY
@@ -1487,11 +1506,14 @@ TYPED_TEST(OptionalAggregateTest, GroupByWithAllNullValuesInGroupColumn) {
 
 TYPED_TEST(OptionalAggregateTest, GroupByWithMixedNullAndNonNullValues) {
     // Insert mix of NULL and non-NULL ages
-    std::ignore = this->qs->insert(AggOptionalPerson{.id = 0, .name = "Alice", .age = 25, .salary = 50000.0});
-    std::ignore = this->qs->insert(AggOptionalPerson{.id = 0, .name = "Bob", .age = std::nullopt, .salary = 60000.0});
-    std::ignore = this->qs->insert(AggOptionalPerson{.id = 0, .name = "Charlie", .age = 25, .salary = 70000.0});
-    std::ignore = this->qs->insert(AggOptionalPerson{.id = 0, .name = "Dave", .age = std::nullopt, .salary = 80000.0});
-    std::ignore = this->qs->insert(AggOptionalPerson{.id = 0, .name = "Eve", .age = 30, .salary = 90000.0});
+    std::ignore = this->qs->insert(AggOptionalPerson{.id = 0, .name = "Alice", .age = 25, .salary = 50000.0}).execute();
+    std::ignore = this->qs->insert(AggOptionalPerson{.id = 0, .name = "Bob", .age = std::nullopt, .salary = 60000.0})
+                          .execute();
+    std::ignore =
+            this->qs->insert(AggOptionalPerson{.id = 0, .name = "Charlie", .age = 25, .salary = 70000.0}).execute();
+    std::ignore = this->qs->insert(AggOptionalPerson{.id = 0, .name = "Dave", .age = std::nullopt, .salary = 80000.0})
+                          .execute();
+    std::ignore = this->qs->insert(AggOptionalPerson{.id = 0, .name = "Eve", .age = 30, .salary = 90000.0}).execute();
 
     // GROUP BY on age - should produce 3 groups: NULL (2 rows), 25 (2 rows), 30 (1 row)
     auto result = this->qs->template group_by<^^AggOptionalPerson::age>().count().select();
@@ -1522,14 +1544,23 @@ TYPED_TEST(OptionalAggregateTest, GroupByWithMixedNullAndNonNullValues) {
 // Negative number tests using the main AggregatePerson model
 TYPED_TEST(AggregateTest, NegativeNumbersInSum) {
     std::ignore = this->qs->insert(
-            AggregatePerson{.id = 0, .name = "Alice", .age = -10, .salary = 50000.0, .years_experience = 3}
-    );
-    std::ignore = this->qs->insert(
-            AggregatePerson{.id = 0, .name = "Bob", .age = 5, .salary = 60000.0, .years_experience = 5}
-    );
-    std::ignore = this->qs->insert(
-            AggregatePerson{.id = 0, .name = "Charlie", .age = -3, .salary = 70000.0, .years_experience = 7}
-    );
+                                  AggregatePerson{
+                                          .id = 0, .name = "Alice", .age = -10, .salary = 50000.0, .years_experience = 3
+                                  }
+    )
+                          .execute();
+    std::ignore =
+            this->qs->insert(
+                            AggregatePerson{.id = 0, .name = "Bob", .age = 5, .salary = 60000.0, .years_experience = 5}
+            )
+                    .execute();
+    std::ignore =
+            this->qs->insert(
+                            AggregatePerson{
+                                    .id = 0, .name = "Charlie", .age = -3, .salary = 70000.0, .years_experience = 7
+                            }
+            )
+                    .execute();
 
     auto sum = this->qs->template sum<^^AggregatePerson::age>().get();
     ASSERT_TRUE(sum.has_value());
@@ -1538,14 +1569,22 @@ TYPED_TEST(AggregateTest, NegativeNumbersInSum) {
 
 TYPED_TEST(AggregateTest, NegativeNumbersInAvg) {
     std::ignore = this->qs->insert(
-            AggregatePerson{.id = 0, .name = "Alice", .age = -12, .salary = 50000.0, .years_experience = 3}
-    );
+                                  AggregatePerson{
+                                          .id = 0, .name = "Alice", .age = -12, .salary = 50000.0, .years_experience = 3
+                                  }
+    )
+                          .execute();
+    std::ignore =
+            this->qs->insert(
+                            AggregatePerson{.id = 0, .name = "Bob", .age = 6, .salary = 60000.0, .years_experience = 5}
+            )
+                    .execute();
     std::ignore = this->qs->insert(
-            AggregatePerson{.id = 0, .name = "Bob", .age = 6, .salary = 60000.0, .years_experience = 5}
-    );
-    std::ignore = this->qs->insert(
-            AggregatePerson{.id = 0, .name = "Charlie", .age = 0, .salary = 70000.0, .years_experience = 7}
-    );
+                                  AggregatePerson{
+                                          .id = 0, .name = "Charlie", .age = 0, .salary = 70000.0, .years_experience = 7
+                                  }
+    )
+                          .execute();
 
     auto avg = this->qs->template avg<^^AggregatePerson::age>().get();
     ASSERT_TRUE(avg.has_value());
@@ -1554,17 +1593,29 @@ TYPED_TEST(AggregateTest, NegativeNumbersInAvg) {
 
 TYPED_TEST(AggregateTest, NegativeNumbersInMinMax) {
     std::ignore = this->qs->insert(
-            AggregatePerson{.id = 0, .name = "Alice", .age = -10, .salary = 50000.0, .years_experience = 3}
-    );
+                                  AggregatePerson{
+                                          .id = 0, .name = "Alice", .age = -10, .salary = 50000.0, .years_experience = 3
+                                  }
+    )
+                          .execute();
+    std::ignore =
+            this->qs->insert(
+                            AggregatePerson{.id = 0, .name = "Bob", .age = 5, .salary = 60000.0, .years_experience = 5}
+            )
+                    .execute();
+    std::ignore =
+            this->qs->insert(
+                            AggregatePerson{
+                                    .id = 0, .name = "Charlie", .age = -20, .salary = 70000.0, .years_experience = 7
+                            }
+            )
+                    .execute();
     std::ignore = this->qs->insert(
-            AggregatePerson{.id = 0, .name = "Bob", .age = 5, .salary = 60000.0, .years_experience = 5}
-    );
-    std::ignore = this->qs->insert(
-            AggregatePerson{.id = 0, .name = "Charlie", .age = -20, .salary = 70000.0, .years_experience = 7}
-    );
-    std::ignore = this->qs->insert(
-            AggregatePerson{.id = 0, .name = "Dave", .age = 15, .salary = 80000.0, .years_experience = 10}
-    );
+                                  AggregatePerson{
+                                          .id = 0, .name = "Dave", .age = 15, .salary = 80000.0, .years_experience = 10
+                                  }
+    )
+                          .execute();
 
     auto min_val = this->qs->template min<^^AggregatePerson::age>().get();
     ASSERT_TRUE(min_val.has_value());
@@ -1577,14 +1628,22 @@ TYPED_TEST(AggregateTest, NegativeNumbersInMinMax) {
 
 TYPED_TEST(AggregateTest, NegativeNumbersInCount) {
     std::ignore = this->qs->insert(
-            AggregatePerson{.id = 0, .name = "Alice", .age = -10, .salary = 50000.0, .years_experience = 3}
-    );
+                                  AggregatePerson{
+                                          .id = 0, .name = "Alice", .age = -10, .salary = 50000.0, .years_experience = 3
+                                  }
+    )
+                          .execute();
+    std::ignore =
+            this->qs->insert(
+                            AggregatePerson{.id = 0, .name = "Bob", .age = -5, .salary = 60000.0, .years_experience = 5}
+            )
+                    .execute();
     std::ignore = this->qs->insert(
-            AggregatePerson{.id = 0, .name = "Bob", .age = -5, .salary = 60000.0, .years_experience = 5}
-    );
-    std::ignore = this->qs->insert(
-            AggregatePerson{.id = 0, .name = "Charlie", .age = 0, .salary = 70000.0, .years_experience = 7}
-    );
+                                  AggregatePerson{
+                                          .id = 0, .name = "Charlie", .age = 0, .salary = 70000.0, .years_experience = 7
+                                  }
+    )
+                          .execute();
 
     // Count should still count all rows regardless of negative values
     auto count = this->qs->count().get();
@@ -1599,20 +1658,34 @@ TYPED_TEST(AggregateTest, NegativeNumbersInCount) {
 
 TYPED_TEST(AggregateTest, NegativeNumbersInWhere) {
     std::ignore = this->qs->insert(
-            AggregatePerson{.id = 0, .name = "Alice", .age = -10, .salary = 50000.0, .years_experience = 3}
-    );
+                                  AggregatePerson{
+                                          .id = 0, .name = "Alice", .age = -10, .salary = 50000.0, .years_experience = 3
+                                  }
+    )
+                          .execute();
+    std::ignore =
+            this->qs->insert(
+                            AggregatePerson{.id = 0, .name = "Bob", .age = -5, .salary = 60000.0, .years_experience = 5}
+            )
+                    .execute();
     std::ignore = this->qs->insert(
-            AggregatePerson{.id = 0, .name = "Bob", .age = -5, .salary = 60000.0, .years_experience = 5}
-    );
+                                  AggregatePerson{
+                                          .id = 0, .name = "Charlie", .age = 0, .salary = 70000.0, .years_experience = 7
+                                  }
+    )
+                          .execute();
     std::ignore = this->qs->insert(
-            AggregatePerson{.id = 0, .name = "Charlie", .age = 0, .salary = 70000.0, .years_experience = 7}
-    );
+                                  AggregatePerson{
+                                          .id = 0, .name = "Dave", .age = 5, .salary = 80000.0, .years_experience = 10
+                                  }
+    )
+                          .execute();
     std::ignore = this->qs->insert(
-            AggregatePerson{.id = 0, .name = "Dave", .age = 5, .salary = 80000.0, .years_experience = 10}
-    );
-    std::ignore = this->qs->insert(
-            AggregatePerson{.id = 0, .name = "Eve", .age = 10, .salary = 90000.0, .years_experience = 15}
-    );
+                                  AggregatePerson{
+                                          .id = 0, .name = "Eve", .age = 10, .salary = 90000.0, .years_experience = 15
+                                  }
+    )
+                          .execute();
 
     // Count where age < 0
     auto result = this->qs->where(storm::orm::where::field<^^AggregatePerson::age>() < 0).count().get();
@@ -1679,7 +1752,8 @@ TYPED_TEST(AggregateTest, FullChain_WhereJoinOrderByLimitOffset) {
                           .template order_by<^^AggMessage::value, false>()
                           .limit(5)
                           .offset(2)
-                          .select();
+                          .select()
+                          .execute();
 
     ASSERT_TRUE(result.has_value()) << "Full chain query failed: " << result.error().message();
 
@@ -1704,7 +1778,8 @@ TYPED_TEST(AggregateTest, FullChain_WhereJoinOrderByLimitOffset) {
                            .template order_by<^^AggMessage::value, true>() // ASC this time
                            .limit(3)
                            .offset(0)
-                           .select();
+                           .select()
+                           .execute();
 
     ASSERT_TRUE(result2.has_value()) << "Second full chain query failed: " << result2.error().message();
 
@@ -1725,7 +1800,8 @@ TYPED_TEST(AggregateTest, FullChain_WhereJoinOrderByLimitOffset) {
     this->msg_qs->reset();
     auto result3 = this->msg_qs->where(storm::orm::where::field<^^AggMessage::value>() == 75)
                            .template join<&AggMessage::sender>()
-                           .select();
+                           .select()
+                           .execute();
 
     ASSERT_TRUE(result3.has_value()) << "JOIN verification query failed";
     EXPECT_EQ(result3.value().size(), 1) << "Expected 1 message with value 75";
@@ -1740,23 +1816,41 @@ TYPED_TEST(AggregateTest, GroupByWithAllAggregateTypes) {
 
     // Insert test data with multiple people having the same years_experience
     std::ignore = this->qs->insert(
-            AggregatePerson{.id = 0, .name = "Alice", .age = 25, .salary = 50000.0, .years_experience = 5}
-    );
+                                  AggregatePerson{
+                                          .id = 0, .name = "Alice", .age = 25, .salary = 50000.0, .years_experience = 5
+                                  }
+    )
+                          .execute();
+    std::ignore =
+            this->qs->insert(
+                            AggregatePerson{.id = 0, .name = "Bob", .age = 30, .salary = 60000.0, .years_experience = 5}
+            )
+                    .execute();
+    std::ignore =
+            this->qs->insert(
+                            AggregatePerson{
+                                    .id = 0, .name = "Charlie", .age = 35, .salary = 70000.0, .years_experience = 10
+                            }
+            )
+                    .execute();
     std::ignore = this->qs->insert(
-            AggregatePerson{.id = 0, .name = "Bob", .age = 30, .salary = 60000.0, .years_experience = 5}
-    );
+                                  AggregatePerson{
+                                          .id = 0, .name = "Dave", .age = 40, .salary = 80000.0, .years_experience = 10
+                                  }
+    )
+                          .execute();
     std::ignore = this->qs->insert(
-            AggregatePerson{.id = 0, .name = "Charlie", .age = 35, .salary = 70000.0, .years_experience = 10}
-    );
+                                  AggregatePerson{
+                                          .id = 0, .name = "Eve", .age = 45, .salary = 90000.0, .years_experience = 10
+                                  }
+    )
+                          .execute();
     std::ignore = this->qs->insert(
-            AggregatePerson{.id = 0, .name = "Dave", .age = 40, .salary = 80000.0, .years_experience = 10}
-    );
-    std::ignore = this->qs->insert(
-            AggregatePerson{.id = 0, .name = "Eve", .age = 45, .salary = 90000.0, .years_experience = 10}
-    );
-    std::ignore = this->qs->insert(
-            AggregatePerson{.id = 0, .name = "Frank", .age = 28, .salary = 55000.0, .years_experience = 5}
-    );
+                                  AggregatePerson{
+                                          .id = 0, .name = "Frank", .age = 28, .salary = 55000.0, .years_experience = 5
+                                  }
+    )
+                          .execute();
 
     // Test data summary by years_experience:
     //   years_experience=5: Alice(25), Bob(30), Frank(28) -> count=3, sum=83, avg=27.67, min=25, max=30
@@ -1964,20 +2058,35 @@ TYPED_TEST(AggregateTest, GroupByWithOffsetOnly) {
 TYPED_TEST(AggregateTest, GroupByMultipleFields) {
     // Insert data with overlapping age and years_experience combinations
     std::ignore = this->qs->insert(
-            AggregatePerson{.id = 0, .name = "Alice", .age = 25, .salary = 50000.0, .years_experience = 5}
-    );
+                                  AggregatePerson{
+                                          .id = 0, .name = "Alice", .age = 25, .salary = 50000.0, .years_experience = 5
+                                  }
+    )
+                          .execute();
+    std::ignore =
+            this->qs->insert(
+                            AggregatePerson{.id = 0, .name = "Bob", .age = 25, .salary = 60000.0, .years_experience = 5}
+            )
+                    .execute();
+    std::ignore =
+            this->qs->insert(
+                            AggregatePerson{
+                                    .id = 0, .name = "Charlie", .age = 25, .salary = 70000.0, .years_experience = 10
+                            }
+            )
+                    .execute();
     std::ignore = this->qs->insert(
-            AggregatePerson{.id = 0, .name = "Bob", .age = 25, .salary = 60000.0, .years_experience = 5}
-    );
+                                  AggregatePerson{
+                                          .id = 0, .name = "Dave", .age = 30, .salary = 80000.0, .years_experience = 5
+                                  }
+    )
+                          .execute();
     std::ignore = this->qs->insert(
-            AggregatePerson{.id = 0, .name = "Charlie", .age = 25, .salary = 70000.0, .years_experience = 10}
-    );
-    std::ignore = this->qs->insert(
-            AggregatePerson{.id = 0, .name = "Dave", .age = 30, .salary = 80000.0, .years_experience = 5}
-    );
-    std::ignore = this->qs->insert(
-            AggregatePerson{.id = 0, .name = "Eve", .age = 30, .salary = 90000.0, .years_experience = 10}
-    );
+                                  AggregatePerson{
+                                          .id = 0, .name = "Eve", .age = 30, .salary = 90000.0, .years_experience = 10
+                                  }
+    )
+                          .execute();
 
     // Group by TWO fields: age AND years_experience
     // Expected groups: (25,5)=2, (25,10)=1, (30,5)=1, (30,10)=1 = 4 groups
@@ -1999,20 +2108,35 @@ TYPED_TEST(AggregateTest, GroupByMultipleFields) {
 TYPED_TEST(AggregateTest, GroupByMultipleFieldsWithOrderByLimit) {
     // Same data setup as above
     std::ignore = this->qs->insert(
-            AggregatePerson{.id = 0, .name = "Alice", .age = 25, .salary = 50000.0, .years_experience = 5}
-    );
+                                  AggregatePerson{
+                                          .id = 0, .name = "Alice", .age = 25, .salary = 50000.0, .years_experience = 5
+                                  }
+    )
+                          .execute();
+    std::ignore =
+            this->qs->insert(
+                            AggregatePerson{.id = 0, .name = "Bob", .age = 25, .salary = 60000.0, .years_experience = 5}
+            )
+                    .execute();
+    std::ignore =
+            this->qs->insert(
+                            AggregatePerson{
+                                    .id = 0, .name = "Charlie", .age = 25, .salary = 70000.0, .years_experience = 10
+                            }
+            )
+                    .execute();
     std::ignore = this->qs->insert(
-            AggregatePerson{.id = 0, .name = "Bob", .age = 25, .salary = 60000.0, .years_experience = 5}
-    );
+                                  AggregatePerson{
+                                          .id = 0, .name = "Dave", .age = 30, .salary = 80000.0, .years_experience = 5
+                                  }
+    )
+                          .execute();
     std::ignore = this->qs->insert(
-            AggregatePerson{.id = 0, .name = "Charlie", .age = 25, .salary = 70000.0, .years_experience = 10}
-    );
-    std::ignore = this->qs->insert(
-            AggregatePerson{.id = 0, .name = "Dave", .age = 30, .salary = 80000.0, .years_experience = 5}
-    );
-    std::ignore = this->qs->insert(
-            AggregatePerson{.id = 0, .name = "Eve", .age = 30, .salary = 90000.0, .years_experience = 10}
-    );
+                                  AggregatePerson{
+                                          .id = 0, .name = "Eve", .age = 30, .salary = 90000.0, .years_experience = 10
+                                  }
+    )
+                          .execute();
 
     // Multi-field GROUP BY with ORDER BY and LIMIT
     auto result = this->qs->template order_by<^^AggregatePerson::age>()
@@ -2031,20 +2155,35 @@ TYPED_TEST(AggregateTest, GroupByMultipleFieldsWithOrderByLimit) {
 TYPED_TEST(AggregateTest, HavingOnGroupByBuilder) {
     // Insert data with duplicate years_experience values
     std::ignore = this->qs->insert(
-            AggregatePerson{.id = 0, .name = "Alice", .age = 25, .salary = 50000.0, .years_experience = 5}
-    );
+                                  AggregatePerson{
+                                          .id = 0, .name = "Alice", .age = 25, .salary = 50000.0, .years_experience = 5
+                                  }
+    )
+                          .execute();
+    std::ignore =
+            this->qs->insert(
+                            AggregatePerson{.id = 0, .name = "Bob", .age = 30, .salary = 60000.0, .years_experience = 5}
+            )
+                    .execute();
+    std::ignore =
+            this->qs->insert(
+                            AggregatePerson{
+                                    .id = 0, .name = "Charlie", .age = 35, .salary = 70000.0, .years_experience = 10
+                            }
+            )
+                    .execute();
     std::ignore = this->qs->insert(
-            AggregatePerson{.id = 0, .name = "Bob", .age = 30, .salary = 60000.0, .years_experience = 5}
-    );
+                                  AggregatePerson{
+                                          .id = 0, .name = "Dave", .age = 40, .salary = 80000.0, .years_experience = 10
+                                  }
+    )
+                          .execute();
     std::ignore = this->qs->insert(
-            AggregatePerson{.id = 0, .name = "Charlie", .age = 35, .salary = 70000.0, .years_experience = 10}
-    );
-    std::ignore = this->qs->insert(
-            AggregatePerson{.id = 0, .name = "Dave", .age = 40, .salary = 80000.0, .years_experience = 10}
-    );
-    std::ignore = this->qs->insert(
-            AggregatePerson{.id = 0, .name = "Eve", .age = 45, .salary = 90000.0, .years_experience = 10}
-    );
+                                  AggregatePerson{
+                                          .id = 0, .name = "Eve", .age = 45, .salary = 90000.0, .years_experience = 10
+                                  }
+    )
+                          .execute();
 
     // HAVING on GroupByBuilder (before aggregate): years_experience > 5
     // Groups: years_experience=5 (filtered out), years_experience=10 (kept)
@@ -2063,20 +2202,35 @@ TYPED_TEST(AggregateTest, HavingOnGroupByBuilder) {
 TYPED_TEST(AggregateTest, HavingOnAggregateStatement) {
     // Insert data with duplicate years_experience values
     std::ignore = this->qs->insert(
-            AggregatePerson{.id = 0, .name = "Alice", .age = 25, .salary = 50000.0, .years_experience = 5}
-    );
+                                  AggregatePerson{
+                                          .id = 0, .name = "Alice", .age = 25, .salary = 50000.0, .years_experience = 5
+                                  }
+    )
+                          .execute();
+    std::ignore =
+            this->qs->insert(
+                            AggregatePerson{.id = 0, .name = "Bob", .age = 30, .salary = 60000.0, .years_experience = 5}
+            )
+                    .execute();
+    std::ignore =
+            this->qs->insert(
+                            AggregatePerson{
+                                    .id = 0, .name = "Charlie", .age = 35, .salary = 70000.0, .years_experience = 10
+                            }
+            )
+                    .execute();
     std::ignore = this->qs->insert(
-            AggregatePerson{.id = 0, .name = "Bob", .age = 30, .salary = 60000.0, .years_experience = 5}
-    );
+                                  AggregatePerson{
+                                          .id = 0, .name = "Dave", .age = 40, .salary = 80000.0, .years_experience = 10
+                                  }
+    )
+                          .execute();
     std::ignore = this->qs->insert(
-            AggregatePerson{.id = 0, .name = "Charlie", .age = 35, .salary = 70000.0, .years_experience = 10}
-    );
-    std::ignore = this->qs->insert(
-            AggregatePerson{.id = 0, .name = "Dave", .age = 40, .salary = 80000.0, .years_experience = 10}
-    );
-    std::ignore = this->qs->insert(
-            AggregatePerson{.id = 0, .name = "Eve", .age = 45, .salary = 90000.0, .years_experience = 10}
-    );
+                                  AggregatePerson{
+                                          .id = 0, .name = "Eve", .age = 45, .salary = 90000.0, .years_experience = 10
+                                  }
+    )
+                          .execute();
 
     // HAVING on AggregateStatement (after aggregate): years_experience > 5
     auto result = this->qs->template group_by<^^AggregatePerson::years_experience>()
@@ -2185,14 +2339,23 @@ TYPED_TEST(AggregateTest, HavingRepeatedQueries) {
 TYPED_TEST(AggregateTest, HavingWithSum) {
     // Insert data where groups have different sum totals
     std::ignore = this->qs->insert(
-            AggregatePerson{.id = 0, .name = "Alice", .age = 25, .salary = 50000.0, .years_experience = 5}
-    );
-    std::ignore = this->qs->insert(
-            AggregatePerson{.id = 0, .name = "Bob", .age = 30, .salary = 60000.0, .years_experience = 5}
-    );
-    std::ignore = this->qs->insert(
-            AggregatePerson{.id = 0, .name = "Charlie", .age = 35, .salary = 70000.0, .years_experience = 10}
-    );
+                                  AggregatePerson{
+                                          .id = 0, .name = "Alice", .age = 25, .salary = 50000.0, .years_experience = 5
+                                  }
+    )
+                          .execute();
+    std::ignore =
+            this->qs->insert(
+                            AggregatePerson{.id = 0, .name = "Bob", .age = 30, .salary = 60000.0, .years_experience = 5}
+            )
+                    .execute();
+    std::ignore =
+            this->qs->insert(
+                            AggregatePerson{
+                                    .id = 0, .name = "Charlie", .age = 35, .salary = 70000.0, .years_experience = 10
+                            }
+            )
+                    .execute();
 
     // GROUP BY years_experience, SUM(age), HAVING years_experience == 5
     auto result = this->qs->template group_by<^^AggregatePerson::years_experience>()

--- a/tests/test_coverage_additional.cpp
+++ b/tests/test_coverage_additional.cpp
@@ -103,7 +103,7 @@ template <typename ConnType> class MultipleAggregatesTest : public ::testing::Te
         };
 
         for (const auto& person : people) {
-            auto r = qs->insert(person);
+            auto r = qs->insert(person).execute();
             ASSERT_TRUE(r.has_value());
         }
     }
@@ -201,10 +201,10 @@ TYPED_TEST(MultipleAggregatesTest, FiveAggregatesAllTypes) {
 TYPED_TEST(MultipleAggregatesTest, MultipleAggregatesEmptyTable) {
     // Test multiple aggregates on empty table (default/zero values)
     // First delete all rows
-    auto all = this->qs->select();
+    auto all = this->qs->select().execute();
     ASSERT_TRUE(all.has_value());
     for (const auto& p : all.value()) {
-        (void)this->qs->remove(p);
+        (void)this->qs->remove(p).execute();
     }
 
     auto result = this->qs->count().template sum<^^AggPerson::age>().template avg<^^AggPerson::salary>().get();
@@ -223,10 +223,10 @@ TYPED_TEST(MultipleAggregatesTest, MultipleAggregatesEmptyTable) {
 
 TYPED_TEST(MultipleAggregatesTest, SingleCountEmptyTable) {
     // Delete all rows first
-    auto all = this->qs->select();
+    auto all = this->qs->select().execute();
     ASSERT_TRUE(all.has_value());
     for (const auto& p : all.value()) {
-        (void)this->qs->remove(p);
+        (void)this->qs->remove(p).execute();
     }
 
     auto result = this->qs->count().get();
@@ -236,10 +236,10 @@ TYPED_TEST(MultipleAggregatesTest, SingleCountEmptyTable) {
 
 TYPED_TEST(MultipleAggregatesTest, SingleSumEmptyTable) {
     // Delete all rows first
-    auto all = this->qs->select();
+    auto all = this->qs->select().execute();
     ASSERT_TRUE(all.has_value());
     for (const auto& p : all.value()) {
-        (void)this->qs->remove(p);
+        (void)this->qs->remove(p).execute();
     }
 
     auto result = this->qs->template sum<^^AggPerson::age>().get();
@@ -249,10 +249,10 @@ TYPED_TEST(MultipleAggregatesTest, SingleSumEmptyTable) {
 
 TYPED_TEST(MultipleAggregatesTest, SingleAvgEmptyTable) {
     // Delete all rows first
-    auto all = this->qs->select();
+    auto all = this->qs->select().execute();
     ASSERT_TRUE(all.has_value());
     for (const auto& p : all.value()) {
-        (void)this->qs->remove(p);
+        (void)this->qs->remove(p).execute();
     }
 
     auto result = this->qs->template avg<^^AggPerson::salary>().get();
@@ -262,10 +262,10 @@ TYPED_TEST(MultipleAggregatesTest, SingleAvgEmptyTable) {
 
 TYPED_TEST(MultipleAggregatesTest, SingleMinEmptyTable) {
     // Delete all rows first
-    auto all = this->qs->select();
+    auto all = this->qs->select().execute();
     ASSERT_TRUE(all.has_value());
     for (const auto& p : all.value()) {
-        (void)this->qs->remove(p);
+        (void)this->qs->remove(p).execute();
     }
 
     auto result = this->qs->template min<^^AggPerson::score>().get();
@@ -274,10 +274,10 @@ TYPED_TEST(MultipleAggregatesTest, SingleMinEmptyTable) {
 
 TYPED_TEST(MultipleAggregatesTest, SingleMaxEmptyTable) {
     // Delete all rows first
-    auto all = this->qs->select();
+    auto all = this->qs->select().execute();
     ASSERT_TRUE(all.has_value());
     for (const auto& p : all.value()) {
-        (void)this->qs->remove(p);
+        (void)this->qs->remove(p).execute();
     }
 
     auto result = this->qs->template max<^^AggPerson::score>().get();
@@ -531,7 +531,7 @@ TYPED_TEST_SUITE(JoinTypeExtractionTest, DatabaseTypes);
 
 TYPED_TEST(JoinTypeExtractionTest, JoinExtractsFloatField) {
     // Tests extract_typed_field for float
-    auto result = this->post_qs->template join<&JoinPost::author>().select();
+    auto result = this->post_qs->template join<&JoinPost::author>().select().execute();
 
     ASSERT_TRUE(result.has_value()) << "JOIN with float field should succeed";
     ASSERT_FALSE(result.value().empty());
@@ -550,7 +550,7 @@ TYPED_TEST(JoinTypeExtractionTest, JoinExtractsFloatField) {
 
 TYPED_TEST(JoinTypeExtractionTest, JoinExtractsBoolField) {
     // Tests extract_typed_field for bool
-    auto result = this->post_qs->template join<&JoinPost::author>().select();
+    auto result = this->post_qs->template join<&JoinPost::author>().select().execute();
 
     ASSERT_TRUE(result.has_value()) << "JOIN with bool field should succeed";
     ASSERT_FALSE(result.value().empty());
@@ -568,7 +568,7 @@ TYPED_TEST(JoinTypeExtractionTest, JoinExtractsBoolField) {
 
 TYPED_TEST(JoinTypeExtractionTest, JoinExtractsOptionalIntWithValue) {
     // Tests extract_typed_field for optional<int> with value
-    auto result = this->post_qs->template join<&JoinPost::author>().select();
+    auto result = this->post_qs->template join<&JoinPost::author>().select().execute();
 
     ASSERT_TRUE(result.has_value()) << "JOIN with optional int should succeed";
     ASSERT_FALSE(result.value().empty());
@@ -586,7 +586,7 @@ TYPED_TEST(JoinTypeExtractionTest, JoinExtractsOptionalIntWithValue) {
 
 TYPED_TEST(JoinTypeExtractionTest, JoinExtractsOptionalIntNull) {
     // Tests extract_typed_field for optional<int> with NULL
-    auto result = this->post_qs->template join<&JoinPost::author>().select();
+    auto result = this->post_qs->template join<&JoinPost::author>().select().execute();
 
     ASSERT_TRUE(result.has_value()) << "JOIN with NULL optional should succeed";
     ASSERT_FALSE(result.value().empty());
@@ -600,7 +600,7 @@ TYPED_TEST(JoinTypeExtractionTest, JoinExtractsOptionalIntNull) {
 
 TYPED_TEST(JoinTypeExtractionTest, JoinExtractsOptionalStringWithValue) {
     // Tests extract_typed_field for optional<string> with value
-    auto result = this->post_qs->template join<&JoinPost::author>().select();
+    auto result = this->post_qs->template join<&JoinPost::author>().select().execute();
 
     ASSERT_TRUE(result.has_value()) << "JOIN with optional string should succeed";
     ASSERT_FALSE(result.value().empty());
@@ -615,7 +615,7 @@ TYPED_TEST(JoinTypeExtractionTest, JoinExtractsOptionalStringWithValue) {
 
 TYPED_TEST(JoinTypeExtractionTest, JoinExtractsOptionalStringNull) {
     // Tests extract_typed_field for optional<string> with NULL
-    auto result = this->post_qs->template join<&JoinPost::author>().select();
+    auto result = this->post_qs->template join<&JoinPost::author>().select().execute();
 
     ASSERT_TRUE(result.has_value()) << "JOIN with NULL optional string should succeed";
     ASSERT_FALSE(result.value().empty());
@@ -631,7 +631,8 @@ TYPED_TEST(JoinTypeExtractionTest, JoinWithWhere) {
     // Test JOIN with WHERE to ensure proper handling
     auto result = this->post_qs->where(storm::orm::where::field<^^JoinPost::views>() > 75)
                           .template join<&JoinPost::author>()
-                          .select();
+                          .select()
+                          .execute();
 
     ASSERT_TRUE(result.has_value()) << "JOIN with WHERE should succeed";
     // Should return posts with views > 75 (Alice's posts with 100/200 and Charlie's with 150)
@@ -640,7 +641,8 @@ TYPED_TEST(JoinTypeExtractionTest, JoinWithWhere) {
 
 TYPED_TEST(JoinTypeExtractionTest, JoinWithOrderBy) {
     // Test JOIN with ORDER BY
-    auto result = this->post_qs->template join<&JoinPost::author>().template order_by<^^JoinPost::views>().select();
+    auto result =
+            this->post_qs->template join<&JoinPost::author>().template order_by<^^JoinPost::views>().select().execute();
 
     ASSERT_TRUE(result.has_value()) << "JOIN with ORDER BY should succeed";
     EXPECT_EQ(result.value().size(), 4);
@@ -712,19 +714,19 @@ TYPED_TEST_SUITE(UpdateOptimizedTest, DatabaseTypes);
 TYPED_TEST(UpdateOptimizedTest, RepeatedSingleUpdates) {
     // Test repeated single updates to exercise cached statement path
     UpdatePerson p{0, "Test", 100};
-    auto         insert_result = this->qs->insert(p);
+    auto         insert_result = this->qs->insert(p).execute();
     ASSERT_TRUE(insert_result.has_value());
     int64_t id = insert_result.value();
 
     // Perform multiple single updates (exercises cached_update_stmt_ path)
     for (int i = 0; i < 10; ++i) {
         UpdatePerson updated{static_cast<int>(id), "Updated" + std::to_string(i), 100 + i};
-        auto         result = this->qs->update(updated);
+        auto         result = this->qs->update(updated).execute();
         ASSERT_TRUE(result.has_value()) << "Update iteration " << i << " should succeed";
     }
 
     // Verify final state
-    auto selected = this->qs->select();
+    auto selected = this->qs->select().execute();
     ASSERT_TRUE(selected.has_value());
     EXPECT_EQ(selected.value().begin()->value, 109);
 }
@@ -737,11 +739,11 @@ TYPED_TEST(UpdateOptimizedTest, BatchUpdateFollowedByInsert) {
             {0, "P3", 3},
     };
 
-    auto insert_result = this->qs->insert(std::span<const UpdatePerson>(batch));
+    auto insert_result = this->qs->insert(std::span<const UpdatePerson>(batch)).execute();
     ASSERT_TRUE(insert_result.has_value());
 
     // Batch update
-    auto selected = this->qs->select();
+    auto selected = this->qs->select().execute();
     ASSERT_TRUE(selected.has_value());
     ASSERT_FALSE(selected.value().empty());
 
@@ -750,11 +752,11 @@ TYPED_TEST(UpdateOptimizedTest, BatchUpdateFollowedByInsert) {
         updates.push_back({p.id, p.name, p.value + 100});
     }
 
-    auto batch_update = this->qs->update(std::span<const UpdatePerson>(updates));
+    auto batch_update = this->qs->update(std::span<const UpdatePerson>(updates)).execute();
     ASSERT_TRUE(batch_update.has_value());
 
     // Verify batch update worked
-    auto after_batch = this->qs->select();
+    auto after_batch = this->qs->select().execute();
     ASSERT_TRUE(after_batch.has_value());
     for (const auto& p : after_batch.value()) {
         EXPECT_GE(p.value, 101) << "Values should be updated";
@@ -762,11 +764,11 @@ TYPED_TEST(UpdateOptimizedTest, BatchUpdateFollowedByInsert) {
 
     // Insert a new record after batch update
     UpdatePerson new_person{0, "NewPerson", 500};
-    auto         new_insert = this->qs->insert(new_person);
+    auto         new_insert = this->qs->insert(new_person).execute();
     ASSERT_TRUE(new_insert.has_value());
 
     // Verify total count
-    auto final_result = this->qs->select();
+    auto final_result = this->qs->select().execute();
     ASSERT_TRUE(final_result.has_value());
     EXPECT_EQ(final_result.value().size(), 4);
 }
@@ -819,7 +821,7 @@ template <typename ConnType> class WhereAdditionalTest : public ::testing::Test 
         };
 
         for (const auto& person : people) {
-            (void)qs->insert(person);
+            (void)qs->insert(person).execute();
         }
     }
 
@@ -841,7 +843,7 @@ TYPED_TEST_SUITE(WhereAdditionalTest, DatabaseTypes);
 
 TYPED_TEST(WhereAdditionalTest, DoubleFieldComparison) {
     // Test WHERE with double field (score)
-    auto result = this->qs->where(storm::orm::where::field<^^CovAddWherePerson::score>() > 85.0).select();
+    auto result = this->qs->where(storm::orm::where::field<^^CovAddWherePerson::score>() > 85.0).select().execute();
 
     ASSERT_TRUE(result.has_value());
     EXPECT_EQ(result.value().size(), 3); // Alice (85.5), Bob (90), Diana (95)
@@ -849,7 +851,7 @@ TYPED_TEST(WhereAdditionalTest, DoubleFieldComparison) {
 
 TYPED_TEST(WhereAdditionalTest, DoubleFieldEquality) {
     // Test WHERE with double equality
-    auto result = this->qs->where(storm::orm::where::field<^^CovAddWherePerson::score>() == 90.0).select();
+    auto result = this->qs->where(storm::orm::where::field<^^CovAddWherePerson::score>() == 90.0).select().execute();
 
     ASSERT_TRUE(result.has_value());
     EXPECT_EQ(result.value().size(), 1);
@@ -858,7 +860,7 @@ TYPED_TEST(WhereAdditionalTest, DoubleFieldEquality) {
 
 TYPED_TEST(WhereAdditionalTest, LikePatternStartsWith) {
     // Test LIKE with starts-with pattern
-    auto result = this->qs->where(storm::orm::where::field<^^CovAddWherePerson::name>().like("A%")).select();
+    auto result = this->qs->where(storm::orm::where::field<^^CovAddWherePerson::name>().like("A%")).select().execute();
 
     ASSERT_TRUE(result.has_value());
     EXPECT_EQ(result.value().size(), 1);
@@ -867,7 +869,7 @@ TYPED_TEST(WhereAdditionalTest, LikePatternStartsWith) {
 
 TYPED_TEST(WhereAdditionalTest, LikePatternEndsWith) {
     // Test LIKE with ends-with pattern
-    auto result = this->qs->where(storm::orm::where::field<^^CovAddWherePerson::name>().like("%e")).select();
+    auto result = this->qs->where(storm::orm::where::field<^^CovAddWherePerson::name>().like("%e")).select().execute();
 
     ASSERT_TRUE(result.has_value());
     EXPECT_EQ(result.value().size(), 3); // Alice, Charlie, Eve
@@ -875,7 +877,8 @@ TYPED_TEST(WhereAdditionalTest, LikePatternEndsWith) {
 
 TYPED_TEST(WhereAdditionalTest, LikePatternContains) {
     // Test LIKE with contains pattern
-    auto result = this->qs->where(storm::orm::where::field<^^CovAddWherePerson::name>().like("%li%")).select();
+    auto result =
+            this->qs->where(storm::orm::where::field<^^CovAddWherePerson::name>().like("%li%")).select().execute();
 
     ASSERT_TRUE(result.has_value());
     EXPECT_EQ(result.value().size(), 2); // Alice, Charlie
@@ -890,7 +893,7 @@ TYPED_TEST(WhereAdditionalTest, ComplexNestedOrAnd) {
     auto score_cond = storm::orm::where::field<^^CovAddWherePerson::score>() > 80.0;
     auto combined   = age_cond and score_cond;
 
-    auto result = this->qs->where(combined).select();
+    auto result = this->qs->where(combined).select().execute();
 
     ASSERT_TRUE(result.has_value());
     // Alice (25, 85.5) and Diana (40, 95) should match
@@ -898,21 +901,21 @@ TYPED_TEST(WhereAdditionalTest, ComplexNestedOrAnd) {
 }
 
 TYPED_TEST(WhereAdditionalTest, WhereWithLessEqual) {
-    auto result = this->qs->where(storm::orm::where::field<^^CovAddWherePerson::age>() <= 28).select();
+    auto result = this->qs->where(storm::orm::where::field<^^CovAddWherePerson::age>() <= 28).select().execute();
 
     ASSERT_TRUE(result.has_value());
     EXPECT_EQ(result.value().size(), 2); // Alice (25), Eve (28)
 }
 
 TYPED_TEST(WhereAdditionalTest, WhereWithGreaterEqual) {
-    auto result = this->qs->where(storm::orm::where::field<^^CovAddWherePerson::age>() >= 35).select();
+    auto result = this->qs->where(storm::orm::where::field<^^CovAddWherePerson::age>() >= 35).select().execute();
 
     ASSERT_TRUE(result.has_value());
     EXPECT_EQ(result.value().size(), 2); // Charlie (35), Diana (40)
 }
 
 TYPED_TEST(WhereAdditionalTest, WhereWithNotEqual) {
-    auto result = this->qs->where(storm::orm::where::field<^^CovAddWherePerson::name>() != "Alice").select();
+    auto result = this->qs->where(storm::orm::where::field<^^CovAddWherePerson::name>() != "Alice").select().execute();
 
     ASSERT_TRUE(result.has_value());
     EXPECT_EQ(result.value().size(), 4); // Everyone except Alice

--- a/tests/test_coverage_gaps.cpp
+++ b/tests/test_coverage_gaps.cpp
@@ -134,7 +134,7 @@ template <typename ConnType> class CoverageGapsTest : public ::testing::Test {
         };
 
         for (const auto& person : people) {
-            auto r = qs->insert(person);
+            auto r = qs->insert(person).execute();
             ASSERT_TRUE(r.has_value());
         }
 
@@ -579,7 +579,7 @@ template <typename ConnType> class LargeBatchTest : public ::testing::Test {
         for (size_t i = 0; i < count; ++i) {
             people.push_back({0, "Person" + std::to_string(i), static_cast<int>(i)});
         }
-        auto result = qs->insert(std::span<const BatchPerson>(people));
+        auto result = qs->insert(std::span<const BatchPerson>(people)).execute();
         ASSERT_TRUE(result.has_value()) << "Failed to insert batch";
     }
 
@@ -592,7 +592,7 @@ TYPED_TEST(LargeBatchTest, RemoveBulkSmall) {
     // Test bulk delete path (2-799 objects, uses IN clause)
     this->insert_batch(50);
 
-    auto select_result = this->qs->select();
+    auto select_result = this->qs->select().execute();
     ASSERT_TRUE(select_result.has_value());
     EXPECT_EQ(select_result.value().size(), 50);
 
@@ -604,7 +604,7 @@ TYPED_TEST(LargeBatchTest, RemoveBulkSmall) {
         to_remove.push_back(p);
     }
 
-    auto remove_result = this->qs->remove(std::span<const BatchPerson>(to_remove));
+    auto remove_result = this->qs->remove(std::span<const BatchPerson>(to_remove)).execute();
     ASSERT_TRUE(remove_result.has_value()) << "Bulk remove should succeed";
 
     // Verify all removed
@@ -617,7 +617,7 @@ TYPED_TEST(LargeBatchTest, RemoveBulkAtLimit) {
     // Test bulk delete at MAX_CHUNK_SIZE boundary (799 objects)
     this->insert_batch(799);
 
-    auto select_result = this->qs->select();
+    auto select_result = this->qs->select().execute();
     ASSERT_TRUE(select_result.has_value());
     EXPECT_EQ(select_result.value().size(), 799);
 
@@ -627,7 +627,7 @@ TYPED_TEST(LargeBatchTest, RemoveBulkAtLimit) {
         to_remove.push_back(p);
     }
 
-    auto remove_result = this->qs->remove(std::span<const BatchPerson>(to_remove));
+    auto remove_result = this->qs->remove(std::span<const BatchPerson>(to_remove)).execute();
     ASSERT_TRUE(remove_result.has_value()) << "Bulk remove at limit should succeed";
 
     auto count_result = this->qs->count().get();
@@ -640,7 +640,7 @@ TYPED_TEST(LargeBatchTest, RemoveChunkedMinimal) {
     // This triggers: 1 full chunk of 799 + remainder of 1
     this->insert_batch(800);
 
-    auto select_result = this->qs->select();
+    auto select_result = this->qs->select().execute();
     ASSERT_TRUE(select_result.has_value());
     EXPECT_EQ(select_result.value().size(), 800);
 
@@ -650,7 +650,7 @@ TYPED_TEST(LargeBatchTest, RemoveChunkedMinimal) {
         to_remove.push_back(p);
     }
 
-    auto remove_result = this->qs->remove(std::span<const BatchPerson>(to_remove));
+    auto remove_result = this->qs->remove(std::span<const BatchPerson>(to_remove)).execute();
     ASSERT_TRUE(remove_result.has_value()) << "Chunked remove should succeed";
 
     auto count_result = this->qs->count().get();
@@ -663,7 +663,7 @@ TYPED_TEST(LargeBatchTest, RemoveChunkedWithRemainder) {
     // 850 = 799 + 51 (tests remainder path)
     this->insert_batch(850);
 
-    auto select_result = this->qs->select();
+    auto select_result = this->qs->select().execute();
     ASSERT_TRUE(select_result.has_value());
     EXPECT_EQ(select_result.value().size(), 850);
 
@@ -673,7 +673,7 @@ TYPED_TEST(LargeBatchTest, RemoveChunkedWithRemainder) {
         to_remove.push_back(p);
     }
 
-    auto remove_result = this->qs->remove(std::span<const BatchPerson>(to_remove));
+    auto remove_result = this->qs->remove(std::span<const BatchPerson>(to_remove)).execute();
     ASSERT_TRUE(remove_result.has_value()) << "Chunked remove with remainder should succeed";
 
     auto count_result = this->qs->count().get();
@@ -685,7 +685,7 @@ TYPED_TEST(LargeBatchTest, RemoveChunkedMultipleChunks) {
     // Test multiple full chunks (1600 = 2*799 + 2)
     this->insert_batch(1600);
 
-    auto select_result = this->qs->select();
+    auto select_result = this->qs->select().execute();
     ASSERT_TRUE(select_result.has_value());
     EXPECT_EQ(select_result.value().size(), 1600);
 
@@ -695,7 +695,7 @@ TYPED_TEST(LargeBatchTest, RemoveChunkedMultipleChunks) {
         to_remove.push_back(p);
     }
 
-    auto remove_result = this->qs->remove(std::span<const BatchPerson>(to_remove));
+    auto remove_result = this->qs->remove(std::span<const BatchPerson>(to_remove)).execute();
     ASSERT_TRUE(remove_result.has_value()) << "Multiple chunk remove should succeed";
 
     auto count_result = this->qs->count().get();
@@ -708,7 +708,7 @@ TYPED_TEST(LargeBatchTest, RemoveChunkedExactMultiple) {
     // No remainder - tests the "no remainder" branch
     this->insert_batch(1598);
 
-    auto select_result = this->qs->select();
+    auto select_result = this->qs->select().execute();
     ASSERT_TRUE(select_result.has_value());
     EXPECT_EQ(select_result.value().size(), 1598);
 
@@ -718,7 +718,7 @@ TYPED_TEST(LargeBatchTest, RemoveChunkedExactMultiple) {
         to_remove.push_back(p);
     }
 
-    auto remove_result = this->qs->remove(std::span<const BatchPerson>(to_remove));
+    auto remove_result = this->qs->remove(std::span<const BatchPerson>(to_remove)).execute();
     ASSERT_TRUE(remove_result.has_value()) << "Exact multiple chunk remove should succeed";
 
     auto count_result = this->qs->count().get();
@@ -731,7 +731,7 @@ TYPED_TEST(LargeBatchTest, RemoveEmpty) {
 
     std::vector<BatchPerson> empty;
 
-    auto remove_result = this->qs->remove(std::span<const BatchPerson>(empty));
+    auto remove_result = this->qs->remove(std::span<const BatchPerson>(empty)).execute();
     ASSERT_TRUE(remove_result.has_value()) << "Empty remove should succeed";
 }
 
@@ -739,7 +739,7 @@ TYPED_TEST(LargeBatchTest, UpdateBulkSmall) {
     // Test bulk update path
     this->insert_batch(50);
 
-    auto select_result = this->qs->select();
+    auto select_result = this->qs->select().execute();
     ASSERT_TRUE(select_result.has_value());
 
     std::vector<BatchPerson> to_update;
@@ -748,11 +748,11 @@ TYPED_TEST(LargeBatchTest, UpdateBulkSmall) {
         to_update.push_back({p.id, p.name, p.value + 1000});
     }
 
-    auto update_result = this->qs->update(std::span<const BatchPerson>(to_update));
+    auto update_result = this->qs->update(std::span<const BatchPerson>(to_update)).execute();
     ASSERT_TRUE(update_result.has_value()) << "Bulk update should succeed";
 
     // Verify updates
-    auto verify_result = this->qs->select();
+    auto verify_result = this->qs->select().execute();
     ASSERT_TRUE(verify_result.has_value());
     for (const auto& p : verify_result.value()) {
         EXPECT_GE(p.value, 1000) << "Values should be updated";
@@ -763,7 +763,7 @@ TYPED_TEST(LargeBatchTest, UpdateChunkedWithRemainder) {
     // Test chunked update with remainder
     this->insert_batch(850);
 
-    auto select_result = this->qs->select();
+    auto select_result = this->qs->select().execute();
     ASSERT_TRUE(select_result.has_value());
     EXPECT_EQ(select_result.value().size(), 850);
 
@@ -773,11 +773,11 @@ TYPED_TEST(LargeBatchTest, UpdateChunkedWithRemainder) {
         to_update.push_back({p.id, p.name, p.value + 2000});
     }
 
-    auto update_result = this->qs->update(std::span<const BatchPerson>(to_update));
+    auto update_result = this->qs->update(std::span<const BatchPerson>(to_update)).execute();
     ASSERT_TRUE(update_result.has_value()) << "Chunked update should succeed";
 
     // Verify updates
-    auto verify_result = this->qs->select();
+    auto verify_result = this->qs->select().execute();
     ASSERT_TRUE(verify_result.has_value());
     for (const auto& p : verify_result.value()) {
         EXPECT_GE(p.value, 2000);
@@ -793,7 +793,7 @@ TYPED_TEST(LargeBatchTest, InsertLargeBatch) {
         people.push_back({0, "LargeBatch" + std::to_string(i), i});
     }
 
-    auto insert_result = this->qs->insert(std::span<const BatchPerson>(people));
+    auto insert_result = this->qs->insert(std::span<const BatchPerson>(people)).execute();
     ASSERT_TRUE(insert_result.has_value()) << "Large batch insert should succeed";
 
     auto count_result = this->qs->count().get();
@@ -867,10 +867,10 @@ TYPED_TEST(OptionalTypesTest, OptionalDoubleWithValue) {
     QuerySet<OptionalDouble, TypeParam> qs;
     OptionalDouble const                obj{.id = 0, .value = 3.14159, .label = "pi"};
 
-    auto result = qs.insert(obj);
+    auto result = qs.insert(obj).execute();
     ASSERT_TRUE(result.has_value());
 
-    auto selected = qs.select();
+    auto selected = qs.select().execute();
     ASSERT_TRUE(selected.has_value());
     ASSERT_TRUE(selected.value().begin()->value.has_value());
     EXPECT_NEAR(selected.value().begin()->value.value(), 3.14159, 0.0001);
@@ -880,10 +880,10 @@ TYPED_TEST(OptionalTypesTest, OptionalDoubleNull) {
     QuerySet<OptionalDouble, TypeParam> qs;
     OptionalDouble const                obj{.id = 0, .value = std::nullopt, .label = "null_double"};
 
-    auto result = qs.insert(obj);
+    auto result = qs.insert(obj).execute();
     ASSERT_TRUE(result.has_value());
 
-    auto selected = qs.select();
+    auto selected = qs.select().execute();
     ASSERT_TRUE(selected.has_value());
     EXPECT_FALSE(selected.value().begin()->value.has_value());
 }
@@ -897,10 +897,10 @@ TYPED_TEST(OptionalTypesTest, OptionalDoubleBatch) {
             {0, std::nullopt, "fourth"},
     };
 
-    auto result = qs.insert(std::span<const OptionalDouble>(batch));
+    auto result = qs.insert(std::span<const OptionalDouble>(batch)).execute();
     ASSERT_TRUE(result.has_value());
 
-    auto selected = qs.select();
+    auto selected = qs.select().execute();
     ASSERT_TRUE(selected.has_value());
     EXPECT_EQ(selected.value().size(), 4);
 
@@ -918,10 +918,10 @@ TYPED_TEST(OptionalTypesTest, OptionalInt64WithValue) {
     QuerySet<OptionalInt64, TypeParam> qs;
     OptionalInt64 const                obj{.id = 0, .big_value = 9223372036854775807LL, .label = "max_int64"};
 
-    auto result = qs.insert(obj);
+    auto result = qs.insert(obj).execute();
     ASSERT_TRUE(result.has_value());
 
-    auto selected = qs.select();
+    auto selected = qs.select().execute();
     ASSERT_TRUE(selected.has_value());
     ASSERT_TRUE(selected.value().begin()->big_value.has_value());
     EXPECT_EQ(selected.value().begin()->big_value.value(), 9223372036854775807LL);
@@ -931,10 +931,10 @@ TYPED_TEST(OptionalTypesTest, OptionalInt64Null) {
     QuerySet<OptionalInt64, TypeParam> qs;
     OptionalInt64 const                obj{.id = 0, .big_value = std::nullopt, .label = "null_int64"};
 
-    auto result = qs.insert(obj);
+    auto result = qs.insert(obj).execute();
     ASSERT_TRUE(result.has_value());
 
-    auto selected = qs.select();
+    auto selected = qs.select().execute();
     ASSERT_TRUE(selected.has_value());
     EXPECT_FALSE(selected.value().begin()->big_value.has_value());
 }
@@ -943,15 +943,15 @@ TYPED_TEST(OptionalTypesTest, UpdateOptionalDoubleToNull) {
     QuerySet<OptionalDouble, TypeParam> qs;
     OptionalDouble const                obj{.id = 0, .value = 100.5, .label = "to_null"};
 
-    auto insert_result = qs.insert(obj);
+    auto insert_result = qs.insert(obj).execute();
     ASSERT_TRUE(insert_result.has_value());
     int64_t const id = insert_result.value();
 
     OptionalDouble const updated{.id = static_cast<int>(id), .value = std::nullopt, .label = "now_null"};
-    auto                 update_result = qs.update(updated);
+    auto                 update_result = qs.update(updated).execute();
     ASSERT_TRUE(update_result.has_value());
 
-    auto selected = qs.select();
+    auto selected = qs.select().execute();
     ASSERT_TRUE(selected.has_value());
     EXPECT_FALSE(selected.value().begin()->value.has_value());
 }
@@ -960,15 +960,15 @@ TYPED_TEST(OptionalTypesTest, UpdateOptionalInt64FromNull) {
     QuerySet<OptionalInt64, TypeParam> qs;
     OptionalInt64 const                obj{.id = 0, .big_value = std::nullopt, .label = "from_null"};
 
-    auto insert_result = qs.insert(obj);
+    auto insert_result = qs.insert(obj).execute();
     ASSERT_TRUE(insert_result.has_value());
     int64_t const id = insert_result.value();
 
     OptionalInt64 const updated{.id = static_cast<int>(id), .big_value = 42LL, .label = "now_has_value"};
-    auto                update_result = qs.update(updated);
+    auto                update_result = qs.update(updated).execute();
     ASSERT_TRUE(update_result.has_value());
 
-    auto selected = qs.select();
+    auto selected = qs.select().execute();
     ASSERT_TRUE(selected.has_value());
     ASSERT_TRUE(selected.value().begin()->big_value.has_value());
     EXPECT_EQ(selected.value().begin()->big_value.value(), 42LL);
@@ -1022,7 +1022,7 @@ template <typename ConnType> class ComplexWhereTest : public ::testing::Test {
         };
 
         for (const auto& person : people) {
-            (void)qs->insert(person);
+            (void)qs->insert(person).execute();
         }
     }
 
@@ -1046,7 +1046,8 @@ TYPED_TEST(ComplexWhereTest, OrCondition) {
     // Test OR operator
     auto result = this->qs->where(storm::orm::where::field<^^CovGapWherePerson::age>() < 26 or
                                   storm::orm::where::field<^^CovGapWherePerson::age>() > 35)
-                          .select();
+                          .select()
+                          .execute();
 
     ASSERT_TRUE(result.has_value()) << "OR condition should work";
     EXPECT_EQ(result.value().size(), 2); // Alice (25) and Diana (40)
@@ -1059,7 +1060,7 @@ TYPED_TEST(ComplexWhereTest, OrWithAnd) {
     auto mkt      = storm::orm::where::field<^^CovGapWherePerson::department>() == "Marketing";
     auto combined = young or (old and mkt);
 
-    auto result = this->qs->where(combined).select();
+    auto result = this->qs->where(combined).select().execute();
     ASSERT_TRUE(result.has_value()) << "Complex OR/AND should work";
     EXPECT_GE(result.value().size(), 1);
 }
@@ -1070,7 +1071,7 @@ TYPED_TEST(ComplexWhereTest, MultipleOrConditions) {
                 storm::orm::where::field<^^CovGapWherePerson::age>() == 30 or
                 storm::orm::where::field<^^CovGapWherePerson::age>() == 35;
 
-    auto result = this->qs->where(cond).select();
+    auto result = this->qs->where(cond).select().execute();
     ASSERT_TRUE(result.has_value());
     EXPECT_EQ(result.value().size(), 3); // Alice (25), Bob (30), Charlie (35)
 }
@@ -1082,7 +1083,7 @@ TYPED_TEST(ComplexWhereTest, NestedAndOr) {
     auto sales_old = storm::orm::where::field<^^CovGapWherePerson::department>() == "Sales" and
                      storm::orm::where::field<^^CovGapWherePerson::age>() > 29;
 
-    auto result = this->qs->where(eng_young or sales_old).select();
+    auto result = this->qs->where(eng_young or sales_old).select().execute();
     ASSERT_TRUE(result.has_value());
     EXPECT_GE(result.value().size(), 1);
 }
@@ -1096,7 +1097,8 @@ TYPED_TEST(ComplexWhereTest, FullChainSelect) {
                           .template order_by<^^CovGapWherePerson::age>()
                           .limit(2)
                           .offset(1)
-                          .select();
+                          .select()
+                          .execute();
 
     ASSERT_TRUE(result.has_value()) << "Full chain SELECT should work";
     EXPECT_LE(result.value().size(), 2);
@@ -1175,11 +1177,11 @@ TYPED_TEST(TransactionTest, MultiRowUpdateInTransaction) {
     // Insert multiple rows
     std::vector<TxnPerson> const people = {{0, "P1", 1}, {0, "P2", 2}, {0, "P3", 3}};
 
-    auto insert_result = this->qs->insert(std::span<const TxnPerson>(people));
+    auto insert_result = this->qs->insert(std::span<const TxnPerson>(people)).execute();
     ASSERT_TRUE(insert_result.has_value());
 
     // Fetch and update all
-    auto select_result = this->qs->select();
+    auto select_result = this->qs->select().execute();
     ASSERT_TRUE(select_result.has_value());
 
     std::vector<TxnPerson> updates;
@@ -1187,11 +1189,11 @@ TYPED_TEST(TransactionTest, MultiRowUpdateInTransaction) {
         updates.push_back({p.id, p.name, p.value + 100});
     }
 
-    auto update_result = this->qs->update(std::span<const TxnPerson>(updates));
+    auto update_result = this->qs->update(std::span<const TxnPerson>(updates)).execute();
     ASSERT_TRUE(update_result.has_value());
 
     // Verify all updated
-    auto verify_result = this->qs->select();
+    auto verify_result = this->qs->select().execute();
     ASSERT_TRUE(verify_result.has_value());
     for (const auto& p : verify_result.value()) {
         EXPECT_GT(p.value, 100);
@@ -1202,42 +1204,42 @@ TYPED_TEST(TransactionTest, EmptyBatchOperations) {
     std::vector<TxnPerson> empty;
 
     // Empty insert
-    auto insert_result = this->qs->insert(std::span<const TxnPerson>(empty));
+    auto insert_result = this->qs->insert(std::span<const TxnPerson>(empty)).execute();
     ASSERT_TRUE(insert_result.has_value());
 
     // Empty update
-    auto update_result = this->qs->update(std::span<const TxnPerson>(empty));
+    auto update_result = this->qs->update(std::span<const TxnPerson>(empty)).execute();
     ASSERT_TRUE(update_result.has_value());
 
     // Empty remove
-    auto remove_result = this->qs->remove(std::span<const TxnPerson>(empty));
+    auto remove_result = this->qs->remove(std::span<const TxnPerson>(empty)).execute();
     ASSERT_TRUE(remove_result.has_value());
 }
 
 TYPED_TEST(TransactionTest, SingleRowOperations) {
     // Single row insert
     TxnPerson const p1{0, "Single", 42};
-    auto            insert_result = this->qs->insert(p1);
+    auto            insert_result = this->qs->insert(p1).execute();
     ASSERT_TRUE(insert_result.has_value());
 
     int64_t const id = insert_result.value();
 
     // Single row update
     TxnPerson const updated{static_cast<int>(id), "Updated", 99};
-    auto            update_result = this->qs->update(updated);
+    auto            update_result = this->qs->update(updated).execute();
     ASSERT_TRUE(update_result.has_value());
 
     // Verify
-    auto select_result = this->qs->select();
+    auto select_result = this->qs->select().execute();
     ASSERT_TRUE(select_result.has_value());
     EXPECT_EQ(select_result.value().begin()->value, 99);
 
     // Single row remove
-    auto remove_result = this->qs->remove(updated);
+    auto remove_result = this->qs->remove(updated).execute();
     ASSERT_TRUE(remove_result.has_value());
 
     // Verify empty
-    auto empty_result = this->qs->select();
+    auto empty_result = this->qs->select().execute();
     ASSERT_TRUE(empty_result.has_value());
     EXPECT_TRUE(empty_result.value().empty());
 }
@@ -1305,10 +1307,10 @@ TYPED_TEST(CovUnsignedTypesTest, InsertMaxValues) {
             .ushort_val = std::numeric_limits<unsigned short>::max()
     };
 
-    auto result = this->qs->insert(obj);
+    auto result = this->qs->insert(obj).execute();
     ASSERT_TRUE(result.has_value());
 
-    auto selected = this->qs->select();
+    auto selected = this->qs->select().execute();
     ASSERT_TRUE(selected.has_value());
     EXPECT_EQ(selected.value().begin()->ushort_val, std::numeric_limits<unsigned short>::max());
 }
@@ -1316,10 +1318,10 @@ TYPED_TEST(CovUnsignedTypesTest, InsertMaxValues) {
 TYPED_TEST(CovUnsignedTypesTest, InsertZeroValues) {
     CovUnsignedTypes const obj{.id = 0, .uint_val = 0, .ulong_val = 0, .ushort_val = 0};
 
-    auto result = this->qs->insert(obj);
+    auto result = this->qs->insert(obj).execute();
     ASSERT_TRUE(result.has_value());
 
-    auto selected = this->qs->select();
+    auto selected = this->qs->select().execute();
     ASSERT_TRUE(selected.has_value());
     EXPECT_EQ(selected.value().begin()->uint_val, 0u);
 }
@@ -1327,10 +1329,10 @@ TYPED_TEST(CovUnsignedTypesTest, InsertZeroValues) {
 TYPED_TEST(CovUnsignedTypesTest, BatchCovUnsignedTypes) {
     std::vector<CovUnsignedTypes> batch = {{0, 100, 1000, 10}, {0, 200, 2000, 20}, {0, 300, 3000, 30}};
 
-    auto result = this->qs->insert(std::span<const CovUnsignedTypes>(batch));
+    auto result = this->qs->insert(std::span<const CovUnsignedTypes>(batch)).execute();
     ASSERT_TRUE(result.has_value());
 
-    auto selected = this->qs->select();
+    auto selected = this->qs->select().execute();
     ASSERT_TRUE(selected.has_value());
     EXPECT_EQ(selected.value().size(), 3);
 }
@@ -1338,15 +1340,15 @@ TYPED_TEST(CovUnsignedTypesTest, BatchCovUnsignedTypes) {
 TYPED_TEST(CovUnsignedTypesTest, UpdateCovUnsignedTypes) {
     CovUnsignedTypes const obj{.id = 0, .uint_val = 100, .ulong_val = 1000, .ushort_val = 10};
 
-    auto insert_result = this->qs->insert(obj);
+    auto insert_result = this->qs->insert(obj).execute();
     ASSERT_TRUE(insert_result.has_value());
     int64_t const id = insert_result.value();
 
     CovUnsignedTypes const updated{.id = static_cast<int>(id), .uint_val = 999, .ulong_val = 9999, .ushort_val = 99};
-    auto                   update_result = this->qs->update(updated);
+    auto                   update_result = this->qs->update(updated).execute();
     ASSERT_TRUE(update_result.has_value());
 
-    auto selected = this->qs->select();
+    auto selected = this->qs->select().execute();
     ASSERT_TRUE(selected.has_value());
     EXPECT_EQ(selected.value().begin()->uint_val, 999u);
 }
@@ -1406,10 +1408,10 @@ TYPED_TEST_SUITE(FloatTypeTest, DatabaseTypes);
 TYPED_TEST(FloatTypeTest, InsertFloatValue) {
     FloatType const obj{.id = 0, .value = 3.14159f, .label = "pi"};
 
-    auto result = this->qs->insert(obj);
+    auto result = this->qs->insert(obj).execute();
     ASSERT_TRUE(result.has_value());
 
-    auto selected = this->qs->select();
+    auto selected = this->qs->select().execute();
     ASSERT_TRUE(selected.has_value());
     EXPECT_NEAR(selected.value().begin()->value, 3.14159f, 0.0001f);
 }
@@ -1417,10 +1419,10 @@ TYPED_TEST(FloatTypeTest, InsertFloatValue) {
 TYPED_TEST(FloatTypeTest, InsertNegativeFloat) {
     FloatType const obj{.id = 0, .value = -123.456f, .label = "negative"};
 
-    auto result = this->qs->insert(obj);
+    auto result = this->qs->insert(obj).execute();
     ASSERT_TRUE(result.has_value());
 
-    auto selected = this->qs->select();
+    auto selected = this->qs->select().execute();
     ASSERT_TRUE(selected.has_value());
     EXPECT_NEAR(selected.value().begin()->value, -123.456f, 0.001f);
 }
@@ -1432,10 +1434,10 @@ TYPED_TEST(FloatTypeTest, BatchFloatValues) {
             {0, 3.3f, "third"},
     };
 
-    auto result = this->qs->insert(std::span<const FloatType>(batch));
+    auto result = this->qs->insert(std::span<const FloatType>(batch)).execute();
     ASSERT_TRUE(result.has_value());
 
-    auto selected = this->qs->select();
+    auto selected = this->qs->select().execute();
     ASSERT_TRUE(selected.has_value());
     EXPECT_EQ(selected.value().size(), 3);
 }
@@ -1485,7 +1487,7 @@ template <typename ConnType> class QueryResetTest : public ::testing::Test {
         };
 
         for (const auto& person : people) {
-            (void)qs->insert(person);
+            (void)qs->insert(person).execute();
         }
     }
 
@@ -1512,32 +1514,32 @@ TYPED_TEST(QueryResetTest, ResetClearsAllState) {
             .limit(2)
             .offset(1);
 
-    auto result1 = this->qs->select();
+    auto result1 = this->qs->select().execute();
     ASSERT_TRUE(result1.has_value());
     EXPECT_LE(result1.value().size(), 2);
 
     // Reset should clear all state
     this->qs->reset();
 
-    auto result2 = this->qs->select();
+    auto result2 = this->qs->select().execute();
     ASSERT_TRUE(result2.has_value());
     EXPECT_EQ(result2.value().size(), 5); // All 5 records
 }
 
 TYPED_TEST(QueryResetTest, ReuseSameQuerySetMultipleTimes) {
     // First query
-    auto result1 = this->qs->where(storm::orm::where::field<^^ResetPerson::score>() > 150).select();
+    auto result1 = this->qs->where(storm::orm::where::field<^^ResetPerson::score>() > 150).select().execute();
     ASSERT_TRUE(result1.has_value());
     EXPECT_EQ(result1.value().size(), 2); // Bob (200), Diana (180)
 
     // Second query with same WHERE (should work due to caching)
-    auto result2 = this->qs->select();
+    auto result2 = this->qs->select().execute();
     ASSERT_TRUE(result2.has_value());
     EXPECT_EQ(result2.value().size(), 2);
 
     // Reset and new query
     this->qs->reset();
-    auto result3 = this->qs->where(storm::orm::where::field<^^ResetPerson::score>() < 130).select();
+    auto result3 = this->qs->where(storm::orm::where::field<^^ResetPerson::score>() < 130).select().execute();
     ASSERT_TRUE(result3.has_value());
     EXPECT_EQ(result3.value().size(), 2); // Alice (100), Eve (120)
 }

--- a/tests/test_distinct.cpp
+++ b/tests/test_distinct.cpp
@@ -142,7 +142,7 @@ TYPED_TEST(DistinctTest, DistinctNameFieldWithDuplicates) {
     std::vector<DistinctPerson> people_to_insert =
             {{1, "Alice", 30}, {2, "Bob", 25}, {3, "Alice", 35}, {4, "Charlie", 40}, {5, "Bob", 28}};
 
-    auto insert_result = queryset.insert(std::span<const DistinctPerson>(people_to_insert));
+    auto insert_result = queryset.insert(std::span<const DistinctPerson>(people_to_insert)).execute();
     ASSERT_TRUE(insert_result.has_value()) << "INSERT failed: " << insert_result.error().message();
 
     // SELECT DISTINCT name
@@ -167,7 +167,7 @@ TYPED_TEST(DistinctTest, DistinctAgeFieldWithDuplicates) {
     std::vector<DistinctPerson> people_to_insert =
             {{1, "Alice", 30}, {2, "Bob", 25}, {3, "Charlie", 30}, {4, "Dave", 25}, {5, "Eve", 35}};
 
-    auto insert_result = queryset.insert(std::span<const DistinctPerson>(people_to_insert));
+    auto insert_result = queryset.insert(std::span<const DistinctPerson>(people_to_insert)).execute();
     ASSERT_TRUE(insert_result.has_value());
 
     // SELECT DISTINCT age
@@ -191,7 +191,7 @@ TYPED_TEST(DistinctTest, DistinctDefaultsToPrimaryKey) {
     // Insert people
     std::vector<DistinctPerson> people_to_insert = {{1, "Alice", 30}, {2, "Bob", 25}, {3, "Charlie", 35}};
 
-    auto insert_result = queryset.insert(std::span<const DistinctPerson>(people_to_insert));
+    auto insert_result = queryset.insert(std::span<const DistinctPerson>(people_to_insert)).execute();
     ASSERT_TRUE(insert_result.has_value());
 
     // SELECT DISTINCT (defaults to PK)
@@ -215,7 +215,7 @@ TYPED_TEST(DistinctTest, DistinctNameFieldAllUnique) {
     // Insert people with all unique names
     std::vector<DistinctPerson> people_to_insert = {{1, "Alice", 30}, {2, "Bob", 25}, {3, "Charlie", 35}};
 
-    auto insert_result = queryset.insert(std::span<const DistinctPerson>(people_to_insert));
+    auto insert_result = queryset.insert(std::span<const DistinctPerson>(people_to_insert)).execute();
     ASSERT_TRUE(insert_result.has_value());
 
     // SELECT DISTINCT name
@@ -244,7 +244,7 @@ TYPED_TEST(DistinctTest, DistinctWithSingleRow) {
 
     // Insert one person
     DistinctPerson const alice{.id = 0, .name = "Alice", .age = 30};
-    auto                 insert_result = queryset.insert(alice);
+    auto                 insert_result = queryset.insert(alice).execute();
     ASSERT_TRUE(insert_result.has_value());
 
     // SELECT DISTINCT name
@@ -267,7 +267,7 @@ TYPED_TEST(DistinctTest, DistinctWithLargeDataset) {
         people_to_insert.emplace_back(i, std::format("Name{}", pattern), 20 + pattern);
     }
 
-    auto insert_result = queryset.insert(std::span<const DistinctPerson>(people_to_insert));
+    auto insert_result = queryset.insert(std::span<const DistinctPerson>(people_to_insert)).execute();
     ASSERT_TRUE(insert_result.has_value());
 
     // SELECT DISTINCT name
@@ -285,7 +285,7 @@ TYPED_TEST(DistinctTest, DistinctWithEmptyStrings) {
     // Insert people with empty and non-empty names
     std::vector<DistinctPerson> people_to_insert = {{1, "", 25}, {2, "", 30}, {3, "Alice", 25}, {4, "", 35}};
 
-    auto insert_result = queryset.insert(std::span<const DistinctPerson>(people_to_insert));
+    auto insert_result = queryset.insert(std::span<const DistinctPerson>(people_to_insert)).execute();
     ASSERT_TRUE(insert_result.has_value());
 
     // SELECT DISTINCT name
@@ -305,7 +305,7 @@ TYPED_TEST(DistinctTest, VerifyReturnTypes) {
     QuerySet<DistinctPerson, TypeParam> queryset;
 
     // Insert test data
-    std::ignore = queryset.insert(DistinctPerson{.id = 0, .name = "Alice", .age = 30});
+    std::ignore = queryset.insert(DistinctPerson{.id = 0, .name = "Alice", .age = 30}).execute();
 
     // Verify return type for distinct on name field is hive of strings
     auto names_result = queryset.template distinct<^^DistinctPerson::name>().select();
@@ -336,7 +336,7 @@ TYPED_TEST(DistinctTest, DistinctTwoFieldsNameAndAge) {
             {6, "Charlie", 30} // Different name, same age as Alice#1
     };
 
-    auto insert_result = queryset.insert(std::span<const DistinctPerson>(people_to_insert));
+    auto insert_result = queryset.insert(std::span<const DistinctPerson>(people_to_insert)).execute();
     ASSERT_TRUE(insert_result.has_value());
 
     // SELECT DISTINCT name, age
@@ -369,7 +369,7 @@ TYPED_TEST(DistinctTest, DistinctThreeFieldsAllFields) {
             {5, "Bob", 30}    // Same name as #2, same age as #1
     };
 
-    auto insert_result = queryset.insert(std::span<const DistinctPerson>(people_to_insert));
+    auto insert_result = queryset.insert(std::span<const DistinctPerson>(people_to_insert)).execute();
     ASSERT_TRUE(insert_result.has_value());
 
     // SELECT DISTINCT name, age (should return 4 unique combinations)
@@ -398,7 +398,7 @@ TYPED_TEST(DistinctTest, DistinctTwoFieldsAllDuplicates) {
         people_to_insert.emplace_back(i, "SameName", 42);
     }
 
-    auto insert_result = queryset.insert(std::span<const DistinctPerson>(people_to_insert));
+    auto insert_result = queryset.insert(std::span<const DistinctPerson>(people_to_insert)).execute();
     ASSERT_TRUE(insert_result.has_value());
 
     // SELECT DISTINCT name, age
@@ -436,7 +436,7 @@ TYPED_TEST(DistinctTest, DistinctTwoFieldsLargeDataset) {
         people_to_insert.emplace_back(i, std::format("DistinctPerson{}", combo_idx / 10), 20 + (combo_idx % 10));
     }
 
-    auto insert_result = queryset.insert(std::span<const DistinctPerson>(people_to_insert));
+    auto insert_result = queryset.insert(std::span<const DistinctPerson>(people_to_insert)).execute();
     ASSERT_TRUE(insert_result.has_value());
 
     // SELECT DISTINCT name, age
@@ -457,7 +457,7 @@ TYPED_TEST(DistinctTest, DistinctTwoFieldsDifferentOrder) {
     std::vector<DistinctPerson> people_to_insert =
             {{1, "Alice", 30}, {2, "Bob", 25}, {3, "Alice", 30}, {4, "Charlie", 25}};
 
-    auto insert_result = queryset.insert(std::span<const DistinctPerson>(people_to_insert));
+    auto insert_result = queryset.insert(std::span<const DistinctPerson>(people_to_insert)).execute();
     ASSERT_TRUE(insert_result.has_value());
 
     // SELECT DISTINCT age, name (reversed order)
@@ -479,7 +479,7 @@ TYPED_TEST(DistinctTest, VerifyMultiFieldReturnTypes) {
     QuerySet<DistinctPerson, TypeParam> queryset;
 
     // Insert test data
-    std::ignore = queryset.insert(DistinctPerson{.id = 0, .name = "Alice", .age = 30});
+    std::ignore = queryset.insert(DistinctPerson{.id = 0, .name = "Alice", .age = 30}).execute();
 
     // Verify return type for distinct on name and age is hive of tuples containing string and int
     auto pairs_result = queryset.template distinct<^^DistinctPerson::name, ^^DistinctPerson::age>().select();
@@ -495,7 +495,7 @@ TYPED_TEST(DistinctTest, DistinctTwoFieldsWithSingleRow) {
     QuerySet<DistinctPerson, TypeParam> queryset;
 
     DistinctPerson const alice{.id = 0, .name = "Alice", .age = 30};
-    auto                 insert_result = queryset.insert(alice);
+    auto                 insert_result = queryset.insert(alice).execute();
     ASSERT_TRUE(insert_result.has_value());
 
     auto result = queryset.template distinct<^^DistinctPerson::name, ^^DistinctPerson::age>().select();
@@ -517,7 +517,7 @@ TYPED_TEST(DistinctTest, DuplicateFieldSpecification) {
             {1, "Alice", 30}, {2, "Bob", 25}, {3, "Alice", 35} // Different Alice (different age)
     };
 
-    auto insert_result = queryset.insert(std::span<const DistinctPerson>(people));
+    auto insert_result = queryset.insert(std::span<const DistinctPerson>(people)).execute();
     ASSERT_TRUE(insert_result.has_value());
 
     // SELECT DISTINCT name, name (redundant but valid SQL)
@@ -548,7 +548,7 @@ TYPED_TEST(DistinctTest, TriplicateFieldSpecification) {
     QuerySet<DistinctPerson, TypeParam> queryset;
 
     std::vector<DistinctPerson> people = {{1, "Alice", 30}, {2, "Bob", 25}};
-    std::ignore                        = queryset.insert(std::span<const DistinctPerson>(people));
+    std::ignore                        = queryset.insert(std::span<const DistinctPerson>(people)).execute();
 
     // SELECT DISTINCT age, age, age (extreme redundancy)
     auto result =
@@ -599,7 +599,7 @@ TYPED_TEST(DistinctTest, CrossStructFieldAccessPrevented) {
 // Test: Return type verification for duplicate fields
 TYPED_TEST(DistinctTest, VerifyDuplicateFieldReturnTypes) {
     QuerySet<DistinctPerson, TypeParam> queryset;
-    std::ignore = queryset.insert(DistinctPerson{.id = 0, .name = "Alice", .age = 30});
+    std::ignore = queryset.insert(DistinctPerson{.id = 0, .name = "Alice", .age = 30}).execute();
 
     // Duplicate field returns tuple with same type repeated
     auto dup_result = queryset.template distinct<^^DistinctPerson::name, ^^DistinctPerson::name>().select();
@@ -618,7 +618,7 @@ TYPED_TEST(DistinctTest, MixedDuplicateFields) {
     std::vector<DistinctPerson> people = {
             {1, "Alice", 30}, {2, "Bob", 25}, {3, "Alice", 30} // Duplicate (name, age)
     };
-    std::ignore = queryset.insert(std::span<const DistinctPerson>(people));
+    std::ignore = queryset.insert(std::span<const DistinctPerson>(people)).execute();
 
     // SELECT DISTINCT name, age, name (name appears twice)
     auto result = queryset.template distinct<^^DistinctPerson::name, ^^DistinctPerson::age, ^^DistinctPerson::name>()
@@ -907,7 +907,7 @@ TYPED_TEST(DistinctTest, DistinctWithWhereSingleField) {
             {0, "David", 35},   // Unique
     };
 
-    auto insert_result = queryset.insert(people);
+    auto insert_result = queryset.insert(people).execute();
     ASSERT_TRUE(insert_result.has_value());
 
     // SELECT DISTINCT name WHERE age > 22
@@ -941,7 +941,7 @@ TYPED_TEST(DistinctTest, DistinctWithWhereMultipleFields) {
             {0, "Alice", 35},
     };
 
-    auto insert_result = queryset.insert(people);
+    auto insert_result = queryset.insert(people).execute();
     ASSERT_TRUE(insert_result.has_value());
 
     // SELECT DISTINCT name, age WHERE age > 22
@@ -971,7 +971,7 @@ TYPED_TEST(DistinctTest, DistinctWithWhereNoResults) {
             {0, "Bob", 30},
     };
 
-    auto insert_result = queryset.insert(people);
+    auto insert_result = queryset.insert(people).execute();
     ASSERT_TRUE(insert_result.has_value());
 
     // SELECT DISTINCT name WHERE age > 100 (no matches)
@@ -997,7 +997,7 @@ TYPED_TEST(DistinctTest, DistinctWithComplexWhere) {
             {0, "David", 40},
     };
 
-    auto insert_result = queryset.insert(people);
+    auto insert_result = queryset.insert(people).execute();
     ASSERT_TRUE(insert_result.has_value());
 
     // SELECT DISTINCT name WHERE age >= 25 AND age <= 35
@@ -1095,7 +1095,7 @@ TYPED_TEST(DistinctTest, DistinctDefaultPKWithWhere) {
             {0, "Charlie", 20},
     };
 
-    auto insert_result = queryset.insert(people);
+    auto insert_result = queryset.insert(people).execute();
     ASSERT_TRUE(insert_result.has_value());
 
     // SELECT DISTINCT id (default PK) WHERE age > 22
@@ -1117,7 +1117,7 @@ TYPED_TEST(DistinctTest, MultipleWhereClausesWithDistinct) {
             {0, "David", 35},
     };
 
-    auto insert_result = queryset.insert(people);
+    auto insert_result = queryset.insert(people).execute();
     ASSERT_TRUE(insert_result.has_value());
 
     // Chain multiple WHERE clauses (should combine with AND)
@@ -1188,7 +1188,7 @@ TYPED_TEST(DistinctTest, DistinctWithOrderByAsc) {
             {0, "Alice", 40}, // Duplicate name
     };
 
-    auto insert_result = queryset.insert(people);
+    auto insert_result = queryset.insert(people).execute();
     ASSERT_TRUE(insert_result.has_value());
 
     // SELECT DISTINCT name ORDER BY name ASC
@@ -1216,7 +1216,7 @@ TYPED_TEST(DistinctTest, DistinctWithOrderByDesc) {
             {0, "Bob", 35},
     };
 
-    auto insert_result = queryset.insert(people);
+    auto insert_result = queryset.insert(people).execute();
     ASSERT_TRUE(insert_result.has_value());
 
     // SELECT DISTINCT name ORDER BY name DESC
@@ -1246,7 +1246,7 @@ TYPED_TEST(DistinctTest, DistinctWithOrderByIntegerField) {
             {0, "Dave", 20}, // Duplicate age
     };
 
-    auto insert_result = queryset.insert(people);
+    auto insert_result = queryset.insert(people).execute();
     ASSERT_TRUE(insert_result.has_value());
 
     // SELECT DISTINCT age ORDER BY age ASC
@@ -1275,7 +1275,7 @@ TYPED_TEST(DistinctTest, DistinctMultiFieldWithOrderBy) {
             {0, "Alice", 30},
     };
 
-    auto insert_result = queryset.insert(people);
+    auto insert_result = queryset.insert(people).execute();
     ASSERT_TRUE(insert_result.has_value());
 
     // SELECT DISTINCT name, age ORDER BY name ASC
@@ -1308,7 +1308,7 @@ TYPED_TEST(DistinctTest, DistinctWithOrderByAndLimit) {
             {0, "Dave", 40},
     };
 
-    auto insert_result = queryset.insert(people);
+    auto insert_result = queryset.insert(people).execute();
     ASSERT_TRUE(insert_result.has_value());
 
     // SELECT DISTINCT name ORDER BY name ASC LIMIT 3
@@ -1340,7 +1340,7 @@ TYPED_TEST(DistinctTest, DistinctWithOrderByDescAndLimit) {
             {0, "Eve", 35},
     };
 
-    auto insert_result = queryset.insert(people);
+    auto insert_result = queryset.insert(people).execute();
     ASSERT_TRUE(insert_result.has_value());
 
     // SELECT DISTINCT name ORDER BY name DESC LIMIT 2
@@ -1371,7 +1371,7 @@ TYPED_TEST(DistinctTest, DistinctWithOrderByLimitOffset) {
             {0, "Eve", 35},
     };
 
-    auto insert_result = queryset.insert(people);
+    auto insert_result = queryset.insert(people).execute();
     ASSERT_TRUE(insert_result.has_value());
 
     // SELECT DISTINCT name ORDER BY name ASC LIMIT 2 OFFSET 2
@@ -1404,7 +1404,7 @@ TYPED_TEST(DistinctTest, DistinctWithWhereOrderByLimit) {
             {0, "Eve", 20}, // Filtered out by WHERE
     };
 
-    auto insert_result = queryset.insert(people);
+    auto insert_result = queryset.insert(people).execute();
     ASSERT_TRUE(insert_result.has_value());
 
     // SELECT DISTINCT name WHERE age > 25 ORDER BY name ASC LIMIT 2
@@ -1441,7 +1441,7 @@ TYPED_TEST(DistinctTest, DistinctOptionalIntFieldWithNulls) {
             {0, "Frank", std::nullopt, "Frankie"},   // Another NULL age
     };
 
-    auto insert_result = queryset.insert(people);
+    auto insert_result = queryset.insert(people).execute();
     ASSERT_TRUE(insert_result.has_value()) << "Insert failed: " << insert_result.error().message();
 
     // SELECT DISTINCT age (should include NULL as a distinct value)
@@ -1482,7 +1482,7 @@ TYPED_TEST(DistinctTest, DistinctOptionalStringFieldWithNulls) {
             {0, "Frank", 50, "Ali"}, // Another duplicate ("Ali")
     };
 
-    auto insert_result = queryset.insert(people);
+    auto insert_result = queryset.insert(people).execute();
     ASSERT_TRUE(insert_result.has_value()) << "Insert failed: " << insert_result.error().message();
 
     // SELECT DISTINCT nickname (should include NULL as a distinct value)
@@ -1526,7 +1526,7 @@ TYPED_TEST(DistinctTest, DistinctOptionalFieldAllNulls) {
             {0, "Charlie", std::nullopt, "Chuck"},
     };
 
-    auto insert_result = queryset.insert(people);
+    auto insert_result = queryset.insert(people).execute();
     ASSERT_TRUE(insert_result.has_value());
 
     // SELECT DISTINCT age (all NULLs)
@@ -1550,7 +1550,7 @@ TYPED_TEST(DistinctTest, DistinctOptionalFieldNoNulls) {
             {0, "Charlie", 25, "Chuck"}, // Duplicate age
     };
 
-    auto insert_result = queryset.insert(people);
+    auto insert_result = queryset.insert(people).execute();
     ASSERT_TRUE(insert_result.has_value());
 
     // SELECT DISTINCT age (no NULLs)
@@ -1579,7 +1579,7 @@ TYPED_TEST(DistinctTest, DistinctMultiFieldWithOptional) {
             {0, "Bob", std::nullopt, "Bobby"}, // Same name as above, NULL age
     };
 
-    auto insert_result = queryset.insert(people);
+    auto insert_result = queryset.insert(people).execute();
     ASSERT_TRUE(insert_result.has_value());
 
     // SELECT DISTINCT name, age
@@ -1603,7 +1603,7 @@ TYPED_TEST(DistinctTest, DistinctOptionalWithWhereOnOptional) {
             {0, "Dave", std::nullopt, "Davey"},
     };
 
-    auto insert_result = queryset.insert(people);
+    auto insert_result = queryset.insert(people).execute();
     ASSERT_TRUE(insert_result.has_value());
 
     // SELECT DISTINCT name WHERE age > 20 (filters out NULLs)
@@ -1634,7 +1634,7 @@ TYPED_TEST(DistinctTest, DistinctOptionalWithOrderBy) {
             {0, "Dave", std::nullopt, "Davey"},
     };
 
-    auto insert_result = queryset.insert(people);
+    auto insert_result = queryset.insert(people).execute();
     ASSERT_TRUE(insert_result.has_value());
 
     // SELECT DISTINCT age ORDER BY age ASC
@@ -1658,7 +1658,7 @@ TYPED_TEST(DistinctTest, DistinctReturnsExpectedType) {
     QuerySet<DistinctPerson, TypeParam> queryset;
 
     // Insert test data
-    std::ignore = queryset.insert(DistinctPerson{.id = 0, .name = "Alice", .age = 30});
+    std::ignore = queryset.insert(DistinctPerson{.id = 0, .name = "Alice", .age = 30}).execute();
 
     // Verify return type is std::expected
     auto result = queryset.template distinct<^^DistinctPerson::name>().select();
@@ -1723,7 +1723,7 @@ TYPED_TEST(DistinctTest, ErrorHandlingInChainedOperations) {
 
     // Insert valid data
     std::vector<DistinctPerson> people        = {{0, "Alice", 25}, {0, "Bob", 30}};
-    auto                        insert_result = queryset.insert(people);
+    auto                        insert_result = queryset.insert(people).execute();
     ASSERT_TRUE(insert_result.has_value());
 
     // Test that chained operations properly propagate results
@@ -1745,7 +1745,7 @@ TYPED_TEST(DistinctTest, NoMatchingRowsReturnsEmptyNotError) {
 
     // Insert data
     std::vector<DistinctPerson> people = {{0, "Alice", 25}, {0, "Bob", 30}};
-    std::ignore                        = queryset.insert(people);
+    std::ignore                        = queryset.insert(people).execute();
 
     // Query with WHERE that matches nothing
     auto result =
@@ -1766,7 +1766,7 @@ TYPED_TEST(DistinctTest, StatementReuseStability) {
             {0, "Bob", 30},
             {0, "Charlie", 35},
     };
-    std::ignore = queryset.insert(people);
+    std::ignore = queryset.insert(people).execute();
 
     // Execute the same DISTINCT query multiple times
     // This tests that statement caching works correctly
@@ -1788,7 +1788,7 @@ TYPED_TEST(DistinctTest, DifferentWhereExpressionsWithCaching) {
             {0, "Charlie", 35},
             {0, "Dave", 40},
     };
-    std::ignore = queryset.insert(people);
+    std::ignore = queryset.insert(people).execute();
 
     // Query 1: age > 25
     auto result1 =

--- a/tests/test_fk_fields.cpp
+++ b/tests/test_fk_fields.cpp
@@ -85,8 +85,8 @@ TYPED_TEST(FKFieldTest, InsertWithFKField) {
     // Insert users first
     FKUser const alice{.id = 0, .name = "Alice", .age = 30};
     FKUser const bob{.id = 0, .name = "Bob", .age = 25};
-    auto         alice_result = user_qs.insert(alice);
-    auto         bob_result   = user_qs.insert(bob);
+    auto         alice_result = user_qs.insert(alice).execute();
+    auto         bob_result   = user_qs.insert(bob).execute();
     ASSERT_TRUE(alice_result.has_value()) << "Alice INSERT failed: " << alice_result.error().message();
     ASSERT_TRUE(bob_result.has_value()) << "Bob INSERT failed: " << bob_result.error().message();
 
@@ -102,7 +102,7 @@ TYPED_TEST(FKFieldTest, InsertWithFKField) {
             .text     = "Hello World"
     };
 
-    auto msg_result = message_qs.insert(msg);
+    auto msg_result = message_qs.insert(msg).execute();
     ASSERT_TRUE(msg_result.has_value()) << "FKMessage INSERT failed: " << msg_result.error().message();
 
     int64_t const msg_id = msg_result.value();
@@ -133,8 +133,8 @@ TYPED_TEST(FKFieldTest, SelectWithFKFieldPartialPopulation) {
     // Insert users
     FKUser const bob{.id = 0, .name = "Bob", .age = 25};
     FKUser const charlie{.id = 0, .name = "Charlie", .age = 35};
-    auto         bob_result     = user_qs.insert(bob);
-    auto         charlie_result = user_qs.insert(charlie);
+    auto         bob_result     = user_qs.insert(bob).execute();
+    auto         charlie_result = user_qs.insert(charlie).execute();
     ASSERT_TRUE(bob_result.has_value());
     ASSERT_TRUE(charlie_result.has_value());
     int64_t const bob_id     = bob_result.value();
@@ -147,11 +147,11 @@ TYPED_TEST(FKFieldTest, SelectWithFKFieldPartialPopulation) {
             .receiver = FKUser{.id = static_cast<int>(charlie_id), .name = "", .age = 0},
             .text     = "Test message"
     };
-    auto msg_result = message_qs.insert(msg);
+    auto msg_result = message_qs.insert(msg).execute();
     ASSERT_TRUE(msg_result.has_value());
 
     // SELECT messages
-    auto select_result = message_qs.select();
+    auto select_result = message_qs.select().execute();
     ASSERT_TRUE(select_result.has_value()) << "SELECT failed: " << select_result.error().message();
 
     const auto& messages = select_result.value();
@@ -178,11 +178,11 @@ TYPED_TEST(FKFieldTest, BatchInsertWithFKFields) {
 
     // Insert users (IDs will be auto-generated)
     std::vector<FKUser> users       = {{0, "Alice", 30}, {0, "Bob", 25}, {0, "Charlie", 35}, {0, "Dave", 40}};
-    auto                user_result = user_qs.insert(users);
+    auto                user_result = user_qs.insert(users).execute();
     ASSERT_TRUE(user_result.has_value());
 
     // SELECT to get auto-generated user IDs
-    auto user_select = user_qs.select();
+    auto user_select = user_qs.select().execute();
     ASSERT_TRUE(user_select.has_value());
     ASSERT_EQ(user_select.value().size(), 4);
 
@@ -200,11 +200,11 @@ TYPED_TEST(FKFieldTest, BatchInsertWithFKFields) {
               FKUser{.id = first_user_id, .name = "", .age = 0},
               "FKMessage from Charlie to Dave"}};
 
-    auto msg_result = message_qs.insert(messages);
+    auto msg_result = message_qs.insert(messages).execute();
     ASSERT_TRUE(msg_result.has_value()) << "Batch INSERT failed: " << msg_result.error().message();
 
     // Verify messages were stored
-    auto select_result = message_qs.select();
+    auto select_result = message_qs.select().execute();
     ASSERT_TRUE(select_result.has_value());
 
     const auto& retrieved_messages = select_result.value();
@@ -230,10 +230,10 @@ TYPED_TEST(FKFieldTest, UpdateWithFKField) {
     FKUser const charlie{.id = 0, .name = "Charlie", .age = 35};
     FKUser const dave{.id = 0, .name = "Dave", .age = 40};
 
-    auto alice_result   = user_qs.insert(alice);
-    auto bob_result     = user_qs.insert(bob);
-    auto charlie_result = user_qs.insert(charlie);
-    auto dave_result    = user_qs.insert(dave);
+    auto alice_result   = user_qs.insert(alice).execute();
+    auto bob_result     = user_qs.insert(bob).execute();
+    auto charlie_result = user_qs.insert(charlie).execute();
+    auto dave_result    = user_qs.insert(dave).execute();
 
     ASSERT_TRUE(alice_result.has_value());
     ASSERT_TRUE(bob_result.has_value());
@@ -252,7 +252,7 @@ TYPED_TEST(FKFieldTest, UpdateWithFKField) {
             .receiver = FKUser{.id = static_cast<int>(bob_id), .name = "", .age = 0},
             .text     = "Original message"
     };
-    auto msg_result = message_qs.insert(msg);
+    auto msg_result = message_qs.insert(msg).execute();
     ASSERT_TRUE(msg_result.has_value());
 
     int64_t const msg_id = msg_result.value();
@@ -265,11 +265,11 @@ TYPED_TEST(FKFieldTest, UpdateWithFKField) {
             .text     = "Updated message"
     };
 
-    auto update_result = message_qs.update(updated_msg);
+    auto update_result = message_qs.update(updated_msg).execute();
     ASSERT_TRUE(update_result.has_value()) << "UPDATE failed: " << update_result.error().message();
 
     // Verify update
-    auto select_result = message_qs.select();
+    auto select_result = message_qs.select().execute();
     ASSERT_TRUE(select_result.has_value());
 
     const auto& messages = select_result.value();
@@ -289,8 +289,8 @@ TYPED_TEST(FKFieldTest, DeleteWithFKField) {
     // Insert users
     FKUser const alice{.id = 0, .name = "Alice", .age = 30};
     FKUser const bob{.id = 0, .name = "Bob", .age = 25};
-    auto         alice_result = user_qs.insert(alice);
-    auto         bob_result   = user_qs.insert(bob);
+    auto         alice_result = user_qs.insert(alice).execute();
+    auto         bob_result   = user_qs.insert(bob).execute();
     ASSERT_TRUE(alice_result.has_value());
     ASSERT_TRUE(bob_result.has_value());
     int64_t const alice_id = alice_result.value();
@@ -307,11 +307,11 @@ TYPED_TEST(FKFieldTest, DeleteWithFKField) {
               FKUser{.id = static_cast<int>(bob_id), .name = "", .age = 0},
               "FKMessage 2"}};
 
-    auto msg_result = message_qs.insert(messages);
+    auto msg_result = message_qs.insert(messages).execute();
     ASSERT_TRUE(msg_result.has_value());
 
     // SELECT to get auto-generated message IDs
-    auto msg_select = message_qs.select();
+    auto msg_select = message_qs.select().execute();
     ASSERT_TRUE(msg_select.has_value());
     ASSERT_EQ(msg_select.value().size(), 2);
 
@@ -329,11 +329,11 @@ TYPED_TEST(FKFieldTest, DeleteWithFKField) {
             .text     = ""
     };
 
-    auto delete_result = message_qs.remove(to_delete);
+    auto delete_result = message_qs.remove(to_delete).execute();
     ASSERT_TRUE(delete_result.has_value()) << "DELETE failed: " << delete_result.error().message();
 
     // Verify only one message remains
-    auto select_result = message_qs.select();
+    auto select_result = message_qs.select().execute();
     ASSERT_TRUE(select_result.has_value());
 
     const auto& remaining_messages = select_result.value();
@@ -373,8 +373,8 @@ TYPED_TEST(FKFieldTest, MultipleFKFieldsToSameType) {
     FKUser const alice{.id = 0, .name = "Alice", .age = 30};
     FKUser const bob{.id = 0, .name = "Bob", .age = 25};
 
-    auto alice_result = user_qs.insert(alice);
-    auto bob_result   = user_qs.insert(bob);
+    auto alice_result = user_qs.insert(alice).execute();
+    auto bob_result   = user_qs.insert(bob).execute();
 
     ASSERT_TRUE(alice_result.has_value());
     ASSERT_TRUE(bob_result.has_value());
@@ -390,11 +390,11 @@ TYPED_TEST(FKFieldTest, MultipleFKFieldsToSameType) {
             .message  = "Hello Bob!"
     };
 
-    auto conv_result = conv_qs.insert(conv);
+    auto conv_result = conv_qs.insert(conv).execute();
     ASSERT_TRUE(conv_result.has_value()) << "Conversation INSERT failed: " << conv_result.error().message();
 
     // SELECT and verify both FK fields are populated
-    auto select_result = conv_qs.select();
+    auto select_result = conv_qs.select().execute();
     ASSERT_TRUE(select_result.has_value());
 
     const auto& conversations = select_result.value();
@@ -413,8 +413,8 @@ TYPED_TEST(FKFieldTest, JoinFullyPopulatesFKObject) {
     // Insert users
     FKUser const alice{.id = 0, .name = "Alice", .age = 30};
     FKUser const bob{.id = 0, .name = "Bob", .age = 25};
-    auto         alice_result = user_qs.insert(alice);
-    auto         bob_result   = user_qs.insert(bob);
+    auto         alice_result = user_qs.insert(alice).execute();
+    auto         bob_result   = user_qs.insert(bob).execute();
     ASSERT_TRUE(alice_result.has_value());
     ASSERT_TRUE(bob_result.has_value());
     int64_t const alice_id = alice_result.value();
@@ -427,11 +427,11 @@ TYPED_TEST(FKFieldTest, JoinFullyPopulatesFKObject) {
             .receiver = FKUser{.id = static_cast<int>(bob_id), .name = "", .age = 0},
             .text     = "Hello from JOIN!"
     };
-    auto msg_result = message_qs.insert(msg);
+    auto msg_result = message_qs.insert(msg).execute();
     ASSERT_TRUE(msg_result.has_value());
 
     // Phase 2: JOIN to get fully populated sender
-    auto join_result = message_qs.template join<&FKMessage::sender>().select();
+    auto join_result = message_qs.template join<&FKMessage::sender>().select().execute();
     ASSERT_TRUE(join_result.has_value()) << "JOIN failed: " << join_result.error().message();
 
     const auto& messages = join_result.value();
@@ -461,8 +461,8 @@ TYPED_TEST(FKFieldTest, JoinMultipleFKFields) {
     // Insert users
     FKUser const alice{.id = 0, .name = "Alice", .age = 30};
     FKUser const bob{.id = 0, .name = "Bob", .age = 25};
-    auto         alice_result = user_qs.insert(alice);
-    auto         bob_result   = user_qs.insert(bob);
+    auto         alice_result = user_qs.insert(alice).execute();
+    auto         bob_result   = user_qs.insert(bob).execute();
     ASSERT_TRUE(alice_result.has_value());
     ASSERT_TRUE(bob_result.has_value());
     int64_t const alice_id = alice_result.value();
@@ -475,11 +475,11 @@ TYPED_TEST(FKFieldTest, JoinMultipleFKFields) {
             .receiver = FKUser{.id = static_cast<int>(bob_id), .name = "", .age = 0},
             .text     = "Hello from multi-JOIN!"
     };
-    auto msg_result = message_qs.insert(msg);
+    auto msg_result = message_qs.insert(msg).execute();
     ASSERT_TRUE(msg_result.has_value());
 
     // Phase 3: Multi-JOIN to get BOTH sender and receiver fully populated
-    auto join_result = message_qs.template join<&FKMessage::sender, &FKMessage::receiver>().select();
+    auto join_result = message_qs.template join<&FKMessage::sender, &FKMessage::receiver>().select().execute();
     ASSERT_TRUE(join_result.has_value()) << "Multi-JOIN failed: " << join_result.error().message();
 
     const auto& messages = join_result.value();
@@ -507,7 +507,7 @@ TYPED_TEST(FKFieldTest, LeftJoinReturnsAllMessages) {
 
     // Insert only one user (Alice)
     FKUser const alice{.id = 0, .name = "Alice", .age = 30};
-    auto         alice_result = user_qs.insert(alice);
+    auto         alice_result = user_qs.insert(alice).execute();
     ASSERT_TRUE(alice_result.has_value());
     int64_t const alice_id = alice_result.value();
 
@@ -526,7 +526,7 @@ TYPED_TEST(FKFieldTest, LeftJoinReturnsAllMessages) {
     ASSERT_EQ(step_result, decltype(stmt)::NO_MORE_ROWS) << "Direct INSERT failed";
 
     // LEFT JOIN on sender - should return message even though receiver doesn't exist
-    auto join_result = message_qs.template left_join<&FKMessage::sender>().select();
+    auto join_result = message_qs.template left_join<&FKMessage::sender>().select().execute();
     ASSERT_TRUE(join_result.has_value()) << "LEFT JOIN failed: " << join_result.error().message();
 
     const auto& messages = join_result.value();
@@ -553,8 +553,8 @@ TYPED_TEST(FKFieldTest, LeftJoinMultipleFKFields) {
     // Insert users
     FKUser const alice{.id = 0, .name = "Alice", .age = 30};
     FKUser const bob{.id = 0, .name = "Bob", .age = 25};
-    auto         alice_result = user_qs.insert(alice);
-    auto         bob_result   = user_qs.insert(bob);
+    auto         alice_result = user_qs.insert(alice).execute();
+    auto         bob_result   = user_qs.insert(bob).execute();
     ASSERT_TRUE(alice_result.has_value());
     ASSERT_TRUE(bob_result.has_value());
     int64_t const alice_id = alice_result.value();
@@ -567,11 +567,11 @@ TYPED_TEST(FKFieldTest, LeftJoinMultipleFKFields) {
             .receiver = FKUser{.id = static_cast<int>(bob_id), .name = "", .age = 0},
             .text     = "Hello with LEFT JOIN"
     };
-    auto msg_result = message_qs.insert(msg);
+    auto msg_result = message_qs.insert(msg).execute();
     ASSERT_TRUE(msg_result.has_value());
 
     // LEFT JOIN on both sender and receiver
-    auto join_result = message_qs.template left_join<&FKMessage::sender, &FKMessage::receiver>().select();
+    auto join_result = message_qs.template left_join<&FKMessage::sender, &FKMessage::receiver>().select().execute();
     ASSERT_TRUE(join_result.has_value()) << "Multi LEFT JOIN failed: " << join_result.error().message();
 
     const auto& messages = join_result.value();
@@ -601,9 +601,9 @@ TYPED_TEST(FKFieldTest, RightJoinBehavior) {
     FKUser const alice{.id = 0, .name = "Alice", .age = 30};
     FKUser const bob{.id = 0, .name = "Bob", .age = 25};
     FKUser const charlie{.id = 0, .name = "Charlie", .age = 35}; // Charlie has no messages
-    auto         alice_result   = user_qs.insert(alice);
-    auto         bob_result     = user_qs.insert(bob);
-    auto         charlie_result = user_qs.insert(charlie);
+    auto         alice_result   = user_qs.insert(alice).execute();
+    auto         bob_result     = user_qs.insert(bob).execute();
+    auto         charlie_result = user_qs.insert(charlie).execute();
     ASSERT_TRUE(alice_result.has_value());
     ASSERT_TRUE(bob_result.has_value());
     ASSERT_TRUE(charlie_result.has_value());
@@ -618,12 +618,12 @@ TYPED_TEST(FKFieldTest, RightJoinBehavior) {
             .receiver = FKUser{.id = static_cast<int>(bob_id), .name = "", .age = 0},
             .text     = "FKMessage to Bob"
     };
-    auto msg_result = message_qs.insert(msg);
+    auto msg_result = message_qs.insert(msg).execute();
     ASSERT_TRUE(msg_result.has_value());
 
     // RIGHT JOIN on sender - should return all users in FKUser table as senders
     // This includes Charlie even though no message references him
-    auto join_result = message_qs.template right_join<&FKMessage::sender>().select();
+    auto join_result = message_qs.template right_join<&FKMessage::sender>().select().execute();
     ASSERT_TRUE(join_result.has_value()) << "RIGHT JOIN failed: " << join_result.error().message();
 
     const auto& messages = join_result.value();
@@ -656,8 +656,8 @@ TYPED_TEST(FKFieldTest, RightJoinMultipleFKFields) {
     // Insert users
     FKUser const alice{.id = 0, .name = "Alice", .age = 30};
     FKUser const bob{.id = 0, .name = "Bob", .age = 25};
-    auto         alice_result = user_qs.insert(alice);
-    auto         bob_result   = user_qs.insert(bob);
+    auto         alice_result = user_qs.insert(alice).execute();
+    auto         bob_result   = user_qs.insert(bob).execute();
     ASSERT_TRUE(alice_result.has_value());
     ASSERT_TRUE(bob_result.has_value());
     int64_t const alice_id = alice_result.value();
@@ -670,11 +670,11 @@ TYPED_TEST(FKFieldTest, RightJoinMultipleFKFields) {
             .receiver = FKUser{.id = static_cast<int>(bob_id), .name = "", .age = 0},
             .text     = "Hello with RIGHT JOIN"
     };
-    auto msg_result = message_qs.insert(msg);
+    auto msg_result = message_qs.insert(msg).execute();
     ASSERT_TRUE(msg_result.has_value());
 
     // RIGHT JOIN on both sender and receiver
-    auto join_result = message_qs.template right_join<&FKMessage::sender, &FKMessage::receiver>().select();
+    auto join_result = message_qs.template right_join<&FKMessage::sender, &FKMessage::receiver>().select().execute();
     ASSERT_TRUE(join_result.has_value()) << "Multi RIGHT JOIN failed: " << join_result.error().message();
 
     const auto& messages = join_result.value();
@@ -767,7 +767,7 @@ TYPED_TEST(NullableFKTest, SelectWithNullFKField) {
     ASSERT_EQ(step_result, decltype(stmt)::NO_MORE_ROWS);
 
     // SELECT should handle NULL FK gracefully
-    auto select_result = message_qs.select();
+    auto select_result = message_qs.select().execute();
     ASSERT_TRUE(select_result.has_value()) << "SELECT with NULL FK failed: " << select_result.error().message();
 
     const auto& messages = select_result.value();
@@ -788,7 +788,7 @@ TYPED_TEST(NullableFKTest, LeftJoinWithNullFKField) {
 
     // Insert a user
     FKUser const alice{.id = 0, .name = "Alice", .age = 30};
-    auto         alice_result = user_qs.insert(alice);
+    auto         alice_result = user_qs.insert(alice).execute();
     ASSERT_TRUE(alice_result.has_value());
     int64_t const alice_id = alice_result.value();
 
@@ -805,7 +805,7 @@ TYPED_TEST(NullableFKTest, LeftJoinWithNullFKField) {
     ASSERT_EQ(step_result, decltype(stmt)::NO_MORE_ROWS);
 
     // LEFT JOIN on sender - should return message even with NULL sender_id
-    auto join_result = message_qs.template left_join<&FKMessage::sender>().select();
+    auto join_result = message_qs.template left_join<&FKMessage::sender>().select().execute();
     ASSERT_TRUE(join_result.has_value()) << "LEFT JOIN with NULL FK failed: " << join_result.error().message();
 
     const auto& messages = join_result.value();
@@ -828,8 +828,8 @@ TYPED_TEST(NullableFKTest, LeftJoinWithMixedNullAndValidFKs) {
     // Insert users
     FKUser const alice{.id = 0, .name = "Alice", .age = 30};
     FKUser const bob{.id = 0, .name = "Bob", .age = 25};
-    auto         alice_result = user_qs.insert(alice);
-    auto         bob_result   = user_qs.insert(bob);
+    auto         alice_result = user_qs.insert(alice).execute();
+    auto         bob_result   = user_qs.insert(bob).execute();
     ASSERT_TRUE(alice_result.has_value());
     ASSERT_TRUE(bob_result.has_value());
     int64_t const alice_id = alice_result.value();
@@ -855,7 +855,7 @@ TYPED_TEST(NullableFKTest, LeftJoinWithMixedNullAndValidFKs) {
     ASSERT_EQ(stm2.step_raw(), decltype(stm2)::NO_MORE_ROWS);
 
     // LEFT JOIN should return both messages
-    auto join_result = message_qs.template left_join<&FKMessage::sender>().select();
+    auto join_result = message_qs.template left_join<&FKMessage::sender>().select().execute();
     ASSERT_TRUE(join_result.has_value());
 
     const auto& messages = join_result.value();
@@ -964,8 +964,8 @@ TYPED_TEST(ExtendedTypesJoinTest, JoinWithExtendedTypes) {
             .id = 0, .name = "Bob Johnson", .salary = 87500.75, .is_active = false, .nickname = std::nullopt
     };
 
-    auto alice_result = employee_qs.insert(alice);
-    auto bob_result   = employee_qs.insert(bob);
+    auto alice_result = employee_qs.insert(alice).execute();
+    auto bob_result   = employee_qs.insert(bob).execute();
 
     ASSERT_TRUE(alice_result.has_value()) << "Failed to insert Alice: " << alice_result.error().message();
     ASSERT_TRUE(bob_result.has_value()) << "Failed to insert Bob: " << bob_result.error().message();
@@ -1001,14 +1001,14 @@ TYPED_TEST(ExtendedTypesJoinTest, JoinWithExtendedTypes) {
             .budget = 75000.0
     };
 
-    auto proj1_result = project_qs.insert(proj1);
-    auto proj2_result = project_qs.insert(proj2);
+    auto proj1_result = project_qs.insert(proj1).execute();
+    auto proj2_result = project_qs.insert(proj2).execute();
 
     ASSERT_TRUE(proj1_result.has_value()) << "Failed to insert project 1: " << proj1_result.error().message();
     ASSERT_TRUE(proj2_result.has_value()) << "Failed to insert project 2: " << proj2_result.error().message();
 
     // JOIN to get projects with fully populated manager (Employee) objects
-    auto join_result = project_qs.template join<&Project::manager>().select();
+    auto join_result = project_qs.template join<&Project::manager>().select().execute();
     ASSERT_TRUE(join_result.has_value()) << "JOIN failed: " << join_result.error().message();
 
     const auto& projects = join_result.value();
@@ -1102,8 +1102,8 @@ TYPED_TEST(ExtendedTypesJoinTest, MultiJoinWithExtendedTypes) {
     Employee const alice{.id = 0, .name = "Alice", .salary = 95000.0, .is_active = true, .nickname = "Ally"};
     Employee const bob{.id = 0, .name = "Bob", .salary = 87500.0, .is_active = false, .nickname = std::nullopt};
 
-    auto alice_result = employee_qs.insert(alice);
-    auto bob_result   = employee_qs.insert(bob);
+    auto alice_result = employee_qs.insert(alice).execute();
+    auto bob_result   = employee_qs.insert(bob).execute();
 
     ASSERT_TRUE(alice_result.has_value());
     ASSERT_TRUE(bob_result.has_value());
@@ -1133,12 +1133,12 @@ TYPED_TEST(ExtendedTypesJoinTest, MultiJoinWithExtendedTypes) {
             .description = "Implement feature X"
     };
 
-    auto task_result = task_qs.insert(task);
+    auto task_result = task_qs.insert(task).execute();
     ASSERT_TRUE(task_result.has_value());
 
     // Multi-JOIN to populate both assignee and reviewer
     // NOLINTNEXTLINE(readability-isolate-declaration) - false positive with template
-    auto join_result = task_qs.template join<&Task::assignee, &Task::reviewer>().select();
+    auto join_result = task_qs.template join<&Task::assignee, &Task::reviewer>().select().execute();
     ASSERT_TRUE(join_result.has_value()) << "Multi-JOIN failed: " << join_result.error().message();
 
     const auto& tasks = join_result.value();
@@ -1218,7 +1218,7 @@ TYPED_TEST(ExtendedTypesJoinTest, JoinWithFloatAndLongLongTypes) {
             .timestamp   = 1700000000000LL // Large timestamp
     };
 
-    auto meas_result = measurement_qs.insert(meas);
+    auto meas_result = measurement_qs.insert(meas).execute();
     ASSERT_TRUE(meas_result.has_value()) << "Failed to insert measurement: " << meas_result.error().message();
 
     int64_t const meas_id = meas_result.value();
@@ -1234,11 +1234,11 @@ TYPED_TEST(ExtendedTypesJoinTest, JoinWithFloatAndLongLongTypes) {
             .value        = 65.3F
     };
 
-    auto reading_result = reading_qs.insert(reading);
+    auto reading_result = reading_qs.insert(reading).execute();
     ASSERT_TRUE(reading_result.has_value()) << "Failed to insert reading: " << reading_result.error().message();
 
     // JOIN to get readings with fully populated measurement
-    auto join_result = reading_qs.template join<&Reading::measurement>().select();
+    auto join_result = reading_qs.template join<&Reading::measurement>().select().execute();
     ASSERT_TRUE(join_result.has_value()) << "JOIN failed: " << join_result.error().message();
 
     const auto& readings = join_result.value();
@@ -1305,7 +1305,7 @@ TYPED_TEST(ExtendedTypesJoinTest, JoinWithLongType) {
     // Insert counter with long value
     Counter const cnt{.id = 0, .name = "PageViews", .count = 9876543210L};
 
-    auto cnt_result = counter_qs.insert(cnt);
+    auto cnt_result = counter_qs.insert(cnt).execute();
     ASSERT_TRUE(cnt_result.has_value()) << "Failed to insert counter: " << cnt_result.error().message();
 
     int64_t const cnt_id = cnt_result.value();
@@ -1315,11 +1315,11 @@ TYPED_TEST(ExtendedTypesJoinTest, JoinWithLongType) {
             .id = 0, .counter = Counter{.id = static_cast<int>(cnt_id), .name = "", .count = 0L}, .report_type = "Daily"
     };
 
-    auto sum_result = summary_qs.insert(sum);
+    auto sum_result = summary_qs.insert(sum).execute();
     ASSERT_TRUE(sum_result.has_value()) << "Failed to insert summary: " << sum_result.error().message();
 
     // JOIN to get summaries with fully populated counter
-    auto join_result = summary_qs.template join<&Summary::counter>().select();
+    auto join_result = summary_qs.template join<&Summary::counter>().select().execute();
     ASSERT_TRUE(join_result.has_value()) << "JOIN failed: " << join_result.error().message();
 
     const auto& summaries = join_result.value();

--- a/tests/test_limit_offset.cpp
+++ b/tests/test_limit_offset.cpp
@@ -51,7 +51,7 @@ template <typename ConnType> class LimitOffsetTest : public ::testing::Test {
         for (int i = 1; i <= 20; i++) {
             people.emplace_back(i, "Person" + std::to_string(i), 20 + i);
         }
-        auto insert_result = queryset.insert(std::span<const LimitOffsetPerson>(people));
+        auto insert_result = queryset.insert(std::span<const LimitOffsetPerson>(people)).execute();
         ASSERT_TRUE(insert_result.has_value()) << "Failed to insert test data: " << insert_result.error().message();
     }
 
@@ -73,7 +73,7 @@ TYPED_TEST_SUITE(LimitOffsetTest, DatabaseTypes);
 TYPED_TEST(LimitOffsetTest, LimitOnly) {
     QuerySet<LimitOffsetPerson, TypeParam> qs;
 
-    auto result = qs.limit(5).select();
+    auto result = qs.limit(5).select().execute();
     ASSERT_TRUE(result.has_value()) << "SELECT with LIMIT failed: " << result.error().message();
 
     const auto& people = result.value();
@@ -90,7 +90,7 @@ TYPED_TEST(LimitOffsetTest, LimitOnly) {
 TYPED_TEST(LimitOffsetTest, LimitZero) {
     QuerySet<LimitOffsetPerson, TypeParam> qs;
 
-    auto result = qs.limit(0).select();
+    auto result = qs.limit(0).select().execute();
     ASSERT_TRUE(result.has_value()) << "SELECT with LIMIT 0 failed: " << result.error().message();
 
     const auto& people = result.value();
@@ -100,7 +100,7 @@ TYPED_TEST(LimitOffsetTest, LimitZero) {
 TYPED_TEST(LimitOffsetTest, LimitGreaterThanResultSet) {
     QuerySet<LimitOffsetPerson, TypeParam> qs;
 
-    auto result = qs.limit(100).select();
+    auto result = qs.limit(100).select().execute();
     ASSERT_TRUE(result.has_value()) << "SELECT with large LIMIT failed: " << result.error().message();
 
     const auto& people = result.value();
@@ -112,7 +112,7 @@ TYPED_TEST(LimitOffsetTest, LimitGreaterThanResultSet) {
 TYPED_TEST(LimitOffsetTest, OffsetOnly) {
     QuerySet<LimitOffsetPerson, TypeParam> qs;
 
-    auto result = qs.offset(10).select();
+    auto result = qs.offset(10).select().execute();
     ASSERT_TRUE(result.has_value()) << "SELECT with OFFSET failed: " << result.error().message();
 
     const auto& people = result.value();
@@ -128,7 +128,7 @@ TYPED_TEST(LimitOffsetTest, OffsetOnly) {
 TYPED_TEST(LimitOffsetTest, OffsetZero) {
     QuerySet<LimitOffsetPerson, TypeParam> qs;
 
-    auto result = qs.offset(0).select();
+    auto result = qs.offset(0).select().execute();
     ASSERT_TRUE(result.has_value()) << "SELECT with OFFSET 0 failed: " << result.error().message();
 
     const auto& people = result.value();
@@ -138,7 +138,7 @@ TYPED_TEST(LimitOffsetTest, OffsetZero) {
 TYPED_TEST(LimitOffsetTest, OffsetGreaterThanResultSet) {
     QuerySet<LimitOffsetPerson, TypeParam> qs;
 
-    auto result = qs.offset(100).select();
+    auto result = qs.offset(100).select().execute();
     ASSERT_TRUE(result.has_value()) << "SELECT with large OFFSET failed: " << result.error().message();
 
     const auto& people = result.value();
@@ -150,7 +150,7 @@ TYPED_TEST(LimitOffsetTest, OffsetGreaterThanResultSet) {
 TYPED_TEST(LimitOffsetTest, LimitAndOffset) {
     QuerySet<LimitOffsetPerson, TypeParam> qs;
 
-    auto result = qs.limit(5).offset(5).select();
+    auto result = qs.limit(5).offset(5).select().execute();
     ASSERT_TRUE(result.has_value()) << "SELECT with LIMIT/OFFSET failed: " << result.error().message();
 
     const auto& people = result.value();
@@ -168,35 +168,35 @@ TYPED_TEST(LimitOffsetTest, LimitOffsetPagination) {
     QuerySet<LimitOffsetPerson, TypeParam> qs;
 
     // Page 1: records 1-5
-    auto page1 = qs.limit(5).offset(0).select();
+    auto page1 = qs.limit(5).offset(0).select().execute();
     ASSERT_TRUE(page1.has_value());
     ASSERT_EQ(page1.value().size(), 5);
     EXPECT_EQ(page1.value().begin()->id, 1);
     EXPECT_EQ(std::ranges::next(page1.value().begin(), 4)->id, 5);
 
     // Page 2: records 6-10
-    auto page2 = qs.limit(5).offset(5).select();
+    auto page2 = qs.limit(5).offset(5).select().execute();
     ASSERT_TRUE(page2.has_value());
     ASSERT_EQ(page2.value().size(), 5);
     EXPECT_EQ(page2.value().begin()->id, 6);
     EXPECT_EQ(std::ranges::next(page2.value().begin(), 4)->id, 10);
 
     // Page 3: records 11-15
-    auto page3 = qs.limit(5).offset(10).select();
+    auto page3 = qs.limit(5).offset(10).select().execute();
     ASSERT_TRUE(page3.has_value());
     ASSERT_EQ(page3.value().size(), 5);
     EXPECT_EQ(page3.value().begin()->id, 11);
     EXPECT_EQ(std::ranges::next(page3.value().begin(), 4)->id, 15);
 
     // Page 4: records 16-20
-    auto page4 = qs.limit(5).offset(15).select();
+    auto page4 = qs.limit(5).offset(15).select().execute();
     ASSERT_TRUE(page4.has_value());
     ASSERT_EQ(page4.value().size(), 5);
     EXPECT_EQ(page4.value().begin()->id, 16);
     EXPECT_EQ(std::ranges::next(page4.value().begin(), 4)->id, 20);
 
     // Page 5: no more records
-    auto page5 = qs.limit(5).offset(20).select();
+    auto page5 = qs.limit(5).offset(20).select().execute();
     ASSERT_TRUE(page5.has_value());
     EXPECT_EQ(page5.value().size(), 0);
 }
@@ -206,7 +206,7 @@ TYPED_TEST(LimitOffsetTest, LimitOffsetPagination) {
 TYPED_TEST(LimitOffsetTest, LimitWithWhere) {
     QuerySet<LimitOffsetPerson, TypeParam> qs;
 
-    auto result = qs.where(field<^^LimitOffsetPerson::age>() > 25).limit(3).select();
+    auto result = qs.where(field<^^LimitOffsetPerson::age>() > 25).limit(3).select().execute();
     ASSERT_TRUE(result.has_value()) << "SELECT WHERE with LIMIT failed: " << result.error().message();
 
     const auto& people = result.value();
@@ -221,7 +221,7 @@ TYPED_TEST(LimitOffsetTest, LimitWithWhere) {
 TYPED_TEST(LimitOffsetTest, LimitOffsetWithWhere) {
     QuerySet<LimitOffsetPerson, TypeParam> qs;
 
-    auto result = qs.where(field<^^LimitOffsetPerson::age>() > 25).limit(3).offset(2).select();
+    auto result = qs.where(field<^^LimitOffsetPerson::age>() > 25).limit(3).offset(2).select().execute();
     ASSERT_TRUE(result.has_value()) << "SELECT WHERE with LIMIT/OFFSET failed: " << result.error().message();
 
     const auto& people = result.value();
@@ -236,7 +236,7 @@ TYPED_TEST(LimitOffsetTest, LimitOffsetWithWhere) {
 TYPED_TEST(LimitOffsetTest, WhereWithOffsetNoLimit) {
     QuerySet<LimitOffsetPerson, TypeParam> qs;
 
-    auto result = qs.where(field<^^LimitOffsetPerson::age>() < 30).offset(2).select();
+    auto result = qs.where(field<^^LimitOffsetPerson::age>() < 30).offset(2).select().execute();
     ASSERT_TRUE(result.has_value()) << "SELECT WHERE with OFFSET failed: " << result.error().message();
 
     // Should get all matching records except first 2
@@ -298,13 +298,13 @@ TYPED_TEST(LimitOffsetTest, ResetClearsLimitOffset) {
     QuerySet<LimitOffsetPerson, TypeParam> qs;
 
     // First query with LIMIT/OFFSET
-    auto result1 = qs.limit(5).offset(5).select();
+    auto result1 = qs.limit(5).offset(5).select().execute();
     ASSERT_TRUE(result1.has_value());
     ASSERT_EQ(result1.value().size(), 5);
 
     // Reset and query again
     qs.reset();
-    auto result2 = qs.select();
+    auto result2 = qs.select().execute();
     ASSERT_TRUE(result2.has_value());
     EXPECT_EQ(result2.value().size(), 20) << "Expected all rows after reset";
 }
@@ -316,13 +316,13 @@ TYPED_TEST(LimitOffsetTest, ReuseLimitOffset) {
     qs.limit(5).offset(10);
 
     // First query
-    auto result1 = qs.select();
+    auto result1 = qs.select().execute();
     ASSERT_TRUE(result1.has_value());
     ASSERT_EQ(result1.value().size(), 5);
     EXPECT_EQ(result1.value().begin()->id, 11);
 
     // Second query reuses same LIMIT/OFFSET
-    auto result2 = qs.select();
+    auto result2 = qs.select().execute();
     ASSERT_TRUE(result2.has_value());
     ASSERT_EQ(result2.value().size(), 5);
     EXPECT_EQ(result2.value().begin()->id, 11);
@@ -332,13 +332,13 @@ TYPED_TEST(LimitOffsetTest, OverwriteLimitOffset) {
     QuerySet<LimitOffsetPerson, TypeParam> qs;
 
     // First LIMIT/OFFSET
-    auto result1 = qs.limit(5).offset(0).select();
+    auto result1 = qs.limit(5).offset(0).select().execute();
     ASSERT_TRUE(result1.has_value());
     ASSERT_EQ(result1.value().size(), 5);
     EXPECT_EQ(result1.value().begin()->id, 1);
 
     // Change LIMIT/OFFSET
-    auto result2 = qs.limit(3).offset(10).select();
+    auto result2 = qs.limit(3).offset(10).select().execute();
     ASSERT_TRUE(result2.has_value());
     ASSERT_EQ(result2.value().size(), 3);
     EXPECT_EQ(result2.value().begin()->id, 11);
@@ -350,7 +350,7 @@ TYPED_TEST(LimitOffsetTest, LimitOffsetAtBoundary) {
     QuerySet<LimitOffsetPerson, TypeParam> qs;
 
     // Exactly at the end
-    auto result = qs.limit(5).offset(15).select();
+    auto result = qs.limit(5).offset(15).select().execute();
     ASSERT_TRUE(result.has_value());
     ASSERT_EQ(result.value().size(), 5) << "Expected exactly 5 rows (records 16-20)";
     EXPECT_EQ(result.value().begin()->id, 16);
@@ -361,7 +361,7 @@ TYPED_TEST(LimitOffsetTest, LimitOffsetPartialPage) {
     QuerySet<LimitOffsetPerson, TypeParam> qs;
 
     // Request more than available
-    auto result = qs.limit(10).offset(15).select();
+    auto result = qs.limit(10).offset(15).select().execute();
     ASSERT_TRUE(result.has_value());
     ASSERT_EQ(result.value().size(), 5) << "Expected only 5 rows (records 16-20)";
 }
@@ -369,7 +369,7 @@ TYPED_TEST(LimitOffsetTest, LimitOffsetPartialPage) {
 TYPED_TEST(LimitOffsetTest, LimitOne) {
     QuerySet<LimitOffsetPerson, TypeParam> qs;
 
-    auto result = qs.limit(1).select();
+    auto result = qs.limit(1).select().execute();
     ASSERT_TRUE(result.has_value());
     ASSERT_EQ(result.value().size(), 1);
     EXPECT_EQ(result.value().begin()->id, 1);
@@ -378,7 +378,7 @@ TYPED_TEST(LimitOffsetTest, LimitOne) {
 TYPED_TEST(LimitOffsetTest, OffsetOne) {
     QuerySet<LimitOffsetPerson, TypeParam> qs;
 
-    auto result = qs.limit(1).offset(1).select();
+    auto result = qs.limit(1).offset(1).select().execute();
     ASSERT_TRUE(result.has_value());
     ASSERT_EQ(result.value().size(), 1);
     EXPECT_EQ(result.value().begin()->id, 2);
@@ -390,11 +390,11 @@ TYPED_TEST(LimitOffsetTest, MethodChainingOrder) {
     QuerySet<LimitOffsetPerson, TypeParam> qs;
 
     // Methods can be chained in any order
-    auto result1 = qs.limit(5).offset(3).select();
+    auto result1 = qs.limit(5).offset(3).select().execute();
     ASSERT_TRUE(result1.has_value());
 
     qs.reset();
-    auto result2 = qs.offset(3).limit(5).select();
+    auto result2 = qs.offset(3).limit(5).select().execute();
     ASSERT_TRUE(result2.has_value());
 
     // Results should be identical

--- a/tests/test_order_by.cpp
+++ b/tests/test_order_by.cpp
@@ -79,7 +79,7 @@ template <typename ConnType> class OrderByTest : public ::testing::Test {
 
         QuerySet<OrderByPerson, ConnType> qs;
         for (const auto& person : test_data) {
-            auto insert_result = qs.insert(person);
+            auto insert_result = qs.insert(person).execute();
             ASSERT_TRUE(insert_result.has_value()) << "Failed to insert person: " << person.name;
         }
     }
@@ -105,7 +105,7 @@ TYPED_TEST(OrderByTest, SingleFieldDefaultAsc) {
     QuerySet<OrderByPerson, TypeParam> qs;
 
     // Order by age (default ASC)
-    auto result = qs.template order_by<^^OrderByPerson::age>().select();
+    auto result = qs.template order_by<^^OrderByPerson::age>().select().execute();
     ASSERT_TRUE(result.has_value());
 
     auto people = result.value();
@@ -128,7 +128,7 @@ TYPED_TEST(OrderByTest, SingleFieldExplicitAsc) {
     QuerySet<OrderByPerson, TypeParam> qs;
 
     // Order by age (explicit ASC)
-    auto result = qs.template order_by<^^OrderByPerson::age, true>().select();
+    auto result = qs.template order_by<^^OrderByPerson::age, true>().select().execute();
     ASSERT_TRUE(result.has_value());
 
     auto people = result.value();
@@ -146,7 +146,7 @@ TYPED_TEST(OrderByTest, SingleFieldDesc) {
     QuerySet<OrderByPerson, TypeParam> qs;
 
     // Order by age DESC
-    auto result = qs.template order_by<^^OrderByPerson::age, false>().select();
+    auto result = qs.template order_by<^^OrderByPerson::age, false>().select().execute();
     ASSERT_TRUE(result.has_value());
 
     auto people = result.value();
@@ -169,7 +169,7 @@ TYPED_TEST(OrderByTest, StringFieldAsc) {
     QuerySet<OrderByPerson, TypeParam> qs;
 
     // Order by name ASC
-    auto result = qs.template order_by<^^OrderByPerson::name>().select();
+    auto result = qs.template order_by<^^OrderByPerson::name>().select().execute();
     ASSERT_TRUE(result.has_value());
 
     auto people = result.value();
@@ -192,7 +192,7 @@ TYPED_TEST(OrderByTest, StringFieldDesc) {
     QuerySet<OrderByPerson, TypeParam> qs;
 
     // Order by name DESC
-    auto result = qs.template order_by<^^OrderByPerson::name, false>().select();
+    auto result = qs.template order_by<^^OrderByPerson::name, false>().select().execute();
     ASSERT_TRUE(result.has_value());
 
     auto people = result.value();
@@ -219,7 +219,7 @@ TYPED_TEST(OrderByTest, MultipleFieldsAllAsc) {
     QuerySet<OrderByPerson, TypeParam> qs;
 
     // Order by age ASC, then name ASC
-    auto result = qs.template order_by<^^OrderByPerson::age, ^^OrderByPerson::name>().select();
+    auto result = qs.template order_by<^^OrderByPerson::age, ^^OrderByPerson::name>().select().execute();
     ASSERT_TRUE(result.has_value());
 
     auto people = result.value();
@@ -244,7 +244,7 @@ TYPED_TEST(OrderByTest, MultipleFieldsMixedDirections) {
     QuerySet<OrderByPerson, TypeParam> qs;
 
     // Order by age ASC, then name DESC
-    auto result = qs.template order_by<^^OrderByPerson::age, true, ^^OrderByPerson::name, false>().select();
+    auto result = qs.template order_by<^^OrderByPerson::age, true, ^^OrderByPerson::name, false>().select().execute();
     ASSERT_TRUE(result.has_value());
 
     auto people = result.value();
@@ -269,7 +269,7 @@ TYPED_TEST(OrderByTest, MultipleFieldsAllDesc) {
     QuerySet<OrderByPerson, TypeParam> qs;
 
     // Order by age DESC, then name DESC
-    auto result = qs.template order_by<^^OrderByPerson::age, false, ^^OrderByPerson::name, false>().select();
+    auto result = qs.template order_by<^^OrderByPerson::age, false, ^^OrderByPerson::name, false>().select().execute();
     ASSERT_TRUE(result.has_value());
 
     auto people = result.value();
@@ -296,7 +296,8 @@ TYPED_TEST(OrderByTest, WithWhereClause) {
     // Filter active users and order by age DESC
     auto result = qs.where(field<^^OrderByPerson::is_active>() == true) // NOLINT(readability-simplify-boolean-expr)
                           .template order_by<^^OrderByPerson::age, false>()
-                          .select();
+                          .select()
+                          .execute();
     ASSERT_TRUE(result.has_value());
 
     auto people = result.value();
@@ -316,7 +317,8 @@ TYPED_TEST(OrderByTest, WhereWithMultipleOrderBy) {
     // Filter age >= 30 and order by age ASC, name DESC
     auto result = qs.where(field<^^OrderByPerson::age>() >= 30)
                           .template order_by<^^OrderByPerson::age, true, ^^OrderByPerson::name, false>()
-                          .select();
+                          .select()
+                          .execute();
     ASSERT_TRUE(result.has_value());
 
     auto people = result.value();
@@ -336,7 +338,7 @@ TYPED_TEST(OrderByTest, WithLimit) {
     QuerySet<OrderByPerson, TypeParam> qs;
 
     // Get youngest 3 people
-    auto result = qs.template order_by<^^OrderByPerson::age>().limit(3).select();
+    auto result = qs.template order_by<^^OrderByPerson::age>().limit(3).select().execute();
     ASSERT_TRUE(result.has_value());
 
     auto people = result.value();
@@ -352,7 +354,7 @@ TYPED_TEST(OrderByTest, WithLimitAndOffset) {
     QuerySet<OrderByPerson, TypeParam> qs;
 
     // Get people ranked 4-6 by name
-    auto result = qs.template order_by<^^OrderByPerson::name>().limit(3).offset(3).select();
+    auto result = qs.template order_by<^^OrderByPerson::name>().limit(3).offset(3).select().execute();
     ASSERT_TRUE(result.has_value());
 
     auto people = result.value();
@@ -367,7 +369,7 @@ TYPED_TEST(OrderByTest, OrderByBeforeLimitOffset) {
     QuerySet<OrderByPerson, TypeParam> qs;
 
     // Test that order_by works correctly with limit and offset
-    auto result = qs.template order_by<^^OrderByPerson::age, false>().limit(5).offset(2).select();
+    auto result = qs.template order_by<^^OrderByPerson::age, false>().limit(5).offset(2).select().execute();
     ASSERT_TRUE(result.has_value());
 
     auto people = result.value();
@@ -385,7 +387,8 @@ TYPED_TEST(OrderByTest, EmptyResult) {
     QuerySet<OrderByPerson, TypeParam> qs;
 
     // Filter that returns no results
-    auto result = qs.where(field<^^OrderByPerson::age>() > 100).template order_by<^^OrderByPerson::name>().select();
+    auto result =
+            qs.where(field<^^OrderByPerson::age>() > 100).template order_by<^^OrderByPerson::name>().select().execute();
     ASSERT_TRUE(result.has_value());
 
     const auto& people = result.value();
@@ -396,7 +399,7 @@ TYPED_TEST(OrderByTest, BooleanField) {
     QuerySet<OrderByPerson, TypeParam> qs;
 
     // Order by boolean field
-    auto result = qs.template order_by<^^OrderByPerson::is_active, false>().select();
+    auto result = qs.template order_by<^^OrderByPerson::is_active, false>().select().execute();
     ASSERT_TRUE(result.has_value());
 
     auto people = result.value();
@@ -415,7 +418,8 @@ TYPED_TEST(OrderByTest, ChainedWithMultipleClauses) {
                           .template order_by<^^OrderByPerson::age, ^^OrderByPerson::name>()
                           .limit(5)
                           .offset(1)
-                          .select();
+                          .select()
+                          .execute();
     ASSERT_TRUE(result.has_value());
 
     auto people = result.value();
@@ -476,7 +480,7 @@ template <typename ConnType> class OrderByNullableTest : public ::testing::Test 
         };
 
         QuerySet<OrderByNullable, ConnType> qs;
-        auto                                insert_result = qs.insert(test_data);
+        auto                                insert_result = qs.insert(test_data).execute();
         ASSERT_TRUE(insert_result.has_value()) << "Failed to insert test data";
     }
 
@@ -498,7 +502,7 @@ TYPED_TEST(OrderByNullableTest, NullableFieldAsc) {
 
     // Order by nullable score ASC
     // In SQLite, NULL values sort first in ASC order by default
-    auto result = qs.template order_by<^^OrderByNullable::score>().select();
+    auto result = qs.template order_by<^^OrderByNullable::score>().select().execute();
     ASSERT_TRUE(result.has_value());
 
     auto items = result.value();
@@ -536,7 +540,7 @@ TYPED_TEST(OrderByNullableTest, NullableFieldDesc) {
 
     // Order by nullable score DESC
     // In SQLite, NULL values sort last in DESC order by default
-    auto result = qs.template order_by<^^OrderByNullable::score, false>().select();
+    auto result = qs.template order_by<^^OrderByNullable::score, false>().select().execute();
     ASSERT_TRUE(result.has_value());
 
     auto items = result.value();
@@ -572,7 +576,8 @@ TYPED_TEST(OrderByNullableTest, NullableFieldWithSecondarySort) {
     QuerySet<OrderByNullable, TypeParam> qs;
 
     // Order by score ASC, then name ASC (to have deterministic ordering within same scores)
-    auto result = qs.template order_by<^^OrderByNullable::score, true, ^^OrderByNullable::name, true>().select();
+    auto result =
+            qs.template order_by<^^OrderByNullable::score, true, ^^OrderByNullable::name, true>().select().execute();
     ASSERT_TRUE(result.has_value());
 
     auto items = result.value();
@@ -618,11 +623,11 @@ TYPED_TEST(OrderByNullableTest, AllNullValues) {
             {2, std::nullopt, "Second"},
             {3, std::nullopt, "Third"},
     };
-    auto insert_result = qs.insert(all_nulls);
+    auto insert_result = qs.insert(all_nulls).execute();
     ASSERT_TRUE(insert_result.has_value());
 
     // Order by nullable field when all values are NULL
-    auto result = qs.template order_by<^^OrderByNullable::score>().select();
+    auto result = qs.template order_by<^^OrderByNullable::score>().select().execute();
     ASSERT_TRUE(result.has_value());
 
     auto items = result.value();
@@ -675,7 +680,7 @@ template <typename ConnType> class OrderByBlobTest : public ::testing::Test {
         };
 
         QuerySet<OrderByBlob, ConnType> qs;
-        auto                            insert_result = qs.insert(test_data);
+        auto                            insert_result = qs.insert(test_data).execute();
         ASSERT_TRUE(insert_result.has_value()) << "Failed to insert test data";
     }
 
@@ -697,7 +702,7 @@ TYPED_TEST(OrderByBlobTest, BlobFieldAsc) {
 
     // Order by BLOB field ASC
     // SQLite sorts BLOBs by memcmp order (byte-by-byte comparison)
-    auto result = qs.template order_by<^^OrderByBlob::data>().select();
+    auto result = qs.template order_by<^^OrderByBlob::data>().select().execute();
     ASSERT_TRUE(result.has_value());
 
     auto items = result.value();
@@ -735,7 +740,7 @@ TYPED_TEST(OrderByBlobTest, BlobFieldDesc) {
     QuerySet<OrderByBlob, TypeParam> qs;
 
     // Order by BLOB field DESC
-    auto result = qs.template order_by<^^OrderByBlob::data, false>().select();
+    auto result = qs.template order_by<^^OrderByBlob::data, false>().select().execute();
     ASSERT_TRUE(result.has_value());
 
     auto items = result.value();
@@ -767,7 +772,7 @@ TYPED_TEST(OrderByBlobTest, BlobWithSecondarySort) {
     QuerySet<OrderByBlob, TypeParam> qs;
 
     // Order by BLOB ASC, then label ASC
-    auto result = qs.template order_by<^^OrderByBlob::data, true, ^^OrderByBlob::label, true>().select();
+    auto result = qs.template order_by<^^OrderByBlob::data, true, ^^OrderByBlob::label, true>().select().execute();
     ASSERT_TRUE(result.has_value());
 
     auto items = result.value();
@@ -788,10 +793,10 @@ TYPED_TEST(OrderByBlobTest, EmptyBlobsOnly) {
             {2, {}, "Second"},
             {3, {}, "Third"},
     };
-    auto insert_result = qs.insert(empty_blobs);
+    auto insert_result = qs.insert(empty_blobs).execute();
     ASSERT_TRUE(insert_result.has_value());
 
-    auto result = qs.template order_by<^^OrderByBlob::data>().select();
+    auto result = qs.template order_by<^^OrderByBlob::data>().select().execute();
     ASSERT_TRUE(result.has_value());
 
     auto items = result.value();
@@ -813,7 +818,8 @@ TYPED_TEST(OrderByTest, EmptyResultWithMultipleOrderBy) {
     // Complex ORDER BY with no matching results
     auto result = qs.where(field<^^OrderByPerson::age>() > 100)
                           .template order_by<^^OrderByPerson::age, false, ^^OrderByPerson::name, true>()
-                          .select();
+                          .select()
+                          .execute();
     ASSERT_TRUE(result.has_value());
 
     const auto& people = result.value();
@@ -826,7 +832,7 @@ TYPED_TEST(OrderByTest, EmptyTableOrderBy) {
     (void)conn->execute("DELETE FROM OrderByPerson");
 
     QuerySet<OrderByPerson, TypeParam> qs;
-    auto                               result = qs.template order_by<^^OrderByPerson::age>().select();
+    auto                               result = qs.template order_by<^^OrderByPerson::age>().select().execute();
     ASSERT_TRUE(result.has_value());
 
     const auto& people = result.value();

--- a/tests/test_select.cpp
+++ b/tests/test_select.cpp
@@ -62,7 +62,7 @@ TYPED_TEST_SUITE(SelectTest, DatabaseTypes);
 TYPED_TEST(SelectTest, SelectFromEmptyTable) {
     QuerySet<SelectPerson, TypeParam> queryset;
 
-    auto result = queryset.select();
+    auto result = queryset.select().execute();
     ASSERT_TRUE(result.has_value()) << "SELECT failed: " << result.error().message();
 
     const auto& people = result.value();
@@ -75,13 +75,13 @@ TYPED_TEST(SelectTest, SelectSingleRow) {
 
     // Insert one person
     SelectPerson const alice{.id = 0, .name = "Alice", .age = 30};
-    auto               insert_result = queryset.insert(alice);
+    auto               insert_result = queryset.insert(alice).execute();
     ASSERT_TRUE(insert_result.has_value()) << "INSERT failed: " << insert_result.error().message();
 
     int64_t const inserted_id = insert_result.value();
 
     // Select all rows
-    auto result = queryset.select();
+    auto result = queryset.select().execute();
     ASSERT_TRUE(result.has_value()) << "SELECT failed: " << result.error().message();
 
     const auto& people = result.value();
@@ -100,12 +100,12 @@ TYPED_TEST(SelectTest, SelectMultipleRows) {
     // Insert multiple people
     std::vector<SelectPerson> people_to_insert = {{0, "Alice", 30}, {0, "Bob", 25}, {0, "Charlie", 35}};
 
-    auto insert_result = queryset.insert(std::span<const SelectPerson>(people_to_insert));
+    auto insert_result = queryset.insert(std::span<const SelectPerson>(people_to_insert)).execute();
     ASSERT_TRUE(insert_result.has_value())
             << "INSERT failed: code=" << insert_result.error().code() << " message=" << insert_result.error().message();
 
     // Select all rows
-    auto result = queryset.select();
+    auto result = queryset.select().execute();
     ASSERT_TRUE(result.has_value()) << "SELECT failed: " << result.error().message();
 
     const auto& people = result.value();
@@ -134,11 +134,11 @@ TYPED_TEST(SelectTest, SelectDifferentFieldTypes) {
 
     // Insert person with specific values
     SelectPerson const dave{.id = 0, .name = "Dave", .age = 40};
-    auto               insert_result = queryset.insert(dave);
+    auto               insert_result = queryset.insert(dave).execute();
     ASSERT_TRUE(insert_result.has_value()) << "INSERT failed: " << insert_result.error().message();
 
     // Select and verify field types are correctly handled
-    auto result = queryset.select();
+    auto result = queryset.select().execute();
     ASSERT_TRUE(result.has_value()) << "SELECT failed: " << result.error().message();
 
     const auto& people = result.value();
@@ -161,11 +161,11 @@ TYPED_TEST(SelectTest, SelectAfterInsertAndDelete) {
     // Insert multiple people
     std::vector<SelectPerson> people_to_insert = {{0, "Alice", 30}, {0, "Bob", 25}, {0, "Charlie", 35}};
 
-    auto insert_result = queryset.insert(std::span<const SelectPerson>(people_to_insert));
+    auto insert_result = queryset.insert(std::span<const SelectPerson>(people_to_insert)).execute();
     ASSERT_TRUE(insert_result.has_value()) << "INSERT failed: " << insert_result.error().message();
 
     // Select to get the auto-generated IDs
-    auto select_result = queryset.select();
+    auto select_result = queryset.select().execute();
     ASSERT_TRUE(select_result.has_value()) << "SELECT failed: " << select_result.error().message();
 
     // Find Bob's ID
@@ -180,11 +180,11 @@ TYPED_TEST(SelectTest, SelectAfterInsertAndDelete) {
 
     // Delete Bob
     SelectPerson const bob_to_delete{.id = bob_id, .name = "Bob", .age = 25};
-    auto               delete_result = queryset.remove(bob_to_delete);
+    auto               delete_result = queryset.remove(bob_to_delete).execute();
     ASSERT_TRUE(delete_result.has_value()) << "DELETE failed: " << delete_result.error().message();
 
     // Select all rows again
-    auto result = queryset.select();
+    auto result = queryset.select().execute();
     ASSERT_TRUE(result.has_value()) << "SELECT failed: " << result.error().message();
 
     const auto& people = result.value();
@@ -208,11 +208,11 @@ TYPED_TEST(SelectTest, SelectLargeDataset) {
         people_to_insert.emplace_back(i, std::format("SelectPerson{}", i), 20 + i);
     }
 
-    auto insert_result = queryset.insert(std::span<const SelectPerson>(people_to_insert));
+    auto insert_result = queryset.insert(std::span<const SelectPerson>(people_to_insert)).execute();
     ASSERT_TRUE(insert_result.has_value()) << "INSERT failed: " << insert_result.error().message();
 
     // Select all rows
-    auto result = queryset.select();
+    auto result = queryset.select().execute();
     ASSERT_TRUE(result.has_value()) << "SELECT failed: " << result.error().message();
 
     const auto& people = result.value();
@@ -238,21 +238,21 @@ TYPED_TEST(SelectTest, MultipleSelectCallsUseCaching) {
 
     // Insert test data
     SelectPerson const alice{.id = 0, .name = "Alice", .age = 30};
-    auto               insert_result = queryset.insert(alice);
+    auto               insert_result = queryset.insert(alice).execute();
     ASSERT_TRUE(insert_result.has_value());
 
     // First SELECT
-    auto result1 = queryset.select();
+    auto result1 = queryset.select().execute();
     ASSERT_TRUE(result1.has_value());
     EXPECT_EQ(result1.value().size(), 1);
 
     // Second SELECT (should use cached statement)
-    auto result2 = queryset.select();
+    auto result2 = queryset.select().execute();
     ASSERT_TRUE(result2.has_value());
     EXPECT_EQ(result2.value().size(), 1);
 
     // Third SELECT
-    auto result3 = queryset.select();
+    auto result3 = queryset.select().execute();
     ASSERT_TRUE(result3.has_value());
     EXPECT_EQ(result3.value().size(), 1);
 }
@@ -263,11 +263,11 @@ TYPED_TEST(SelectTest, SelectWithEmptyString) {
 
     // Insert person with empty name
     SelectPerson const anonymous{.id = 0, .name = "", .age = 25};
-    auto               insert_result = queryset.insert(anonymous);
+    auto               insert_result = queryset.insert(anonymous).execute();
     ASSERT_TRUE(insert_result.has_value());
 
     // Select and verify
-    auto result = queryset.select();
+    auto result = queryset.select().execute();
     ASSERT_TRUE(result.has_value());
 
     const auto& people = result.value();
@@ -284,11 +284,11 @@ TYPED_TEST(SelectTest, SelectPreservesRowOrder) {
     std::vector<SelectPerson> people_to_insert =
             {{1, "First", 1}, {2, "Second", 2}, {3, "Third", 3}, {4, "Fourth", 4}, {5, "Fifth", 5}};
 
-    auto insert_result = queryset.insert(std::span<const SelectPerson>(people_to_insert));
+    auto insert_result = queryset.insert(std::span<const SelectPerson>(people_to_insert)).execute();
     ASSERT_TRUE(insert_result.has_value());
 
     // Select and verify order is preserved
-    auto result = queryset.select();
+    auto result = queryset.select().execute();
     ASSERT_TRUE(result.has_value());
 
     const auto& people = result.value();

--- a/tests/test_select_large.cpp
+++ b/tests/test_select_large.cpp
@@ -73,11 +73,11 @@ TYPED_TEST(SelectLargeTest, SelectMoreThan10KRows) {
         records.emplace_back(i, i * 10, std::format("Record_{}", i));
     }
 
-    auto insert_result = queryset.insert(std::span<const TestRecord>(records));
+    auto insert_result = queryset.insert(std::span<const TestRecord>(records)).execute();
     ASSERT_TRUE(insert_result.has_value()) << "Batch INSERT failed: " << insert_result.error().message();
 
     // SELECT all rows - this will exercise exponential growth
-    auto select_result = queryset.select();
+    auto select_result = queryset.select().execute();
     ASSERT_TRUE(select_result.has_value()) << "SELECT failed: " << select_result.error().message();
 
     const auto& retrieved = select_result.value();
@@ -113,11 +113,11 @@ TYPED_TEST(SelectLargeTest, SelectExactly10KRows) {
         records.emplace_back(i, i, std::format("R{}", i));
     }
 
-    auto insert_result = queryset.insert(std::span<const TestRecord>(records));
+    auto insert_result = queryset.insert(std::span<const TestRecord>(records)).execute();
     ASSERT_TRUE(insert_result.has_value());
 
     // SELECT all rows - should fit in initial capacity exactly
-    auto select_result = queryset.select();
+    auto select_result = queryset.select().execute();
     ASSERT_TRUE(select_result.has_value());
 
     const auto& retrieved = select_result.value();
@@ -140,11 +140,11 @@ TYPED_TEST(SelectLargeTest, SelectSlightlyOver10KRows) {
         records.emplace_back(i, i, "Test");
     }
 
-    auto insert_result = queryset.insert(std::span<const TestRecord>(records));
+    auto insert_result = queryset.insert(std::span<const TestRecord>(records)).execute();
     ASSERT_TRUE(insert_result.has_value());
 
     // SELECT all rows - will grow to 20K
-    auto select_result = queryset.select();
+    auto select_result = queryset.select().execute();
     ASSERT_TRUE(select_result.has_value());
 
     const auto& retrieved = select_result.value();
@@ -174,12 +174,12 @@ TYPED_TEST(SelectLargeTest, SelectVeryLargeDataset) {
             batch_records.emplace_back(record_num, record_num, std::format("B{}", batch));
         }
 
-        auto insert_result = queryset.insert(std::span<const TestRecord>(batch_records));
+        auto insert_result = queryset.insert(std::span<const TestRecord>(batch_records)).execute();
         ASSERT_TRUE(insert_result.has_value()) << "Batch " << batch << " INSERT failed";
     }
 
     // SELECT all 100K rows
-    auto select_result = queryset.select();
+    auto select_result = queryset.select().execute();
     ASSERT_TRUE(select_result.has_value()) << "SELECT 100K rows failed: " << select_result.error().message();
 
     const auto& retrieved = select_result.value();

--- a/tests/test_select_one.cpp
+++ b/tests/test_select_one.cpp
@@ -68,7 +68,7 @@ TYPED_TEST_SUITE(SelectOneTest, DatabaseTypes);
 TYPED_TEST(SelectOneTest, FirstFromEmptyTable) {
     QuerySet<SelectOnePerson, TypeParam> queryset;
 
-    auto result = queryset.first();
+    auto result = queryset.first().execute();
     ASSERT_TRUE(result.has_value()) << "first() failed: " << result.error().message();
     EXPECT_FALSE(result.value().has_value()) << "Expected nullopt from empty table";
 }
@@ -78,10 +78,10 @@ TYPED_TEST(SelectOneTest, FirstSingleRow) {
     QuerySet<SelectOnePerson, TypeParam> queryset;
 
     SelectOnePerson const alice{.id = 0, .name = "Alice", .age = 30};
-    auto                  insert_result = queryset.insert(alice);
+    auto                  insert_result = queryset.insert(alice).execute();
     ASSERT_TRUE(insert_result.has_value()) << "INSERT failed: " << insert_result.error().message();
 
-    auto result = queryset.first();
+    auto result = queryset.first().execute();
     ASSERT_TRUE(result.has_value()) << "first() failed: " << result.error().message();
     ASSERT_TRUE(result.value().has_value()) << "Expected a row, got nullopt";
 
@@ -95,11 +95,11 @@ TYPED_TEST(SelectOneTest, FirstMultipleRows) {
     QuerySet<SelectOnePerson, TypeParam> queryset;
 
     for (const auto& p : std::vector<SelectOnePerson>{{0, "Alice", 30}, {0, "Bob", 25}, {0, "Charlie", 35}}) {
-        auto insert_result = queryset.insert(p);
+        auto insert_result = queryset.insert(p).execute();
         ASSERT_TRUE(insert_result.has_value()) << "INSERT failed: " << insert_result.error().message();
     }
 
-    auto result = queryset.first();
+    auto result = queryset.first().execute();
     ASSERT_TRUE(result.has_value()) << "first() failed: " << result.error().message();
     ASSERT_TRUE(result.value().has_value()) << "Expected a row, got nullopt";
 
@@ -112,11 +112,11 @@ TYPED_TEST(SelectOneTest, FirstWithWhere) {
     QuerySet<SelectOnePerson, TypeParam> queryset;
 
     for (const auto& p : std::vector<SelectOnePerson>{{0, "Alice", 30}, {0, "Bob", 25}, {0, "Charlie", 35}}) {
-        auto insert_result = queryset.insert(p);
+        auto insert_result = queryset.insert(p).execute();
         ASSERT_TRUE(insert_result.has_value()) << "INSERT failed: " << insert_result.error().message();
     }
 
-    auto result = queryset.where(field<^^SelectOnePerson::name>() == "Bob").first();
+    auto result = queryset.where(field<^^SelectOnePerson::name>() == "Bob").first().execute();
     ASSERT_TRUE(result.has_value()) << "first() failed: " << result.error().message();
     ASSERT_TRUE(result.value().has_value()) << "Expected Bob, got nullopt";
 
@@ -130,10 +130,10 @@ TYPED_TEST(SelectOneTest, FirstWhereNoMatch) {
     QuerySet<SelectOnePerson, TypeParam> queryset;
 
     SelectOnePerson const alice{.id = 0, .name = "Alice", .age = 30};
-    auto                  insert_result = queryset.insert(alice);
+    auto                  insert_result = queryset.insert(alice).execute();
     ASSERT_TRUE(insert_result.has_value()) << "INSERT failed: " << insert_result.error().message();
 
-    auto result = queryset.where(field<^^SelectOnePerson::name>() == "NonExistent").first();
+    auto result = queryset.where(field<^^SelectOnePerson::name>() == "NonExistent").first().execute();
     ASSERT_TRUE(result.has_value()) << "first() should not return error for no match";
     EXPECT_FALSE(result.value().has_value()) << "Expected nullopt for non-matching WHERE";
 }
@@ -143,12 +143,12 @@ TYPED_TEST(SelectOneTest, FirstWithOrderBy) {
     QuerySet<SelectOnePerson, TypeParam> queryset;
 
     for (const auto& p : std::vector<SelectOnePerson>{{0, "Alice", 30}, {0, "Bob", 25}, {0, "Charlie", 35}}) {
-        auto insert_result = queryset.insert(p);
+        auto insert_result = queryset.insert(p).execute();
         ASSERT_TRUE(insert_result.has_value()) << "INSERT failed: " << insert_result.error().message();
     }
 
     // ORDER BY age ASC - should get Bob (age 25)
-    auto result = queryset.template order_by<^^SelectOnePerson::age>().first();
+    auto result = queryset.template order_by<^^SelectOnePerson::age>().first().execute();
     ASSERT_TRUE(result.has_value()) << "first() failed: " << result.error().message();
     ASSERT_TRUE(result.value().has_value()) << "Expected a row, got nullopt";
     EXPECT_EQ(result.value().value().name, "Bob");
@@ -159,12 +159,12 @@ TYPED_TEST(SelectOneTest, FirstWithOrderByDesc) {
     QuerySet<SelectOnePerson, TypeParam> queryset;
 
     for (const auto& p : std::vector<SelectOnePerson>{{0, "Alice", 30}, {0, "Bob", 25}, {0, "Charlie", 35}}) {
-        auto insert_result = queryset.insert(p);
+        auto insert_result = queryset.insert(p).execute();
         ASSERT_TRUE(insert_result.has_value()) << "INSERT failed: " << insert_result.error().message();
     }
 
     // ORDER BY age DESC - should get Charlie (age 35)
-    auto result = queryset.template order_by<^^SelectOnePerson::age, false>().first();
+    auto result = queryset.template order_by<^^SelectOnePerson::age, false>().first().execute();
     ASSERT_TRUE(result.has_value()) << "first() failed: " << result.error().message();
     ASSERT_TRUE(result.value().has_value()) << "Expected a row, got nullopt";
     EXPECT_EQ(result.value().value().name, "Charlie");
@@ -175,11 +175,11 @@ TYPED_TEST(SelectOneTest, FirstMultipleCallsUseCaching) {
     QuerySet<SelectOnePerson, TypeParam> queryset;
 
     SelectOnePerson const alice{.id = 0, .name = "Alice", .age = 30};
-    auto                  insert_result = queryset.insert(alice);
+    auto                  insert_result = queryset.insert(alice).execute();
     ASSERT_TRUE(insert_result.has_value());
 
     for (int i = 0; i < 3; ++i) {
-        auto result = queryset.first();
+        auto result = queryset.first().execute();
         ASSERT_TRUE(result.has_value()) << "first() call " << i << " failed";
         ASSERT_TRUE(result.value().has_value()) << "Expected a row on call " << i;
         EXPECT_EQ(result.value().value().name, "Alice");
@@ -194,7 +194,7 @@ TYPED_TEST(SelectOneTest, FirstMultipleCallsUseCaching) {
 TYPED_TEST(SelectOneTest, GetFromEmptyTable) {
     QuerySet<SelectOnePerson, TypeParam> queryset;
 
-    auto result = queryset.get();
+    auto result = queryset.get().execute();
     ASSERT_FALSE(result.has_value()) << "get() should return error for empty table";
     EXPECT_EQ(result.error().code(), -1);
     EXPECT_EQ(result.error().message(), "No row found matching query");
@@ -205,10 +205,10 @@ TYPED_TEST(SelectOneTest, GetSingleRow) {
     QuerySet<SelectOnePerson, TypeParam> queryset;
 
     SelectOnePerson const alice{.id = 0, .name = "Alice", .age = 30};
-    auto                  insert_result = queryset.insert(alice);
+    auto                  insert_result = queryset.insert(alice).execute();
     ASSERT_TRUE(insert_result.has_value()) << "INSERT failed: " << insert_result.error().message();
 
-    auto result = queryset.get();
+    auto result = queryset.get().execute();
     ASSERT_TRUE(result.has_value()) << "get() failed: " << result.error().message();
 
     EXPECT_EQ(result.value().name, "Alice");
@@ -220,11 +220,11 @@ TYPED_TEST(SelectOneTest, GetMultipleRowsReturnsError) {
     QuerySet<SelectOnePerson, TypeParam> queryset;
 
     for (const auto& p : std::vector<SelectOnePerson>{{0, "Alice", 30}, {0, "Bob", 25}, {0, "Charlie", 35}}) {
-        auto insert_result = queryset.insert(p);
+        auto insert_result = queryset.insert(p).execute();
         ASSERT_TRUE(insert_result.has_value()) << "INSERT failed: " << insert_result.error().message();
     }
 
-    auto result = queryset.get();
+    auto result = queryset.get().execute();
     ASSERT_FALSE(result.has_value()) << "get() should return error for multiple rows";
     EXPECT_EQ(result.error().code(), -1);
     EXPECT_EQ(result.error().message(), "Multiple rows found matching query");
@@ -235,11 +235,11 @@ TYPED_TEST(SelectOneTest, GetWithWhere) {
     QuerySet<SelectOnePerson, TypeParam> queryset;
 
     for (const auto& p : std::vector<SelectOnePerson>{{0, "Alice", 30}, {0, "Bob", 25}}) {
-        auto insert_result = queryset.insert(p);
+        auto insert_result = queryset.insert(p).execute();
         ASSERT_TRUE(insert_result.has_value()) << "INSERT failed: " << insert_result.error().message();
     }
 
-    auto result = queryset.where(field<^^SelectOnePerson::name>() == "Bob").get();
+    auto result = queryset.where(field<^^SelectOnePerson::name>() == "Bob").get().execute();
     ASSERT_TRUE(result.has_value()) << "get() failed: " << result.error().message();
     EXPECT_EQ(result.value().name, "Bob");
     EXPECT_EQ(result.value().age, 25);
@@ -250,10 +250,10 @@ TYPED_TEST(SelectOneTest, GetWhereNoMatch) {
     QuerySet<SelectOnePerson, TypeParam> queryset;
 
     SelectOnePerson const alice{.id = 0, .name = "Alice", .age = 30};
-    auto                  insert_result = queryset.insert(alice);
+    auto                  insert_result = queryset.insert(alice).execute();
     ASSERT_TRUE(insert_result.has_value()) << "INSERT failed: " << insert_result.error().message();
 
-    auto result = queryset.where(field<^^SelectOnePerson::name>() == "NonExistent").get();
+    auto result = queryset.where(field<^^SelectOnePerson::name>() == "NonExistent").get().execute();
     ASSERT_FALSE(result.has_value()) << "get() should return error for non-matching WHERE";
     EXPECT_EQ(result.error().code(), -1);
     EXPECT_EQ(result.error().message(), "No row found matching query");
@@ -264,12 +264,12 @@ TYPED_TEST(SelectOneTest, GetWhereMultipleMatch) {
     QuerySet<SelectOnePerson, TypeParam> queryset;
 
     for (const auto& p : std::vector<SelectOnePerson>{{0, "Alice", 30}, {0, "Bob", 30}, {0, "Charlie", 25}}) {
-        auto insert_result = queryset.insert(p);
+        auto insert_result = queryset.insert(p).execute();
         ASSERT_TRUE(insert_result.has_value()) << "INSERT failed: " << insert_result.error().message();
     }
 
     // Two people have age 30
-    auto result = queryset.where(field<^^SelectOnePerson::age>() == 30).get();
+    auto result = queryset.where(field<^^SelectOnePerson::age>() == 30).get().execute();
     ASSERT_FALSE(result.has_value()) << "get() should return error when WHERE matches multiple rows";
     EXPECT_EQ(result.error().code(), -1);
     EXPECT_EQ(result.error().message(), "Multiple rows found matching query");

--- a/tests/test_sql_inspection.cpp
+++ b/tests/test_sql_inspection.cpp
@@ -1,0 +1,520 @@
+#include <gtest/gtest.h>
+#include "test_db_helpers.h"
+
+// NOLINTBEGIN(misc-use-internal-linkage,modernize-use-trailing-return-type,readability-named-parameter,readability-convert-member-functions-to-static)
+
+import storm;
+import <string>;
+import <string_view>;
+import <vector>;
+import <expected>;
+import <span>;
+import <optional>;
+
+using namespace storm;
+using namespace storm::orm::where;
+
+// ============================================================================
+// Test model for SQL inspection
+// ============================================================================
+
+struct SqlPerson {
+    [[= storm::meta::FieldAttr::primary]] int id{};
+    std::string                               name;
+    int                                       age{};
+};
+
+// ============================================================================
+// Test fixture
+// ============================================================================
+
+template <typename ConnType> class SqlInspectionTest : public ::testing::Test {
+  protected:
+    auto SetUp() -> void override {
+        if (!storm::test::backend_available<ConnType>()) {
+            GTEST_SKIP() << "PostgreSQL unavailable";
+        }
+
+        const auto& conn_str = storm::test::get_connection_string<ConnType>();
+        auto        result   = QuerySet<SqlPerson, ConnType>::set_default_connection(conn_str);
+        ASSERT_TRUE(result.has_value()) << "Failed to open database: " << result.error().message();
+
+        const auto& conn = QuerySet<SqlPerson, ConnType>::get_default_connection();
+
+        auto create_result = storm::test::ensure_table<ConnType>(
+                conn,
+                "CREATE TABLE SqlPerson ("
+                "id INTEGER PRIMARY KEY AUTOINCREMENT, "
+                "name TEXT NOT NULL, "
+                "age INTEGER NOT NULL"
+                ")"
+        );
+        ASSERT_TRUE(create_result.has_value()) << "Failed to create table: " << create_result.error().message();
+
+        storm::test::begin_test_txn<ConnType>(conn, {"SqlPerson"});
+    }
+
+    auto TearDown() -> void override {
+        if constexpr (storm::test::is_postgresql<ConnType>()) {
+            if (QuerySet<SqlPerson, ConnType>::has_default_connection()) {
+                const auto& conn = QuerySet<SqlPerson, ConnType>::get_default_connection();
+                storm::test::rollback_test_txn<ConnType>(conn);
+            }
+        }
+        QuerySet<SqlPerson, ConnType>::clear_default_connection();
+    }
+};
+
+TYPED_TEST_SUITE(SqlInspectionTest, DatabaseTypes);
+
+// ============================================================================
+// Helper: check that string contains a substring
+// ============================================================================
+
+static auto contains(const std::string& str, std::string_view substr) -> bool {
+    return str.find(substr) != std::string::npos;
+}
+
+// ============================================================================
+// SELECT .to_sql() tests
+// ============================================================================
+
+TYPED_TEST(SqlInspectionTest, SelectBareToSql) {
+    QuerySet<SqlPerson, TypeParam> qs;
+    auto                           result = qs.select().to_sql();
+    ASSERT_TRUE(result.has_value()) << "to_sql() failed: " << result.error().message();
+
+    const std::string& sql = result.value();
+    EXPECT_FALSE(sql.empty()) << "SQL should not be empty";
+    EXPECT_TRUE(contains(sql, "SELECT")) << "Should contain SELECT";
+    EXPECT_TRUE(contains(sql, "SqlPerson")) << "Should contain table name";
+    EXPECT_TRUE(contains(sql, "name")) << "Should contain field 'name'";
+    EXPECT_TRUE(contains(sql, "age")) << "Should contain field 'age'";
+    // No WHERE clause
+    EXPECT_FALSE(contains(sql, "WHERE")) << "Bare select should have no WHERE";
+}
+
+TYPED_TEST(SqlInspectionTest, SelectWithWhereToSql) {
+    QuerySet<SqlPerson, TypeParam> qs;
+    auto                           result = qs.where(field<^^SqlPerson::age>() > 30).select().to_sql();
+    ASSERT_TRUE(result.has_value()) << "to_sql() failed: " << result.error().message();
+
+    const std::string& sql = result.value();
+    EXPECT_TRUE(contains(sql, "SELECT")) << "Should contain SELECT";
+    EXPECT_TRUE(contains(sql, "WHERE")) << "Should contain WHERE";
+    EXPECT_TRUE(contains(sql, "age")) << "Should contain field 'age'";
+    // Value 30 should appear in the SQL (either as 30 or '30')
+    EXPECT_TRUE(contains(sql, "30")) << "Should contain value 30";
+}
+
+TYPED_TEST(SqlInspectionTest, SelectWithStringWhereToSql) {
+    QuerySet<SqlPerson, TypeParam> qs;
+    auto                           result = qs.where(field<^^SqlPerson::name>() == "Alice").select().to_sql();
+    ASSERT_TRUE(result.has_value()) << "to_sql() failed: " << result.error().message();
+
+    const std::string& sql = result.value();
+    EXPECT_TRUE(contains(sql, "WHERE")) << "Should contain WHERE";
+    EXPECT_TRUE(contains(sql, "Alice")) << "Should contain string value 'Alice'";
+}
+
+TYPED_TEST(SqlInspectionTest, SelectWithLimitToSql) {
+    QuerySet<SqlPerson, TypeParam> qs;
+    auto                           result = qs.limit(10).select().to_sql();
+    ASSERT_TRUE(result.has_value()) << "to_sql() failed: " << result.error().message();
+
+    const std::string& sql = result.value();
+    EXPECT_TRUE(contains(sql, "LIMIT")) << "Should contain LIMIT";
+    EXPECT_TRUE(contains(sql, "10")) << "Should contain limit value";
+}
+
+TYPED_TEST(SqlInspectionTest, SelectWithOffsetToSql) {
+    QuerySet<SqlPerson, TypeParam> qs;
+    auto                           result = qs.limit(5).offset(10).select().to_sql();
+    ASSERT_TRUE(result.has_value()) << "to_sql() failed: " << result.error().message();
+
+    const std::string& sql = result.value();
+    EXPECT_TRUE(contains(sql, "LIMIT")) << "Should contain LIMIT";
+    EXPECT_TRUE(contains(sql, "OFFSET")) << "Should contain OFFSET";
+    EXPECT_TRUE(contains(sql, "10")) << "Should contain offset value";
+}
+
+TYPED_TEST(SqlInspectionTest, SelectWithOrderByToSql) {
+    QuerySet<SqlPerson, TypeParam> qs;
+    auto                           result = qs.template order_by<^^SqlPerson::age>().select().to_sql();
+    ASSERT_TRUE(result.has_value()) << "to_sql() failed: " << result.error().message();
+
+    const std::string& sql = result.value();
+    EXPECT_TRUE(contains(sql, "ORDER BY")) << "Should contain ORDER BY";
+    EXPECT_TRUE(contains(sql, "age")) << "Should contain sorted field";
+}
+
+TYPED_TEST(SqlInspectionTest, SelectWithWhereAndLimitToSql) {
+    QuerySet<SqlPerson, TypeParam> qs;
+    auto                           result = qs.where(field<^^SqlPerson::age>() > 25).limit(5).select().to_sql();
+    ASSERT_TRUE(result.has_value()) << "to_sql() failed: " << result.error().message();
+
+    const std::string& sql = result.value();
+    EXPECT_TRUE(contains(sql, "WHERE")) << "Should contain WHERE";
+    EXPECT_TRUE(contains(sql, "LIMIT")) << "Should contain LIMIT";
+    EXPECT_TRUE(contains(sql, "25")) << "Should contain WHERE value";
+    EXPECT_TRUE(contains(sql, "5")) << "Should contain LIMIT value";
+}
+
+TYPED_TEST(SqlInspectionTest, SelectOperatorsToSql) {
+    QuerySet<SqlPerson, TypeParam> qs;
+
+    // Test all comparison operators generate proper SQL
+    auto r_eq = qs.where(field<^^SqlPerson::age>() == 30).select().to_sql();
+    auto r_ne = qs.where(field<^^SqlPerson::age>() != 30).select().to_sql();
+    auto r_gt = qs.where(field<^^SqlPerson::age>() > 30).select().to_sql();
+    auto r_ge = qs.where(field<^^SqlPerson::age>() >= 30).select().to_sql();
+    auto r_lt = qs.where(field<^^SqlPerson::age>() < 30).select().to_sql();
+    auto r_le = qs.where(field<^^SqlPerson::age>() <= 30).select().to_sql();
+
+    ASSERT_TRUE(r_eq.has_value());
+    ASSERT_TRUE(r_ne.has_value());
+    ASSERT_TRUE(r_gt.has_value());
+    ASSERT_TRUE(r_ge.has_value());
+    ASSERT_TRUE(r_lt.has_value());
+    ASSERT_TRUE(r_le.has_value());
+
+    EXPECT_TRUE(contains(r_eq.value(), "=")) << "EQ should use =";
+    EXPECT_TRUE(contains(r_ne.value(), "!=") || contains(r_ne.value(), "<>")) << "NE should use != or <>";
+    EXPECT_TRUE(contains(r_gt.value(), ">")) << "GT should use >";
+    EXPECT_TRUE(contains(r_ge.value(), ">=")) << "GE should use >=";
+    EXPECT_TRUE(contains(r_lt.value(), "<")) << "LT should use <";
+    EXPECT_TRUE(contains(r_le.value(), "<=")) << "LE should use <=";
+}
+
+TYPED_TEST(SqlInspectionTest, SelectWithInToSql) {
+    QuerySet<SqlPerson, TypeParam> qs;
+    auto                           result = qs.where(field<^^SqlPerson::age>().in(20, 25, 30)).select().to_sql();
+    ASSERT_TRUE(result.has_value()) << "to_sql() failed: " << result.error().message();
+
+    const std::string& sql = result.value();
+    EXPECT_TRUE(contains(sql, "IN")) << "Should contain IN";
+    EXPECT_TRUE(contains(sql, "20")) << "Should contain first value";
+    EXPECT_TRUE(contains(sql, "25")) << "Should contain second value";
+    EXPECT_TRUE(contains(sql, "30")) << "Should contain third value";
+}
+
+TYPED_TEST(SqlInspectionTest, SelectWithBetweenToSql) {
+    QuerySet<SqlPerson, TypeParam> qs;
+    auto                           result = qs.where(field<^^SqlPerson::age>().between(20, 40)).select().to_sql();
+    ASSERT_TRUE(result.has_value()) << "to_sql() failed: " << result.error().message();
+
+    const std::string& sql = result.value();
+    EXPECT_TRUE(contains(sql, "BETWEEN")) << "Should contain BETWEEN";
+    EXPECT_TRUE(contains(sql, "20")) << "Should contain lower bound";
+    EXPECT_TRUE(contains(sql, "40")) << "Should contain upper bound";
+}
+
+TYPED_TEST(SqlInspectionTest, SelectWithLikeToSql) {
+    QuerySet<SqlPerson, TypeParam> qs;
+    auto                           result = qs.where(field<^^SqlPerson::name>().like("A%")).select().to_sql();
+    ASSERT_TRUE(result.has_value()) << "to_sql() failed: " << result.error().message();
+
+    const std::string& sql = result.value();
+    EXPECT_TRUE(contains(sql, "LIKE")) << "Should contain LIKE";
+    EXPECT_TRUE(contains(sql, "A%")) << "Should contain LIKE pattern";
+}
+
+TYPED_TEST(SqlInspectionTest, SelectWithAndOrToSql) {
+    QuerySet<SqlPerson, TypeParam> qs;
+    auto result = qs.where((field<^^SqlPerson::age>() > 25) && (field<^^SqlPerson::age>() < 50)).select().to_sql();
+    ASSERT_TRUE(result.has_value()) << "to_sql() failed: " << result.error().message();
+
+    const std::string& sql = result.value();
+    EXPECT_TRUE(contains(sql, "AND")) << "Should contain AND";
+    EXPECT_TRUE(contains(sql, "25")) << "Should contain lower bound value";
+    EXPECT_TRUE(contains(sql, "50")) << "Should contain upper bound value";
+}
+
+// ============================================================================
+// FIRST .to_sql() tests
+// ============================================================================
+
+TYPED_TEST(SqlInspectionTest, FirstBareToSql) {
+    QuerySet<SqlPerson, TypeParam> qs;
+    auto                           result = qs.first().to_sql();
+    ASSERT_TRUE(result.has_value()) << "first().to_sql() failed: " << result.error().message();
+
+    const std::string& sql = result.value();
+    EXPECT_TRUE(contains(sql, "SELECT")) << "Should contain SELECT";
+    EXPECT_TRUE(contains(sql, "LIMIT 1")) << "first() should use LIMIT 1";
+}
+
+TYPED_TEST(SqlInspectionTest, FirstWithWhereToSql) {
+    QuerySet<SqlPerson, TypeParam> qs;
+    auto                           result = qs.where(field<^^SqlPerson::age>() > 25).first().to_sql();
+    ASSERT_TRUE(result.has_value()) << "first().to_sql() failed: " << result.error().message();
+
+    const std::string& sql = result.value();
+    EXPECT_TRUE(contains(sql, "WHERE")) << "Should contain WHERE";
+    EXPECT_TRUE(contains(sql, "LIMIT 1")) << "first() should use LIMIT 1";
+    EXPECT_TRUE(contains(sql, "25")) << "Should contain value";
+}
+
+TYPED_TEST(SqlInspectionTest, FirstWithOrderByToSql) {
+    QuerySet<SqlPerson, TypeParam> qs;
+    auto                           result = qs.template order_by<^^SqlPerson::age>().first().to_sql();
+    ASSERT_TRUE(result.has_value()) << "first().to_sql() failed: " << result.error().message();
+
+    const std::string& sql = result.value();
+    EXPECT_TRUE(contains(sql, "ORDER BY")) << "Should contain ORDER BY";
+    EXPECT_TRUE(contains(sql, "LIMIT 1")) << "first() should use LIMIT 1";
+}
+
+// ============================================================================
+// GET .to_sql() tests
+// ============================================================================
+
+TYPED_TEST(SqlInspectionTest, GetBareToSql) {
+    QuerySet<SqlPerson, TypeParam> qs;
+    auto                           result = qs.get().to_sql();
+    ASSERT_TRUE(result.has_value()) << "get().to_sql() failed: " << result.error().message();
+
+    const std::string& sql = result.value();
+    EXPECT_TRUE(contains(sql, "SELECT")) << "Should contain SELECT";
+    EXPECT_TRUE(contains(sql, "LIMIT 2")) << "get() should use LIMIT 2";
+}
+
+TYPED_TEST(SqlInspectionTest, GetWithWhereToSql) {
+    QuerySet<SqlPerson, TypeParam> qs;
+    auto                           result = qs.where(field<^^SqlPerson::id>() == 42).get().to_sql();
+    ASSERT_TRUE(result.has_value()) << "get().to_sql() failed: " << result.error().message();
+
+    const std::string& sql = result.value();
+    EXPECT_TRUE(contains(sql, "WHERE")) << "Should contain WHERE";
+    EXPECT_TRUE(contains(sql, "LIMIT 2")) << "get() should use LIMIT 2";
+    EXPECT_TRUE(contains(sql, "42")) << "Should contain value";
+}
+
+// ============================================================================
+// INSERT .to_sql() tests
+// ============================================================================
+
+TYPED_TEST(SqlInspectionTest, InsertSingleToSql) {
+    QuerySet<SqlPerson, TypeParam> qs;
+    SqlPerson                      alice{.id = 0, .name = "Alice", .age = 30};
+
+    auto result = qs.insert(alice).to_sql();
+    ASSERT_TRUE(result.has_value()) << "insert().to_sql() failed: " << result.error().message();
+
+    const std::string& sql = result.value();
+    EXPECT_TRUE(contains(sql, "INSERT INTO")) << "Should contain INSERT INTO";
+    EXPECT_TRUE(contains(sql, "SqlPerson")) << "Should contain table name";
+    EXPECT_TRUE(contains(sql, "VALUES")) << "Should contain VALUES";
+    EXPECT_TRUE(contains(sql, "Alice")) << "Should contain name value";
+    EXPECT_TRUE(contains(sql, "30")) << "Should contain age value";
+}
+
+TYPED_TEST(SqlInspectionTest, InsertSingleToSqlDoesNotExecute) {
+    QuerySet<SqlPerson, TypeParam> qs;
+    SqlPerson                      alice{.id = 0, .name = "Alice", .age = 30};
+
+    // Calling to_sql() should NOT insert into the database
+    auto sql_result = qs.insert(alice).to_sql();
+    ASSERT_TRUE(sql_result.has_value());
+
+    // Table should still be empty
+    auto select_result = qs.select().execute();
+    ASSERT_TRUE(select_result.has_value());
+    EXPECT_TRUE(select_result.value().empty()) << "to_sql() should not insert data";
+}
+
+TYPED_TEST(SqlInspectionTest, InsertBulkToSql) {
+    QuerySet<SqlPerson, TypeParam> qs;
+    std::vector<SqlPerson>         people = {
+            SqlPerson{.id = 0, .name = "Alice", .age = 30},
+            SqlPerson{.id = 0, .name = "Bob", .age = 25},
+    };
+
+    auto result = qs.insert(std::span<const SqlPerson>(people)).to_sql();
+    ASSERT_TRUE(result.has_value()) << "bulk insert().to_sql() failed: " << result.error().message();
+
+    const std::string& sql = result.value();
+    EXPECT_TRUE(contains(sql, "INSERT INTO")) << "Should contain INSERT INTO";
+    EXPECT_TRUE(contains(sql, "VALUES")) << "Should contain VALUES";
+    EXPECT_TRUE(contains(sql, "Alice")) << "Should contain first name";
+    EXPECT_TRUE(contains(sql, "Bob")) << "Should contain second name";
+}
+
+TYPED_TEST(SqlInspectionTest, InsertWithSpecialCharsToSql) {
+    QuerySet<SqlPerson, TypeParam> qs;
+    SqlPerson                      tricky{.id = 0, .name = "O'Brien", .age = 35};
+
+    auto result = qs.insert(tricky).to_sql();
+    ASSERT_TRUE(result.has_value()) << "insert().to_sql() failed: " << result.error().message();
+
+    const std::string& sql = result.value();
+    EXPECT_FALSE(sql.empty());
+    EXPECT_TRUE(contains(sql, "O")) << "Should contain part of name";
+    EXPECT_TRUE(contains(sql, "Brien")) << "Should contain part of name";
+}
+
+// ============================================================================
+// UPDATE .to_sql() tests
+// ============================================================================
+
+TYPED_TEST(SqlInspectionTest, UpdateSingleToSql) {
+    QuerySet<SqlPerson, TypeParam> qs;
+    // First insert to get a valid ID
+    SqlPerson alice{.id = 0, .name = "Alice", .age = 30};
+    auto      insert_result = qs.insert(alice).execute();
+    ASSERT_TRUE(insert_result.has_value());
+    alice.id = static_cast<int>(insert_result.value());
+
+    alice.age   = 31;
+    auto result = qs.update(alice).to_sql();
+    ASSERT_TRUE(result.has_value()) << "update().to_sql() failed: " << result.error().message();
+
+    const std::string& sql = result.value();
+    EXPECT_TRUE(contains(sql, "UPDATE")) << "Should contain UPDATE";
+    EXPECT_TRUE(contains(sql, "SqlPerson")) << "Should contain table name";
+    EXPECT_TRUE(contains(sql, "SET")) << "Should contain SET";
+    EXPECT_TRUE(contains(sql, "WHERE")) << "Should contain WHERE";
+    EXPECT_TRUE(contains(sql, "31")) << "Should contain updated age value";
+}
+
+TYPED_TEST(SqlInspectionTest, UpdateToSqlDoesNotExecute) {
+    QuerySet<SqlPerson, TypeParam> qs;
+    SqlPerson                      alice{.id = 0, .name = "Alice", .age = 30};
+    auto                           insert_result = qs.insert(alice).execute();
+    ASSERT_TRUE(insert_result.has_value());
+    alice.id = static_cast<int>(insert_result.value());
+
+    // Get SQL without executing
+    SqlPerson modified = alice;
+    modified.age       = 99;
+    auto sql_result    = qs.update(modified).to_sql();
+    ASSERT_TRUE(sql_result.has_value());
+
+    // Check original value unchanged
+    auto select_result = qs.select().execute();
+    ASSERT_TRUE(select_result.has_value());
+    ASSERT_EQ(select_result.value().size(), 1U);
+    EXPECT_EQ(select_result.value().begin()->age, 30) << "to_sql() should not update data";
+}
+
+// ============================================================================
+// REMOVE .to_sql() tests
+// ============================================================================
+
+TYPED_TEST(SqlInspectionTest, RemoveSingleToSql) {
+    QuerySet<SqlPerson, TypeParam> qs;
+    SqlPerson                      alice{.id = 0, .name = "Alice", .age = 30};
+    auto                           insert_result = qs.insert(alice).execute();
+    ASSERT_TRUE(insert_result.has_value());
+    alice.id = static_cast<int>(insert_result.value());
+
+    auto result = qs.remove(alice).to_sql();
+    ASSERT_TRUE(result.has_value()) << "remove().to_sql() failed: " << result.error().message();
+
+    const std::string& sql = result.value();
+    EXPECT_TRUE(contains(sql, "DELETE FROM")) << "Should contain DELETE FROM";
+    EXPECT_TRUE(contains(sql, "SqlPerson")) << "Should contain table name";
+    EXPECT_TRUE(contains(sql, "WHERE")) << "Should contain WHERE (id condition)";
+}
+
+TYPED_TEST(SqlInspectionTest, RemoveToSqlDoesNotExecute) {
+    QuerySet<SqlPerson, TypeParam> qs;
+    SqlPerson                      alice{.id = 0, .name = "Alice", .age = 30};
+    auto                           insert_result = qs.insert(alice).execute();
+    ASSERT_TRUE(insert_result.has_value());
+    alice.id = static_cast<int>(insert_result.value());
+
+    // Get SQL without executing
+    auto sql_result = qs.remove(alice).to_sql();
+    ASSERT_TRUE(sql_result.has_value());
+
+    // Row should still be there
+    auto select_result = qs.select().execute();
+    ASSERT_TRUE(select_result.has_value());
+    EXPECT_EQ(select_result.value().size(), 1U) << "to_sql() should not delete data";
+}
+
+TYPED_TEST(SqlInspectionTest, RemoveBulkToSql) {
+    QuerySet<SqlPerson, TypeParam> qs;
+    std::vector<SqlPerson>         people = {
+            SqlPerson{.id = 0, .name = "Alice", .age = 30},
+            SqlPerson{.id = 0, .name = "Bob", .age = 25},
+    };
+
+    // Insert and get IDs
+    for (auto& p : people) {
+        auto r = qs.insert(p).execute();
+        ASSERT_TRUE(r.has_value());
+        p.id = static_cast<int>(r.value());
+    }
+
+    auto result = qs.remove(std::span<const SqlPerson>(people)).to_sql();
+    ASSERT_TRUE(result.has_value()) << "bulk remove().to_sql() failed: " << result.error().message();
+
+    const std::string& sql = result.value();
+    EXPECT_TRUE(contains(sql, "DELETE FROM")) << "Should contain DELETE FROM";
+    EXPECT_FALSE(sql.empty()) << "Bulk delete SQL should not be empty";
+}
+
+// ============================================================================
+// No side effects: execute() still works after to_sql()
+// ============================================================================
+
+TYPED_TEST(SqlInspectionTest, ToSqlAndExecuteAreIndependent) {
+    QuerySet<SqlPerson, TypeParam> qs;
+    SqlPerson                      alice{.id = 0, .name = "Alice", .age = 30};
+
+    // Call to_sql() first
+    auto sql_result = qs.insert(alice).to_sql();
+    ASSERT_TRUE(sql_result.has_value());
+    EXPECT_FALSE(sql_result.value().empty());
+
+    // Then call execute() — should succeed
+    auto exec_result = qs.insert(alice).execute();
+    ASSERT_TRUE(exec_result.has_value());
+
+    // Data should now be in the database
+    auto select_result = qs.select().execute();
+    ASSERT_TRUE(select_result.has_value());
+    EXPECT_EQ(select_result.value().size(), 1U);
+}
+
+TYPED_TEST(SqlInspectionTest, SelectToSqlAndExecuteAreIndependent) {
+    QuerySet<SqlPerson, TypeParam> qs;
+    SqlPerson                      alice{.id = 0, .name = "Alice", .age = 30};
+    ASSERT_TRUE(qs.insert(alice).execute().has_value());
+
+    // Call to_sql()
+    auto sql_result = qs.select().to_sql();
+    ASSERT_TRUE(sql_result.has_value());
+    EXPECT_FALSE(sql_result.value().empty());
+
+    // Call execute() — should return data
+    auto exec_result = qs.select().execute();
+    ASSERT_TRUE(exec_result.has_value());
+    EXPECT_EQ(exec_result.value().size(), 1U);
+}
+
+// ============================================================================
+// Empty span edge case
+// ============================================================================
+
+TYPED_TEST(SqlInspectionTest, InsertEmptySpanToSql) {
+    QuerySet<SqlPerson, TypeParam> qs;
+    std::vector<SqlPerson>         empty;
+
+    auto result = qs.insert(std::span<const SqlPerson>(empty)).to_sql();
+    ASSERT_TRUE(result.has_value());
+    EXPECT_TRUE(result.value().empty()) << "Empty span should return empty SQL";
+}
+
+TYPED_TEST(SqlInspectionTest, RemoveEmptySpanToSql) {
+    QuerySet<SqlPerson, TypeParam> qs;
+    std::vector<SqlPerson>         empty;
+
+    auto result = qs.remove(std::span<const SqlPerson>(empty)).to_sql();
+    ASSERT_TRUE(result.has_value());
+    EXPECT_TRUE(result.value().empty()) << "Empty span should return empty SQL";
+}
+
+// NOLINTEND(misc-use-internal-linkage,modernize-use-trailing-return-type,readability-named-parameter,readability-convert-member-functions-to-static)

--- a/tests/test_sqlite.cpp
+++ b/tests/test_sqlite.cpp
@@ -88,7 +88,7 @@ template <typename ConnType> class QuerySetRemoveTest : public ::testing::Test {
     static auto personExists(int person_id) -> bool {
         using namespace storm::orm::where;
         storm::QuerySet<SqlitePerson, ConnType> qs;
-        auto                                    result = qs.where(field<^^SqlitePerson::id>() == person_id).select();
+        auto result = qs.where(field<^^SqlitePerson::id>() == person_id).select().execute();
         return result.has_value() && !result.value().empty();
     }
 };
@@ -119,7 +119,7 @@ TYPED_TEST(QuerySetRemoveTest, RemoveExistingSqlitePerson) {
     EXPECT_EQ(this->countSqlitePersons(), 3) << "Should have 3 persons before removal";
 
     // Remove Alice using QuerySet.remove()
-    auto result = queryset.remove(alice);
+    auto result = queryset.remove(alice).execute();
 
     // Verify removal was successful
     ASSERT_TRUE(result.has_value()) << "Remove operation should succeed for existing person";
@@ -146,7 +146,7 @@ TYPED_TEST(QuerySetRemoveTest, RemoveNonExistentSqlitePerson) {
     EXPECT_EQ(this->countSqlitePersons(), 3) << "Should have 3 persons before removal attempt";
 
     // Attempt to remove non-existent person using QuerySet.remove()
-    auto result = queryset.remove(nonexistent);
+    auto result = queryset.remove(nonexistent).execute();
 
     // Verify operation completes (SQLite DELETE with no matching rows is not an error)
     ASSERT_TRUE(result.has_value()) << "Remove operation should not error for non-existent person";
@@ -170,13 +170,13 @@ TYPED_TEST(QuerySetRemoveTest, RemoveMultipleSqlitePersonsSequentially) {
     EXPECT_EQ(this->countSqlitePersons(), 3) << "Should have 3 persons initially";
 
     // Remove Alice using QuerySet.remove()
-    auto result1 = queryset.remove(alice);
+    auto result1 = queryset.remove(alice).execute();
     ASSERT_TRUE(result1.has_value()) << "First remove should succeed";
     // No need to check result1.value() for void std::expected - success is indicated by has_value()
     EXPECT_EQ(this->countSqlitePersons(), 2) << "Should have 2 persons after first removal";
 
     // Remove Bob using QuerySet.remove()
-    auto result2 = queryset.remove(bob);
+    auto result2 = queryset.remove(bob).execute();
     ASSERT_TRUE(result2.has_value()) << "Second remove should succeed";
     // No need to check result2.value() for void std::expected - success is indicated by has_value()
     EXPECT_EQ(this->countSqlitePersons(), 1) << "Should have 1 person after second removal";
@@ -198,7 +198,7 @@ TYPED_TEST(QuerySetRemoveTest, RemoveWithZeroId) {
     EXPECT_EQ(this->countSqlitePersons(), 3) << "Should have 3 persons initially";
 
     // Attempt to remove person with id 0 using QuerySet.remove()
-    auto result = queryset.remove(zero_person);
+    auto result = queryset.remove(zero_person).execute();
 
     // Verify operation completes without error
     ASSERT_TRUE(result.has_value()) << "Remove operation should complete for id 0";
@@ -232,7 +232,7 @@ TYPED_TEST(QuerySetRemoveTest, RemoveBatchSmall) {
     }
 
     // Remove batch using new batch API
-    auto result = queryset.remove(std::span<const SqlitePerson>(batch_to_remove));
+    auto result = queryset.remove(std::span<const SqlitePerson>(batch_to_remove)).execute();
 
     // Verify removal was successful
     ASSERT_TRUE(result.has_value()) << "Batch remove operation should succeed";
@@ -275,7 +275,7 @@ TYPED_TEST(QuerySetRemoveTest, RemoveBatchLarge) {
     }
 
     // Remove large batch - should use individual statements with transaction
-    auto result = queryset.remove(std::span<const SqlitePerson>(large_batch));
+    auto result = queryset.remove(std::span<const SqlitePerson>(large_batch)).execute();
 
     // Verify removal was successful
     if (!result.has_value()) {
@@ -309,7 +309,7 @@ TYPED_TEST(QuerySetRemoveTest, RemoveBatchEmpty) {
     std::vector<SqlitePerson> empty_batch;
 
     // Attempt to remove empty batch
-    auto result = queryset.remove(std::span<const SqlitePerson>(empty_batch));
+    auto result = queryset.remove(std::span<const SqlitePerson>(empty_batch)).execute();
 
     // Verify operation completes without error
     ASSERT_TRUE(result.has_value()) << "Empty batch remove should not error";
@@ -338,7 +338,7 @@ TYPED_TEST(QuerySetRemoveTest, RemoveBatchPartialExist) {
     };
 
     // Remove mixed batch
-    auto result = queryset.remove(std::span<const SqlitePerson>(mixed_batch));
+    auto result = queryset.remove(std::span<const SqlitePerson>(mixed_batch)).execute();
 
     // Verify operation completes successfully (non-existing deletes are not errors)
     ASSERT_TRUE(result.has_value()) << "Mixed batch remove should succeed";
@@ -369,7 +369,7 @@ TYPED_TEST(QuerySetRemoveTest, RemoveBatchPerformance) {
     auto start_individual = std::chrono::steady_clock::now();
     for (int i = 1; i <= 50; i++) {
         SqlitePerson const person{.id = i, .name = "SqlitePerson" + std::to_string(i), .age = 20 + (i % 60)};
-        auto               result = queryset.remove(person);
+        auto               result = queryset.remove(person).execute();
         ASSERT_TRUE(result.has_value()) << "Individual remove should succeed";
     }
     auto end_individual = std::chrono::steady_clock::now();
@@ -384,7 +384,7 @@ TYPED_TEST(QuerySetRemoveTest, RemoveBatchPerformance) {
 
     // Measure batch remove
     auto start_batch = std::chrono::steady_clock::now();
-    auto result      = queryset.remove(std::span<const SqlitePerson>(batch));
+    auto result      = queryset.remove(std::span<const SqlitePerson>(batch)).execute();
     ASSERT_TRUE(result.has_value()) << "Batch remove should succeed";
     auto end_batch      = std::chrono::steady_clock::now();
     auto duration_batch = std::chrono::duration_cast<std::chrono::microseconds>(end_batch - start_batch).count();
@@ -413,7 +413,7 @@ TYPED_TEST(QuerySetRemoveTest, InsertSingleSqlitePerson) {
     EXPECT_EQ(this->countSqlitePersons(), 3) << "Should have 3 persons initially";
 
     // Insert Dave using QuerySet.insert()
-    auto result = queryset.insert(dave);
+    auto result = queryset.insert(dave).execute();
 
     // Verify insertion was successful and ID was returned
     ASSERT_TRUE(result.has_value()) << "Insert operation should succeed: "
@@ -441,7 +441,7 @@ TYPED_TEST(QuerySetRemoveTest, InsertSmallBatch) {
     EXPECT_EQ(this->countSqlitePersons(), 3) << "Should have 3 persons initially";
 
     // Insert batch using QuerySet.insert() with span
-    auto result = queryset.insert(std::span<const SqlitePerson>(small_batch));
+    auto result = queryset.insert(std::span<const SqlitePerson>(small_batch)).execute();
 
     // Verify batch insertion was successful (returns void)
     ASSERT_TRUE(result.has_value()) << "Batch insert operation should succeed: "
@@ -451,7 +451,7 @@ TYPED_TEST(QuerySetRemoveTest, InsertSmallBatch) {
     EXPECT_EQ(this->countSqlitePersons(), 6) << "Should have 6 persons after batch insertion";
 
     // Verify persons exist by selecting and checking names
-    auto select_result = queryset.select();
+    auto select_result = queryset.select().execute();
     ASSERT_TRUE(select_result.has_value());
     bool found_dave  = false; // NOLINT(misc-const-correctness) - modified in loop
     bool found_eve   = false; // NOLINT(misc-const-correctness) - modified in loop
@@ -486,7 +486,7 @@ TYPED_TEST(QuerySetRemoveTest, InsertMediumBatch) {
     EXPECT_EQ(this->countSqlitePersons(), 3) << "Should have 3 persons initially";
 
     // Insert batch using QuerySet.insert() with span
-    auto result = queryset.insert(std::span<const SqlitePerson>(medium_batch));
+    auto result = queryset.insert(std::span<const SqlitePerson>(medium_batch)).execute();
 
     // Verify batch insertion was successful (returns void)
     ASSERT_TRUE(result.has_value()) << "Medium batch insert operation should succeed: "
@@ -510,7 +510,7 @@ TYPED_TEST(QuerySetRemoveTest, InsertLargeBatch) {
     EXPECT_EQ(this->countSqlitePersons(), 3) << "Should have 3 persons initially";
 
     // Insert batch using QuerySet.insert() with span
-    auto result = queryset.insert(std::span<const SqlitePerson>(large_batch));
+    auto result = queryset.insert(std::span<const SqlitePerson>(large_batch)).execute();
 
     // Verify batch insertion was successful (returns void)
     ASSERT_TRUE(result.has_value()) << "Large batch insert operation should succeed: "
@@ -531,7 +531,7 @@ TYPED_TEST(QuerySetRemoveTest, InsertEmptyBatch) {
     EXPECT_EQ(this->countSqlitePersons(), 3) << "Should have 3 persons initially";
 
     // Insert empty batch using QuerySet.insert() with span
-    auto result = queryset.insert(std::span<const SqlitePerson>(empty_batch));
+    auto result = queryset.insert(std::span<const SqlitePerson>(empty_batch)).execute();
 
     // Verify operation succeeds for empty batch (returns void)
     ASSERT_TRUE(result.has_value()) << "Empty batch insert operation should succeed";
@@ -568,7 +568,7 @@ TYPED_TEST(QuerySetRemoveTest, RemoveBatchChunked) {
     }
 
     // Remove chunked batch - should use execute_chunked with transaction
-    auto result = queryset.remove(std::span<const SqlitePerson>(chunked_batch));
+    auto result = queryset.remove(std::span<const SqlitePerson>(chunked_batch)).execute();
 
     // Verify removal was successful
     if (!result.has_value()) {
@@ -619,7 +619,7 @@ TYPED_TEST(QuerySetRemoveTest, RemoveBatchChunkedWithRemainder) {
     }
 
     // Remove chunked batch - should use execute_chunked with remainder
-    auto result = queryset.remove(std::span<const SqlitePerson>(chunked_batch));
+    auto result = queryset.remove(std::span<const SqlitePerson>(chunked_batch)).execute();
 
     // Verify removal was successful
     ASSERT_TRUE(result.has_value()) << "Chunked batch remove with remainder should succeed: "
@@ -707,7 +707,7 @@ template <typename ConnType> class QuerySetUpdateTest : public ::testing::Test {
     static auto getSqlitePerson(int person_id) -> std::optional<SqlitePerson> {
         using namespace storm::orm::where;
         storm::QuerySet<SqlitePerson, ConnType> qs;
-        auto                                    result = qs.where(field<^^SqlitePerson::id>() == person_id).select();
+        auto result = qs.where(field<^^SqlitePerson::id>() == person_id).select().execute();
         if (!result.has_value() || result.value().empty()) {
             return std::nullopt;
         }
@@ -758,7 +758,7 @@ TYPED_TEST(QuerySetUpdateTest, UpdateExistingSqlitePerson) {
 
     // Update Alice's information
     SqlitePerson const updated_alice{.id = 1, .name = "Alice Smith", .age = 31};
-    auto               result = queryset.update(updated_alice);
+    auto               result = queryset.update(updated_alice).execute();
 
     // Verify update was successful
     ASSERT_TRUE(result.has_value()) << "Update operation should succeed";
@@ -789,7 +789,7 @@ TYPED_TEST(QuerySetUpdateTest, UpdateNonExistingSqlitePerson) {
 
     // Attempt to update non-existing person
     SqlitePerson const non_existing{.id = 999, .name = "Ghost SqlitePerson", .age = 99};
-    auto               result = queryset.update(non_existing);
+    auto               result = queryset.update(non_existing).execute();
 
     // Verify operation completes without error (UPDATE of non-existing row is not an error in SQL)
     ASSERT_TRUE(result.has_value()) << "Update of non-existing person should not error";
@@ -805,7 +805,7 @@ TYPED_TEST(QuerySetUpdateTest, UpdateMultipleTimes) {
 
     // Update Alice multiple times
     SqlitePerson const alice_v1{.id = 1, .name = "Alice A", .age = 31};
-    auto               result1 = queryset.update(alice_v1);
+    auto               result1 = queryset.update(alice_v1).execute();
     ASSERT_TRUE(result1.has_value()) << "First update should succeed";
 
     auto check1 = this->getSqlitePerson(1);
@@ -814,7 +814,7 @@ TYPED_TEST(QuerySetUpdateTest, UpdateMultipleTimes) {
     EXPECT_EQ(check1->age, 31);
 
     SqlitePerson const alice_v2{.id = 1, .name = "Alice B", .age = 32};
-    auto               result2 = queryset.update(alice_v2);
+    auto               result2 = queryset.update(alice_v2).execute();
     ASSERT_TRUE(result2.has_value()) << "Second update should succeed";
 
     auto check2 = this->getSqlitePerson(1);
@@ -823,7 +823,7 @@ TYPED_TEST(QuerySetUpdateTest, UpdateMultipleTimes) {
     EXPECT_EQ(check2->age, 32);
 
     SqlitePerson const alice_v3{.id = 1, .name = "Alice C", .age = 33};
-    auto               result3 = queryset.update(alice_v3);
+    auto               result3 = queryset.update(alice_v3).execute();
     ASSERT_TRUE(result3.has_value()) << "Third update should succeed";
 
     auto check3 = this->getSqlitePerson(1);
@@ -844,7 +844,7 @@ TYPED_TEST(QuerySetUpdateTest, UpdateBatchSmall) {
             {{1, "Alice Updated", 31}, {2, "Bob Updated", 26}, {3, "Charlie Updated", 36}};
 
     // Update batch using batch API
-    auto result = queryset.update(std::span<const SqlitePerson>(batch_to_update));
+    auto result = queryset.update(std::span<const SqlitePerson>(batch_to_update)).execute();
 
     // Verify update was successful
     ASSERT_TRUE(result.has_value()) << "Batch update operation should succeed";
@@ -894,7 +894,7 @@ TYPED_TEST(QuerySetUpdateTest, UpdateBatchMedium) {
     }
 
     // Update batch
-    auto result = queryset.update(std::span<const SqlitePerson>(batch_to_update));
+    auto result = queryset.update(std::span<const SqlitePerson>(batch_to_update)).execute();
 
     // Verify update was successful
     ASSERT_TRUE(result.has_value()) << "Batch update operation should succeed";
@@ -944,7 +944,7 @@ TYPED_TEST(QuerySetUpdateTest, UpdateBatchLarge) {
     }
 
     // Update large batch - should use individual statements with transaction
-    auto result = queryset.update(std::span<const SqlitePerson>(large_batch));
+    auto result = queryset.update(std::span<const SqlitePerson>(large_batch)).execute();
 
     // Verify update was successful
     if (!result.has_value()) {
@@ -984,7 +984,7 @@ TYPED_TEST(QuerySetUpdateTest, UpdateBatchSingleElement) {
     std::vector<SqlitePerson> single_batch = {{1, "Alice BatchSingle", 99}};
 
     // Update using batch API with single element
-    auto result = queryset.update(std::span<const SqlitePerson>(single_batch));
+    auto result = queryset.update(std::span<const SqlitePerson>(single_batch)).execute();
 
     // Verify update was successful
     ASSERT_TRUE(result.has_value()) << "Single element batch update should succeed";
@@ -1016,7 +1016,7 @@ TYPED_TEST(QuerySetUpdateTest, UpdateBatchEmpty) {
     std::vector<SqlitePerson> empty_batch;
 
     // Attempt to update empty batch
-    auto result = queryset.update(std::span<const SqlitePerson>(empty_batch));
+    auto result = queryset.update(std::span<const SqlitePerson>(empty_batch)).execute();
 
     // Verify operation completes without error
     ASSERT_TRUE(result.has_value()) << "Empty batch update should not error";
@@ -1047,7 +1047,7 @@ TYPED_TEST(QuerySetUpdateTest, UpdateBatchPartialExist) {
     };
 
     // Update mixed batch
-    auto result = queryset.update(std::span<const SqlitePerson>(mixed_batch));
+    auto result = queryset.update(std::span<const SqlitePerson>(mixed_batch)).execute();
 
     // Verify operation completes successfully (non-existing updates are not errors)
     ASSERT_TRUE(result.has_value()) << "Mixed batch update should succeed";
@@ -1083,7 +1083,7 @@ TYPED_TEST(QuerySetUpdateTest, UpdateCachedStatementReuse) {
     // Perform multiple updates to verify statement caching works correctly
     for (int i = 0; i < 10; ++i) {
         SqlitePerson const updated_alice{.id = 1, .name = "Alice V" + std::to_string(i), .age = 30 + i};
-        auto               result = queryset.update(updated_alice);
+        auto               result = queryset.update(updated_alice).execute();
         ASSERT_TRUE(result.has_value()) << "Update iteration " << i << " should succeed";
 
         auto alice = this->getSqlitePerson(1);

--- a/tests/test_sqlite_errors.cpp
+++ b/tests/test_sqlite_errors.cpp
@@ -892,12 +892,12 @@ TEST_F(ORMErrorTest, InsertUniqueConstraintViolation) {
 
     // Insert first person
     UniqueTestPerson const person1{.id = 0, .email = "test@example.com", .value = 100};
-    auto                   result1 = qs.insert(person1);
+    auto                   result1 = qs.insert(person1).execute();
     ASSERT_TRUE(result1.has_value()) << "First insert should succeed";
 
     // Try to insert duplicate email (unique constraint violation)
     UniqueTestPerson const person2{.id = 0, .email = "test@example.com", .value = 200};
-    auto                   result2 = qs.insert(person2);
+    auto                   result2 = qs.insert(person2).execute();
 
     ASSERT_FALSE(result2.has_value()) << "Duplicate email insert should fail";
     // Should be SQLITE_CONSTRAINT
@@ -910,7 +910,7 @@ TEST_F(ORMErrorTest, BatchInsertUniqueConstraintViolation) {
 
     // Insert first person
     UniqueTestPerson const person1{.id = 0, .email = "first@example.com", .value = 100};
-    auto                   result1 = qs.insert(person1);
+    auto                   result1 = qs.insert(person1).execute();
     ASSERT_TRUE(result1.has_value()) << "First insert should succeed";
 
     // Try batch insert with one duplicate
@@ -918,7 +918,7 @@ TEST_F(ORMErrorTest, BatchInsertUniqueConstraintViolation) {
             {{0, "second@example.com", 200},
              {0, "first@example.com", 300}, // Duplicate!
              {0, "third@example.com", 400}};
-    auto result2 = qs.insert(std::span<const UniqueTestPerson>(batch));
+    auto result2 = qs.insert(std::span<const UniqueTestPerson>(batch)).execute();
 
     // Batch insert should fail due to constraint violation
     ASSERT_FALSE(result2.has_value()) << "Batch insert with duplicate should fail";
@@ -931,13 +931,13 @@ TEST_F(ORMErrorTest, UpdateUniqueConstraintViolation) {
     // Insert two unique persons
     UniqueTestPerson const person1{.id = 0, .email = "first@example.com", .value = 100};
     UniqueTestPerson const person2{.id = 0, .email = "second@example.com", .value = 200};
-    auto                   r1 = qs.insert(person1);
-    auto                   r2 = qs.insert(person2);
+    auto                   r1 = qs.insert(person1).execute();
+    auto                   r2 = qs.insert(person2).execute();
     ASSERT_TRUE(r1.has_value() && r2.has_value());
 
     // Try to update person2's email to person1's email
     UniqueTestPerson const updated{.id = static_cast<int>(r2.value()), .email = "first@example.com", .value = 300};
-    auto                   update_result = qs.update(updated);
+    auto                   update_result = qs.update(updated).execute();
 
     ASSERT_FALSE(update_result.has_value()) << "Update violating unique constraint should fail";
     EXPECT_TRUE((update_result.error().code() & 0xFF) == SQLITE_CONSTRAINT);
@@ -947,7 +947,7 @@ TEST_F(ORMErrorTest, SelectEmptyResult) {
     storm::QuerySet<ErrorTestPerson> qs;
 
     // Select from empty table - should succeed with empty result
-    auto result = qs.select();
+    auto result = qs.select().execute();
     ASSERT_TRUE(result.has_value()) << "Select from empty table should succeed";
     EXPECT_TRUE(result.value().empty()) << "Result should be empty";
 }
@@ -957,11 +957,11 @@ TEST_F(ORMErrorTest, SelectWithWhereNoMatch) {
 
     // Insert some data
     ErrorTestPerson const person{.id = 0, .name = "Alice", .age = 30};
-    auto                  insert_result = qs.insert(person);
+    auto                  insert_result = qs.insert(person).execute();
     ASSERT_TRUE(insert_result.has_value());
 
     // Select with WHERE that matches nothing
-    auto result = qs.where(storm::orm::where::field<^^ErrorTestPerson::age>() > 100).select();
+    auto result = qs.where(storm::orm::where::field<^^ErrorTestPerson::age>() > 100).select().execute();
     ASSERT_TRUE(result.has_value()) << "Select with no matches should succeed";
     EXPECT_TRUE(result.value().empty()) << "Result should be empty";
 }
@@ -971,7 +971,7 @@ TEST_F(ORMErrorTest, RemoveNonExistent) {
 
     // Try to remove non-existent person
     ErrorTestPerson const nonexistent{.id = 999, .name = "Ghost", .age = 0};
-    auto                  result = qs.remove(nonexistent);
+    auto                  result = qs.remove(nonexistent).execute();
 
     // Remove of non-existent should succeed (SQLite DELETE with no matches is not an error)
     ASSERT_TRUE(result.has_value()) << "Remove of non-existent should succeed";
@@ -1001,7 +1001,7 @@ TEST_F(ORMErrorTest, AggregateWithWhereNoMatch) {
 
     // Insert data
     ErrorTestPerson const person{.id = 0, .name = "Alice", .age = 30};
-    auto                  insert_result = qs.insert(person);
+    auto                  insert_result = qs.insert(person).execute();
     ASSERT_TRUE(insert_result.has_value());
 
     // COUNT with WHERE that matches nothing
@@ -1036,12 +1036,12 @@ TEST_F(ORMErrorTest, BatchUpdateWithConstraintViolation) {
             {{0, "first@example.com", 100}, {0, "second@example.com", 200}, {0, "third@example.com", 300}};
 
     for (const auto& p : initial) {
-        auto r = qs.insert(p);
+        auto r = qs.insert(p).execute();
         ASSERT_TRUE(r.has_value()) << "Initial insert should succeed";
     }
 
     // Get the inserted persons
-    auto select_result = qs.select();
+    auto select_result = qs.select().execute();
     ASSERT_TRUE(select_result.has_value());
     ASSERT_EQ(select_result.value().size(), 3);
 
@@ -1057,7 +1057,7 @@ TEST_F(ORMErrorTest, BatchUpdateWithConstraintViolation) {
         }
     }
 
-    auto update_result = qs.update(std::span<const UniqueTestPerson>(updates));
+    auto update_result = qs.update(std::span<const UniqueTestPerson>(updates)).execute();
     ASSERT_FALSE(update_result.has_value()) << "Batch update with constraint violation should fail";
     EXPECT_TRUE((update_result.error().code() & 0xFF) == SQLITE_CONSTRAINT);
 }
@@ -1068,7 +1068,7 @@ TEST_F(ORMErrorTest, BatchRemoveFromEmptyTable) {
     // Try to batch remove from empty table
     std::vector<ErrorTestPerson> to_remove = {{1, "Ghost1", 25}, {2, "Ghost2", 30}, {3, "Ghost3", 35}};
 
-    auto result = qs.remove(std::span<const ErrorTestPerson>(to_remove));
+    auto result = qs.remove(std::span<const ErrorTestPerson>(to_remove)).execute();
     // Should succeed - SQLite DELETE with no matches is not an error
     ASSERT_TRUE(result.has_value()) << "Batch remove of non-existent should succeed";
 }
@@ -1084,7 +1084,7 @@ TEST_F(ORMErrorTest, LargeBatchInsertThenRemove) {
     }
 
     // Batch insert returns void (not IDs) because consecutive ID assumption is unreliable
-    auto insert_result = qs.insert(std::span<const ErrorTestPerson>(batch));
+    auto insert_result = qs.insert(std::span<const ErrorTestPerson>(batch)).execute();
     ASSERT_TRUE(insert_result.has_value()) << "Large batch insert should succeed";
 
     // Verify count
@@ -1093,7 +1093,7 @@ TEST_F(ORMErrorTest, LargeBatchInsertThenRemove) {
     EXPECT_EQ(count_result.value(), 100);
 
     // Now batch remove all
-    auto select_result = qs.select();
+    auto select_result = qs.select().execute();
     ASSERT_TRUE(select_result.has_value());
     EXPECT_EQ(select_result.value().size(), 100);
 
@@ -1103,7 +1103,7 @@ TEST_F(ORMErrorTest, LargeBatchInsertThenRemove) {
         to_remove.push_back(p);
     }
 
-    auto remove_result = qs.remove(std::span<const ErrorTestPerson>(to_remove));
+    auto remove_result = qs.remove(std::span<const ErrorTestPerson>(to_remove)).execute();
     ASSERT_TRUE(remove_result.has_value()) << "Large batch remove should succeed";
 
     // Verify all removed
@@ -1120,12 +1120,12 @@ TEST_F(ORMErrorTest, InsertThenSelectWithOrderBy) {
             {{0, "Charlie", 35}, {0, "Alice", 25}, {0, "Bob", 30}, {0, "Diana", 28}, {0, "Eve", 40}};
 
     for (const auto& p : batch) {
-        auto r = qs.insert(p);
+        auto r = qs.insert(p).execute();
         ASSERT_TRUE(r.has_value());
     }
 
     // Select with ORDER BY age ascending
-    auto result = qs.order_by<^^ErrorTestPerson::age>().select();
+    auto result = qs.order_by<^^ErrorTestPerson::age>().select().execute();
     ASSERT_TRUE(result.has_value());
     ASSERT_EQ(result.value().size(), 5);
 
@@ -1147,12 +1147,12 @@ TEST_F(ORMErrorTest, SelectWithLimitOffset) {
     // Insert 10 persons
     for (int i = 1; i <= 10; ++i) {
         ErrorTestPerson const p{.id = 0, .name = "Person" + std::to_string(i), .age = 20 + i};
-        auto                  r = qs.insert(p);
+        auto                  r = qs.insert(p).execute();
         ASSERT_TRUE(r.has_value());
     }
 
     // Select with limit 3, offset 2
-    auto result = qs.order_by<^^ErrorTestPerson::age>().limit(3).offset(2).select();
+    auto result = qs.order_by<^^ErrorTestPerson::age>().limit(3).offset(2).select().execute();
     ASSERT_TRUE(result.has_value());
     EXPECT_EQ(result.value().size(), 3);
 

--- a/tests/test_types.cpp
+++ b/tests/test_types.cpp
@@ -94,10 +94,10 @@ TYPED_TEST(IntTypesInsertUpdateTest, InsertSingleIntTypes) {
     QuerySet<IntTypes, TypeParam> qs;
     IntTypes const                obj{.id = 0, .big_num = 9223372036854775807LL, .small_num = 32767};
 
-    auto result = qs.insert(obj);
+    auto result = qs.insert(obj).execute();
     ASSERT_TRUE(result.has_value());
 
-    auto selected = qs.select();
+    auto selected = qs.select().execute();
     ASSERT_TRUE(selected.has_value());
     ASSERT_EQ(selected.value().size(), 1);
     EXPECT_EQ(selected.value().begin()->big_num, 9223372036854775807LL);
@@ -108,11 +108,11 @@ TYPED_TEST(IntTypesInsertUpdateTest, InsertBatchIntTypes) {
     QuerySet<IntTypes, TypeParam> qs;
     std::vector<IntTypes>         batch = {{0, 100LL, 10}, {0, 200LL, 20}, {0, 300LL, 30}};
 
-    auto result = qs.insert(batch);
+    auto result = qs.insert(batch).execute();
     ASSERT_TRUE(result.has_value());
 
     // Batch insert returns void, verify via SELECT
-    auto selected = qs.select();
+    auto selected = qs.select().execute();
     ASSERT_TRUE(selected.has_value());
     EXPECT_EQ(selected.value().size(), 3);
     EXPECT_EQ(selected.value().begin()->big_num, 100LL);
@@ -122,12 +122,12 @@ TYPED_TEST(IntTypesInsertUpdateTest, UpdateSingleIntTypes) {
     QuerySet<IntTypes, TypeParam> qs;
     IntTypes const                obj{.id = 0, .big_num = 100LL, .small_num = 10};
 
-    auto insert_result = qs.insert(obj);
+    auto insert_result = qs.insert(obj).execute();
     ASSERT_TRUE(insert_result.has_value());
     int64_t const id = insert_result.value();
 
     // Verify INSERT worked
-    auto check1 = qs.select();
+    auto check1 = qs.select().execute();
     ASSERT_TRUE(check1.has_value());
     auto it1 = check1.value().begin();
     EXPECT_EQ(it1->big_num, 100LL);
@@ -135,10 +135,10 @@ TYPED_TEST(IntTypesInsertUpdateTest, UpdateSingleIntTypes) {
 
     // Update with the returned ID
     IntTypes const updated{.id = static_cast<int>(id), .big_num = 999LL, .small_num = 99};
-    auto           update_result = qs.update(updated);
+    auto           update_result = qs.update(updated).execute();
     ASSERT_TRUE(update_result.has_value());
 
-    auto selected = qs.select();
+    auto selected = qs.select().execute();
     ASSERT_TRUE(selected.has_value());
     auto it2 = selected.value().begin();
     EXPECT_EQ(it2->big_num, 999LL);
@@ -149,15 +149,15 @@ TYPED_TEST(IntTypesInsertUpdateTest, UpdateBatchIntTypes) {
     QuerySet<IntTypes, TypeParam> qs;
     std::vector<IntTypes>         batch = {{1, 100LL, 10}, {2, 200LL, 20}, {3, 300LL, 30}};
 
-    auto insert_result = qs.insert(batch);
+    auto insert_result = qs.insert(batch).execute();
     ASSERT_TRUE(insert_result.has_value());
 
     // Update all
     std::vector<IntTypes> updates       = {{1, 111LL, 11}, {2, 222LL, 22}, {3, 333LL, 33}};
-    auto                  update_result = qs.update(std::span<const IntTypes>(updates));
+    auto                  update_result = qs.update(std::span<const IntTypes>(updates)).execute();
     ASSERT_TRUE(update_result.has_value());
 
-    auto selected = qs.select();
+    auto selected = qs.select().execute();
     ASSERT_TRUE(selected.has_value());
     auto it = selected.value().begin();
     EXPECT_EQ(it->big_num, 111LL);
@@ -209,10 +209,10 @@ TYPED_TEST(FloatTypesInsertUpdateTest, InsertSingleFloatTypes) {
     QuerySet<FloatTypes, TypeParam> qs;
     FloatTypes const                obj{.id = 0, .precise = std::numbers::pi, .approx = std::numbers::e_v<float>};
 
-    auto result = qs.insert(obj);
+    auto result = qs.insert(obj).execute();
     ASSERT_TRUE(result.has_value());
 
-    auto selected = qs.select();
+    auto selected = qs.select().execute();
     ASSERT_TRUE(selected.has_value());
     EXPECT_NEAR(selected.value().begin()->precise, std::numbers::pi, 1e-10);
     EXPECT_NEAR(selected.value().begin()->approx, std::numbers::e_v<float>, 1e-6);
@@ -222,17 +222,17 @@ TYPED_TEST(FloatTypesInsertUpdateTest, UpdateSingleFloatTypes) {
     QuerySet<FloatTypes, TypeParam> qs;
     FloatTypes const                obj{.id = 0, .precise = 1.0, .approx = 1.0F};
 
-    auto insert_result = qs.insert(obj);
+    auto insert_result = qs.insert(obj).execute();
     ASSERT_TRUE(insert_result.has_value());
     int64_t const id = insert_result.value();
 
     FloatTypes const updated{
             .id = static_cast<int>(id), .precise = std::numbers::e, .approx = std::numbers::pi_v<float>
     };
-    auto update_result = qs.update(updated);
+    auto update_result = qs.update(updated).execute();
     ASSERT_TRUE(update_result.has_value());
 
-    auto selected = qs.select();
+    auto selected = qs.select().execute();
     ASSERT_TRUE(selected.has_value());
     EXPECT_NEAR(selected.value().begin()->precise, std::numbers::e, 1e-10);
     EXPECT_NEAR(selected.value().begin()->approx, std::numbers::pi_v<float>, 1e-6);
@@ -280,10 +280,10 @@ TYPED_TEST(MixedTypesInsertUpdateTest, InsertBooleanTrue) {
     QuerySet<MixedTypes, TypeParam> qs;
     MixedTypes const                obj{.id = 0, .active = true, .name = "active_user"};
 
-    auto result = qs.insert(obj);
+    auto result = qs.insert(obj).execute();
     ASSERT_TRUE(result.has_value());
 
-    auto selected = qs.select();
+    auto selected = qs.select().execute();
     ASSERT_TRUE(selected.has_value());
     EXPECT_TRUE(selected.value().begin()->active);
     EXPECT_EQ(selected.value().begin()->name, "active_user");
@@ -293,10 +293,10 @@ TYPED_TEST(MixedTypesInsertUpdateTest, InsertBooleanFalse) {
     QuerySet<MixedTypes, TypeParam> qs;
     MixedTypes const                obj{.id = 0, .active = false, .name = "inactive_user"};
 
-    auto result = qs.insert(obj);
+    auto result = qs.insert(obj).execute();
     ASSERT_TRUE(result.has_value());
 
-    auto selected = qs.select();
+    auto selected = qs.select().execute();
     ASSERT_TRUE(selected.has_value());
     EXPECT_FALSE(selected.value().begin()->active);
     EXPECT_EQ(selected.value().begin()->name, "inactive_user");
@@ -306,15 +306,15 @@ TYPED_TEST(MixedTypesInsertUpdateTest, UpdateBooleanAndString) {
     QuerySet<MixedTypes, TypeParam> qs;
     MixedTypes const                obj{.id = 0, .active = false, .name = "old_name"};
 
-    auto insert_result = qs.insert(obj);
+    auto insert_result = qs.insert(obj).execute();
     ASSERT_TRUE(insert_result.has_value());
     int64_t const id = insert_result.value();
 
     MixedTypes const updated{.id = static_cast<int>(id), .active = true, .name = "new_name"};
-    auto             update_result = qs.update(updated);
+    auto             update_result = qs.update(updated).execute();
     ASSERT_TRUE(update_result.has_value());
 
-    auto selected = qs.select();
+    auto selected = qs.select().execute();
     ASSERT_TRUE(selected.has_value());
     EXPECT_TRUE(selected.value().begin()->active);
     EXPECT_EQ(selected.value().begin()->name, "new_name");
@@ -324,10 +324,10 @@ TYPED_TEST(MixedTypesInsertUpdateTest, InsertBatchMixedTypes) {
     QuerySet<MixedTypes, TypeParam> qs;
     std::vector<MixedTypes>         batch = {{1, true, "user1"}, {2, false, "user2"}, {3, true, "user3"}};
 
-    auto result = qs.insert(batch);
+    auto result = qs.insert(batch).execute();
     ASSERT_TRUE(result.has_value());
 
-    auto selected = qs.select();
+    auto selected = qs.select().execute();
     ASSERT_TRUE(selected.has_value());
     EXPECT_EQ(selected.value().size(), 3);
     auto it = selected.value().begin();
@@ -380,10 +380,10 @@ TYPED_TEST(OptTypesInsertUpdateTest, InsertWithValues) {
     QuerySet<OptTypes, TypeParam> qs;
     OptTypes const                obj{.id = 0, .maybe_num = std::optional<int>(42), .name = "with_value"};
 
-    auto result = qs.insert(obj);
+    auto result = qs.insert(obj).execute();
     ASSERT_TRUE(result.has_value());
 
-    auto selected = qs.select();
+    auto selected = qs.select().execute();
     ASSERT_TRUE(selected.has_value());
     ASSERT_TRUE(selected.value().begin()->maybe_num.has_value());
     EXPECT_EQ(selected.value().begin()->maybe_num.value(), 42);
@@ -394,10 +394,10 @@ TYPED_TEST(OptTypesInsertUpdateTest, InsertWithNull) {
     QuerySet<OptTypes, TypeParam> qs;
     OptTypes const                obj{.id = 0, .maybe_num = std::nullopt, .name = "null_value"};
 
-    auto result = qs.insert(obj);
+    auto result = qs.insert(obj).execute();
     ASSERT_TRUE(result.has_value());
 
-    auto selected = qs.select();
+    auto selected = qs.select().execute();
     ASSERT_TRUE(selected.has_value());
     EXPECT_FALSE(selected.value().begin()->maybe_num.has_value());
     EXPECT_EQ(selected.value().begin()->name, "null_value");
@@ -407,16 +407,16 @@ TYPED_TEST(OptTypesInsertUpdateTest, UpdateFromValueToNull) {
     QuerySet<OptTypes, TypeParam> qs;
     OptTypes const                obj{.id = 0, .maybe_num = std::optional<int>(100), .name = "original"};
 
-    auto insert_result = qs.insert(obj);
+    auto insert_result = qs.insert(obj).execute();
     ASSERT_TRUE(insert_result.has_value());
     int64_t const id = insert_result.value();
 
     // Update to NULL
     OptTypes const updated{.id = static_cast<int>(id), .maybe_num = std::nullopt, .name = "updated_to_null"};
-    auto           update_result = qs.update(updated);
+    auto           update_result = qs.update(updated).execute();
     ASSERT_TRUE(update_result.has_value());
 
-    auto selected = qs.select();
+    auto selected = qs.select().execute();
     ASSERT_TRUE(selected.has_value());
     EXPECT_FALSE(selected.value().begin()->maybe_num.has_value());
     EXPECT_EQ(selected.value().begin()->name, "updated_to_null");
@@ -426,7 +426,7 @@ TYPED_TEST(OptTypesInsertUpdateTest, UpdateFromNullToValue) {
     QuerySet<OptTypes, TypeParam> qs;
     OptTypes const                obj{.id = 0, .maybe_num = std::nullopt, .name = "null_start"};
 
-    auto insert_result = qs.insert(obj);
+    auto insert_result = qs.insert(obj).execute();
     ASSERT_TRUE(insert_result.has_value());
     int64_t const id = insert_result.value();
 
@@ -434,10 +434,10 @@ TYPED_TEST(OptTypesInsertUpdateTest, UpdateFromNullToValue) {
     OptTypes const updated{
             .id = static_cast<int>(id), .maybe_num = std::optional<int>(999), .name = "updated_to_value"
     };
-    auto update_result = qs.update(updated);
+    auto update_result = qs.update(updated).execute();
     ASSERT_TRUE(update_result.has_value());
 
-    auto selected = qs.select();
+    auto selected = qs.select().execute();
     ASSERT_TRUE(selected.has_value());
     ASSERT_TRUE(selected.value().begin()->maybe_num.has_value());
     EXPECT_EQ(selected.value().begin()->maybe_num.value(), 999);
@@ -452,10 +452,10 @@ TYPED_TEST(OptTypesInsertUpdateTest, InsertBatchMixedNulls) {
              {3, std::optional<int>(3), "has_value2"},
              {4, std::nullopt, "is_null2"}};
 
-    auto result = qs.insert(batch);
+    auto result = qs.insert(batch).execute();
     ASSERT_TRUE(result.has_value());
 
-    auto selected = qs.select();
+    auto selected = qs.select().execute();
     ASSERT_TRUE(selected.has_value());
     EXPECT_EQ(selected.value().size(), 4);
 
@@ -514,10 +514,10 @@ TYPED_TEST(DataTypesInsertUpdateTest, InsertSmallBlob) {
     QuerySet<DataTypes, TypeParam> qs;
     DataTypes const                obj{.id = 0, .binary_data = {0xDE, 0xAD, 0xBE, 0xEF}, .label = "test_blob"};
 
-    auto result = qs.insert(obj);
+    auto result = qs.insert(obj).execute();
     ASSERT_TRUE(result.has_value());
 
-    auto selected = qs.select();
+    auto selected = qs.select().execute();
     ASSERT_TRUE(selected.has_value());
     EXPECT_EQ(selected.value().begin()->binary_data, (std::vector<uint8_t>{0xDE, 0xAD, 0xBE, 0xEF}));
     EXPECT_EQ(selected.value().begin()->label, "test_blob");
@@ -532,10 +532,10 @@ TYPED_TEST(DataTypesInsertUpdateTest, InsertLargeBlob) {
     }
 
     DataTypes const obj{.id = 0, .binary_data = large_data, .label = "large"};
-    auto            result = qs.insert(obj);
+    auto            result = qs.insert(obj).execute();
     ASSERT_TRUE(result.has_value());
 
-    auto selected = qs.select();
+    auto selected = qs.select().execute();
     ASSERT_TRUE(selected.has_value());
     auto it = selected.value().begin();
     ASSERT_EQ(it->binary_data.size(), 1024);
@@ -549,10 +549,10 @@ TYPED_TEST(DataTypesInsertUpdateTest, InsertEmptyBlob) {
     QuerySet<DataTypes, TypeParam> qs;
     DataTypes const                obj{.id = 0, .binary_data = {}, .label = "empty"};
 
-    auto result = qs.insert(obj);
+    auto result = qs.insert(obj).execute();
     ASSERT_TRUE(result.has_value());
 
-    auto selected = qs.select();
+    auto selected = qs.select().execute();
     ASSERT_TRUE(selected.has_value());
     EXPECT_TRUE(selected.value().begin()->binary_data.empty());
 }
@@ -561,16 +561,16 @@ TYPED_TEST(DataTypesInsertUpdateTest, UpdateBlob) {
     QuerySet<DataTypes, TypeParam> qs;
     DataTypes const                obj{.id = 0, .binary_data = {0x01, 0x02}, .label = "original"};
 
-    auto insert_result = qs.insert(obj);
+    auto insert_result = qs.insert(obj).execute();
     ASSERT_TRUE(insert_result.has_value());
     int64_t const id = insert_result.value();
 
     // Update with different blob
     DataTypes const updated{.id = static_cast<int>(id), .binary_data = {0xFF, 0xEE, 0xDD}, .label = "updated"};
-    auto            update_result = qs.update(updated);
+    auto            update_result = qs.update(updated).execute();
     ASSERT_TRUE(update_result.has_value());
 
-    auto selected = qs.select();
+    auto selected = qs.select().execute();
     ASSERT_TRUE(selected.has_value());
     EXPECT_EQ(selected.value().begin()->binary_data, (std::vector<uint8_t>{0xFF, 0xEE, 0xDD}));
     EXPECT_EQ(selected.value().begin()->label, "updated");
@@ -580,10 +580,10 @@ TYPED_TEST(DataTypesInsertUpdateTest, InsertBatchBlobs) {
     QuerySet<DataTypes, TypeParam> qs;
     std::vector<DataTypes> batch = {{1, {0x01}, "blob1"}, {2, {0x02, 0x03}, "blob2"}, {3, {0x04, 0x05, 0x06}, "blob3"}};
 
-    auto result = qs.insert(batch);
+    auto result = qs.insert(batch).execute();
     ASSERT_TRUE(result.has_value());
 
-    auto selected = qs.select();
+    auto selected = qs.select().execute();
     ASSERT_TRUE(selected.has_value());
     EXPECT_EQ(selected.value().size(), 3);
     auto it = selected.value().begin();
@@ -601,10 +601,10 @@ TYPED_TEST(IntTypesInsertUpdateTest, ExtremeIntegerValues) {
 
     // Min values
     IntTypes const min_obj{.id = 0, .big_num = -9223372036854775807LL - 1, .small_num = -32768};
-    auto           result = qs.insert(min_obj);
+    auto           result = qs.insert(min_obj).execute();
     ASSERT_TRUE(result.has_value());
 
-    auto selected = qs.select();
+    auto selected = qs.select().execute();
     ASSERT_TRUE(selected.has_value());
     auto it = selected.value().begin();
     EXPECT_EQ(it->big_num, -9223372036854775807LL - 1);
@@ -616,10 +616,10 @@ TYPED_TEST(FloatTypesInsertUpdateTest, SpecialFloatValues) {
 
     // Zero, negative, very small
     FloatTypes const obj{.id = 0, .precise = 0.0, .approx = -0.0F};
-    auto             result = qs.insert(obj);
+    auto             result = qs.insert(obj).execute();
     ASSERT_TRUE(result.has_value());
 
-    auto selected = qs.select();
+    auto selected = qs.select().execute();
     ASSERT_TRUE(selected.has_value());
     EXPECT_DOUBLE_EQ(selected.value().begin()->precise, 0.0);
 }
@@ -668,11 +668,11 @@ TYPED_TEST(InsertOptionsTest, BatchInsertReturnsVoid) {
     std::vector<IntTypes>         batch = {{0, 100LL, 10}, {0, 200LL, 20}, {0, 300LL, 30}};
 
     // Batch insert returns void (no IDs - SQLite's last_insert_rowid is unreliable for batch)
-    auto result = qs.insert(batch);
+    auto result = qs.insert(batch).execute();
     ASSERT_TRUE(result.has_value());
 
     // Verify data was inserted by selecting
-    auto selected = qs.select();
+    auto selected = qs.select().execute();
     ASSERT_TRUE(selected.has_value());
     EXPECT_EQ(selected.value().size(), 3);
 }
@@ -688,10 +688,10 @@ TYPED_TEST(InsertOptionsTest, InsertWithCustomBatchSize) {
     }
 
     // Use batch_size of 10
-    auto result = qs.insert(batch, {{.batch_size = 10}});
+    auto result = qs.insert(batch, {{.batch_size = 10}}).execute();
     ASSERT_TRUE(result.has_value());
 
-    auto selected = qs.select();
+    auto selected = qs.select().execute();
     ASSERT_TRUE(selected.has_value());
     EXPECT_EQ(selected.value().size(), 100);
 }
@@ -702,10 +702,10 @@ TYPED_TEST(InsertOptionsTest, InsertBatchSizeCappedToMax) {
 
     // IntTypes has 2 non-PK fields, so max = 999/2 = 499
     // Request batch_size of 1000, should be capped to 499
-    auto result = qs.insert(batch, {{.batch_size = 1000}});
+    auto result = qs.insert(batch, {{.batch_size = 1000}}).execute();
     ASSERT_TRUE(result.has_value());
 
-    auto selected = qs.select();
+    auto selected = qs.select().execute();
     ASSERT_TRUE(selected.has_value());
     EXPECT_EQ(selected.value().size(), 2);
 }
@@ -715,11 +715,11 @@ TYPED_TEST(InsertOptionsTest, SingleInsertReturnsId) {
     IntTypes const                obj{.id = 0, .big_num = 999LL, .small_num = 99};
 
     // Single insert still returns the auto-generated ID
-    auto result = qs.insert(obj);
+    auto result = qs.insert(obj).execute();
     ASSERT_TRUE(result.has_value());
     EXPECT_EQ(result.value(), 1);
 
-    auto selected = qs.select();
+    auto selected = qs.select().execute();
     ASSERT_TRUE(selected.has_value());
     EXPECT_EQ(selected.value().size(), 1);
     EXPECT_EQ(selected.value().begin()->big_num, 999LL);
@@ -736,10 +736,10 @@ TYPED_TEST(InsertOptionsTest, LargeBatchWithCustomChunkSize) {
     }
 
     // Use small batch_size to force multiple chunks
-    auto result = qs.insert(batch, {{.batch_size = 50}});
+    auto result = qs.insert(batch, {{.batch_size = 50}}).execute();
     ASSERT_TRUE(result.has_value());
 
-    auto selected = qs.select();
+    auto selected = qs.select().execute();
     ASSERT_TRUE(selected.has_value());
     EXPECT_EQ(selected.value().size(), 1000);
 }
@@ -749,10 +749,10 @@ TYPED_TEST(InsertOptionsTest, OptionsWithOnlyBatchSize) {
     std::vector<IntTypes>         batch = {{0, 100LL, 10}, {0, 200LL, 20}};
 
     // Only specify batch_size
-    auto result = qs.insert(batch, {{.batch_size = 1}});
+    auto result = qs.insert(batch, {{.batch_size = 1}}).execute();
     ASSERT_TRUE(result.has_value());
 
-    auto selected = qs.select();
+    auto selected = qs.select().execute();
     ASSERT_TRUE(selected.has_value());
     EXPECT_EQ(selected.value().size(), 2);
 }
@@ -808,10 +808,10 @@ TYPED_TEST(UnsignedTypesInsertUpdateTest, InsertUnsignedValues) {
     QuerySet<UnsignedTypes, TypeParam> qs;
     UnsignedTypes const                obj{.id = 0, .u_int = 4294967295U, .u_short = 65535, .u_long = 1000000UL};
 
-    auto result = qs.insert(obj);
+    auto result = qs.insert(obj).execute();
     ASSERT_TRUE(result.has_value());
 
-    auto selected = qs.select();
+    auto selected = qs.select().execute();
     ASSERT_TRUE(selected.has_value());
     ASSERT_EQ(selected.value().size(), 1);
     EXPECT_EQ(selected.value().begin()->u_int, 4294967295U);
@@ -823,10 +823,10 @@ TYPED_TEST(UnsignedTypesInsertUpdateTest, InsertBatchUnsigned) {
     QuerySet<UnsignedTypes, TypeParam> qs;
     std::vector<UnsignedTypes>         batch = {{0, 100U, 10, 1000UL}, {0, 200U, 20, 2000UL}, {0, 300U, 30, 3000UL}};
 
-    auto result = qs.insert(batch);
+    auto result = qs.insert(batch).execute();
     ASSERT_TRUE(result.has_value());
 
-    auto selected = qs.select();
+    auto selected = qs.select().execute();
     ASSERT_TRUE(selected.has_value());
     EXPECT_EQ(selected.value().size(), 3);
 }
@@ -835,15 +835,15 @@ TYPED_TEST(UnsignedTypesInsertUpdateTest, UpdateUnsignedValues) {
     QuerySet<UnsignedTypes, TypeParam> qs;
     UnsignedTypes const                obj{.id = 0, .u_int = 100U, .u_short = 10, .u_long = 1000UL};
 
-    auto insert_result = qs.insert(obj);
+    auto insert_result = qs.insert(obj).execute();
     ASSERT_TRUE(insert_result.has_value());
     int64_t const id = insert_result.value();
 
     UnsignedTypes const updated{.id = static_cast<int>(id), .u_int = 999U, .u_short = 99, .u_long = 9999UL};
-    auto                update_result = qs.update(updated);
+    auto                update_result = qs.update(updated).execute();
     ASSERT_TRUE(update_result.has_value());
 
-    auto selected = qs.select();
+    auto selected = qs.select().execute();
     ASSERT_TRUE(selected.has_value());
     EXPECT_EQ(selected.value().begin()->u_int, 999U);
     EXPECT_EQ(selected.value().begin()->u_short, 99);
@@ -900,10 +900,10 @@ TYPED_TEST(LongLongTypesInsertUpdateTest, InsertLongLongValues) {
     QuerySet<LongLongTypes, TypeParam> qs;
     LongLongTypes const obj{.id = 0, .ll_signed = 9223372036854775807LL, .ll_unsigned = 9223372036854775807ULL};
 
-    auto result = qs.insert(obj);
+    auto result = qs.insert(obj).execute();
     ASSERT_TRUE(result.has_value());
 
-    auto selected = qs.select();
+    auto selected = qs.select().execute();
     ASSERT_TRUE(selected.has_value());
     ASSERT_EQ(selected.value().size(), 1);
     EXPECT_EQ(selected.value().begin()->ll_signed, 9223372036854775807LL);
@@ -915,10 +915,10 @@ TYPED_TEST(LongLongTypesInsertUpdateTest, InsertNegativeLongLong) {
     QuerySet<LongLongTypes, TypeParam> qs;
     LongLongTypes const                obj{.id = 0, .ll_signed = -9223372036854775807LL, .ll_unsigned = 0ULL};
 
-    auto result = qs.insert(obj);
+    auto result = qs.insert(obj).execute();
     ASSERT_TRUE(result.has_value());
 
-    auto selected = qs.select();
+    auto selected = qs.select().execute();
     ASSERT_TRUE(selected.has_value());
     EXPECT_EQ(selected.value().begin()->ll_signed, -9223372036854775807LL);
     EXPECT_EQ(selected.value().begin()->ll_unsigned, 0ULL);
@@ -928,15 +928,15 @@ TYPED_TEST(LongLongTypesInsertUpdateTest, UpdateLongLongValues) {
     QuerySet<LongLongTypes, TypeParam> qs;
     LongLongTypes const                obj{.id = 0, .ll_signed = 100LL, .ll_unsigned = 200ULL};
 
-    auto insert_result = qs.insert(obj);
+    auto insert_result = qs.insert(obj).execute();
     ASSERT_TRUE(insert_result.has_value());
     int64_t const id = insert_result.value();
 
     LongLongTypes const updated{.id = static_cast<int>(id), .ll_signed = -999LL, .ll_unsigned = 999ULL};
-    auto                update_result = qs.update(updated);
+    auto                update_result = qs.update(updated).execute();
     ASSERT_TRUE(update_result.has_value());
 
-    auto selected = qs.select();
+    auto selected = qs.select().execute();
     ASSERT_TRUE(selected.has_value());
     EXPECT_EQ(selected.value().begin()->ll_signed, -999LL);
     EXPECT_EQ(selected.value().begin()->ll_unsigned, 999ULL);
@@ -974,7 +974,7 @@ TEST(ErrorHandlingTest, SelectFromNonExistentTable) {
 
     // Try to select from non-existent table
     QuerySet<IntTypes> qs;
-    auto               select_result = qs.select();
+    auto               select_result = qs.select().execute();
 
     // Should fail because table doesn't exist
     ASSERT_FALSE(select_result.has_value()) << "Should fail to select from non-existent table";

--- a/tests/test_values.cpp
+++ b/tests/test_values.cpp
@@ -145,7 +145,7 @@ TYPED_TEST(ValuesTest, SingleFieldNameWithDuplicates) {
     std::vector<ValuesPerson> people =
             {{1, "Alice", 30}, {2, "Bob", 25}, {3, "Alice", 35}, {4, "Charlie", 40}, {5, "Bob", 28}};
 
-    auto insert_result = queryset.insert(std::span<const ValuesPerson>(people));
+    auto insert_result = queryset.insert(std::span<const ValuesPerson>(people)).execute();
     ASSERT_TRUE(insert_result.has_value()) << "INSERT failed: " << insert_result.error().message();
 
     // SELECT name (no DISTINCT — should return ALL rows including duplicates)
@@ -163,7 +163,7 @@ TYPED_TEST(ValuesTest, SingleFieldAgeWithDuplicates) {
 
     std::vector<ValuesPerson> people = {{1, "Alice", 30}, {2, "Bob", 25}, {3, "Charlie", 30}, {4, "Dave", 25}};
 
-    auto insert_result = queryset.insert(std::span<const ValuesPerson>(people));
+    auto insert_result = queryset.insert(std::span<const ValuesPerson>(people)).execute();
     ASSERT_TRUE(insert_result.has_value());
 
     // SELECT age — should return 4 rows (duplicates preserved)
@@ -204,7 +204,7 @@ TYPED_TEST(ValuesTest, SingleFieldWithSingleRow) {
     QuerySet<ValuesPerson, TypeParam> queryset;
 
     ValuesPerson const alice{.id = 0, .name = "Alice", .age = 30};
-    auto               insert_result = queryset.insert(alice);
+    auto               insert_result = queryset.insert(alice).execute();
     ASSERT_TRUE(insert_result.has_value());
 
     auto result = queryset.template values<^^ValuesPerson::name>().select();
@@ -230,7 +230,7 @@ TYPED_TEST(ValuesTest, TwoFieldsNameAndAge) {
             {4, "Charlie", 30},
     };
 
-    auto insert_result = queryset.insert(std::span<const ValuesPerson>(people));
+    auto insert_result = queryset.insert(std::span<const ValuesPerson>(people)).execute();
     ASSERT_TRUE(insert_result.has_value());
 
     auto result = queryset.template values<^^ValuesPerson::name, ^^ValuesPerson::age>().select();
@@ -245,7 +245,7 @@ TYPED_TEST(ValuesTest, TwoFieldsNameAndAge) {
 TYPED_TEST(ValuesTest, VerifyReturnTypes) {
     QuerySet<ValuesPerson, TypeParam> queryset;
 
-    std::ignore = queryset.insert(ValuesPerson{.id = 0, .name = "Alice", .age = 30});
+    std::ignore = queryset.insert(ValuesPerson{.id = 0, .name = "Alice", .age = 30}).execute();
 
     // Verify return type for values on name field is hive of strings
     auto names_result = queryset.template values<^^ValuesPerson::name>().select();
@@ -278,7 +278,7 @@ TYPED_TEST(ValuesTest, DuplicatesPreserved) {
         people.emplace_back(i, "SameName", 42);
     }
 
-    auto insert_result = queryset.insert(std::span<const ValuesPerson>(people));
+    auto insert_result = queryset.insert(std::span<const ValuesPerson>(people)).execute();
     ASSERT_TRUE(insert_result.has_value());
 
     // values() should return ALL 10 rows
@@ -308,7 +308,7 @@ TYPED_TEST(ValuesTest, WithWhereSingleField) {
             {0, "David", 35},
     };
 
-    auto insert_result = queryset.insert(people);
+    auto insert_result = queryset.insert(people).execute();
     ASSERT_TRUE(insert_result.has_value());
 
     // SELECT name WHERE age > 22
@@ -331,7 +331,7 @@ TYPED_TEST(ValuesTest, WithMultipleWhereClauses) {
             {0, "David", 35},
     };
 
-    auto insert_result = queryset.insert(people);
+    auto insert_result = queryset.insert(people).execute();
     ASSERT_TRUE(insert_result.has_value());
 
     // Chain multiple WHERE clauses (AND)
@@ -357,7 +357,7 @@ TYPED_TEST(ValuesTest, WithComplexWhere) {
             {0, "David", 40},
     };
 
-    auto insert_result = queryset.insert(people);
+    auto insert_result = queryset.insert(people).execute();
     ASSERT_TRUE(insert_result.has_value());
 
     // SELECT name WHERE age BETWEEN 25 AND 35
@@ -375,7 +375,7 @@ TYPED_TEST(ValuesTest, WithWhereNoResults) {
     QuerySet<ValuesPerson, TypeParam> queryset;
 
     std::vector<ValuesPerson> people        = {{0, "Alice", 25}, {0, "Bob", 30}};
-    auto                      insert_result = queryset.insert(people);
+    auto                      insert_result = queryset.insert(people).execute();
     ASSERT_TRUE(insert_result.has_value());
 
     auto result = queryset.where(field<^^ValuesPerson::age>() > 100).template values<^^ValuesPerson::name>().select();
@@ -439,7 +439,7 @@ TYPED_TEST(ValuesTest, WithOrderByAsc) {
             {0, "Bob", 35},
     };
 
-    auto insert_result = queryset.insert(people);
+    auto insert_result = queryset.insert(people).execute();
     ASSERT_TRUE(insert_result.has_value());
 
     auto result = queryset.template order_by<^^ValuesPerson::name>().template values<^^ValuesPerson::name>().select();
@@ -464,7 +464,7 @@ TYPED_TEST(ValuesTest, WithOrderByDesc) {
             {0, "Bob", 35},
     };
 
-    auto insert_result = queryset.insert(people);
+    auto insert_result = queryset.insert(people).execute();
     ASSERT_TRUE(insert_result.has_value());
 
     auto result =
@@ -496,7 +496,7 @@ TYPED_TEST(ValuesTest, WithLimit) {
             {0, "Eve", 40},
     };
 
-    auto insert_result = queryset.insert(people);
+    auto insert_result = queryset.insert(people).execute();
     ASSERT_TRUE(insert_result.has_value());
 
     auto result = queryset.template order_by<^^ValuesPerson::name>()
@@ -526,7 +526,7 @@ TYPED_TEST(ValuesTest, WithLimitAndOffset) {
             {0, "Eve", 40},
     };
 
-    auto insert_result = queryset.insert(people);
+    auto insert_result = queryset.insert(people).execute();
     ASSERT_TRUE(insert_result.has_value());
 
     // Skip Alice, Bob and return Charlie, Dave
@@ -557,7 +557,7 @@ TYPED_TEST(ValuesTest, WithWhereOrderByLimit) {
             {0, "Eve", 20}, // Filtered out by WHERE
     };
 
-    auto insert_result = queryset.insert(people);
+    auto insert_result = queryset.insert(people).execute();
     ASSERT_TRUE(insert_result.has_value());
 
     auto result = queryset.where(field<^^ValuesPerson::age>() > 25)
@@ -592,7 +592,7 @@ TYPED_TEST(ValuesTest, OptionalIntFieldWithNulls) {
             {0, "Eve", 25, "Evie"}, // Duplicate age
     };
 
-    auto insert_result = queryset.insert(people);
+    auto insert_result = queryset.insert(people).execute();
     ASSERT_TRUE(insert_result.has_value()) << "Insert failed: " << insert_result.error().message();
 
     auto result = queryset.template values<^^ValuesOptionalPerson::age>().select();
@@ -623,7 +623,7 @@ TYPED_TEST(ValuesTest, OptionalStringFieldWithNulls) {
             {0, "Dave", 40, std::nullopt}, // Duplicate NULL
     };
 
-    auto insert_result = queryset.insert(people);
+    auto insert_result = queryset.insert(people).execute();
     ASSERT_TRUE(insert_result.has_value());
 
     auto result = queryset.template values<^^ValuesOptionalPerson::nickname>().select();
@@ -659,7 +659,7 @@ TYPED_TEST(ValuesTest, StatementReuseStability) {
             {0, "Bob", 30},
             {0, "Charlie", 35},
     };
-    std::ignore = queryset.insert(people);
+    std::ignore = queryset.insert(people).execute();
 
     for (int i = 0; i < 5; ++i) {
         auto result = queryset.template values<^^ValuesPerson::name>().select();
@@ -678,7 +678,7 @@ TYPED_TEST(ValuesTest, DifferentWhereExpressionsWithCaching) {
             {0, "Charlie", 35},
             {0, "Dave", 40},
     };
-    std::ignore = queryset.insert(people);
+    std::ignore = queryset.insert(people).execute();
 
     // Query 1: age > 25
     auto result1 = queryset.where(field<^^ValuesPerson::age>() > 25).template values<^^ValuesPerson::name>().select();

--- a/tests/test_where.cpp
+++ b/tests/test_where.cpp
@@ -52,7 +52,7 @@ template <typename ConnType> class WhereTest : public ::testing::Test {
         QuerySet<WherePerson, ConnType> queryset;
         // Insert one by one to avoid batch insert issues
         for (const auto& person : people) {
-            auto insert_result = queryset.insert(person);
+            auto insert_result = queryset.insert(person).execute();
             ASSERT_TRUE(insert_result.has_value()) << "Failed to insert test data: " << insert_result.error().message();
         }
     }
@@ -74,7 +74,7 @@ TYPED_TEST_SUITE(WhereTest, DatabaseTypes);
 TYPED_TEST(WhereTest, WhereSingleIntegerCondition) {
     QuerySet<WherePerson, TypeParam> queryset;
 
-    auto result = queryset.where(field<^^WherePerson::age>() == 30).select();
+    auto result = queryset.where(field<^^WherePerson::age>() == 30).select().execute();
     ASSERT_TRUE(result.has_value()) << "WHERE failed: " << result.error().message();
 
     const auto& people = result.value();
@@ -88,7 +88,7 @@ TYPED_TEST(WhereTest, WhereSingleIntegerCondition) {
 TYPED_TEST(WhereTest, WhereGreaterThan) {
     QuerySet<WherePerson, TypeParam> queryset;
 
-    auto result = queryset.where(field<^^WherePerson::age>() > 30).select();
+    auto result = queryset.where(field<^^WherePerson::age>() > 30).select().execute();
     ASSERT_TRUE(result.has_value()) << "WHERE failed: " << result.error().message();
 
     const auto& people = result.value();
@@ -105,7 +105,7 @@ TYPED_TEST(WhereTest, WhereGreaterThan) {
 TYPED_TEST(WhereTest, WhereLessThan) {
     QuerySet<WherePerson, TypeParam> queryset;
 
-    auto result = queryset.where(field<^^WherePerson::age>() < 30).select();
+    auto result = queryset.where(field<^^WherePerson::age>() < 30).select().execute();
     ASSERT_TRUE(result.has_value()) << "WHERE failed: " << result.error().message();
 
     const auto& people = result.value();
@@ -122,7 +122,7 @@ TYPED_TEST(WhereTest, WhereLessThan) {
 TYPED_TEST(WhereTest, WhereStringCondition) {
     QuerySet<WherePerson, TypeParam> queryset;
 
-    auto result = queryset.where(field<^^WherePerson::name>() == "Bob").select();
+    auto result = queryset.where(field<^^WherePerson::name>() == "Bob").select().execute();
     ASSERT_TRUE(result.has_value()) << "WHERE failed: " << result.error().message();
 
     const auto& people = result.value();
@@ -136,7 +136,7 @@ TYPED_TEST(WhereTest, WhereStringCondition) {
 TYPED_TEST(WhereTest, WhereLikePattern) {
     QuerySet<WherePerson, TypeParam> queryset;
 
-    auto result = queryset.where(field<^^WherePerson::name>().like("A%")).select();
+    auto result = queryset.where(field<^^WherePerson::name>().like("A%")).select().execute();
     ASSERT_TRUE(result.has_value()) << "WHERE failed: " << result.error().message();
 
     const auto& people = result.value();
@@ -150,7 +150,7 @@ TYPED_TEST(WhereTest, WhereMultipleConditions) {
 
     auto expr1  = field<^^WherePerson::age>() > 25;
     auto expr2  = field<^^WherePerson::age>() < 40;
-    auto result = queryset.where(expr1 && expr2).select();
+    auto result = queryset.where(expr1 && expr2).select().execute();
     ASSERT_TRUE(result.has_value()) << "WHERE failed: " << result.error().message();
 
     const auto& people = result.value();
@@ -170,7 +170,7 @@ TYPED_TEST(WhereTest, WhereThreeConditions) {
     auto expr1  = field<^^WherePerson::age>() >= 28;
     auto expr2  = field<^^WherePerson::age>() <= 35;
     auto expr3  = field<^^WherePerson::name>() != "Charlie";
-    auto result = queryset.where(expr1 && expr2 && expr3).select();
+    auto result = queryset.where(expr1 && expr2 && expr3).select().execute();
     ASSERT_TRUE(result.has_value()) << "WHERE failed: " << result.error().message();
 
     const auto& people = result.value();
@@ -185,7 +185,7 @@ TYPED_TEST(WhereTest, WhereThreeConditions) {
 TYPED_TEST(WhereTest, WhereBetween) {
     QuerySet<WherePerson, TypeParam> queryset;
 
-    auto result = queryset.where(field<^^WherePerson::age>().between(28, 35)).select();
+    auto result = queryset.where(field<^^WherePerson::age>().between(28, 35)).select().execute();
     ASSERT_TRUE(result.has_value()) << "WHERE failed: " << result.error().message();
 
     const auto& people = result.value();
@@ -203,7 +203,7 @@ TYPED_TEST(WhereTest, WhereIn) {
     QuerySet<WherePerson, TypeParam> queryset;
 
     // IN expressions use runtime builder pattern, requires .select()
-    auto result = queryset.where(field<^^WherePerson::age>().in(25, 30, 40)).select();
+    auto result = queryset.where(field<^^WherePerson::age>().in(25, 30, 40)).select().execute();
     ASSERT_TRUE(result.has_value()) << "WHERE failed: " << result.error().message();
 
     const auto& people = result.value();
@@ -220,7 +220,7 @@ TYPED_TEST(WhereTest, WhereIn) {
 TYPED_TEST(WhereTest, WhereNoMatch) {
     QuerySet<WherePerson, TypeParam> queryset;
 
-    auto result = queryset.where(field<^^WherePerson::age>() > 100).select();
+    auto result = queryset.where(field<^^WherePerson::age>() > 100).select().execute();
     ASSERT_TRUE(result.has_value()) << "WHERE failed: " << result.error().message();
 
     const auto& people = result.value();
@@ -231,7 +231,7 @@ TYPED_TEST(WhereTest, WhereNoMatch) {
 TYPED_TEST(WhereTest, WhereMatchesAll) {
     QuerySet<WherePerson, TypeParam> queryset;
 
-    auto result = queryset.where(field<^^WherePerson::age>() > 0).select();
+    auto result = queryset.where(field<^^WherePerson::age>() > 0).select().execute();
     ASSERT_TRUE(result.has_value()) << "WHERE failed: " << result.error().message();
 
     const auto& people = result.value();
@@ -245,7 +245,7 @@ TYPED_TEST(WhereTest, WhereComplexExpression) {
     auto expr1  = field<^^WherePerson::age>() < 30;
     auto expr2  = field<^^WherePerson::age>() > 35;
     auto expr3  = field<^^WherePerson::name>() != "Charlie";
-    auto result = queryset.where((expr1 || expr2) && expr3).select();
+    auto result = queryset.where((expr1 || expr2) && expr3).select().execute();
     ASSERT_TRUE(result.has_value()) << "WHERE failed: " << result.error().message();
 
     const auto& people = result.value();
@@ -266,24 +266,24 @@ TYPED_TEST(WhereTest, WherePreservesStateAfterSelect) {
     queryset.where(field<^^WherePerson::age>() >= 25);
 
     // First query uses the filter
-    auto result1 = queryset.select();
+    auto result1 = queryset.select().execute();
     ASSERT_TRUE(result1.has_value());
     ASSERT_EQ(result1.value().size(), 5) << "Expected 5 people with age >= 25";
 
     // Second query still has the same filter (state preserved)
-    auto result2 = queryset.select();
+    auto result2 = queryset.select().execute();
     ASSERT_TRUE(result2.has_value());
     ASSERT_EQ(result2.value().size(), 5) << "State should persist after first select()";
 
     // Add more conditions - they accumulate
     queryset.where(field<^^WherePerson::age>() < 40);
-    auto result3 = queryset.select();
+    auto result3 = queryset.select().execute();
     ASSERT_TRUE(result3.has_value());
     ASSERT_EQ(result3.value().size(), 4) << "Expected 4 people with age >= 25 AND age < 40";
 
     // reset() clears all state
     queryset.reset();
-    auto result4 = queryset.select();
+    auto result4 = queryset.select().execute();
     ASSERT_TRUE(result4.has_value());
     ASSERT_EQ(result4.value().size(), 5) << "After reset() should select all rows";
 }
@@ -293,7 +293,7 @@ TYPED_TEST(WhereTest, WhereStringView) {
     QuerySet<WherePerson, TypeParam> queryset;
 
     std::string_view const name_view = "Charlie";
-    auto                   result    = queryset.where(field<^^WherePerson::name>() == name_view).select();
+    auto                   result    = queryset.where(field<^^WherePerson::name>() == name_view).select().execute();
     ASSERT_TRUE(result.has_value()) << "WHERE failed: " << result.error().message();
 
     const auto& people = result.value();
@@ -306,7 +306,7 @@ TYPED_TEST(WhereTest, WhereConstCharPtr) {
     QuerySet<WherePerson, TypeParam> queryset;
 
     const char* name_ptr = "Bob";
-    auto        result   = queryset.where(field<^^WherePerson::name>() == name_ptr).select();
+    auto        result   = queryset.where(field<^^WherePerson::name>() == name_ptr).select().execute();
     ASSERT_TRUE(result.has_value()) << "WHERE failed: " << result.error().message();
 
     const auto& people = result.value();
@@ -322,7 +322,7 @@ TYPED_TEST(WhereTest, WhereMixedTypes) {
 
     auto expr1  = field<^^WherePerson::name>() == "Diana";
     auto expr2  = field<^^WherePerson::age>() == 28;
-    auto result = queryset.where(expr1 && expr2).select();
+    auto result = queryset.where(expr1 && expr2).select().execute();
     ASSERT_TRUE(result.has_value()) << "WHERE failed: " << result.error().message();
 
     const auto& people = result.value();
@@ -384,51 +384,60 @@ template <typename ConnType> class WhereJoinTest : public ::testing::Test {
 
         // Insert users (use ID 0 to let AUTOINCREMENT generate IDs)
         QuerySet<WhereUser, ConnType> user_qs;
-        auto                          alice_id = user_qs.insert(WhereUser{.id = 0, .username = "alice", .level = 10});
+        auto alice_id = user_qs.insert(WhereUser{.id = 0, .username = "alice", .level = 10}).execute();
         ASSERT_TRUE(alice_id.has_value()) << "Failed to insert alice: " << alice_id.error().message();
 
-        auto bob_id = user_qs.insert(WhereUser{.id = 0, .username = "bob", .level = 5});
+        auto bob_id = user_qs.insert(WhereUser{.id = 0, .username = "bob", .level = 5}).execute();
         ASSERT_TRUE(bob_id.has_value()) << "Failed to insert bob: " << bob_id.error().message();
 
-        auto charlie_id = user_qs.insert(WhereUser{.id = 0, .username = "charlie", .level = 15});
+        auto charlie_id = user_qs.insert(WhereUser{.id = 0, .username = "charlie", .level = 15}).execute();
         ASSERT_TRUE(charlie_id.has_value()) << "Failed to insert charlie: " << charlie_id.error().message();
 
         // Insert messages (use generated user IDs)
         QuerySet<WhereMessage, ConnType> msg_qs;
-        auto                             msg1 = msg_qs.insert(
-                WhereMessage{
-                                                    .id      = 0,
-                                                    .content = "Hello from Alice",
-                                                    .sender = WhereUser{.id = static_cast<int>(alice_id.value()), .username = "", .level = 0}
-                }
-        );
+        auto                             msg1 =
+                msg_qs
+                        .insert(WhereMessage{
+                                .id      = 0,
+                                .content = "Hello from Alice",
+                                .sender =
+                                        WhereUser{.id = static_cast<int>(alice_id.value()), .username = "", .level = 0}
+                        })
+                        .execute();
         ASSERT_TRUE(msg1.has_value()) << "Failed to insert message 1: " << msg1.error().message();
 
-        auto msg2 = msg_qs.insert(
-                WhereMessage{
-                        .id      = 0,
-                        .content = "Hi from Bob",
-                        .sender  = WhereUser{.id = static_cast<int>(bob_id.value()), .username = "", .level = 0}
-                }
-        );
+        auto msg2 =
+                msg_qs
+                        .insert(WhereMessage{
+                                .id      = 0,
+                                .content = "Hi from Bob",
+                                .sender  = WhereUser{.id = static_cast<int>(bob_id.value()), .username = "", .level = 0}
+                        })
+                        .execute();
         ASSERT_TRUE(msg2.has_value()) << "Failed to insert message 2: " << msg2.error().message();
 
-        auto msg3 = msg_qs.insert(
-                WhereMessage{
-                        .id      = 0,
-                        .content = "Greetings from Alice",
-                        .sender  = WhereUser{.id = static_cast<int>(alice_id.value()), .username = "", .level = 0}
-                }
-        );
+        auto msg3 =
+                msg_qs
+                        .insert(WhereMessage{
+                                .id      = 0,
+                                .content = "Greetings from Alice",
+                                .sender =
+                                        WhereUser{.id = static_cast<int>(alice_id.value()), .username = "", .level = 0}
+                        })
+                        .execute();
         ASSERT_TRUE(msg3.has_value()) << "Failed to insert message 3: " << msg3.error().message();
 
-        auto msg4 = msg_qs.insert(
-                WhereMessage{
-                        .id      = 0,
-                        .content = "Greetings Charlie",
-                        .sender  = WhereUser{.id = static_cast<int>(charlie_id.value()), .username = "", .level = 0}
-                }
-        );
+        auto msg4 =
+                msg_qs
+                        .insert(WhereMessage{
+                                .id      = 0,
+                                .content = "Greetings Charlie",
+                                .sender =
+                                        WhereUser{
+                                                .id = static_cast<int>(charlie_id.value()), .username = "", .level = 0
+                                        }
+                        })
+                        .execute();
         ASSERT_TRUE(msg4.has_value()) << "Failed to insert message 4: " << msg4.error().message();
     }
 
@@ -450,7 +459,8 @@ TYPED_TEST(WhereJoinTest, WhereWithJoin) {
     QuerySet<WhereMessage, TypeParam> queryset;
 
     // SELECT with JOIN and WHERE filtering by WhereUser.level
-    auto result = queryset.template join<&WhereMessage::sender>().where(field<^^WhereUser::level>() >= 10).select();
+    auto result =
+            queryset.template join<&WhereMessage::sender>().where(field<^^WhereUser::level>() >= 10).select().execute();
     ASSERT_TRUE(result.has_value()) << "WHERE + JOIN failed: " << result.error().message();
 
     const auto& messages = result.value();
@@ -473,7 +483,8 @@ TYPED_TEST(WhereJoinTest, WhereWithJoinContentFilter) {
 
     auto result = queryset.template join<&WhereMessage::sender>()
                           .where(field<^^WhereMessage::content>().like("%Alice%"))
-                          .select();
+                          .select()
+                          .execute();
     ASSERT_TRUE(result.has_value()) << "WHERE + JOIN failed: " << result.error().message();
 
     const auto& messages = result.value();
@@ -486,7 +497,7 @@ TYPED_TEST(WhereJoinTest, WhereWithJoinMultipleConditions) {
 
     auto expr1  = field<^^WhereUser::level>() > 5;
     auto expr2  = field<^^WhereMessage::content>().like("%from%");
-    auto result = queryset.template join<&WhereMessage::sender>().where(expr1 && expr2).select();
+    auto result = queryset.template join<&WhereMessage::sender>().where(expr1 && expr2).select().execute();
     ASSERT_TRUE(result.has_value()) << "WHERE + JOIN failed: " << result.error().message();
 
     const auto& messages = result.value();
@@ -500,7 +511,8 @@ TYPED_TEST(WhereJoinTest, WhereWithNaturalOperators) {
     // Using natural 'and' operator (also works with &&)
     auto result = queryset.template join<&WhereMessage::sender>()
                           .where(field<^^WhereUser::level>() > 5 and field<^^WhereMessage::content>().like("%from%"))
-                          .select();
+                          .select()
+                          .execute();
     ASSERT_TRUE(result.has_value()) << "WHERE + JOIN failed: " << result.error().message();
 
     const auto& messages = result.value();
@@ -518,7 +530,8 @@ TYPED_TEST(WhereTest, WhereNaturalOperatorsComplex) {
     // Using natural 'and' and 'or' operators
     auto result = queryset.where((field<^^WherePerson::age>() < 30 or field<^^WherePerson::age>() > 35) and
                                  field<^^WherePerson::name>() != "Charlie")
-                          .select();
+                          .select()
+                          .execute();
     ASSERT_TRUE(result.has_value()) << "WHERE failed: " << result.error().message();
 
     const auto& people = result.value();
@@ -538,19 +551,19 @@ TYPED_TEST(WhereTest, WhereReuseCondition) {
 
     // First use - should return 4 people (Alice=30, Charlie=35, Diana=28, Eve=40)
     QuerySet<WherePerson, TypeParam> queryset1;
-    auto                             result1 = queryset1.where(age_condition).select();
+    auto                             result1 = queryset1.where(age_condition).select().execute();
     ASSERT_TRUE(result1.has_value()) << "First WHERE failed: " << result1.error().message();
     EXPECT_EQ(result1.value().size(), 4) << "Expected 4 people with age > 25";
 
     // Reuse same condition with fresh QuerySet - should return same results
     QuerySet<WherePerson, TypeParam> queryset2;
-    auto                             result2 = queryset2.where(age_condition).select();
+    auto                             result2 = queryset2.where(age_condition).select().execute();
     ASSERT_TRUE(result2.has_value()) << "Second WHERE failed: " << result2.error().message();
     EXPECT_EQ(result2.value().size(), 4) << "Expected 4 people with age > 25 (reused condition)";
 
     // Combine reused condition with new one
     QuerySet<WherePerson, TypeParam> queryset3;
-    auto result3 = queryset3.where(age_condition and field<^^WherePerson::name>() == "Alice").select();
+    auto result3 = queryset3.where(age_condition and field<^^WherePerson::name>() == "Alice").select().execute();
     ASSERT_TRUE(result3.has_value()) << "Combined WHERE failed: " << result3.error().message();
     ASSERT_EQ(result3.value().size(), 1) << "Expected 1 person matching both conditions";
     auto it = result3.value().begin();
@@ -559,7 +572,7 @@ TYPED_TEST(WhereTest, WhereReuseCondition) {
 
     // Reuse the original condition again with fresh QuerySet
     QuerySet<WherePerson, TypeParam> queryset4;
-    auto                             result4 = queryset4.where(age_condition).select();
+    auto                             result4 = queryset4.where(age_condition).select().execute();
     ASSERT_TRUE(result4.has_value()) << "Third WHERE failed: " << result4.error().message();
     EXPECT_EQ(result4.value().size(), 4) << "Expected 4 people with age > 25 (reused after combining)";
 }
@@ -573,30 +586,30 @@ TYPED_TEST(WhereTest, WhereComposableFilters) {
 
     // Use filters independently with fresh QuerySets
     QuerySet<WherePerson, TypeParam> qs1;
-    auto                             young_people = qs1.where(young_filter).select();
+    auto                             young_people = qs1.where(young_filter).select().execute();
     ASSERT_TRUE(young_people.has_value());
     EXPECT_EQ(young_people.value().size(), 2) << "Expected 2 young people (Bob=25, Diana=28)";
 
     QuerySet<WherePerson, TypeParam> qs2;
-    auto                             old_people = qs2.where(old_filter).select();
+    auto                             old_people = qs2.where(old_filter).select().execute();
     ASSERT_TRUE(old_people.has_value());
     EXPECT_EQ(old_people.value().size(), 2) << "Expected 2 old people (Charlie=35, Eve=40)";
 
     // Combine filters
     QuerySet<WherePerson, TypeParam> qs3;
-    auto                             young_or_old = qs3.where(young_filter or old_filter).select();
+    auto                             young_or_old = qs3.where(young_filter or old_filter).select().execute();
     ASSERT_TRUE(young_or_old.has_value());
     EXPECT_EQ(young_or_old.value().size(), 4) << "Expected 4 people (young or old)";
 
     // Complex composition
     QuerySet<WherePerson, TypeParam> qs4;
-    auto                             young_a_names = qs4.where(young_filter and name_starts_with_a).select();
+    auto                             young_a_names = qs4.where(young_filter and name_starts_with_a).select().execute();
     ASSERT_TRUE(young_a_names.has_value());
     EXPECT_EQ(young_a_names.value().size(), 0) << "Expected 0 people (no young people with A names)";
 
     // Reuse filters in different combinations
     QuerySet<WherePerson, TypeParam> qs5;
-    auto                             old_a_names = qs5.where(old_filter and name_starts_with_a).select();
+    auto                             old_a_names = qs5.where(old_filter and name_starts_with_a).select().execute();
     ASSERT_TRUE(old_a_names.has_value());
     EXPECT_EQ(old_a_names.value().size(), 0) << "Expected 0 people (no old people with A names)";
 }
@@ -609,18 +622,18 @@ TYPED_TEST(WhereTest, ReusableBaseQuerySet) {
     queryset.where(field<^^WherePerson::age>() >= 25);
 
     // Reuse base filter multiple times
-    auto result1 = queryset.select();
+    auto result1 = queryset.select().execute();
     ASSERT_TRUE(result1.has_value());
     ASSERT_EQ(result1.value().size(), 5) << "Expected 5 people with age >= 25";
 
     // Still has base filter on second call
-    auto result2 = queryset.select();
+    auto result2 = queryset.select().execute();
     ASSERT_TRUE(result2.has_value());
     ASSERT_EQ(result2.value().size(), 5) << "Base filter should persist";
 
     // Refine the base filter
     queryset.where(field<^^WherePerson::age>() >= 30);
-    auto adults = queryset.select();
+    auto adults = queryset.select().execute();
     ASSERT_TRUE(adults.has_value());
     ASSERT_EQ(adults.value().size(), 3) << "Expected 3 people (age >= 25 AND age >= 30)";
 }
@@ -631,19 +644,19 @@ TYPED_TEST(WhereTest, ProgressiveQueryBuilding) {
 
     // Start with broad filter
     queryset.where(field<^^WherePerson::age>() >= 25);
-    auto result1 = queryset.select();
+    auto result1 = queryset.select().execute();
     ASSERT_TRUE(result1.has_value());
     EXPECT_EQ(result1.value().size(), 5) << "All people are >= 25";
 
     // Narrow it down
     queryset.where(field<^^WherePerson::age>() < 35);
-    auto result2 = queryset.select();
+    auto result2 = queryset.select().execute();
     ASSERT_TRUE(result2.has_value());
     EXPECT_EQ(result2.value().size(), 3) << "Expected 3 people (25 <= age < 35)";
 
     // Add another condition (names starting with certain letter)
     queryset.where(field<^^WherePerson::name>().like("D%"));
-    auto result3 = queryset.select();
+    auto result3 = queryset.select().execute();
     ASSERT_TRUE(result3.has_value());
     EXPECT_EQ(result3.value().size(), 1) << "Expected 1 person matching all conditions (Diana)";
     EXPECT_EQ(result3.value().begin()->name, "Diana");
@@ -658,20 +671,20 @@ TYPED_TEST(WhereTest, ResetClearsAllConditions) {
     queryset.where(field<^^WherePerson::age>() < 40);
     queryset.where(field<^^WherePerson::name>().like("D%"));
 
-    auto filtered = queryset.select();
+    auto filtered = queryset.select().execute();
     ASSERT_TRUE(filtered.has_value());
     EXPECT_EQ(filtered.value().size(), 1) << "Complex filter should match Diana only";
     EXPECT_EQ(filtered.value().begin()->name, "Diana");
 
     // Reset and verify clean slate
     queryset.reset();
-    auto all_people = queryset.select();
+    auto all_people = queryset.select().execute();
     ASSERT_TRUE(all_people.has_value());
     EXPECT_EQ(all_people.value().size(), 5) << "After reset() should get all rows";
 
     // Can build new filter after reset
     queryset.where(field<^^WherePerson::age>() == 25);
-    auto bob_only = queryset.select();
+    auto bob_only = queryset.select().execute();
     ASSERT_TRUE(bob_only.has_value());
     EXPECT_EQ(bob_only.value().size(), 1) << "New filter after reset works";
     EXPECT_EQ(bob_only.value().begin()->name, "Bob");
@@ -687,7 +700,7 @@ TYPED_TEST(WhereTest, WhereInEmptyValuesReturnsFalse) {
     QuerySet<WherePerson, TypeParam> queryset;
 
     // .in() with no arguments creates InExpression with empty vector → "1 = 0"
-    auto result = queryset.where(field<^^WherePerson::age>().in()).select();
+    auto result = queryset.where(field<^^WherePerson::age>().in()).select().execute();
     ASSERT_TRUE(result.has_value()) << "Empty IN should succeed";
     EXPECT_TRUE(result.value().empty()) << "Empty IN (1=0) should match nothing";
 }
@@ -711,7 +724,7 @@ TYPED_TEST(WhereTest, ExprDirectConstructionFromVariant) {
 
     // Also verify it works with QuerySet::where()
     QuerySet<WherePerson, TypeParam> queryset;
-    auto                             result = queryset.where(direct_expr).select();
+    auto                             result = queryset.where(direct_expr).select().execute();
     ASSERT_TRUE(result.has_value());
     EXPECT_EQ(result.value().size(), 4) << "Should find 4 people with age > 25";
 }


### PR DESCRIPTION
## Summary

- Moves proxy types (`SingleQuery`, `BulkQuery`) from anonymous inline structs in `queryset.cppm` into their respective statement modules (`insert.cppm`, `remove.cppm`, `update.cppm`, `select.cppm`)
- Adds `to_sql()` methods to all statement types for SQL inspection without execution
- Adds extraction helpers to `BaseStatement` to work around P2996 compiler limitations in `select.cppm`
- Simplifies `QuerySet` methods into single-line delegations
- Adds comprehensive tests in `tests/test_sql_inspection.cpp` covering all SQL inspection paths
- Adds mock error tests to reach 100% line coverage

Closes #86

## Test plan

- [x] All 1201 existing SQLite tests pass
- [x] 12 new mock-SQLite tests for `to_sql()` error paths (prepare/bind failures for select, insert, remove, update)
- [x] 4 new mock-libpq tests for `PgStatement::expanded_sql()` edge cases
- [x] 2 new mock-libpq tests for PG insert `to_sql()` error paths
- [x] New `tests/test_sql_inspection.cpp` with 30+ typed tests (SQLite + PostgreSQL)
- [x] Line coverage: 99.2% → 100%
- [x] Pre-commit hook passes (format, tidy, tests, coverage, sonar)

🤖 Generated with [Claude Code](https://claude.com/claude-code)