### PR TITLE
infra: add ASAN+UBSAN and TSAN sanitizer build presets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,11 +30,13 @@ Storm is a C++26 ORM library for SQLite using compile-time reflection to automat
 
 ### CMake Presets
 
-| Preset | Build type | Tests | Coverage | Bench | Use for |
-|---|---|---|---|---|---|
-| `ninja-debug` | Debug | ✓ | ✓ | — | Development, coverage |
-| `ninja-release` | Release | ✓ | — | ✓ | CI, benchmarking |
-| `ninja-prod` | Release | — | — | — | Production artifact |
+| Preset | Build type | Tests | Coverage | Bench | Sanitizer | Use for |
+|---|---|---|---|---|---|---|
+| `ninja-debug` | Debug | ✓ | ✓ | — | — | Development, coverage |
+| `ninja-release` | Release | ✓ | — | ✓ | — | CI, benchmarking |
+| `ninja-prod` | Release | — | — | — | — | Production artifact |
+| `ninja-asan-ubsan` | Debug | ✓ | — | — | ASAN+UBSAN | Memory safety + undefined behavior |
+| `ninja-tsan` | Debug | ✓ | — | — | TSAN | Data race detection |
 
 ### Build & Test
 ```bash

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -46,6 +46,30 @@
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release"
       }
+    },
+    {
+      "name": "ninja-asan-ubsan",
+      "displayName": "Ninja ASAN+UBSAN",
+      "description": "Debug build with AddressSanitizer + UndefinedBehaviorSanitizer — memory safety and undefined behavior",
+      "inherits": "base",
+      "binaryDir": "${sourceDir}/build/asan-ubsan",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "ENABLE_TESTS": "ON",
+        "USE_SANITIZER": "address,undefined"
+      }
+    },
+    {
+      "name": "ninja-tsan",
+      "displayName": "Ninja TSAN",
+      "description": "Debug build with ThreadSanitizer — detects data races in thread_local patterns",
+      "inherits": "base",
+      "binaryDir": "${sourceDir}/build/tsan",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "ENABLE_TESTS": "ON",
+        "USE_SANITIZER": "thread"
+      }
     }
   ],
   "buildPresets": [
@@ -67,6 +91,14 @@
     {
       "name": "ninja-prod",
       "configurePreset": "ninja-prod"
+    },
+    {
+      "name": "ninja-asan-ubsan",
+      "configurePreset": "ninja-asan-ubsan"
+    },
+    {
+      "name": "ninja-tsan",
+      "configurePreset": "ninja-tsan"
     }
   ],
   "testPresets": [
@@ -98,6 +130,49 @@
       "configurePreset": "ninja-release",
       "output": {
         "outputOnFailure": true
+      }
+    },
+    {
+      "name": "ninja-asan-ubsan",
+      "configurePreset": "ninja-asan-ubsan",
+      "output": {
+        "outputOnFailure": true
+      },
+      "execution": {
+        "jobs": 1
+      },
+      "environment": {
+        "STORM_PG_CONNSTR": "host=/var/run/postgresql dbname=storm_db user=storm_db",
+        "ASAN_OPTIONS": "detect_leaks=1:abort_on_error=1",
+        "UBSAN_OPTIONS": "print_stacktrace=1:abort_on_error=1"
+      }
+    },
+    {
+      "name": "ninja-asan-ubsan-sqlite",
+      "inherits": "ninja-asan-ubsan",
+      "environment": {
+        "STORM_PG_CONNSTR": null
+      }
+    },
+    {
+      "name": "ninja-tsan",
+      "configurePreset": "ninja-tsan",
+      "output": {
+        "outputOnFailure": true
+      },
+      "execution": {
+        "jobs": 1
+      },
+      "environment": {
+        "STORM_PG_CONNSTR": "host=/var/run/postgresql dbname=storm_db user=storm_db",
+        "TSAN_OPTIONS": "abort_on_error=1"
+      }
+    },
+    {
+      "name": "ninja-tsan-sqlite",
+      "inherits": "ninja-tsan",
+      "environment": {
+        "STORM_PG_CONNSTR": null
       }
     }
   ]

--- a/cmake/sanitizers.cmake
+++ b/cmake/sanitizers.cmake
@@ -20,5 +20,6 @@ if(USE_SANITIZER)
     message(STATUS "Sanitizer options configured for ${USE_SANITIZER}")
   endif()
 
-  add_compile_options(-g)
+  # Better stack traces for all sanitizers
+  add_compile_options(-g -fno-omit-frame-pointer)
 endif()

--- a/docs/README.md
+++ b/docs/README.md
@@ -51,6 +51,7 @@ Welcome to Storm ORM - a modern C++26 ORM library using compile-time reflection 
 - **[Compiler Attributes](development/COMPILER_ATTRIBUTES.md)** - Guide for using hot, flatten, and always_inline attributes
 - **[Compiler Issues](development/COMPILER_ISSUES.md)** - Known workarounds for clang-p2996
 - **[Formatting](development/FORMATTING.md)** - clang-format and cmake-format targets, pre-commit integration, and `.clang-format` settings
+- **[Sanitizers](development/SANITIZERS.md)** - ASAN+UBSAN and TSAN presets, what each sanitizer catches, MSAN status
 
 ## Open Issues
 

--- a/docs/development/SANITIZERS.md
+++ b/docs/development/SANITIZERS.md
@@ -1,0 +1,84 @@
+# Sanitizer Builds
+
+Storm provides sanitizer-enabled CMake presets for catching memory, concurrency, and undefined-behavior bugs at runtime.
+
+## Available Presets
+
+| Preset | Sanitizers | Detects | SQLite-only variant |
+|--------|-----------|---------|-------------------|
+| `ninja-asan-ubsan` | ASAN + LSAN + UBSAN | Memory errors, leaks, undefined behavior | `ninja-asan-ubsan-sqlite` |
+| `ninja-tsan` | TSAN | Data races in `thread_local` patterns | `ninja-tsan-sqlite` |
+
+> **Note**: ASAN and TSAN are mutually exclusive — they cannot be combined in a single build.
+
+## Quick Start
+
+```bash
+# Configure + build + test with ASAN+UBSAN
+cmake --preset ninja-asan-ubsan && cmake --build --preset ninja-asan-ubsan
+ctest --preset ninja-asan-ubsan
+
+# SQLite only (skips PostgreSQL)
+ctest --preset ninja-asan-ubsan-sqlite
+
+# Configure + build + test with TSAN
+cmake --preset ninja-tsan && cmake --build --preset ninja-tsan
+ctest --preset ninja-tsan
+
+# TSAN SQLite only
+ctest --preset ninja-tsan-sqlite
+```
+
+## What Each Sanitizer Catches
+
+### ASAN — AddressSanitizer
+- Buffer overflows (stack, heap, global)
+- Use-after-free
+- Use-after-return / use-after-scope
+- Double-free, invalid free
+
+### LSAN — LeakSanitizer (bundled with ASAN on Linux)
+On Linux, **LSAN is automatically included in ASAN** — no separate preset needed.
+It runs at program exit and reports any memory that was allocated but never freed.
+The `ninja-asan-ubsan` test preset sets `ASAN_OPTIONS=detect_leaks=1` to make this explicit.
+
+### UBSAN — UndefinedBehaviorSanitizer
+- Signed integer overflow
+- Null pointer dereference
+- Out-of-bounds array access
+- Invalid enum values
+- Misaligned pointer use
+
+The `ninja-asan-ubsan` test preset sets `UBSAN_OPTIONS=print_stacktrace=1:abort_on_error=1`
+so that every UB violation prints a full stack trace and aborts immediately.
+
+### TSAN — ThreadSanitizer
+- Data races between threads
+- Lock-order inversions
+- Races on `thread_local` storage
+
+Particularly relevant for Storm's `thread_local` connection pattern.
+The test preset uses `jobs: 1` (serial execution) for clean, non-interleaved output.
+
+## Build Directories
+
+Each sanitizer preset uses its own binary directory to avoid cache conflicts:
+
+| Preset | Binary dir |
+|--------|-----------|
+| `ninja-debug` | `build/debug` |
+| `ninja-asan-ubsan` | `build/asan-ubsan` |
+| `ninja-tsan` | `build/tsan` |
+
+## Important Notes
+
+- **No coverage**: Sanitizer presets do not enable `ENABLE_COVERAGE`. Coverage and sanitizers conflict — use `ninja-debug` for coverage.
+- **Serial tests**: Sanitizer test presets run with `jobs: 1` for readable output. Expect ~35 seconds per full run.
+- **Stack traces**: All presets add `-fno-omit-frame-pointer` for accurate stack traces in sanitizer reports.
+- **False positives**: TSAN may produce false positives if SQLite or libpq were not compiled with TSAN. If you see races only in third-party code, suppress them with a TSAN suppression file.
+
+## MSAN — MemorySanitizer (not yet available)
+
+MSAN detects reads from **uninitialized memory** — a bug class not covered by the other sanitizers.
+
+It is tracked in issue [#116](https://github.com/spiritEcosse/storm/issues/116) but is not currently available because MSAN requires **every library in the dependency chain** (including libc++) to be compiled with MSAN instrumentation. Storm depends on a custom `clang-p2996` build for C++26 reflection support, and rebuilding this entire toolchain with MSAN is not practical until C++26 / P2996 reflection stabilizes in upstream Clang.


### PR DESCRIPTION
## Summary

- Adds `ninja-asan-ubsan` preset combining AddressSanitizer + UndefinedBehaviorSanitizer (with LSAN leak detection bundled on Linux)
- Adds `ninja-tsan` preset for ThreadSanitizer (data race detection, relevant for `thread_local` patterns)
- Adds `-sqlite` variants of both for SQLite-only test runs
- Adds `-fno-omit-frame-pointer` to all sanitizer builds for accurate stack traces
- Adds `docs/development/SANITIZERS.md` documenting all sanitizers, LSAN/ASAN bundling on Linux, and why MSAN is tracked separately
- Updates `docs/README.md` and `CLAUDE.md` preset table

## MSAN note

MSAN requires the full toolchain (Clang + libc++ + libc++abi) to be rebuilt with MSAN instrumentation. Not practical until C++26/P2996 stabilises upstream. Tracked in #116.

## Test plan

- [x] `ninja-asan-ubsan`: 1202/1202 tests pass
- [x] `ninja-tsan`: 1202/1202 tests pass
- [x] Pre-commit hook passes (cmake-format, tests, coverage)

Closes #93