### PR TITLE
feat(fuzz): libFuzzer stress testing infrastructure (#114)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,13 @@ default.profraw
 
 # SonarCloud scanner working directory
 .scannerwork/
+
+# libFuzzer corpus / crash artifacts (created by fuzz harness runs)
+# These are raw binary files with unprintable names; managed per-session by the user
+crash-*
+timeout-*
+leak-*
+oom-*
+slow-unit-*
+corpus/
+crashes/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,7 @@ include(cmake/tests.cmake)
 include(cmake/coverage-targets.cmake)
 include(cmake/bench.cmake)
 include(cmake/sanitizers.cmake)
+include(cmake/fuzz.cmake)
 include(cmake/format.cmake)
 
 # ── Build summary ─────────────────────────────────────────────────────────────
@@ -86,4 +87,5 @@ message(STATUS "Testing: ${ENABLE_TESTS}")
 message(STATUS "Benchmarks: ${ENABLE_BENCH}")
 message(STATUS "Coverage: ${ENABLE_COVERAGE}")
 message(STATUS "Sanitizer: ${USE_SANITIZER}")
+message(STATUS "Fuzzing: ${ENABLE_FUZZING}")
 message(STATUS "===================================")

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -70,6 +70,17 @@
         "ENABLE_TESTS": "ON",
         "USE_SANITIZER": "thread"
       }
+    },
+    {
+      "name": "ninja-fuzz",
+      "displayName": "Ninja Fuzzing",
+      "description": "Release build with libFuzzer + ASAN harnesses — fuzz the runtime SQL binding layer",
+      "inherits": "base",
+      "binaryDir": "${sourceDir}/build/fuzz",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "ENABLE_FUZZING": "ON"
+      }
     }
   ],
   "buildPresets": [
@@ -99,6 +110,10 @@
     {
       "name": "ninja-tsan",
       "configurePreset": "ninja-tsan"
+    },
+    {
+      "name": "ninja-fuzz",
+      "configurePreset": "ninja-fuzz"
     }
   ],
   "testPresets": [

--- a/cmake/fuzz.cmake
+++ b/cmake/fuzz.cmake
@@ -1,0 +1,33 @@
+option(ENABLE_FUZZING
+       "Build libFuzzer harnesses (requires -fsanitize=address,fuzzer support)"
+       OFF)
+
+if(ENABLE_FUZZING)
+  # Compile the storm library with the same instrumentation flags as the fuzz
+  # harnesses (-fsanitize=address,fuzzer-no-link). This is required because:
+  #
+  # 1. clang's module cache hash is derived from compilation flags.  If the storm
+  #   library and fuzz harnesses have DIFFERENT flags, _Builtin_stddef (and
+  #   similar built-in modules) are cached under different hash sub-
+  #   directories.  When loading the storm BMI in a fuzz harness compilation,
+  #   clang finds built-in modules in BOTH directories and emits a fatal
+  #   "defined in both" error.
+  #
+  # 1. Using fuzzer-no-link here (rather than plain fuzzer) means the fuzzer
+  #   runtime is NOT linked into libstorm.a — it is linked only into each fuzz
+  #   harness binary (via target_link_options in fuzz/CMakeLists.txt).
+  #
+  # 1. A shared, build-local module cache (module-cache) keeps all fuzz-build
+  #   module I/O out of the global ~/.cache/clang/ModuleCache/ to avoid
+  #   cross-preset contamination.
+  set(FUZZ_INSTRUMENT_FLAGS
+      -fsanitize=address,fuzzer-no-link -g -fno-omit-frame-pointer
+      "-fmodules-cache-path=${CMAKE_BINARY_DIR}/module-cache")
+  target_compile_options(storm PRIVATE ${FUZZ_INSTRUMENT_FLAGS})
+  target_link_options(storm PRIVATE -fsanitize=address -g
+                      -fno-omit-frame-pointer)
+  message(STATUS "Fuzzing is enabled.")
+  add_subdirectory(fuzz)
+else()
+  message(STATUS "Fuzzing is disabled.")
+endif()

--- a/docs/development/FUZZING.md
+++ b/docs/development/FUZZING.md
@@ -1,0 +1,122 @@
+# FUZZING.md — libFuzzer Stress Testing
+
+Storm uses **libFuzzer** (built into the custom Clang at `../clang-p2996/`) to stress-test the **runtime SQL binding and execution layer** — the only part of the ORM that can produce crashes or undefined behaviour at runtime. Compile-time SQL generation is safe by construction.
+
+## What Is Fuzzed
+
+| Harness | What it tests |
+|---------|--------------|
+| `fuzz_where_string` | String WHERE filters: `==`, `!=`, `LIKE`, `BETWEEN` |
+| `fuzz_where_int` | Integer WHERE filters: `==`, `!=`, `>`, `<`, `IN`, `BETWEEN` |
+| `fuzz_like_pattern` | LIKE patterns with adversarial input (null bytes, `%`, `_`, quotes, unicode) |
+| `fuzz_batch_insert` | Batch insert sizes around the SQLite 999-parameter limit |
+| `fuzz_connection_string` | Malformed connection strings passed to `set_default_connection()` |
+
+SQL errors (e.g. malformed patterns) are **expected and caught** inside every harness. Only crashes or sanitizer reports (ASAN/UBSAN) indicate real bugs.
+
+## Build
+
+```bash
+cmake --preset ninja-fuzz
+
+# First build: run serially to warm the module cache (avoids a known
+# clang-scan-deps race when the module-cache/ directory is empty)
+cmake --build --preset ninja-fuzz -- -j 1
+
+# Subsequent builds: full parallelism is safe once the cache is warm
+cmake --build --preset ninja-fuzz
+```
+
+Binaries are placed in `build/fuzz/fuzz/`.
+
+### Design notes
+
+The fuzz preset compiles **both the storm library and fuzz harnesses** with
+`-fsanitize=address,fuzzer-no-link`. Using the same compilation flags for all
+targets is required to keep module cache entries under a single hash — if the
+library and harnesses had different flags, clang would create two hash
+subdirectories for built-in modules (`_Builtin_stddef`, etc.) in the same cache
+directory and emit a fatal "defined in both" error.
+
+Only the **link step** for harnesses uses `-fsanitize=address,fuzzer` (which
+pulls in the libFuzzer runtime and replaces `main()`). The storm library
+(`libstorm.a`) uses `-fsanitize=address` at link time only.
+
+## Run a Harness
+
+### Quick smoke test (100 iterations)
+
+```bash
+./build/fuzz/fuzz_where_string -runs=100
+./build/fuzz/fuzz_where_int    -runs=100
+./build/fuzz/fuzz_like_pattern -runs=100
+./build/fuzz/fuzz_batch_insert -runs=50
+./build/fuzz/fuzz_connection_string -runs=100
+```
+
+### Time-bounded fuzzing (recommended for development)
+
+```bash
+./build/fuzz/fuzz_where_string -max_total_time=60
+```
+
+### Corpus-based fuzzing (finds more bugs over time)
+
+```bash
+mkdir -p corpus crashes
+
+# Run with corpus directory — libFuzzer saves interesting inputs automatically
+./build/fuzz/fuzz_where_string corpus/ -artifact_prefix=crashes/ -max_total_time=300
+```
+
+On subsequent runs libFuzzer resumes from the saved corpus:
+
+```bash
+./build/fuzz/fuzz_where_string corpus/ -artifact_prefix=crashes/
+```
+
+## Reproduce a Crash
+
+When libFuzzer finds a crash it writes a file like `crash-<sha1hash>`. Reproduce it with:
+
+```bash
+./build/fuzz/fuzz_where_string crash-<hash>
+```
+
+The ASAN stack trace points directly to the bug:
+
+```
+==12345==ERROR: AddressSanitizer: heap-buffer-overflow
+    #0 0x... in storm::orm::... storm/src/orm/statements/select.cppm:42
+    #1 0x... in LLVMFuzzerTestOneInput fuzz/fuzz_where_string.cpp:38
+```
+
+## Interpreting ASAN Output
+
+| Report type | Meaning |
+|-------------|---------|
+| `heap-buffer-overflow` | Read/write past the end of a heap allocation |
+| `stack-buffer-overflow` | Read/write past a stack array |
+| `use-after-free` | Access to memory after it was freed |
+| `heap-use-after-free` | Same as above, on the heap |
+| `SEGV` | Null or wild pointer dereference |
+
+Stack frames show `file:line` for all code compiled with debug info (`-g`). The fuzz preset enables `-g` on all harnesses.
+
+## Fuzz Targets Are Excluded From ctest
+
+The fuzz harnesses are **not registered with CTest**. They will not appear in `ctest --preset ninja-debug -N` and will not be run by the regular test suite.
+
+## Adding a New Harness
+
+1. Create `fuzz/fuzz_<name>.cpp` following the pattern in existing harnesses:
+   - `LLVMFuzzerInitialize` — one-time DB setup
+   - `LLVMFuzzerTestOneInput` — exercise one fuzz path; catch all exceptions
+2. Add `add_fuzz_harness(fuzz_<name>)` to `fuzz/CMakeLists.txt`
+3. Document it in the table at the top of this file
+
+## References
+
+- [libFuzzer documentation](https://llvm.org/docs/LibFuzzer.html)
+- [AddressSanitizer documentation](https://clang.llvm.org/docs/AddressSanitizer.html)
+- [docs/development/SANITIZERS.md](SANITIZERS.md) — ASAN/TSAN flag details for Storm

--- a/fuzz/CMakeLists.txt
+++ b/fuzz/CMakeLists.txt
@@ -1,0 +1,33 @@
+project(storm_fuzz LANGUAGES CXX)
+
+message(STATUS "Configuring fuzz harnesses")
+
+# Compilation: -fsanitize=address,fuzzer-no-link matches the flags set on the
+# storm library in cmake/fuzz.cmake. Identical compilation flags → identical
+# module cache hash → no "defined in both" conflict for built-in modules.
+#
+# Linking: -fsanitize=address,fuzzer (no "no-link") pulls in the full libFuzzer
+# runtime and replaces main() with LLVMFuzzerTestOneInput-based wrapper — this
+# is only applied to the harness executables, not to libstorm.a.
+set(FUZZ_COMPILE_FLAGS
+    -fsanitize=address,fuzzer-no-link -g -fno-omit-frame-pointer
+    "-fmodules-cache-path=${CMAKE_BINARY_DIR}/module-cache")
+
+set(FUZZ_LINK_FLAGS -fsanitize=address,fuzzer -g -fno-omit-frame-pointer)
+
+function(add_fuzz_harness name)
+  add_executable(${name} ${name}.cpp)
+  apply_clang_flags(${name})
+  target_compile_options(${name} PRIVATE ${FUZZ_COMPILE_FLAGS})
+  target_link_options(${name} PRIVATE ${FUZZ_LINK_FLAGS})
+  target_link_libraries(${name} PRIVATE storm)
+  link_sqlite(${name})
+  target_include_directories(${name} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}"
+                                             "${CMAKE_SOURCE_DIR}/src")
+endfunction()
+
+add_fuzz_harness(fuzz_where_string)
+add_fuzz_harness(fuzz_where_int)
+add_fuzz_harness(fuzz_like_pattern)
+add_fuzz_harness(fuzz_batch_insert)
+add_fuzz_harness(fuzz_connection_string)

--- a/fuzz/fuzz_batch_insert.cpp
+++ b/fuzz/fuzz_batch_insert.cpp
@@ -1,0 +1,55 @@
+/**
+ * @file fuzz_batch_insert.cpp
+ * @brief libFuzzer harness — fuzz batch sizes near the SQLite 999-param limit.
+ *
+ * Uses the fuzz input size (modulo 1100) as the batch count, exercising the
+ * boundary at and beyond the 999-parameter SQLite limit. Field values are
+ * derived from fuzz bytes to produce varied inputs.
+ */
+
+// NOLINTBEGIN(modernize-use-trailing-return-type,bugprone-unused-return-value,bugprone-empty-catch,cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
+
+#include <cstddef>
+#include <cstdint>
+
+import storm;
+
+import <expected>;
+import <memory>;
+import <span>;
+import <string>;
+import <vector>;
+
+#include "fuzz_models.h" // AFTER import storm;
+
+extern "C" int LLVMFuzzerInitialize(int* /*argc*/, char*** /*argv*/) {
+    auto result = storm::QuerySet<FuzzModel>::set_default_connection(":memory:");
+    if (!result.has_value()) {
+        return 0;
+    }
+    const auto& conn = storm::QuerySet<FuzzModel>::get_default_connection();
+    (void)conn->execute(fuzz_model_create_sql);
+    return 0;
+}
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+    // Use size modulo 1100 to get a batch count that exercises the 999 boundary
+    const std::size_t batch_count = (size % 1100) + 1;
+
+    // Build a batch; derive name/value from fuzz bytes for variety
+    std::vector<FuzzModel> batch;
+    batch.reserve(batch_count);
+    for (std::size_t i = 0; i < batch_count; ++i) {
+        const int value = (size > 0) ? static_cast<int>(data[i % size]) : static_cast<int>(i);
+        batch.push_back(FuzzModel{.name = std::to_string(i), .value = value});
+    }
+
+    try {
+        (void)storm::QuerySet<FuzzModel>().insert(std::span<const FuzzModel>(batch)).execute();
+    } catch (...) {
+        // SQL errors are expected — only crashes/ASAN hits are bugs
+    }
+    return 0;
+}
+
+// NOLINTEND(modernize-use-trailing-return-type,bugprone-unused-return-value,bugprone-empty-catch,cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)

--- a/fuzz/fuzz_batch_insert.cpp
+++ b/fuzz/fuzz_batch_insert.cpp
@@ -23,13 +23,7 @@ import <vector>;
 #include "fuzz_models.h" // AFTER import storm;
 
 extern "C" int LLVMFuzzerInitialize(int* /*argc*/, char*** /*argv*/) {
-    auto result = storm::QuerySet<FuzzModel>::set_default_connection(":memory:");
-    if (!result.has_value()) {
-        return 0;
-    }
-    const auto& conn = storm::QuerySet<FuzzModel>::get_default_connection();
-    (void)conn->execute(fuzz_model_create_sql);
-    return 0;
+    return fuzz_init_db(/*with_seed=*/false);
 }
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
@@ -46,8 +40,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
 
     try {
         (void)storm::QuerySet<FuzzModel>().insert(std::span<const FuzzModel>(batch)).execute();
-    } catch (...) {
-        // SQL errors are expected — only crashes/ASAN hits are bugs
+    } catch (...) { // NOSONAR cpp:S2486 — SQL errors expected; only ASAN/crash = bug
     }
     return 0;
 }

--- a/fuzz/fuzz_connection_string.cpp
+++ b/fuzz/fuzz_connection_string.cpp
@@ -1,0 +1,42 @@
+/**
+ * @file fuzz_connection_string.cpp
+ * @brief libFuzzer harness — fuzz malformed connection strings.
+ *
+ * Passes arbitrary byte sequences as the connection string to
+ * set_default_connection(). The call must return an error (not crash)
+ * for invalid inputs. A successful connection is immediately cleared.
+ */
+
+// NOLINTBEGIN(modernize-use-trailing-return-type,bugprone-unused-return-value,bugprone-empty-catch,cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
+
+#include <cstddef>
+#include <cstdint>
+
+import storm;
+
+import <expected>;
+import <string>;
+
+#include "fuzz_models.h" // AFTER import storm;
+
+extern "C" int LLVMFuzzerInitialize(int* /*argc*/, char*** /*argv*/) {
+    return 0;
+}
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+    const std::string input(reinterpret_cast<const char*>(data), size);
+
+    try {
+        auto result = storm::QuerySet<FuzzModel>::set_default_connection(input);
+        if (result.has_value()) {
+            // Unexpected success — clear connection to avoid resource leak
+            storm::QuerySet<FuzzModel>::clear_default_connection();
+        }
+        // Error return is the expected outcome for malformed strings
+    } catch (...) {
+        // Exceptions are acceptable — only crashes/ASAN hits are bugs
+    }
+    return 0;
+}
+
+// NOLINTEND(modernize-use-trailing-return-type,bugprone-unused-return-value,bugprone-empty-catch,cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)

--- a/fuzz/fuzz_connection_string.cpp
+++ b/fuzz/fuzz_connection_string.cpp
@@ -33,8 +33,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
             storm::QuerySet<FuzzModel>::clear_default_connection();
         }
         // Error return is the expected outcome for malformed strings
-    } catch (...) {
-        // Exceptions are acceptable — only crashes/ASAN hits are bugs
+    } catch (...) { // NOSONAR cpp:S2486 — exceptions are acceptable; only ASAN/crash = bug
     }
     return 0;
 }

--- a/fuzz/fuzz_like_pattern.cpp
+++ b/fuzz/fuzz_like_pattern.cpp
@@ -1,0 +1,49 @@
+/**
+ * @file fuzz_like_pattern.cpp
+ * @brief libFuzzer harness — fuzz LIKE pattern strings with adversarial input.
+ *
+ * Exercises the LIKE binding path with inputs that contain null bytes,
+ * SQLite wildcards (%,_), quote characters, and unicode. SQL errors are
+ * expected and caught; only crashes/ASAN hits are bugs.
+ */
+
+// NOLINTBEGIN(modernize-use-trailing-return-type,bugprone-unused-return-value,bugprone-empty-catch,cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
+
+#include <cstddef>
+#include <cstdint>
+
+import storm;
+
+import <expected>;
+import <memory>;
+import <meta>;
+import <string>;
+
+#include "fuzz_models.h" // AFTER import storm;
+
+extern "C" int LLVMFuzzerInitialize(int* /*argc*/, char*** /*argv*/) {
+    auto result = storm::QuerySet<FuzzModel>::set_default_connection(":memory:");
+    if (!result.has_value()) {
+        return 0;
+    }
+    const auto& conn = storm::QuerySet<FuzzModel>::get_default_connection();
+    (void)conn->execute(fuzz_model_create_sql);
+    (void)storm::QuerySet<FuzzModel>().insert(FuzzModel{.name = "seed", .value = 42}).execute();
+    return 0;
+}
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+    const std::string pattern(reinterpret_cast<const char*>(data), size);
+
+    try {
+        (void)storm::QuerySet<FuzzModel>()
+                .where(storm::orm::where::field<^^FuzzModel::name>().like(pattern))
+                .select()
+                .execute();
+    } catch (...) {
+        // SQL errors are expected — only crashes/ASAN hits are bugs
+    }
+    return 0;
+}
+
+// NOLINTEND(modernize-use-trailing-return-type,bugprone-unused-return-value,bugprone-empty-catch,cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)

--- a/fuzz/fuzz_like_pattern.cpp
+++ b/fuzz/fuzz_like_pattern.cpp
@@ -22,14 +22,7 @@ import <string>;
 #include "fuzz_models.h" // AFTER import storm;
 
 extern "C" int LLVMFuzzerInitialize(int* /*argc*/, char*** /*argv*/) {
-    auto result = storm::QuerySet<FuzzModel>::set_default_connection(":memory:");
-    if (!result.has_value()) {
-        return 0;
-    }
-    const auto& conn = storm::QuerySet<FuzzModel>::get_default_connection();
-    (void)conn->execute(fuzz_model_create_sql);
-    (void)storm::QuerySet<FuzzModel>().insert(FuzzModel{.name = "seed", .value = 42}).execute();
-    return 0;
+    return fuzz_init_db();
 }
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
@@ -40,8 +33,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
                 .where(storm::orm::where::field<^^FuzzModel::name>().like(pattern))
                 .select()
                 .execute();
-    } catch (...) {
-        // SQL errors are expected — only crashes/ASAN hits are bugs
+    } catch (...) { // NOSONAR cpp:S2486 — SQL errors expected; only ASAN/crash = bug
     }
     return 0;
 }

--- a/fuzz/fuzz_models.h
+++ b/fuzz/fuzz_models.h
@@ -18,3 +18,23 @@ inline constexpr const char *fuzz_model_create_sql = "CREATE TABLE IF NOT EXISTS
                                                      "name TEXT NOT NULL, "
                                                      "value INTEGER NOT NULL)";
 // NOLINTEND(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
+
+// NOLINTBEGIN(modernize-use-trailing-return-type,bugprone-unused-return-value,cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
+
+/// Common DB initialisation — call from LLVMFuzzerInitialize().
+/// @param with_seed  Insert one seed row so WHERE/LIKE queries can match.
+/// @return 0 (libFuzzer convention; failures are non-fatal here).
+inline int fuzz_init_db(bool with_seed = true) {
+    auto result = storm::QuerySet<FuzzModel>::set_default_connection(":memory:");
+    if (!result.has_value()) {
+        return 0;
+    }
+    const auto &conn = storm::QuerySet<FuzzModel>::get_default_connection();
+    (void)conn->execute(fuzz_model_create_sql);
+    if (with_seed) {
+        (void)storm::QuerySet<FuzzModel>().insert(FuzzModel{.name = "seed", .value = 42}).execute();
+    }
+    return 0;
+}
+
+// NOLINTEND(modernize-use-trailing-return-type,bugprone-unused-return-value,cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)

--- a/fuzz/fuzz_models.h
+++ b/fuzz/fuzz_models.h
@@ -1,0 +1,20 @@
+#pragma once
+
+// IMPORTANT: Include this file AFTER `import storm;`
+// The [[= storm::meta::FieldAttr::primary]] attribute requires the storm module
+// to be imported before this struct is compiled.
+
+#include <string>
+
+struct FuzzModel {
+    [[= storm::meta::FieldAttr::primary]] int id{};
+    std::string name;
+    int value{};
+};
+
+// NOLINTBEGIN(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
+inline constexpr const char *fuzz_model_create_sql = "CREATE TABLE IF NOT EXISTS FuzzModel ("
+                                                     "id INTEGER PRIMARY KEY AUTOINCREMENT, "
+                                                     "name TEXT NOT NULL, "
+                                                     "value INTEGER NOT NULL)";
+// NOLINTEND(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)

--- a/fuzz/fuzz_where_int.cpp
+++ b/fuzz/fuzz_where_int.cpp
@@ -22,14 +22,7 @@ import <meta>;
 #include "fuzz_models.h" // AFTER import storm;
 
 extern "C" int LLVMFuzzerInitialize(int* /*argc*/, char*** /*argv*/) {
-    auto result = storm::QuerySet<FuzzModel>::set_default_connection(":memory:");
-    if (!result.has_value()) {
-        return 0;
-    }
-    const auto& conn = storm::QuerySet<FuzzModel>::get_default_connection();
-    (void)conn->execute(fuzz_model_create_sql);
-    (void)storm::QuerySet<FuzzModel>().insert(FuzzModel{.name = "seed", .value = 42}).execute();
-    return 0;
+    return fuzz_init_db();
 }
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
@@ -77,8 +70,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
                 .where(storm::orm::where::field<^^FuzzModel::value>().between(lower, upper))
                 .select()
                 .execute();
-    } catch (...) {
-        // SQL errors are expected — only crashes/ASAN hits are bugs
+    } catch (...) { // NOSONAR cpp:S2486 — SQL errors expected; only ASAN/crash = bug
     }
     return 0;
 }

--- a/fuzz/fuzz_where_int.cpp
+++ b/fuzz/fuzz_where_int.cpp
@@ -1,0 +1,86 @@
+/**
+ * @file fuzz_where_int.cpp
+ * @brief libFuzzer harness — fuzz int/double WHERE filter values.
+ *
+ * Interprets raw fuzz bytes as int/double values and exercises
+ * the runtime SQL binding layer for numeric comparisons:
+ * ==, !=, >, <, IN, BETWEEN.
+ */
+
+// NOLINTBEGIN(modernize-use-trailing-return-type,bugprone-unused-return-value,bugprone-empty-catch,cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+
+import storm;
+
+import <expected>;
+import <memory>;
+import <meta>;
+
+#include "fuzz_models.h" // AFTER import storm;
+
+extern "C" int LLVMFuzzerInitialize(int* /*argc*/, char*** /*argv*/) {
+    auto result = storm::QuerySet<FuzzModel>::set_default_connection(":memory:");
+    if (!result.has_value()) {
+        return 0;
+    }
+    const auto& conn = storm::QuerySet<FuzzModel>::get_default_connection();
+    (void)conn->execute(fuzz_model_create_sql);
+    (void)storm::QuerySet<FuzzModel>().insert(FuzzModel{.name = "seed", .value = 42}).execute();
+    return 0;
+}
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+    // Extract two int values from the fuzz input (pad with zeros if short)
+    int val1 = 0;
+    int val2 = 0;
+
+    if (size >= sizeof(int)) {
+        std::memcpy(&val1, data, sizeof(int));
+    }
+    if (size >= 2 * sizeof(int)) {
+        std::memcpy(&val2, data + sizeof(int), sizeof(int));
+    }
+
+    try {
+        // Equal int
+        (void)storm::QuerySet<FuzzModel>()
+                .where(storm::orm::where::field<^^FuzzModel::value>() == val1)
+                .select()
+                .execute();
+        // Not equal
+        (void)storm::QuerySet<FuzzModel>()
+                .where(storm::orm::where::field<^^FuzzModel::value>() != val1)
+                .select()
+                .execute();
+        // Greater than
+        (void)storm::QuerySet<FuzzModel>()
+                .where(storm::orm::where::field<^^FuzzModel::value>() > val1)
+                .select()
+                .execute();
+        // Less than
+        (void)storm::QuerySet<FuzzModel>()
+                .where(storm::orm::where::field<^^FuzzModel::value>() < val2)
+                .select()
+                .execute();
+        // IN with two values
+        (void)storm::QuerySet<FuzzModel>()
+                .where(storm::orm::where::field<^^FuzzModel::value>().in(val1, val2))
+                .select()
+                .execute();
+        // BETWEEN (ensure lower <= upper to form a valid range)
+        const int lower = val1 < val2 ? val1 : val2;
+        const int upper = val1 < val2 ? val2 : val1;
+        (void)storm::QuerySet<FuzzModel>()
+                .where(storm::orm::where::field<^^FuzzModel::value>().between(lower, upper))
+                .select()
+                .execute();
+    } catch (...) {
+        // SQL errors are expected — only crashes/ASAN hits are bugs
+    }
+    return 0;
+}
+
+// NOLINTEND(modernize-use-trailing-return-type,bugprone-unused-return-value,bugprone-empty-catch,cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)

--- a/fuzz/fuzz_where_string.cpp
+++ b/fuzz/fuzz_where_string.cpp
@@ -1,0 +1,61 @@
+/**
+ * @file fuzz_where_string.cpp
+ * @brief libFuzzer harness — fuzz string WHERE filter values.
+ *
+ * Exercises the runtime SQL binding layer for string comparisons:
+ * ==, !=, LIKE. SQL errors are expected and caught;
+ * only crashes or ASAN/UBSAN reports indicate real bugs.
+ */
+
+// NOLINTBEGIN(modernize-use-trailing-return-type,bugprone-unused-return-value,bugprone-empty-catch,cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
+
+#include <cstddef>
+#include <cstdint>
+
+import storm;
+
+import <expected>;
+import <memory>;
+import <meta>;
+import <string>;
+
+#include "fuzz_models.h" // AFTER import storm;
+
+extern "C" int LLVMFuzzerInitialize(int* /*argc*/, char*** /*argv*/) {
+    auto result = storm::QuerySet<FuzzModel>::set_default_connection(":memory:");
+    if (!result.has_value()) {
+        return 0;
+    }
+    const auto& conn = storm::QuerySet<FuzzModel>::get_default_connection();
+    (void)conn->execute(fuzz_model_create_sql);
+    // Seed one row so WHERE queries can find results
+    (void)storm::QuerySet<FuzzModel>().insert(FuzzModel{.name = "seed", .value = 42}).execute();
+    return 0;
+}
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+    const std::string input(reinterpret_cast<const char*>(data), size);
+
+    try {
+        // Equal
+        (void)storm::QuerySet<FuzzModel>()
+                .where(storm::orm::where::field<^^FuzzModel::name>() == input)
+                .select()
+                .execute();
+        // Not equal
+        (void)storm::QuerySet<FuzzModel>()
+                .where(storm::orm::where::field<^^FuzzModel::name>() != input)
+                .select()
+                .execute();
+        // LIKE
+        (void)storm::QuerySet<FuzzModel>()
+                .where(storm::orm::where::field<^^FuzzModel::name>().like(input))
+                .select()
+                .execute();
+    } catch (...) {
+        // SQL errors are expected — only crashes/ASAN hits are bugs
+    }
+    return 0;
+}
+
+// NOLINTEND(modernize-use-trailing-return-type,bugprone-unused-return-value,bugprone-empty-catch,cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)

--- a/fuzz/fuzz_where_string.cpp
+++ b/fuzz/fuzz_where_string.cpp
@@ -22,15 +22,7 @@ import <string>;
 #include "fuzz_models.h" // AFTER import storm;
 
 extern "C" int LLVMFuzzerInitialize(int* /*argc*/, char*** /*argv*/) {
-    auto result = storm::QuerySet<FuzzModel>::set_default_connection(":memory:");
-    if (!result.has_value()) {
-        return 0;
-    }
-    const auto& conn = storm::QuerySet<FuzzModel>::get_default_connection();
-    (void)conn->execute(fuzz_model_create_sql);
-    // Seed one row so WHERE queries can find results
-    (void)storm::QuerySet<FuzzModel>().insert(FuzzModel{.name = "seed", .value = 42}).execute();
-    return 0;
+    return fuzz_init_db();
 }
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
@@ -52,8 +44,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
                 .where(storm::orm::where::field<^^FuzzModel::name>().like(input))
                 .select()
                 .execute();
-    } catch (...) {
-        // SQL errors are expected — only crashes/ASAN hits are bugs
+    } catch (...) { // NOSONAR cpp:S2486 — SQL errors expected; only ASAN/crash = bug
     }
     return 0;
 }

--- a/scripts/run_clang_tidy.sh
+++ b/scripts/run_clang_tidy.sh
@@ -119,6 +119,11 @@ is_cpp26_module_file() {
         return 0
     fi
 
+    # All fuzz harnesses import Storm modules
+    if [[ "$file" == fuzz/*.cpp ]]; then
+        return 0
+    fi
+
     return 1
 }
 export -f is_cpp26_module_file


### PR DESCRIPTION
## Summary

- Add `cmake/fuzz.cmake` with `ENABLE_FUZZING` option (scoped flags, not global — does not affect tests/benchmarks/sanitizers)
- Add `ninja-fuzz` CMake preset (Release + ASAN + libFuzzer, excluded from ctest)
- Add `fuzz/` directory with 5 harnesses targeting the runtime SQL binding layer:
  - `fuzz_where_string` — string WHERE filters: `==`, `!=`, `LIKE`
  - `fuzz_where_int` — integer WHERE filters: `==`, `!=`, `>`, `<`, `IN`, `BETWEEN`
  - `fuzz_like_pattern` — adversarial LIKE patterns (null bytes, `%`, `_`, quotes, unicode)
  - `fuzz_batch_insert` — batch sizes around the SQLite 999-parameter limit
  - `fuzz_connection_string` — malformed connection strings to `set_default_connection()`
- Compile storm + harnesses with `-fsanitize=address,fuzzer-no-link` (identical flags → single module cache hash, prevents "defined in both" error)
- Link harnesses only with `-fsanitize=address,fuzzer` (pulls in libFuzzer runtime)
- Add `docs/development/FUZZING.md` covering build, run, corpus, and crash reproduction
- Update `scripts/run_clang_tidy.sh` to skip `fuzz/*.cpp` (they use C++26 module imports)
- Add corpus/crash artifact patterns to `.gitignore`

## Test plan

- [x] All 5 harnesses build with `cmake --preset ninja-fuzz && cmake --build --preset ninja-fuzz -- -j 1`
- [x] Smoke tests pass: `./build/fuzz/fuzz_where_string -runs=100` (and all other harnesses)
- [x] Fuzz targets absent from `ctest --preset ninja-debug -N`
- [x] Pre-commit hook passes: clang-format, cmake-format, clang-tidy, tests, 100% line coverage
- [x] `.gitignore` covers libFuzzer corpus/crash artifacts

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)