### PR TITLE
feat(schema): composite (multi-column) INDEX support

### DIFF
--- a/src/orm/schema.cppm
+++ b/src/orm/schema.cppm
@@ -16,6 +16,8 @@ import <optional>;
 import <vector>;
 import <array>;
 import <utility>;
+import <tuple>;
+import <iterator>;
 
 export namespace storm::orm::schema {
 
@@ -256,8 +258,59 @@ export namespace storm::orm::schema {
             return result;
         }
 
+        // Build CREATE INDEX SQL for a single composite index type at compile-time
+        template <typename IdxType> static consteval auto build_composite_index_sql() {
+            ConstexprString<INDEX_SQL_BUFFER> sql;
+            if constexpr (IdxType::unique) {
+                sql.append("CREATE UNIQUE INDEX IF NOT EXISTS idx_");
+            } else {
+                sql.append("CREATE INDEX IF NOT EXISTS idx_");
+            }
+            sql.append(Base::table_name_);
+            for (size_t i = 0; i < IdxType::fields.size(); ++i) {
+                sql.append("_");
+                sql.append(std::meta::identifier_of(IdxType::fields[i]));
+            }
+            sql.append(" ON ");
+            sql.append(Base::table_name_);
+            sql.append("(");
+            for (size_t i = 0; i < IdxType::fields.size(); ++i) {
+                if (i > 0) {
+                    sql.append(", ");
+                }
+                if (Base::is_fk_field(IdxType::fields[i])) {
+                    sql.append(std::meta::identifier_of(IdxType::fields[i]));
+                    sql.append("_id");
+                } else {
+                    sql.append(std::meta::identifier_of(IdxType::fields[i]));
+                }
+            }
+            sql.append(")");
+            return sql;
+        }
+
+        // Collect composite index SQL strings into a vector
+        template <typename Tuple, size_t... Is>
+        static auto build_composite_index_sql_vector(std::index_sequence<Is...> /*unused*/)
+                -> std::vector<std::string> {
+            std::vector<std::string> result;
+            ((result.emplace_back(std::string(build_composite_index_sql<std::tuple_element_t<Is, Tuple>>()))), ...);
+            return result;
+        }
+
         static auto build_all_index_sql() -> std::vector<std::string> {
-            return build_index_sql_vector(std::make_index_sequence<Base::field_count_>{});
+            auto result         = build_index_sql_vector(std::make_index_sequence<Base::field_count_>{});
+            using CompositeIdxs = statements::indexes_t<T>;
+            if constexpr (std::tuple_size_v<CompositeIdxs> > 0) {
+                auto composite = build_composite_index_sql_vector<CompositeIdxs>(
+                        std::make_index_sequence<std::tuple_size_v<CompositeIdxs>>{}
+                );
+                result
+                        .insert(result.end(),
+                                std::make_move_iterator(composite.begin()),
+                                std::make_move_iterator(composite.end()));
+            }
+            return result;
         }
 
         // Pre-computed index SQL strings

--- a/src/orm/statements/base.cppm
+++ b/src/orm/statements/base.cppm
@@ -21,6 +21,7 @@ import <optional>;
 import <vector>;
 import <cstdint>;
 import <memory>;
+import <tuple>;
 
 export namespace storm::orm::statements {
 
@@ -31,6 +32,24 @@ export namespace storm::orm::statements {
     namespace meta {
         enum class FieldAttr { primary, indexed, unique, fk };
     }
+
+    // Composite index types — variadic on std::meta::info field reflections
+    template <std::meta::info... Fields> struct Index {
+        static constexpr auto fields = std::array{Fields...};
+        static constexpr bool unique = false;
+    };
+
+    template <std::meta::info... Fields> struct UniqueIndex {
+        static constexpr auto fields = std::array{Fields...};
+        static constexpr bool unique = true;
+    };
+
+    // Default trait — no composite indexes. Users specialize for their models.
+    template <typename T> struct Indexes {
+        using type = std::tuple<>;
+    };
+
+    template <typename T> using indexes_t = typename Indexes<T>::type;
 
     // Shared reflection utilities for all statement types
     template <typename T> class BaseStatement {

--- a/src/storm.cppm
+++ b/src/storm.cppm
@@ -65,6 +65,12 @@ export namespace storm {
         return orm::schema::SchemaStatement<T>::create_table_if_not_exists(conn);
     }
 
+    // Composite index types — convenience aliases in storm:: namespace
+    using orm::statements::Index;
+    using orm::statements::UniqueIndex;
+    // Note: Indexes<T> trait lives in storm::orm::statements::Indexes<T>.
+    // Users specialize it as: template<> struct storm::orm::statements::Indexes<MyModel> { ... };
+
     // Returns the pre-computed CREATE INDEX SQL statements for model T.
     template <typename T> auto create_index_sql() -> const std::vector<std::string>& {
         return orm::schema::SchemaStatement<T>::create_index_sql();

--- a/tests/schema/test_orm_schema.cpp
+++ b/tests/schema/test_orm_schema.cpp
@@ -181,10 +181,10 @@ TEST(SchemaUnitTest, PersonIndexSqlContainsUniqueField) {
     EXPECT_TRUE(found) << "Expected CREATE UNIQUE INDEX for name field";
 }
 
-// Test: Person has exactly 2 index SQL statements (name + department)
+// Test: Person has exactly 4 index SQL statements (2 single-column + 2 composite)
 TEST(SchemaUnitTest, PersonIndexSqlCount) {
     const auto& indexes = storm::create_index_sql<Person>();
-    EXPECT_EQ(indexes.size(), 2u) << "Expected 2 indexes (name + department), got " << indexes.size();
+    EXPECT_EQ(indexes.size(), 4u) << "Expected 4 indexes (name + department + 2 composite), got " << indexes.size();
 }
 
 // Test: Message index SQL contains CREATE INDEX for FK sender_id field
@@ -210,6 +210,42 @@ TEST(SchemaUnitTest, SimpleRecordIndexSqlIsEmpty) {
 TEST(SchemaUnitTest, TaskIndexSqlContainsTwoFkFields) {
     const auto& indexes = storm::create_index_sql<Task>();
     EXPECT_EQ(indexes.size(), 2u) << "Expected 2 indexes for Task (2 FKs), got " << indexes.size();
+}
+
+// ============================================================================
+// COMPOSITE INDEX SQL Generation Unit Tests
+// ============================================================================
+
+// Test: Person composite index SQL contains CREATE INDEX for (department, age)
+TEST(SchemaUnitTest, CompositeIndexSqlContainsDeptAge) {
+    const auto& indexes = storm::create_index_sql<Person>();
+    bool        found   = false;
+    for (const auto& sql : indexes) {
+        if (sql.contains("CREATE INDEX IF NOT EXISTS idx_Person_department_age ON Person(department, age)")) {
+            found = true;
+            break;
+        }
+    }
+    EXPECT_TRUE(found) << "Expected composite CREATE INDEX for (department, age)";
+}
+
+// Test: Person composite unique index SQL contains CREATE UNIQUE INDEX for (name, department)
+TEST(SchemaUnitTest, CompositeUniqueIndexSqlContainsNameDept) {
+    const auto& indexes = storm::create_index_sql<Person>();
+    bool        found   = false;
+    for (const auto& sql : indexes) {
+        if (sql.contains("CREATE UNIQUE INDEX IF NOT EXISTS idx_Person_name_department ON Person(name, department)")) {
+            found = true;
+            break;
+        }
+    }
+    EXPECT_TRUE(found) << "Expected composite CREATE UNIQUE INDEX for (name, department)";
+}
+
+// Test: SimpleRecord has no composite indexes (no Indexes<> specialization)
+TEST(SchemaUnitTest, SimpleRecordNoCompositeIndexes) {
+    const auto& indexes = storm::create_index_sql<SimpleRecord>();
+    EXPECT_TRUE(indexes.empty()) << "Expected no indexes for SimpleRecord, got " << indexes.size();
 }
 
 // ============================================================================

--- a/tests/test_models.h
+++ b/tests/test_models.h
@@ -36,6 +36,12 @@ struct Person {
     std::vector<uint8_t> avatar;
 };
 
+// Composite indexes for Person — specialize the trait after struct definition
+template <> struct storm::orm::statements::Indexes<Person> {
+    using type = std::tuple<storm::Index<^^Person::department, ^^Person::age>,
+                            storm::UniqueIndex<^^Person::name, ^^Person::department>>;
+};
+
 // Shared simple record — covers batch/transaction/update/reset tests needing {id, name, value}.
 struct SimpleRecord {
     [[= storm::meta::FieldAttr::primary]] int id{};


### PR DESCRIPTION
## Summary

- Add `Index<Fields...>` and `UniqueIndex<Fields...>` types plus `Indexes<T>` trait for declaring composite indexes via trait specialization
- Composite index SQL generated at compile-time and merged with single-column indexes in `build_all_index_sql()`
- Created via the existing `create_indexes_if_not_exist()` API — no new public methods needed

Closes #133

## Test plan

- [x] Unit tests: composite SQL content (dept+age), unique variant (name+dept), count (4 total), no-composite model
- [x] Integration tests: existing create_indexes tests still pass on both SQLite + PostgreSQL
- [x] All 1302 tests pass (1299 existing + 3 new)
- [x] ASAN+UBSAN: clean
- [x] TSAN: clean
- [ ] SonarCloud gate: pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)