### PR TITLE
refactor(schema): move composite index types to storm_orm_indexes module

### DIFF
--- a/src/orm/indexes.cppm
+++ b/src/orm/indexes.cppm
@@ -1,0 +1,30 @@
+module;
+
+#include <meta>
+
+export module storm_orm_indexes;
+
+import <tuple>;
+import <array>;
+
+export namespace storm {
+
+    // Composite index types — variadic on std::meta::info field reflections
+    template <std::meta::info... Fields> struct Index {
+        static constexpr auto fields = std::array{Fields...};
+        static constexpr bool unique = false;
+    };
+
+    template <std::meta::info... Fields> struct UniqueIndex {
+        static constexpr auto fields = std::array{Fields...};
+        static constexpr bool unique = true;
+    };
+
+    // Default trait — no composite indexes. Users specialize for their models.
+    template <typename T> struct Indexes {
+        using type = std::tuple<>;
+    };
+
+    template <typename T> using indexes_t = typename Indexes<T>::type;
+
+} // namespace storm

--- a/src/orm/schema.cppm
+++ b/src/orm/schema.cppm
@@ -5,6 +5,7 @@ module;
 export module storm_orm_schema;
 
 import storm_orm_statements_base;
+import storm_orm_indexes;
 import storm_orm_utilities;
 import storm_db_concept;
 
@@ -300,7 +301,7 @@ export namespace storm::orm::schema {
 
         static auto build_all_index_sql() -> std::vector<std::string> {
             auto result         = build_index_sql_vector(std::make_index_sequence<Base::field_count_>{});
-            using CompositeIdxs = statements::indexes_t<T>;
+            using CompositeIdxs = storm::indexes_t<T>;
             if constexpr (std::tuple_size_v<CompositeIdxs> > 0) {
                 auto composite = build_composite_index_sql_vector<CompositeIdxs>(
                         std::make_index_sequence<std::tuple_size_v<CompositeIdxs>>{}

--- a/src/orm/statements/base.cppm
+++ b/src/orm/statements/base.cppm
@@ -21,7 +21,6 @@ import <optional>;
 import <vector>;
 import <cstdint>;
 import <memory>;
-import <tuple>;
 
 export namespace storm::orm::statements {
 
@@ -32,24 +31,6 @@ export namespace storm::orm::statements {
     namespace meta {
         enum class FieldAttr { primary, indexed, unique, fk };
     }
-
-    // Composite index types — variadic on std::meta::info field reflections
-    template <std::meta::info... Fields> struct Index {
-        static constexpr auto fields = std::array{Fields...};
-        static constexpr bool unique = false;
-    };
-
-    template <std::meta::info... Fields> struct UniqueIndex {
-        static constexpr auto fields = std::array{Fields...};
-        static constexpr bool unique = true;
-    };
-
-    // Default trait — no composite indexes. Users specialize for their models.
-    template <typename T> struct Indexes {
-        using type = std::tuple<>;
-    };
-
-    template <typename T> using indexes_t = typename Indexes<T>::type;
 
     // Shared reflection utilities for all statement types
     template <typename T> class BaseStatement {

--- a/src/storm.cppm
+++ b/src/storm.cppm
@@ -16,6 +16,7 @@ export import storm_orm_statements_join;
 export import storm_orm_statements_orderby;
 export import storm_orm_where;
 export import storm_orm_queryset;
+export import storm_orm_indexes;
 export import storm_orm_schema;
 import <meta>;
 import <string>;
@@ -64,12 +65,6 @@ export namespace storm {
         auto conn = QuerySet<T, ConnType>::get_default_connection();
         return orm::schema::SchemaStatement<T>::create_table_if_not_exists(conn);
     }
-
-    // Composite index types — convenience aliases in storm:: namespace
-    using orm::statements::Index;
-    using orm::statements::UniqueIndex;
-    // Note: Indexes<T> trait lives in storm::orm::statements::Indexes<T>.
-    // Users specialize it as: template<> struct storm::orm::statements::Indexes<MyModel> { ... };
 
     // Returns the pre-computed CREATE INDEX SQL statements for model T.
     template <typename T> auto create_index_sql() -> const std::vector<std::string>& {

--- a/tests/test_models.h
+++ b/tests/test_models.h
@@ -37,7 +37,7 @@ struct Person {
 };
 
 // Composite indexes for Person — specialize the trait after struct definition
-template <> struct storm::orm::statements::Indexes<Person> {
+template <> struct storm::Indexes<Person> {
     using type = std::tuple<storm::Index<^^Person::department, ^^Person::age>,
                             storm::UniqueIndex<^^Person::name, ^^Person::department>>;
 };


### PR DESCRIPTION
## Summary

- Extract `Index<Fields...>`, `UniqueIndex<Fields...>`, and `Indexes<T>` into a new `storm_orm_indexes` module under `namespace storm`
- Enables clean specialization syntax: `template<> struct storm::Indexes<Person>` (was `storm::orm::statements::Indexes<Person>`)
- Breaks circular dependency that prevented defining these types directly in `storm.cppm`

Closes #135

## Test plan

- [x] All 1302 tests pass
- [x] ASAN+UBSAN: clean
- [x] TSAN: clean
- [ ] SonarCloud gate: pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)