### PR TITLE
feat: add UNION/UNION ALL/EXCEPT/INTERSECT set operations

### DIFF
--- a/benchmarks/operations/setop.hpp
+++ b/benchmarks/operations/setop.hpp
@@ -158,33 +158,36 @@ namespace storm::benchmark {
 
       private:
         static constexpr const char* op_name() {
-            if constexpr (OpType == SetOpBenchType::Union)
+            using enum SetOpBenchType;
+            if constexpr (OpType == Union)
                 return "UNION";
-            else if constexpr (OpType == SetOpBenchType::UnionAll)
+            else if constexpr (OpType == UnionAll)
                 return "UNION ALL";
-            else if constexpr (OpType == SetOpBenchType::Except)
+            else if constexpr (OpType == Except)
                 return "EXCEPT";
             else
                 return "INTERSECT";
         }
 
         static constexpr const char* op_sql() {
-            if constexpr (OpType == SetOpBenchType::Union)
+            using enum SetOpBenchType;
+            if constexpr (OpType == Union)
                 return " UNION ";
-            else if constexpr (OpType == SetOpBenchType::UnionAll)
+            else if constexpr (OpType == UnionAll)
                 return " UNION ALL ";
-            else if constexpr (OpType == SetOpBenchType::Except)
+            else if constexpr (OpType == Except)
                 return " EXCEPT ";
             else
                 return " INTERSECT ";
         }
 
         auto make_builder(QuerySet<Model>& left, QuerySet<Model>& right) {
-            if constexpr (OpType == SetOpBenchType::Union) {
+            using enum SetOpBenchType;
+            if constexpr (OpType == Union) {
                 return left.union_(right);
-            } else if constexpr (OpType == SetOpBenchType::UnionAll) {
+            } else if constexpr (OpType == UnionAll) {
                 return left.union_all(right);
-            } else if constexpr (OpType == SetOpBenchType::Except) {
+            } else if constexpr (OpType == Except) {
                 return left.except_(right);
             } else {
                 return left.intersect_(right);

--- a/benchmarks/operations/setop.hpp
+++ b/benchmarks/operations/setop.hpp
@@ -1,0 +1,241 @@
+#pragma once
+
+/**
+ * Set Operation Benchmarks - UNION, UNION ALL, EXCEPT, INTERSECT
+ *
+ * Unlike other benchmarks, set operations use SetOpBuilder instead of QuerySet.
+ * Each benchmark creates two QuerySets with WHERE filters, combines them with
+ * a set operation, then executes.
+ *
+ * WHERE conditions per operation type (ages range 21..69):
+ * - UNION/UNION ALL: disjoint (age < 45, age >= 45) — combines both halves
+ * - EXCEPT:          overlapping (age < 55, age > 35) — left minus overlap
+ * - INTERSECT:       overlapping (age < 55, age > 35) — overlap only
+ *
+ * Storm side:  qs_left.where(...).union_(qs_right.where(...)).execute()
+ * Raw side:    "SELECT ... WHERE ... UNION SELECT ... WHERE ..."
+ */
+
+#include "base.hpp"
+#include <format>
+#include <plf_hive/plf_hive.h>
+#include <string>
+
+namespace storm::benchmark {
+
+    using storm::orm::where::field;
+
+    // Set operation type enum for compile-time dispatch
+    enum class SetOpBenchType { Union, UnionAll, Except, Intersect };
+
+    template <typename Model, SetOpBenchType OpType, bool WithOrderBy = false, bool WithLimit = false>
+    class SetOpBenchmark : public DataBenchmarkBase<SetOpBenchmark<Model, OpType, WithOrderBy, WithLimit>, Model, 1> {
+        using Base = DataBenchmarkBase<SetOpBenchmark<Model, OpType, WithOrderBy, WithLimit>, Model, 1>;
+
+        // Left WHERE: age <op> left_threshold_
+        // Right WHERE: age <op> right_threshold_
+        int left_threshold_  = 0;
+        int right_threshold_ = 0;
+        int limit_value_     = 0;
+        QuerySet<Model> qs_right_;
+
+        // For UNION/UNION ALL: disjoint halves (age < 45, age >= 45)
+        // For EXCEPT/INTERSECT: overlapping ranges (age < 55, age > 35)
+        static constexpr bool needs_overlap =
+                (OpType == SetOpBenchType::Except || OpType == SetOpBenchType::Intersect);
+
+      public:
+        explicit SetOpBenchmark(int dataset_size = 1000, int limit_value = 0)
+            : Base(dataset_size), limit_value_(limit_value) {
+            if constexpr (needs_overlap) {
+                left_threshold_  = 55;
+                right_threshold_ = 35;
+            } else {
+                left_threshold_  = 45;
+                right_threshold_ = 45;
+            }
+        }
+
+        static Model create_model(int index = 0) {
+            int i = index + 1;
+            return Model{
+                    .id        = 0,
+                    .name      = std::format("Person{}", i),
+                    .age       = 20 + (i % 50),
+                    .is_active = (i % 2 == 0),
+                    .salary    = 30000.0 + (i * 1000.0)
+            };
+        }
+
+        void prepare(int iterations) {
+            Base::prepare_with_insert(iterations);
+        }
+
+        void print_info() const {
+            std::cout << "Operation: SELECT " << op_name();
+            if constexpr (WithOrderBy) {
+                std::cout << " + ORDER BY";
+            }
+            if constexpr (WithLimit) {
+                std::cout << " + LIMIT " << limit_value_;
+            }
+            if constexpr (needs_overlap) {
+                std::cout << " (WHERE age < " << left_threshold_ << " " << op_name() << " WHERE age > "
+                          << right_threshold_ << ")";
+            } else {
+                std::cout << " (WHERE age < " << left_threshold_ << " " << op_name() << " WHERE age >= "
+                          << right_threshold_ << ")";
+            }
+            std::cout << "\n";
+            std::cout << "  Dataset: " << Base::batch_size() << " rows\n";
+        }
+
+        int execute(int iterations) {
+            // Build WHERE expressions and set operation builder ONCE (setup cost)
+            auto left_where = field<^^Model::age>() < left_threshold_;
+            Base::qs().where(left_where);
+
+            if constexpr (needs_overlap) {
+                auto right_where = field<^^Model::age>() > right_threshold_;
+                qs_right_.where(right_where);
+            } else {
+                auto right_where = field<^^Model::age>() >= right_threshold_;
+                qs_right_.where(right_where);
+            }
+
+            auto builder = make_builder(Base::qs(), qs_right_);
+            apply_modifiers(builder);
+
+            // Execute in loop — statement caching kicks in after first call
+            int total = 0;
+            for (int i = 0; i < iterations; i++) {
+                auto result = builder.execute();
+                if (result.has_value()) {
+                    total += static_cast<int>(result.value().size());
+                }
+            }
+
+            Base::qs().reset();
+            qs_right_.reset();
+            return total;
+        }
+
+        int execute_raw(int iterations) {
+            sqlite3* db = get_db<Model>();
+            if (!db)
+                return 0;
+
+            std::string sql = build_raw_sql();
+
+            sqlite3_stmt* stmt = nullptr;
+            sqlite3_prepare_v2(db, sql.c_str(), -1, &stmt, nullptr);
+            if (!stmt)
+                return 0;
+
+            int total = 0;
+            for (int i = 0; i < iterations; i++) {
+                sqlite3_bind_int(stmt, 1, left_threshold_);
+                sqlite3_bind_int(stmt, 2, right_threshold_);
+
+                // Store results same as Storm ORM (plf::hive) for fair comparison
+                std::vector<Model> results;
+                while (sqlite3_step(stmt) == SQLITE_ROW) {
+                    Model obj;
+                    obj.id        = sqlite3_column_int(stmt, 0);
+                    auto name_ptr = sqlite3_column_text(stmt, 1);
+                    obj.name      = name_ptr ? reinterpret_cast<const char*>(name_ptr) : "";
+                    obj.age       = sqlite3_column_int(stmt, 2);
+                    obj.is_active = sqlite3_column_int(stmt, 3) != 0;
+                    obj.salary    = sqlite3_column_double(stmt, 4);
+                    results.push_back(std::move(obj));
+                }
+                total += static_cast<int>(results.size());
+                sqlite3_reset(stmt);
+            }
+            sqlite3_finalize(stmt);
+            return total;
+        }
+
+      private:
+        static constexpr const char* op_name() {
+            if constexpr (OpType == SetOpBenchType::Union)
+                return "UNION";
+            else if constexpr (OpType == SetOpBenchType::UnionAll)
+                return "UNION ALL";
+            else if constexpr (OpType == SetOpBenchType::Except)
+                return "EXCEPT";
+            else
+                return "INTERSECT";
+        }
+
+        static constexpr const char* op_sql() {
+            if constexpr (OpType == SetOpBenchType::Union)
+                return " UNION ";
+            else if constexpr (OpType == SetOpBenchType::UnionAll)
+                return " UNION ALL ";
+            else if constexpr (OpType == SetOpBenchType::Except)
+                return " EXCEPT ";
+            else
+                return " INTERSECT ";
+        }
+
+        auto make_builder(QuerySet<Model>& left, QuerySet<Model>& right) {
+            if constexpr (OpType == SetOpBenchType::Union) {
+                return left.union_(right);
+            } else if constexpr (OpType == SetOpBenchType::UnionAll) {
+                return left.union_all(right);
+            } else if constexpr (OpType == SetOpBenchType::Except) {
+                return left.except_(right);
+            } else {
+                return left.intersect_(right);
+            }
+        }
+
+        template <typename Builder> void apply_modifiers(Builder& builder) {
+            if constexpr (WithOrderBy) {
+                builder.template order_by<^^Model::age, true>();
+            }
+            if constexpr (WithLimit) {
+                builder.limit(limit_value_);
+            }
+        }
+
+        std::string build_raw_sql() const {
+            std::string sql = "SELECT id, name, age, is_active, salary FROM Person WHERE age < ?";
+            sql += op_sql();
+            if constexpr (needs_overlap) {
+                sql += "SELECT id, name, age, is_active, salary FROM Person WHERE age > ?";
+            } else {
+                sql += "SELECT id, name, age, is_active, salary FROM Person WHERE age >= ?";
+            }
+            if constexpr (WithOrderBy) {
+                sql += " ORDER BY age ASC";
+            }
+            if constexpr (WithLimit) {
+                sql += " LIMIT ";
+                sql += std::to_string(limit_value_);
+            }
+            return sql;
+        }
+    };
+
+    // Type aliases for cleaner usage
+    template <typename Model>
+    using SetOpUnionBenchmark = SetOpBenchmark<Model, SetOpBenchType::Union>;
+
+    template <typename Model>
+    using SetOpUnionAllBenchmark = SetOpBenchmark<Model, SetOpBenchType::UnionAll>;
+
+    template <typename Model>
+    using SetOpExceptBenchmark = SetOpBenchmark<Model, SetOpBenchType::Except>;
+
+    template <typename Model>
+    using SetOpIntersectBenchmark = SetOpBenchmark<Model, SetOpBenchType::Intersect>;
+
+    template <typename Model>
+    using SetOpUnionOrderByBenchmark = SetOpBenchmark<Model, SetOpBenchType::Union, true>;
+
+    template <typename Model, int LimitValue>
+    using SetOpUnionLimitBenchmark = SetOpBenchmark<Model, SetOpBenchType::Union, false, true>;
+
+} // namespace storm::benchmark

--- a/benchmarks/runner.hpp
+++ b/benchmarks/runner.hpp
@@ -24,6 +24,7 @@
 #include "operations/distinct.hpp"        // DISTINCT benchmarks
 #include "operations/where_operators.hpp" // LIKE, BETWEEN, IN, AND/OR benchmarks
 #include "operations/first_get.hpp"       // first() and get() benchmarks
+#include "operations/setop.hpp"           // UNION, UNION ALL, EXCEPT, INTERSECT benchmarks
 
 namespace storm::benchmark {
 
@@ -1444,6 +1445,83 @@ namespace storm::benchmark {
             );
         }
 
+        // ====================================================================
+        // SET OPERATION handlers (UNION, UNION ALL, EXCEPT, INTERSECT)
+        // ====================================================================
+
+        template <typename Model, auto& test, SetOpBenchType OpType, bool WithOrderBy = false, bool WithLimit = false>
+        static void run_setop_operation_impl(BenchmarkRunner& runner, int iterations) {
+            constexpr auto profile_str = test.size_profile.view();
+            constexpr auto profile     = sizes::profile_from_string(profile_str);
+
+            if constexpr (profile == sizes::SizeProfile::DatasetStandard) {
+                for (int size : sizes::DATASET_STANDARD) {
+                    int         actual_iterations = sizes::iterations_for_dataset(size);
+                    std::string name              = std::format("{}_{}", test.test_name.view(), size);
+                    if constexpr (WithLimit) {
+                        constexpr int limit_value = test.limit_value;
+                        runner.run_benchmark(
+                                name.c_str(),
+                                SetOpBenchmark<Model, OpType, WithOrderBy, WithLimit>{size, limit_value},
+                                actual_iterations
+                        );
+                    } else {
+                        runner.run_benchmark(
+                                name.c_str(),
+                                SetOpBenchmark<Model, OpType, WithOrderBy, WithLimit>{size},
+                                actual_iterations
+                        );
+                    }
+                }
+            } else {
+                constexpr int dataset_size = test.dataset_size;
+                if constexpr (WithLimit) {
+                    constexpr int limit_value = test.limit_value;
+                    runner.run_benchmark(
+                            test.test_name.c_str(),
+                            SetOpBenchmark<Model, OpType, WithOrderBy, WithLimit>{dataset_size, limit_value},
+                            iterations
+                    );
+                } else {
+                    runner.run_benchmark(
+                            test.test_name.c_str(),
+                            SetOpBenchmark<Model, OpType, WithOrderBy, WithLimit>{dataset_size},
+                            iterations
+                    );
+                }
+            }
+        }
+
+        template <typename Model, auto& test>
+        static void run_setop_union_operation(BenchmarkRunner& runner, int iterations) {
+            run_setop_operation_impl<Model, test, SetOpBenchType::Union>(runner, iterations);
+        }
+
+        template <typename Model, auto& test>
+        static void run_setop_union_all_operation(BenchmarkRunner& runner, int iterations) {
+            run_setop_operation_impl<Model, test, SetOpBenchType::UnionAll>(runner, iterations);
+        }
+
+        template <typename Model, auto& test>
+        static void run_setop_except_operation(BenchmarkRunner& runner, int iterations) {
+            run_setop_operation_impl<Model, test, SetOpBenchType::Except>(runner, iterations);
+        }
+
+        template <typename Model, auto& test>
+        static void run_setop_intersect_operation(BenchmarkRunner& runner, int iterations) {
+            run_setop_operation_impl<Model, test, SetOpBenchType::Intersect>(runner, iterations);
+        }
+
+        template <typename Model, auto& test>
+        static void run_setop_union_order_by_operation(BenchmarkRunner& runner, int iterations) {
+            run_setop_operation_impl<Model, test, SetOpBenchType::Union, true>(runner, iterations);
+        }
+
+        template <typename Model, auto& test>
+        static void run_setop_union_limit_operation(BenchmarkRunner& runner, int iterations) {
+            run_setop_operation_impl<Model, test, SetOpBenchType::Union, false, true>(runner, iterations);
+        }
+
       public:
         // Template recursion to execute tests at compile time
         template <typename Model, size_t TestIndex, size_t TotalTests> struct TestExecutor {
@@ -1600,6 +1678,18 @@ namespace storm::benchmark {
                         runner.run_first_where_operation<Model, test>(runner, actual_iterations);
                     } else if constexpr (operation == "get_where") {
                         runner.run_get_where_operation<Model, test>(runner, actual_iterations);
+                    } else if constexpr (operation == "setop_union") {
+                        runner.run_setop_union_operation<Model, test>(runner, actual_iterations);
+                    } else if constexpr (operation == "setop_union_all") {
+                        runner.run_setop_union_all_operation<Model, test>(runner, actual_iterations);
+                    } else if constexpr (operation == "setop_except") {
+                        runner.run_setop_except_operation<Model, test>(runner, actual_iterations);
+                    } else if constexpr (operation == "setop_intersect") {
+                        runner.run_setop_intersect_operation<Model, test>(runner, actual_iterations);
+                    } else if constexpr (operation == "setop_union_order_by") {
+                        runner.run_setop_union_order_by_operation<Model, test>(runner, actual_iterations);
+                    } else if constexpr (operation == "setop_union_limit") {
+                        runner.run_setop_union_limit_operation<Model, test>(runner, actual_iterations);
                     }
                 }
 

--- a/benchmarks/tests/benchmark_tests.yaml
+++ b/benchmarks/tests/benchmark_tests.yaml
@@ -716,3 +716,49 @@ tests:
     where_value_int: 1
     iterations: 10000
     dataset_size: 10000
+
+  # ============================================================================
+  # SET OPERATIONS (UNION, UNION ALL, EXCEPT, INTERSECT)
+  # ============================================================================
+  - name: setop_union
+    category: SETOP
+    description: "UNION with WHERE on both sides"
+    model: Person
+    operation: setop_union
+    size_profile: dataset_standard
+
+  - name: setop_union_all
+    category: SETOP
+    description: "UNION ALL with WHERE on both sides"
+    model: Person
+    operation: setop_union_all
+    size_profile: dataset_standard
+
+  - name: setop_except
+    category: SETOP
+    description: "EXCEPT with WHERE on both sides"
+    model: Person
+    operation: setop_except
+    size_profile: dataset_standard
+
+  - name: setop_intersect
+    category: SETOP
+    description: "INTERSECT with WHERE on both sides"
+    model: Person
+    operation: setop_intersect
+    size_profile: dataset_standard
+
+  - name: setop_union_order_by
+    category: SETOP_ORDER
+    description: "UNION + ORDER BY age ASC"
+    model: Person
+    operation: setop_union_order_by
+    size_profile: dataset_standard
+
+  - name: setop_union_limit
+    category: SETOP_LIMIT
+    description: "UNION + LIMIT 100"
+    model: Person
+    operation: setop_union_limit
+    limit_value: 100
+    size_profile: dataset_standard

--- a/src/orm/queryset.cppm
+++ b/src/orm/queryset.cppm
@@ -18,6 +18,7 @@ import storm_orm_statements_join;
 import storm_orm_statements_orderby;
 import storm_orm_where;
 import storm_orm_statements_aggregate;
+import storm_orm_statements_setop;
 import storm_orm_utilities;
 
 import <expected>;
@@ -286,6 +287,43 @@ export namespace storm {
                     conn_.get(), where_expr_, join_stmt_, limit_value_, offset_value_, order_by_wrapper_
             };
         }
+        // =====================================================================
+        // SET OPERATIONS: UNION, UNION ALL, EXCEPT, INTERSECT
+        // =====================================================================
+
+        auto union_(const QuerySet& other) {
+            return make_setop_builder(other, orm::statements::SetOpType::Union);
+        }
+
+        auto union_all(const QuerySet& other) {
+            return make_setop_builder(other, orm::statements::SetOpType::UnionAll);
+        }
+
+        auto except_(const QuerySet& other) {
+            return make_setop_builder(other, orm::statements::SetOpType::Except);
+        }
+
+        auto intersect_(const QuerySet& other) {
+            return make_setop_builder(other, orm::statements::SetOpType::Intersect);
+        }
+
+        // Replace assert with [[pre:]] when C++26 contracts land in Clang
+        auto capture_operand() const -> orm::statements::SetOpOperand<T> {
+            assert(!order_by_wrapper_.has_value() &&
+                   "ORDER BY on individual set operation operand is ignored — use SetOpBuilder.order_by()");
+            assert(!limit_value_.has_value() &&
+                   "LIMIT on individual set operation operand is ignored — use SetOpBuilder.limit()");
+            assert(!offset_value_.has_value() &&
+                   "OFFSET on individual set operation operand is ignored — use SetOpBuilder.offset()");
+            std::string sql = join_stmt_.has_value() ? std::string(join_stmt_->get_complete_sql())
+                                                     : orm::statements::SelectStatement<T, ConnType>::get_select_sql();
+            if (where_expr_) {
+                sql += " WHERE ";
+                sql += orm::where::to_sql(*where_expr_);
+            }
+            return {std::move(sql), where_expr_};
+        }
+
         // SUM aggregate (multi-field: SUM(f1 + f2 + ...))
         // Supports WHERE and JOIN clauses
         // Usage: queryset.sum<^^Person::age>().get()
@@ -439,6 +477,18 @@ export namespace storm {
                 select_stmt_ = std::make_unique<orm::statements::SelectStatement<T, ConnType>>(conn_);
             }
             return *select_stmt_;
+        }
+
+        auto make_setop_builder(const QuerySet& other, orm::statements::SetOpType op)
+                -> orm::statements::SetOpBuilder<T, ConnType> {
+            auto                                          left  = capture_operand();
+            auto                                          right = other.capture_operand();
+            std::vector<orm::statements::SetOpOperand<T>> operands;
+            operands.push_back(std::move(left));
+            operands.push_back(std::move(right));
+            std::vector<orm::statements::SetOpType> operators;
+            operators.push_back(op);
+            return {conn_, std::move(operands), std::move(operators)};
         }
 
         std::shared_ptr<ConnType>                                              conn_;

--- a/src/orm/statements/select.cppm
+++ b/src/orm/statements/select.cppm
@@ -69,12 +69,12 @@ export namespace storm::orm::statements {
         // Pre-computed SELECT ... LIMIT 2 SQL for get() fast path
         static inline const std::string select_limit2_sql_string = std::string(select_sql_array) + " LIMIT 2";
 
+      public:
         // Generate SELECT SQL string (compile-time computed, runtime accessible)
         static auto get_select_sql() -> const std::string& {
             return select_sql_string;
         }
 
-      public:
         explicit SelectStatement(std::shared_ptr<ConnType> conn) : conn_(std::move(conn)) {}
 
         // Returns the SQL that would be executed by select()

--- a/src/orm/statements/setop.cppm
+++ b/src/orm/statements/setop.cppm
@@ -1,0 +1,216 @@
+module;
+
+#include <meta>
+#include <plf_hive/plf_hive.h>
+
+export module storm_orm_statements_setop;
+
+import storm_orm_statements_base;
+import storm_orm_statements_join;
+import storm_orm_statements_orderby;
+import storm_orm_where;
+import storm_db_concept;
+
+import <concepts>;
+import <expected>;
+import <string>;
+import <vector>;
+import <optional>;
+import <memory>;
+
+export namespace storm::orm::statements {
+
+    enum class SetOpType { Union, UnionAll, Except, Intersect };
+
+    template <typename T> struct SetOpOperand {
+        std::string                      sql;
+        orm::where::ExpressionVariantPtr where_expr;
+    };
+
+    template <typename T, storm::db::DatabaseConnection ConnType> class SetOpBuilder : private BaseStatement<T> {
+        using Base      = BaseStatement<T>;
+        using Error     = typename ConnType::Error;
+        using Statement = typename ConnType::Statement;
+
+      public:
+        SetOpBuilder(
+                std::shared_ptr<ConnType> conn, std::vector<SetOpOperand<T>> operands, std::vector<SetOpType> operators
+        )
+            : conn_(std::move(conn)), operands_(std::move(operands)), operators_(std::move(operators)) {}
+
+        template <typename U>
+            requires std::same_as<U, T>
+        auto union_(SetOpOperand<U> operand) -> SetOpBuilder&& {
+            operands_.push_back(std::move(operand));
+            operators_.push_back(SetOpType::Union);
+            cached_stmt_ = nullptr;
+            return std::move(*this);
+        }
+
+        template <typename U>
+            requires std::same_as<U, T>
+        auto union_all(SetOpOperand<U> operand) -> SetOpBuilder&& {
+            operands_.push_back(std::move(operand));
+            operators_.push_back(SetOpType::UnionAll);
+            cached_stmt_ = nullptr;
+            return std::move(*this);
+        }
+
+        template <typename U>
+            requires std::same_as<U, T>
+        auto except_(SetOpOperand<U> operand) -> SetOpBuilder&& {
+            operands_.push_back(std::move(operand));
+            operators_.push_back(SetOpType::Except);
+            cached_stmt_ = nullptr;
+            return std::move(*this);
+        }
+
+        template <typename U>
+            requires std::same_as<U, T>
+        auto intersect_(SetOpOperand<U> operand) -> SetOpBuilder&& {
+            operands_.push_back(std::move(operand));
+            operators_.push_back(SetOpType::Intersect);
+            cached_stmt_ = nullptr;
+            return std::move(*this);
+        }
+
+        template <auto... Args> auto order_by() -> SetOpBuilder&& {
+            order_by_wrapper_ = make_order_by_wrapper<Args...>();
+            cached_stmt_      = nullptr;
+            return std::move(*this);
+        }
+
+        auto limit(int n) -> SetOpBuilder&& {
+            limit_value_ = n;
+            cached_stmt_ = nullptr;
+            return std::move(*this);
+        }
+
+        auto offset(int n) -> SetOpBuilder&& {
+            offset_value_ = n;
+            cached_stmt_  = nullptr;
+            return std::move(*this);
+        }
+
+        [[nodiscard]] auto execute() -> std::expected<plf::hive<T>, Error> {
+            if (!cached_stmt_) {
+                auto prepare_result = prepare_statement();
+                if (!prepare_result) [[unlikely]] {
+                    return std::unexpected(prepare_result.error());
+                }
+            }
+            cached_stmt_->reset();
+
+            auto bind_result = bind_all_params(cached_stmt_);
+            if (!bind_result) [[unlikely]] {
+                return std::unexpected(bind_result.error());
+            }
+
+            return execute_query_loop(cached_stmt_);
+        }
+
+        [[nodiscard]] auto to_sql() -> std::expected<std::string, Error> {
+            if (!cached_stmt_) {
+                auto prepare_result = prepare_statement();
+                if (!prepare_result) [[unlikely]] {
+                    return std::unexpected(prepare_result.error());
+                }
+            }
+            cached_stmt_->reset();
+
+            auto bind_result = bind_all_params(cached_stmt_);
+            if (!bind_result) [[unlikely]] {
+                return std::unexpected(bind_result.error());
+            }
+
+            return cached_stmt_->expanded_sql();
+        }
+
+      private:
+        [[nodiscard]] auto prepare_statement() -> std::expected<void, Error> {
+            std::string sql         = build_combined_sql();
+            auto        stmt_result = conn_->prepare_cached(sql);
+            if (!stmt_result) [[unlikely]] {
+                return std::unexpected(stmt_result.error());
+            }
+            cached_stmt_ = *stmt_result;
+            return {};
+        }
+
+        [[nodiscard]] auto build_combined_sql() const -> std::string {
+            std::string sql;
+
+            for (size_t i = 0; i < operands_.size(); ++i) {
+                if (i > 0) {
+                    sql += op_to_sql(operators_[i - 1]);
+                }
+                sql += operands_[i].sql;
+            }
+
+            Base::template append_order_by<ConnType>(sql, order_by_wrapper_);
+            Base::template append_limit_offset<ConnType>(sql, limit_value_, offset_value_);
+
+            return sql;
+        }
+
+        [[nodiscard]] auto bind_all_params(Statement* stmt_ptr) const -> std::expected<void, Error> {
+            int param_index = 1;
+            for (const auto& operand : operands_) {
+                if (operand.where_expr) {
+                    auto bind_result = orm::where::bind_params_direct<Statement, Error>(
+                            *operand.where_expr, stmt_ptr, param_index
+                    );
+                    if (!bind_result) [[unlikely]] {
+                        stmt_ptr->reset();
+                        return std::unexpected(bind_result.error());
+                    }
+                }
+            }
+            return {};
+        }
+
+        [[nodiscard]] auto execute_query_loop(Statement* stmt_ptr) const noexcept
+                -> std::expected<plf::hive<T>, Error> {
+            plf::hive<T> results;
+            int          step_result = 0;
+
+            while ((step_result = stmt_ptr->step_raw()) == Statement::ROW_AVAILABLE) {
+                T obj;
+                Base::extract_all_columns(stmt_ptr, obj);
+                results.insert(std::move(obj));
+            }
+
+            if (step_result != Statement::NO_MORE_ROWS) {
+                stmt_ptr->reset();
+                return std::unexpected(Error{step_result, stmt_ptr->get_error_message()});
+            }
+
+            stmt_ptr->reset();
+            return results;
+        }
+
+        static constexpr auto op_to_sql(SetOpType op) -> std::string_view {
+            switch (op) {
+            case SetOpType::Union:
+                return " UNION ";
+            case SetOpType::UnionAll:
+                return " UNION ALL ";
+            case SetOpType::Except:
+                return " EXCEPT ";
+            case SetOpType::Intersect:
+                return " INTERSECT ";
+            } // LCOV_EXCL_START
+            std::unreachable();
+        }
+        // LCOV_EXCL_STOP
+
+        std::shared_ptr<ConnType>     conn_;
+        std::vector<SetOpOperand<T>>  operands_;
+        std::vector<SetOpType>        operators_;
+        std::optional<OrderByWrapper> order_by_wrapper_;
+        std::optional<int>            limit_value_;
+        std::optional<int>            offset_value_;
+        Statement*                    cached_stmt_ = nullptr;
+    };
+
+} // namespace storm::orm::statements

--- a/src/orm/statements/setop.cppm
+++ b/src/orm/statements/setop.cppm
@@ -190,14 +190,15 @@ export namespace storm::orm::statements {
         }
 
         static constexpr auto op_to_sql(SetOpType op) -> std::string_view {
+            using enum SetOpType;
             switch (op) {
-            case SetOpType::Union:
+            case Union:
                 return " UNION ";
-            case SetOpType::UnionAll:
+            case UnionAll:
                 return " UNION ALL ";
-            case SetOpType::Except:
+            case Except:
                 return " EXCEPT ";
-            case SetOpType::Intersect:
+            case Intersect:
                 return " INTERSECT ";
             } // LCOV_EXCL_START
             std::unreachable();

--- a/src/orm/statements/setop.cppm
+++ b/src/orm/statements/setop.cppm
@@ -157,7 +157,7 @@ export namespace storm::orm::statements {
             int param_index = 1;
             for (const auto& operand : operands_) {
                 if (operand.where_expr) {
-                    auto bind_result = orm::where::bind_params_direct<Statement, Error>(
+                    std::expected<void, Error> bind_result = orm::where::bind_params_direct<Statement, Error>(
                             *operand.where_expr, stmt_ptr, param_index
                     );
                     if (!bind_result) [[unlikely]] {

--- a/src/storm.cppm
+++ b/src/storm.cppm
@@ -13,6 +13,7 @@ export import storm_orm_statements_base;
 export import storm_orm_statements_insert;
 export import storm_orm_statements_select;
 export import storm_orm_statements_join;
+export import storm_orm_statements_setop;
 export import storm_orm_statements_orderby;
 export import storm_orm_where;
 export import storm_orm_queryset;

--- a/tests/mock_sqlite/test_orm_mock_errors.cpp
+++ b/tests/mock_sqlite/test_orm_mock_errors.cpp
@@ -2363,6 +2363,75 @@ namespace {
         EXPECT_GE(MockSqlite3Config::get_step_call_count(), 5);
     }
 
+    // ============================================================================
+    // SetOp Error Tests — covers error paths in setop.cppm
+    // ============================================================================
+
+    TEST_F(ORMMockErrorTest, SetOpExecuteFailsOnPrepareError) {
+        MockSqlite3Config::prepare_returns(SQLITE_ERROR);
+
+        QuerySet<MockPerson> qs1;
+        QuerySet<MockPerson> qs2;
+        auto                 result = qs1.where(storm::orm::where::field<^^MockPerson::age>() > 30)
+                              .union_(qs2.where(storm::orm::where::field<^^MockPerson::age>() < 10))
+                              .execute();
+
+        ASSERT_FALSE(result.has_value());
+        EXPECT_EQ(result.error().code(), SQLITE_ERROR);
+    }
+
+    TEST_F(ORMMockErrorTest, SetOpExecuteFailsOnBindError) {
+        MockSqlite3Config::bind_int_returns(SQLITE_NOMEM);
+
+        QuerySet<MockPerson> qs1;
+        QuerySet<MockPerson> qs2;
+        auto                 result = qs1.where(storm::orm::where::field<^^MockPerson::age>() > 30)
+                              .union_(qs2.where(storm::orm::where::field<^^MockPerson::age>() < 10))
+                              .execute();
+
+        ASSERT_FALSE(result.has_value());
+        EXPECT_EQ(result.error().code(), SQLITE_NOMEM);
+    }
+
+    TEST_F(ORMMockErrorTest, SetOpExecuteFailsOnStepError) {
+        MockSqlite3Config::step_returns(SQLITE_CORRUPT);
+
+        QuerySet<MockPerson> qs1;
+        QuerySet<MockPerson> qs2;
+        auto                 result = qs1.where(storm::orm::where::field<^^MockPerson::age>() > 30)
+                              .union_(qs2.where(storm::orm::where::field<^^MockPerson::age>() < 10))
+                              .execute();
+
+        ASSERT_FALSE(result.has_value());
+        EXPECT_EQ(result.error().code(), SQLITE_CORRUPT);
+    }
+
+    TEST_F(ORMMockErrorTest, SetOpToSqlFailsOnPrepareError) {
+        MockSqlite3Config::prepare_returns(SQLITE_ERROR);
+
+        QuerySet<MockPerson> qs1;
+        QuerySet<MockPerson> qs2;
+        auto                 result = qs1.where(storm::orm::where::field<^^MockPerson::age>() > 30)
+                              .union_(qs2.where(storm::orm::where::field<^^MockPerson::age>() < 10))
+                              .to_sql();
+
+        ASSERT_FALSE(result.has_value());
+        EXPECT_EQ(result.error().code(), SQLITE_ERROR);
+    }
+
+    TEST_F(ORMMockErrorTest, SetOpToSqlFailsOnBindError) {
+        MockSqlite3Config::bind_int_returns(SQLITE_NOMEM);
+
+        QuerySet<MockPerson> qs1;
+        QuerySet<MockPerson> qs2;
+        auto                 result = qs1.where(storm::orm::where::field<^^MockPerson::age>() > 30)
+                              .union_(qs2.where(storm::orm::where::field<^^MockPerson::age>() < 10))
+                              .to_sql();
+
+        ASSERT_FALSE(result.has_value());
+        EXPECT_EQ(result.error().code(), SQLITE_NOMEM);
+    }
+
 } // namespace
 
 // NOLINTEND(readability-convert-member-functions-to-static,misc-const-correctness) // NOSONAR(cpp:S125)

--- a/tests/query/test_setop.cpp
+++ b/tests/query/test_setop.cpp
@@ -1,0 +1,747 @@
+#include <gtest/gtest.h>
+#include "test_db_helpers.h"
+#include "plf_hive/plf_hive.h"
+
+// NOLINTBEGIN(misc-use-internal-linkage,modernize-use-trailing-return-type,readability-named-parameter,readability-convert-member-functions-to-static)
+
+import storm;
+import <string>;
+import <vector>;
+import <expected>;
+import <algorithm>;
+import <set>;
+import <format>;
+import <optional>;
+
+using namespace storm;
+using namespace storm::orm::where;
+
+#include "test_models.h" // NOSONAR cpp:S954
+
+template <typename ConnType> class SetOpTest : public StormTestFixture<Person, ConnType, Message> {
+  protected:
+    auto on_after_setup(const std::shared_ptr<ConnType>& /*conn*/) -> void override {
+        QuerySet<Person, ConnType> qs;
+        auto                       result = qs.insert(std::span<const Person>(storm::test::PEOPLE_25)).execute();
+        ASSERT_TRUE(result.has_value()) << "Seed insert failed: " << result.error().message();
+    }
+};
+
+TYPED_TEST_SUITE(SetOpTest, DatabaseTypes);
+
+// ============================================================================
+// Basic UNION
+// ============================================================================
+
+TYPED_TEST(SetOpTest, UnionBasic) {
+    QuerySet<Person, TypeParam> qs_left;
+    QuerySet<Person, TypeParam> qs_right;
+
+    // age > 40: Frank(45), Leo(42), Olivia(48), Victor(45) = 4
+    // age < 24: Paul(22), Yara(22) = 2
+    // No overlap -> UNION = 6
+    auto result =
+            qs_left.where(field<^^Person::age>() > 40).union_(qs_right.where(field<^^Person::age>() < 24)).execute();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+    EXPECT_EQ(result->size(), 6);
+}
+
+TYPED_TEST(SetOpTest, UnionDeduplicates) {
+    QuerySet<Person, TypeParam> qs_left;
+    QuerySet<Person, TypeParam> qs_right;
+
+    // age >= 40: Eve(40), Frank(45), Leo(42), Olivia(48), Sam(40), Victor(45) = 6
+    // age <= 45: all except Olivia(48) = 24
+    // UNION deduplicates -> all 25
+    auto result =
+            qs_left.where(field<^^Person::age>() >= 40).union_(qs_right.where(field<^^Person::age>() <= 45)).execute();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+    EXPECT_EQ(result->size(), 25);
+}
+
+// ============================================================================
+// Basic UNION ALL
+// ============================================================================
+
+TYPED_TEST(SetOpTest, UnionAllKeepsDuplicates) {
+    QuerySet<Person, TypeParam> qs_left;
+    QuerySet<Person, TypeParam> qs_right;
+
+    // age >= 40: 6, age <= 45: 24, overlap: 5
+    // UNION ALL = 6 + 24 = 30
+    auto result = qs_left.where(field<^^Person::age>() >= 40)
+                          .union_all(qs_right.where(field<^^Person::age>() <= 45))
+                          .execute();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+    EXPECT_EQ(result->size(), 30);
+}
+
+// ============================================================================
+// Basic EXCEPT
+// ============================================================================
+
+TYPED_TEST(SetOpTest, ExceptBasic) {
+    QuerySet<Person, TypeParam> qs_left;
+    QuerySet<Person, TypeParam> qs_right;
+
+    // Active (16) EXCEPT (active AND age>35: Frank,Leo,Olivia,Sam,Victor = 5)
+    // Result = 11
+    auto result = qs_left.where(field<^^Person::is_active>() == true)
+                          .except_(qs_right.where(field<^^Person::is_active>() == true && field<^^Person::age>() > 35))
+                          .execute();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+    EXPECT_EQ(result->size(), 11);
+}
+
+// ============================================================================
+// Basic INTERSECT
+// ============================================================================
+
+TYPED_TEST(SetOpTest, IntersectBasic) {
+    QuerySet<Person, TypeParam> qs_left;
+    QuerySet<Person, TypeParam> qs_right;
+
+    // Active(16) INTERSECT age>35(8) = active AND age>35: Frank,Leo,Olivia,Sam,Victor = 5
+    auto result = qs_left.where(field<^^Person::is_active>() == true)
+                          .intersect_(qs_right.where(field<^^Person::age>() > 35))
+                          .execute();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+    EXPECT_EQ(result->size(), 5);
+}
+
+// ============================================================================
+// WHERE on both sides
+// ============================================================================
+
+TYPED_TEST(SetOpTest, UnionBothWithWhere) {
+    QuerySet<Person, TypeParam> qs_left;
+    QuerySet<Person, TypeParam> qs_right;
+
+    // Engineering(6) UNION Sales(5) = 11
+    auto result = qs_left.where(field<^^Person::department>() == "Engineering")
+                          .union_(qs_right.where(field<^^Person::department>() == "Sales"))
+                          .execute();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+    EXPECT_EQ(result->size(), 11);
+}
+
+// ============================================================================
+// WHERE on left only (right selects all via broad condition)
+// ============================================================================
+
+TYPED_TEST(SetOpTest, UnionLeftWhereOnly) {
+    QuerySet<Person, TypeParam> qs_left;
+    QuerySet<Person, TypeParam> qs_right;
+
+    // Engineering(6) UNION all(via age>0, 25) = 25
+    auto result = qs_left.where(field<^^Person::department>() == "Engineering")
+                          .union_(qs_right.where(field<^^Person::age>() > 0))
+                          .execute();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+    EXPECT_EQ(result->size(), 25);
+}
+
+// ============================================================================
+// ORDER BY on combined result
+// ============================================================================
+
+TYPED_TEST(SetOpTest, UnionWithOrderBy) {
+    QuerySet<Person, TypeParam> qs_left;
+    QuerySet<Person, TypeParam> qs_right;
+
+    auto result = qs_left.where(field<^^Person::department>() == "Engineering")
+                          .union_(qs_right.where(field<^^Person::department>() == "Sales"))
+                          .template order_by<^^Person::name>()
+                          .execute();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+    ASSERT_EQ(result->size(), 11);
+
+    std::vector<std::string> names;
+    for (const auto& p : *result) {
+        names.push_back(p.name);
+    }
+    EXPECT_TRUE(std::ranges::is_sorted(names));
+}
+
+// ============================================================================
+// ORDER BY + LIMIT
+// ============================================================================
+
+TYPED_TEST(SetOpTest, UnionWithOrderByAndLimit) {
+    QuerySet<Person, TypeParam> qs_left;
+    QuerySet<Person, TypeParam> qs_right;
+
+    auto result = qs_left.where(field<^^Person::department>() == "Engineering")
+                          .union_(qs_right.where(field<^^Person::department>() == "Sales"))
+                          .template order_by<^^Person::name>()
+                          .limit(3)
+                          .execute();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+    EXPECT_EQ(result->size(), 3);
+}
+
+// ============================================================================
+// ORDER BY + LIMIT + OFFSET
+// ============================================================================
+
+TYPED_TEST(SetOpTest, UnionWithOrderByLimitOffset) {
+    QuerySet<Person, TypeParam> qs_left;
+    QuerySet<Person, TypeParam> qs_right;
+
+    auto result = qs_left.where(field<^^Person::department>() == "Engineering")
+                          .union_(qs_right.where(field<^^Person::department>() == "Sales"))
+                          .template order_by<^^Person::name>()
+                          .limit(3)
+                          .offset(2)
+                          .execute();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+    EXPECT_EQ(result->size(), 3);
+}
+
+// ============================================================================
+// LIMIT without ORDER BY
+// ============================================================================
+
+TYPED_TEST(SetOpTest, UnionWithLimitOnly) {
+    QuerySet<Person, TypeParam> qs_left;
+    QuerySet<Person, TypeParam> qs_right;
+
+    auto result = qs_left.where(field<^^Person::department>() == "Engineering")
+                          .union_(qs_right.where(field<^^Person::department>() == "Sales"))
+                          .limit(5)
+                          .execute();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+    EXPECT_EQ(result->size(), 5);
+}
+
+// ============================================================================
+// 3-way chaining: UNION via SetOpBuilder
+// ============================================================================
+
+TYPED_TEST(SetOpTest, ThreeWayUnion) {
+    QuerySet<Person, TypeParam> qs1;
+    QuerySet<Person, TypeParam> qs2;
+    QuerySet<Person, TypeParam> qs3;
+
+    // Engineering(6) UNION Sales(5) UNION HR(4) = 15
+    auto builder = qs1.where(field<^^Person::department>() == "Engineering")
+                           .union_(qs2.where(field<^^Person::department>() == "Sales"));
+    auto result =
+            std::move(builder).union_(qs3.where(field<^^Person::department>() == "HR").capture_operand()).execute();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+    EXPECT_EQ(result->size(), 15);
+}
+
+// ============================================================================
+// Mixed ops chaining: UNION then EXCEPT
+// ============================================================================
+
+TYPED_TEST(SetOpTest, MixedOpsUnionThenExcept) {
+    QuerySet<Person, TypeParam> qs1;
+    QuerySet<Person, TypeParam> qs2;
+    QuerySet<Person, TypeParam> qs3;
+
+    // (Engineering UNION Sales) EXCEPT age>40
+    // Engineering(6) UNION Sales(5) = 11
+    // age>40: Frank(45),Leo(42),Olivia(48),Victor(45) = 4
+    // Result = 11 - 4 = 7
+    auto builder = qs1.where(field<^^Person::department>() == "Engineering")
+                           .union_(qs2.where(field<^^Person::department>() == "Sales"));
+    auto result = std::move(builder).except_(qs3.where(field<^^Person::age>() > 40).capture_operand()).execute();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+    EXPECT_EQ(result->size(), 7);
+}
+
+// ============================================================================
+// Empty result: INTERSECT with no common rows
+// ============================================================================
+
+TYPED_TEST(SetOpTest, IntersectNoCommon) {
+    QuerySet<Person, TypeParam> qs_left;
+    QuerySet<Person, TypeParam> qs_right;
+
+    // Engineering INTERSECT Sales = empty
+    auto result = qs_left.where(field<^^Person::department>() == "Engineering")
+                          .intersect_(qs_right.where(field<^^Person::department>() == "Sales"))
+                          .execute();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+    EXPECT_EQ(result->size(), 0);
+}
+
+// ============================================================================
+// Empty result: Both sides empty
+// ============================================================================
+
+TYPED_TEST(SetOpTest, UnionBothEmpty) {
+    QuerySet<Person, TypeParam> qs_left;
+    QuerySet<Person, TypeParam> qs_right;
+
+    auto result =
+            qs_left.where(field<^^Person::age>() > 100).union_(qs_right.where(field<^^Person::age>() < 0)).execute();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+    EXPECT_EQ(result->size(), 0);
+}
+
+// ============================================================================
+// EXCEPT: all match (empty result)
+// ============================================================================
+
+TYPED_TEST(SetOpTest, ExceptAllMatch) {
+    QuerySet<Person, TypeParam> qs_left;
+    QuerySet<Person, TypeParam> qs_right;
+
+    // Engineering EXCEPT Engineering = empty
+    auto result = qs_left.where(field<^^Person::department>() == "Engineering")
+                          .except_(qs_right.where(field<^^Person::department>() == "Engineering"))
+                          .execute();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+    EXPECT_EQ(result->size(), 0);
+}
+
+// ============================================================================
+// to_sql() verification
+// ============================================================================
+
+TYPED_TEST(SetOpTest, ToSqlUnion) {
+    QuerySet<Person, TypeParam> qs_left;
+    QuerySet<Person, TypeParam> qs_right;
+
+    auto sql = qs_left.where(field<^^Person::age>() > 30).union_(qs_right.where(field<^^Person::age>() < 25)).to_sql();
+    ASSERT_TRUE(sql.has_value()) << sql.error().message();
+    EXPECT_TRUE(sql->find("UNION") != std::string::npos) << "SQL should contain UNION: " << *sql;
+    EXPECT_TRUE(sql->find("UNION ALL") == std::string::npos) << "SQL should not contain UNION ALL: " << *sql;
+}
+
+TYPED_TEST(SetOpTest, ToSqlUnionAll) {
+    QuerySet<Person, TypeParam> qs_left;
+    QuerySet<Person, TypeParam> qs_right;
+
+    auto sql =
+            qs_left.where(field<^^Person::age>() > 30).union_all(qs_right.where(field<^^Person::age>() < 25)).to_sql();
+    ASSERT_TRUE(sql.has_value()) << sql.error().message();
+    EXPECT_TRUE(sql->find("UNION ALL") != std::string::npos) << "SQL should contain UNION ALL: " << *sql;
+}
+
+TYPED_TEST(SetOpTest, ToSqlExcept) {
+    QuerySet<Person, TypeParam> qs_left;
+    QuerySet<Person, TypeParam> qs_right;
+
+    auto sql = qs_left.where(field<^^Person::age>() > 30).except_(qs_right.where(field<^^Person::age>() < 25)).to_sql();
+    ASSERT_TRUE(sql.has_value()) << sql.error().message();
+    EXPECT_TRUE(sql->find("EXCEPT") != std::string::npos) << "SQL should contain EXCEPT: " << *sql;
+}
+
+TYPED_TEST(SetOpTest, ToSqlIntersect) {
+    QuerySet<Person, TypeParam> qs_left;
+    QuerySet<Person, TypeParam> qs_right;
+
+    auto sql =
+            qs_left.where(field<^^Person::age>() > 30).intersect_(qs_right.where(field<^^Person::age>() < 40)).to_sql();
+    ASSERT_TRUE(sql.has_value()) << sql.error().message();
+    EXPECT_TRUE(sql->find("INTERSECT") != std::string::npos) << "SQL should contain INTERSECT: " << *sql;
+}
+
+// ============================================================================
+// Self-union (same query)
+// ============================================================================
+
+TYPED_TEST(SetOpTest, SelfUnion) {
+    QuerySet<Person, TypeParam> qs_left;
+    QuerySet<Person, TypeParam> qs_right;
+
+    // UNION deduplicates -> same as one side
+    auto result = qs_left.where(field<^^Person::department>() == "Engineering")
+                          .union_(qs_right.where(field<^^Person::department>() == "Engineering"))
+                          .execute();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+    EXPECT_EQ(result->size(), 6);
+}
+
+// ============================================================================
+// Self UNION ALL -> doubles
+// ============================================================================
+
+TYPED_TEST(SetOpTest, SelfUnionAll) {
+    QuerySet<Person, TypeParam> qs_left;
+    QuerySet<Person, TypeParam> qs_right;
+
+    auto result = qs_left.where(field<^^Person::department>() == "Engineering")
+                          .union_all(qs_right.where(field<^^Person::department>() == "Engineering"))
+                          .execute();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+    EXPECT_EQ(result->size(), 12);
+}
+
+// ============================================================================
+// Single-row result
+// ============================================================================
+
+TYPED_TEST(SetOpTest, UnionSingleRow) {
+    QuerySet<Person, TypeParam> qs_left;
+    QuerySet<Person, TypeParam> qs_right;
+
+    auto result = qs_left.where(field<^^Person::name>() == "Alice")
+                          .union_(qs_right.where(field<^^Person::name>() == "Alice"))
+                          .execute();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+    EXPECT_EQ(result->size(), 1);
+    EXPECT_EQ(result->begin()->name, "Alice");
+}
+
+// ============================================================================
+// Large result set
+// ============================================================================
+
+TYPED_TEST(SetOpTest, UnionAllLargeResult) {
+    QuerySet<Person, TypeParam> qs_left;
+    QuerySet<Person, TypeParam> qs_right;
+
+    // UNION ALL of all 25 with all 25 = 50
+    auto result =
+            qs_left.where(field<^^Person::age>() > 0).union_all(qs_right.where(field<^^Person::age>() > 0)).execute();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+    EXPECT_EQ(result->size(), 50);
+}
+
+// ============================================================================
+// to_sql() with ORDER BY + LIMIT
+// ============================================================================
+
+TYPED_TEST(SetOpTest, ToSqlWithModifiers) {
+    QuerySet<Person, TypeParam> qs_left;
+    QuerySet<Person, TypeParam> qs_right;
+
+    auto sql = qs_left.where(field<^^Person::age>() > 30)
+                       .union_(qs_right.where(field<^^Person::age>() < 25))
+                       .template order_by<^^Person::name>()
+                       .limit(5)
+                       .to_sql();
+    ASSERT_TRUE(sql.has_value()) << sql.error().message();
+    EXPECT_TRUE(sql->find("UNION") != std::string::npos);
+    EXPECT_TRUE(sql->find("ORDER BY") != std::string::npos);
+    EXPECT_TRUE(sql->find("LIMIT") != std::string::npos);
+}
+
+// ============================================================================
+// Missing operator: !=
+// ============================================================================
+
+TYPED_TEST(SetOpTest, UnionWithNotEquals) {
+    QuerySet<Person, TypeParam> qs_left;
+    QuerySet<Person, TypeParam> qs_right;
+
+    // department != "Engineering" (19) UNION department == "Sales" (5)
+    // Sales is subset of non-Engineering -> UNION = 19
+    auto result = qs_left.where(field<^^Person::department>() != "Engineering")
+                          .union_(qs_right.where(field<^^Person::department>() == "Sales"))
+                          .execute();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+    EXPECT_EQ(result->size(), 19);
+}
+
+// ============================================================================
+// Double type coverage (salary)
+// ============================================================================
+
+TYPED_TEST(SetOpTest, UnionWithDoubleWhere) {
+    QuerySet<Person, TypeParam> qs_left;
+    QuerySet<Person, TypeParam> qs_right;
+
+    // salary >= 90000: Eve(92k),Leo(95k),Olivia(98k),Sam(90k),Victor(93k) = 5
+    // salary < 40000: Paul(32k),Yara(35k) = 2
+    // No overlap -> UNION = 7
+    auto result = qs_left.where(field<^^Person::salary>() >= 90000.0)
+                          .union_(qs_right.where(field<^^Person::salary>() < 40000.0))
+                          .execute();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+    EXPECT_EQ(result->size(), 7);
+}
+
+TYPED_TEST(SetOpTest, ExceptWithDoubleWhere) {
+    QuerySet<Person, TypeParam> qs_left;
+    QuerySet<Person, TypeParam> qs_right;
+
+    // salary >= 80000 (8): Jack,Leo,Frank,Olivia,Sam,Victor,Xander,Eve
+    // salary >= 90000 (5): Eve,Leo,Olivia,Sam,Victor
+    // EXCEPT = 3: Jack(85k),Frank(88k),Xander(82k)
+    auto result = qs_left.where(field<^^Person::salary>() >= 80000.0)
+                          .except_(qs_right.where(field<^^Person::salary>() >= 90000.0))
+                          .execute();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+    EXPECT_EQ(result->size(), 3);
+}
+
+// ============================================================================
+// OR logical combination
+// ============================================================================
+
+TYPED_TEST(SetOpTest, UnionWithOrWhere) {
+    QuerySet<Person, TypeParam> qs_left;
+    QuerySet<Person, TypeParam> qs_right;
+
+    // Left: age < 25 OR salary > 90000
+    //   age<25: Paul(22),Yara(22) = 2
+    //   salary>90000: Eve(92k),Leo(95k),Olivia(98k),Victor(93k) = 4
+    //   No overlap -> 6
+    // Right: department == "HR" -> Diana,Jack,Paul,Uma = 4
+    // UNION: 6+4 - Paul(overlap) = 9
+    auto result = qs_left.where(field<^^Person::age>() < 25 || field<^^Person::salary>() > 90000.0)
+                          .union_(qs_right.where(field<^^Person::department>() == "HR"))
+                          .execute();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+    EXPECT_EQ(result->size(), 9);
+}
+
+// ============================================================================
+// Complex nested expression: (A && B) || C
+// ============================================================================
+
+TYPED_TEST(SetOpTest, IntersectWithComplexNested) {
+    QuerySet<Person, TypeParam> qs_left;
+    QuerySet<Person, TypeParam> qs_right;
+
+    // Left: (age > 40 && is_active) || department == "HR"
+    //   age>40 && active: Frank(45),Leo(42),Olivia(48),Victor(45) = 4
+    //   HR: Diana,Jack,Paul,Uma = 4
+    //   No overlap -> 8
+    // Right: salary > 50000
+    //   All with salary > 50000 = 18 (excludes Paul(32k),Yara(35k),Tina(44k),Mia(46k),Diana(48k)) -> wait
+    //   salary > 50000: 25 - 5 (Paul=32k,Yara=35k,Tina=44k,Mia=46k,Diana=48k) = 20
+    // INTERSECT: rows in both = those from 8 that have salary>50k
+    //   Frank(88k)✓,Leo(95k)✓,Olivia(98k)✓,Victor(93k)✓,Jack(85k)✓,Uma(69k)✓ = 6
+    //   Diana(48k)✗,Paul(32k)✗ -> 6
+    auto result = qs_left.where((field<^^Person::age>() > 40 && field<^^Person::is_active>() == true) ||
+                                field<^^Person::department>() == "HR")
+                          .intersect_(qs_right.where(field<^^Person::salary>() > 50000.0))
+                          .execute();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+    EXPECT_EQ(result->size(), 6);
+}
+
+// ============================================================================
+// Special expressions: LIKE
+// ============================================================================
+
+TYPED_TEST(SetOpTest, UnionWithLike) {
+    QuerySet<Person, TypeParam> qs_left;
+    QuerySet<Person, TypeParam> qs_right;
+
+    // name LIKE "A%" -> Alice = 1
+    // name LIKE "B%" -> Bob = 1
+    // UNION = 2
+    auto result = qs_left.where(field<^^Person::name>().like("A%"))
+                          .union_(qs_right.where(field<^^Person::name>().like("B%")))
+                          .execute();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+    EXPECT_EQ(result->size(), 2);
+}
+
+// ============================================================================
+// Special expressions: BETWEEN
+// ============================================================================
+
+TYPED_TEST(SetOpTest, ExceptWithBetween) {
+    QuerySet<Person, TypeParam> qs_left;
+    QuerySet<Person, TypeParam> qs_right;
+
+    // Left: age BETWEEN 30 AND 40 -> Bob,Charlie,Eve,Henry,Ivy,Jack,Nick,Quinn,Rachel,Sam,Uma,Xander = 12
+    // Right: age BETWEEN 35 AND 40 -> Charlie,Eve,Jack,Nick,Rachel,Sam,Xander = 7
+    // EXCEPT = 5: Bob(30),Henry(33),Ivy(30),Quinn(30),Uma(33)
+    auto result = qs_left.where(field<^^Person::age>().between(30, 40))
+                          .except_(qs_right.where(field<^^Person::age>().between(35, 40)))
+                          .execute();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+    EXPECT_EQ(result->size(), 5);
+}
+
+// ============================================================================
+// Special expressions: IN
+// ============================================================================
+
+TYPED_TEST(SetOpTest, IntersectWithIn) {
+    QuerySet<Person, TypeParam> qs_left;
+    QuerySet<Person, TypeParam> qs_right;
+
+    // Left: age IN (25, 30, 35) -> Alice,Bob,Charlie,Grace,Ivy,Karen,Nick,Quinn = 8
+    // Right: department == "Engineering" -> Alice,Eve,Ivy,Leo,Quinn,Victor = 6
+    // INTERSECT = Alice,Ivy,Quinn = 3
+    auto result = qs_left.where(field<^^Person::age>().in(25, 30, 35))
+                          .intersect_(qs_right.where(field<^^Person::department>() == "Engineering"))
+                          .execute();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+    EXPECT_EQ(result->size(), 3);
+}
+
+// ============================================================================
+// ORDER BY DESC
+// ============================================================================
+
+TYPED_TEST(SetOpTest, UnionWithOrderByDesc) {
+    QuerySet<Person, TypeParam> qs_left;
+    QuerySet<Person, TypeParam> qs_right;
+
+    auto result = qs_left.where(field<^^Person::department>() == "Engineering")
+                          .union_(qs_right.where(field<^^Person::department>() == "Sales"))
+                          .template order_by<^^Person::age, false>()
+                          .execute();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+    ASSERT_EQ(result->size(), 11);
+
+    std::vector<int> ages;
+    for (const auto& p : *result) {
+        ages.push_back(p.age);
+    }
+    EXPECT_TRUE(std::ranges::is_sorted(ages, std::greater<>{}));
+}
+
+// ============================================================================
+// OFFSET without ORDER BY
+// ============================================================================
+
+TYPED_TEST(SetOpTest, UnionWithOffsetOnly) {
+    QuerySet<Person, TypeParam> qs_left;
+    QuerySet<Person, TypeParam> qs_right;
+
+    // Engineering(6) UNION Sales(5) = 11, skip first 5 -> 6
+    auto result = qs_left.where(field<^^Person::department>() == "Engineering")
+                          .union_(qs_right.where(field<^^Person::department>() == "Sales"))
+                          .offset(5)
+                          .execute();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+    EXPECT_EQ(result->size(), 6);
+}
+
+// ============================================================================
+// Large result set (100+ rows via 5-way UNION ALL)
+// ============================================================================
+
+TYPED_TEST(SetOpTest, UnionAllLarge100Plus) {
+    QuerySet<Person, TypeParam> qs1;
+    QuerySet<Person, TypeParam> qs2;
+    QuerySet<Person, TypeParam> qs3;
+    QuerySet<Person, TypeParam> qs4;
+    QuerySet<Person, TypeParam> qs5;
+
+    // 5x UNION ALL of all 25 = 125
+    auto builder = qs1.where(field<^^Person::age>() > 0).union_all(qs2.where(field<^^Person::age>() > 0));
+    auto result  = std::move(builder)
+                          .union_all(qs3.where(field<^^Person::age>() > 0).capture_operand())
+                          .union_all(qs4.where(field<^^Person::age>() > 0).capture_operand())
+                          .union_all(qs5.where(field<^^Person::age>() > 0).capture_operand())
+                          .execute();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+    EXPECT_EQ(result->size(), 125);
+}
+
+// ============================================================================
+// Repeated execution (statement caching correctness)
+// ============================================================================
+
+TYPED_TEST(SetOpTest, RepeatedExecution) {
+    QuerySet<Person, TypeParam> qs_left;
+    QuerySet<Person, TypeParam> qs_right;
+
+    auto builder = qs_left.where(field<^^Person::department>() == "Engineering")
+                           .union_(qs_right.where(field<^^Person::department>() == "Sales"));
+
+    auto result1 = builder.execute();
+    ASSERT_TRUE(result1.has_value()) << result1.error().message();
+    EXPECT_EQ(result1->size(), 11);
+
+    // Second execution on same builder should use cached statement
+    auto result2 = builder.execute();
+    ASSERT_TRUE(result2.has_value()) << result2.error().message();
+    EXPECT_EQ(result2->size(), 11);
+}
+
+// ============================================================================
+// Additional chaining: EXCEPT then UNION
+// ============================================================================
+
+TYPED_TEST(SetOpTest, ExceptThenUnion) {
+    QuerySet<Person, TypeParam> qs1;
+    QuerySet<Person, TypeParam> qs2;
+    QuerySet<Person, TypeParam> qs3;
+
+    // (Engineering EXCEPT age>40) UNION HR
+    // Engineering(6) EXCEPT age>40(Frank45,Leo42,Victor45 = 3 in Eng) = 3 (Alice,Eve,Ivy,Quinn minus Eve? wait)
+    // Engineering: Alice(25),Eve(40),Ivy(30),Leo(42),Quinn(30),Victor(45)
+    // age>40: Frank(45-Sales),Leo(42),Olivia(48),Victor(45)
+    // EXCEPT: Engineering rows NOT in age>40 -> Alice,Eve(40 not >40),Ivy,Quinn = 4
+    // HR: Diana,Jack,Paul,Uma = 4
+    // UNION = 8
+    auto builder =
+            qs1.where(field<^^Person::department>() == "Engineering").except_(qs2.where(field<^^Person::age>() > 40));
+    auto result =
+            std::move(builder).union_(qs3.where(field<^^Person::department>() == "HR").capture_operand()).execute();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+    EXPECT_EQ(result->size(), 8);
+}
+
+// ============================================================================
+// Additional chaining: INTERSECT then UNION ALL
+// ============================================================================
+
+TYPED_TEST(SetOpTest, IntersectThenUnionAll) {
+    QuerySet<Person, TypeParam> qs1;
+    QuerySet<Person, TypeParam> qs2;
+    QuerySet<Person, TypeParam> qs3;
+
+    // (active INTERSECT age>35) UNION ALL HR
+    // Active(16) INTERSECT age>35(8) = active AND age>35: Frank,Leo,Olivia,Sam,Victor = 5
+    // HR: Diana,Jack,Paul,Uma = 4
+    // UNION ALL = 9
+    auto builder = qs1.where(field<^^Person::is_active>() == true).intersect_(qs2.where(field<^^Person::age>() > 35));
+    auto result =
+            std::move(builder).union_all(qs3.where(field<^^Person::department>() == "HR").capture_operand()).execute();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+    EXPECT_EQ(result->size(), 9);
+}
+
+// ============================================================================
+// 4-way chaining: UNION x3
+// ============================================================================
+
+TYPED_TEST(SetOpTest, FourWayUnion) {
+    QuerySet<Person, TypeParam> qs1;
+    QuerySet<Person, TypeParam> qs2;
+    QuerySet<Person, TypeParam> qs3;
+    QuerySet<Person, TypeParam> qs4;
+
+    // Engineering(6) UNION Sales(5) UNION HR(4) UNION Marketing(5) = 20
+    auto builder = qs1.where(field<^^Person::department>() == "Engineering")
+                           .union_(qs2.where(field<^^Person::department>() == "Sales"));
+    auto result = std::move(builder)
+                          .union_(qs3.where(field<^^Person::department>() == "HR").capture_operand())
+                          .union_(qs4.where(field<^^Person::department>() == "Marketing").capture_operand())
+                          .execute();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+    EXPECT_EQ(result->size(), 20);
+}
+
+// ============================================================================
+// UNION ALL with EXCEPT (all 4 set ops in one chain)
+// ============================================================================
+
+TYPED_TEST(SetOpTest, AllFourOpsChained) {
+    QuerySet<Person, TypeParam> qs1;
+    QuerySet<Person, TypeParam> qs2;
+    QuerySet<Person, TypeParam> qs3;
+    QuerySet<Person, TypeParam> qs4;
+    QuerySet<Person, TypeParam> qs5;
+
+    // Uses UNION ALL + EXCEPT + UNION (same precedence, left-to-right in all backends).
+    // Avoids INTERSECT which has higher precedence in PostgreSQL vs left-to-right in SQLite.
+    // Eng(6) UNION ALL Sales(5)=11 → EXCEPT age>40=7 → UNION HR(4)=11 → EXCEPT !active=7
+    auto builder = qs1.where(field<^^Person::department>() == "Engineering")
+                           .union_all(qs2.where(field<^^Person::department>() == "Sales"));
+    auto result = std::move(builder)
+                          .except_(qs3.where(field<^^Person::age>() > 40).capture_operand())
+                          .union_(qs4.where(field<^^Person::department>() == "HR").capture_operand())
+                          .except_(qs5.where(field<^^Person::is_active>() == false).capture_operand())
+                          .execute();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+    EXPECT_EQ(result->size(), 7);
+}
+
+// NOLINTEND(misc-use-internal-linkage,modernize-use-trailing-return-type,readability-named-parameter,readability-convert-member-functions-to-static)

--- a/tests/query/test_setop.cpp
+++ b/tests/query/test_setop.cpp
@@ -37,9 +37,8 @@ TYPED_TEST(SetOpTest, UnionBasic) {
     QuerySet<Person, TypeParam> qs_left;
     QuerySet<Person, TypeParam> qs_right;
 
-    // age > 40: Frank(45), Leo(42), Olivia(48), Victor(45) = 4
-    // age < 24: Paul(22), Yara(22) = 2
-    // No overlap -> UNION = 6
+    // Left: 4 people with age above 40, right: 2 people with age below 24
+    // No overlap, UNION yields 6
     auto result =
             qs_left.where(field<^^Person::age>() > 40).union_(qs_right.where(field<^^Person::age>() < 24)).execute();
     ASSERT_TRUE(result.has_value()) << result.error().message();
@@ -117,7 +116,7 @@ TYPED_TEST(SetOpTest, UnionBothWithWhere) {
     QuerySet<Person, TypeParam> qs_left;
     QuerySet<Person, TypeParam> qs_right;
 
-    // Engineering(6) UNION Sales(5) = 11
+    // 6 Engineering + 5 Sales, no overlap, UNION yields 11
     auto result = qs_left.where(field<^^Person::department>() == "Engineering")
                           .union_(qs_right.where(field<^^Person::department>() == "Sales"))
                           .execute();
@@ -223,7 +222,7 @@ TYPED_TEST(SetOpTest, ThreeWayUnion) {
     QuerySet<Person, TypeParam> qs2;
     QuerySet<Person, TypeParam> qs3;
 
-    // Engineering(6) UNION Sales(5) UNION HR(4) = 15
+    // 6 Engineering + 5 Sales + 4 HR, no overlap, UNION yields 15
     auto builder = qs1.where(field<^^Person::department>() == "Engineering")
                            .union_(qs2.where(field<^^Person::department>() == "Sales"));
     auto result =
@@ -708,7 +707,7 @@ TYPED_TEST(SetOpTest, FourWayUnion) {
     QuerySet<Person, TypeParam> qs3;
     QuerySet<Person, TypeParam> qs4;
 
-    // Engineering(6) UNION Sales(5) UNION HR(4) UNION Marketing(5) = 20
+    // 6 Engineering + 5 Sales + 4 HR + 5 Marketing, no overlap, UNION yields 20
     auto builder = qs1.where(field<^^Person::department>() == "Engineering")
                            .union_(qs2.where(field<^^Person::department>() == "Sales"));
     auto result = std::move(builder)


### PR DESCRIPTION
## Summary
- New `SetOpBuilder<T, ConnType>` class with statement caching and compile-time model type safety (`requires std::same_as<U, T>`)
- 5 new QuerySet methods: `union_()`, `union_all()`, `except_()`, `intersect_()`, `capture_operand()`
- Debug assertions in `capture_operand()` catch invalid ORDER BY/LIMIT/OFFSET on individual operands
- 41 typed tests (82 with both backends) + 5 mock error tests for full coverage
- 6 SETOP benchmarks: 94-118% efficiency vs raw SQLite

## Test plan
- [x] 1409/1409 tests pass (debug)
- [x] ASAN+UBSAN clean
- [x] TSAN clean
- [x] 100% line coverage
- [x] Release benchmarks: no regressions, SETOP efficiency 94-118%
- [x] Compile-time model type mismatch produces clear `requires` error

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)