### PR TITLE
feat: compile-time set operation clause safety

### DIFF
--- a/benchmarks/operations/setop.hpp
+++ b/benchmarks/operations/setop.hpp
@@ -34,15 +34,14 @@ namespace storm::benchmark {
 
         // Left WHERE: age <op> left_threshold_
         // Right WHERE: age <op> right_threshold_
-        int left_threshold_  = 0;
-        int right_threshold_ = 0;
-        int limit_value_     = 0;
+        int             left_threshold_  = 0;
+        int             right_threshold_ = 0;
+        int             limit_value_     = 0;
         QuerySet<Model> qs_right_;
 
         // For UNION/UNION ALL: disjoint halves (age < 45, age >= 45)
         // For EXCEPT/INTERSECT: overlapping ranges (age < 55, age > 35)
-        static constexpr bool needs_overlap =
-                (OpType == SetOpBenchType::Except || OpType == SetOpBenchType::Intersect);
+        static constexpr bool needs_overlap = (OpType == SetOpBenchType::Except || OpType == SetOpBenchType::Intersect);
 
       public:
         explicit SetOpBenchmark(int dataset_size = 1000, int limit_value = 0)
@@ -83,8 +82,8 @@ namespace storm::benchmark {
                 std::cout << " (WHERE age < " << left_threshold_ << " " << op_name() << " WHERE age > "
                           << right_threshold_ << ")";
             } else {
-                std::cout << " (WHERE age < " << left_threshold_ << " " << op_name() << " WHERE age >= "
-                          << right_threshold_ << ")";
+                std::cout << " (WHERE age < " << left_threshold_ << " " << op_name()
+                          << " WHERE age >= " << right_threshold_ << ")";
             }
             std::cout << "\n";
             std::cout << "  Dataset: " << Base::batch_size() << " rows\n";
@@ -223,20 +222,15 @@ namespace storm::benchmark {
     };
 
     // Type aliases for cleaner usage
-    template <typename Model>
-    using SetOpUnionBenchmark = SetOpBenchmark<Model, SetOpBenchType::Union>;
+    template <typename Model> using SetOpUnionBenchmark = SetOpBenchmark<Model, SetOpBenchType::Union>;
 
-    template <typename Model>
-    using SetOpUnionAllBenchmark = SetOpBenchmark<Model, SetOpBenchType::UnionAll>;
+    template <typename Model> using SetOpUnionAllBenchmark = SetOpBenchmark<Model, SetOpBenchType::UnionAll>;
 
-    template <typename Model>
-    using SetOpExceptBenchmark = SetOpBenchmark<Model, SetOpBenchType::Except>;
+    template <typename Model> using SetOpExceptBenchmark = SetOpBenchmark<Model, SetOpBenchType::Except>;
 
-    template <typename Model>
-    using SetOpIntersectBenchmark = SetOpBenchmark<Model, SetOpBenchType::Intersect>;
+    template <typename Model> using SetOpIntersectBenchmark = SetOpBenchmark<Model, SetOpBenchType::Intersect>;
 
-    template <typename Model>
-    using SetOpUnionOrderByBenchmark = SetOpBenchmark<Model, SetOpBenchType::Union, true>;
+    template <typename Model> using SetOpUnionOrderByBenchmark = SetOpBenchmark<Model, SetOpBenchType::Union, true>;
 
     template <typename Model, int LimitValue>
     using SetOpUnionLimitBenchmark = SetOpBenchmark<Model, SetOpBenchType::Union, false, true>;

--- a/src/orm/queryset.cppm
+++ b/src/orm/queryset.cppm
@@ -45,14 +45,25 @@ export namespace storm {
         }
     } // namespace detail
 
-    template <class T, storm::db::DatabaseConnection ConnType = storm::db::sqlite::Connection>
+    template <
+            class T,
+            storm::db::DatabaseConnection ConnType   = storm::db::sqlite::Connection,
+            bool                          Finalized_ = false>
     class QuerySet { // NOSONAR(cpp:S1448) — ORM facade class; method count grows with supported operations
         using Error     = typename ConnType::Error;
         using Statement = typename ConnType::Statement;
 
+        template <class U, storm::db::DatabaseConnection C, bool F> friend class QuerySet;
+
       public:
         // Default constructor using default connection
         QuerySet() : conn_(get_default_connection()) {}
+
+        // LCOV_EXCL_START — compile-time only, used in static_assert
+        static constexpr auto is_finalized() -> bool {
+            return Finalized_;
+        }
+        // LCOV_EXCL_STOP
 
         // Remove single object - returns proxy with .execute() and .to_sql()
         auto remove(const T& obj) {
@@ -114,28 +125,30 @@ export namespace storm {
             return std::forward<decltype(self)>(self);
         }
 
-        // LIMIT clause support - builder pattern with method chaining
+        // LIMIT clause support - returns finalized QuerySet (prevents use as set-op operand)
         // Usage: queryset.limit(10).select()
         //        queryset.where(age > 25).limit(10).select()
-        constexpr auto limit(this auto&& self, int n) -> auto&& { // NOSONAR(cpp:S6189)
-            self.limit_value_ = n;
-            return std::forward<decltype(self)>(self);
+        constexpr auto limit(int n) -> QuerySet<T, ConnType, true> {
+            auto result         = to_finalized();
+            result.limit_value_ = n;
+            return result;
         }
 
-        // OFFSET clause support - builder pattern with method chaining
+        // OFFSET clause support - returns finalized QuerySet (prevents use as set-op operand)
         // Usage: queryset.offset(5).select()
         //        queryset.limit(10).offset(5).select()
-        constexpr auto offset(this auto&& self, int n) -> auto&& { // NOSONAR(cpp:S6189)
-            self.offset_value_ = n;
-            return std::forward<decltype(self)>(self);
+        constexpr auto offset(int n) -> QuerySet<T, ConnType, true> {
+            auto result          = to_finalized();
+            result.offset_value_ = n;
+            return result;
         }
 
-        // ORDER BY clause support - builder pattern with method chaining
+        // ORDER BY clause support - returns finalized QuerySet (prevents use as set-op operand)
         // Supports single/multiple fields with ASC (default) or DESC direction
-        template <auto... Args> constexpr auto order_by(this auto&& self) -> auto&& { // NOSONAR(cpp:S6189)
-            // Create lightweight wrapper to compile-time generated static SQL
-            self.order_by_wrapper_ = orm::statements::make_order_by_wrapper<Args...>();
-            return std::forward<decltype(self)>(self);
+        template <auto... Args> constexpr auto order_by() -> QuerySet<T, ConnType, true> {
+            auto result              = to_finalized();
+            result.order_by_wrapper_ = orm::statements::make_order_by_wrapper<Args...>();
+            return result;
         }
 
         // Select - returns proxy with .execute() and .to_sql()
@@ -291,30 +304,38 @@ export namespace storm {
         // SET OPERATIONS: UNION, UNION ALL, EXCEPT, INTERSECT
         // =====================================================================
 
-        auto union_(const QuerySet& other) {
+        template <bool F_ = Finalized_>
+        auto union_(const QuerySet<T, ConnType, false>& other)
+            requires(!F_)
+        {
             return make_setop_builder(other, orm::statements::SetOpType::Union);
         }
 
-        auto union_all(const QuerySet& other) {
+        template <bool F_ = Finalized_>
+        auto union_all(const QuerySet<T, ConnType, false>& other)
+            requires(!F_)
+        {
             return make_setop_builder(other, orm::statements::SetOpType::UnionAll);
         }
 
-        auto except_(const QuerySet& other) {
+        template <bool F_ = Finalized_>
+        auto except_(const QuerySet<T, ConnType, false>& other)
+            requires(!F_)
+        {
             return make_setop_builder(other, orm::statements::SetOpType::Except);
         }
 
-        auto intersect_(const QuerySet& other) {
+        template <bool F_ = Finalized_>
+        auto intersect_(const QuerySet<T, ConnType, false>& other)
+            requires(!F_)
+        {
             return make_setop_builder(other, orm::statements::SetOpType::Intersect);
         }
 
-        // Replace assert with [[pre:]] when C++26 contracts land in Clang
-        auto capture_operand() const -> orm::statements::SetOpOperand<T> {
-            assert(!order_by_wrapper_.has_value() &&
-                   "ORDER BY on individual set operation operand is ignored — use SetOpBuilder.order_by()");
-            assert(!limit_value_.has_value() &&
-                   "LIMIT on individual set operation operand is ignored — use SetOpBuilder.limit()");
-            assert(!offset_value_.has_value() &&
-                   "OFFSET on individual set operation operand is ignored — use SetOpBuilder.offset()");
+        template <bool F_ = Finalized_>
+        auto capture_operand() const -> orm::statements::SetOpOperand<T>
+            requires(!F_)
+        {
             std::string sql = join_stmt_.has_value() ? std::string(join_stmt_->get_complete_sql())
                                                      : orm::statements::SelectStatement<T, ConnType>::get_select_sql();
             if (where_expr_) {
@@ -479,7 +500,22 @@ export namespace storm {
             return *select_stmt_;
         }
 
-        auto make_setop_builder(const QuerySet& other, orm::statements::SetOpType op)
+        // Private constructor for to_finalized() — takes explicit connection
+        explicit QuerySet(std::shared_ptr<ConnType> conn) : conn_(std::move(conn)) {}
+
+        // Create a finalized copy carrying conn_, where, join, limit, offset, order_by state
+        // Statement caches are NOT copied — they are lazy-init'd on demand via prepare_cached()
+        auto to_finalized() const -> QuerySet<T, ConnType, true> {
+            QuerySet<T, ConnType, true> result(conn_);
+            result.where_expr_       = where_expr_;
+            result.join_stmt_        = join_stmt_;
+            result.limit_value_      = limit_value_;
+            result.offset_value_     = offset_value_;
+            result.order_by_wrapper_ = order_by_wrapper_;
+            return result;
+        }
+
+        auto make_setop_builder(const QuerySet<T, ConnType, false>& other, orm::statements::SetOpType op)
                 -> orm::statements::SetOpBuilder<T, ConnType> {
             auto                                          left  = capture_operand();
             auto                                          right = other.capture_operand();

--- a/tests/crud/test_crud.cpp
+++ b/tests/crud/test_crud.cpp
@@ -425,12 +425,9 @@ template <typename ConnType> class QueryResetTest : public StormTestFixture<Pers
 TYPED_TEST_SUITE(QueryResetTest, DatabaseTypes);
 
 TYPED_TEST(QueryResetTest, ResetClearsAllState) {
-    this->qs->where(storm::orm::where::field<^^Person::age>() > 25)
-            .template order_by<^^Person::name>()
-            .limit(2)
-            .offset(1);
+    this->qs->where(storm::orm::where::field<^^Person::age>() > 25);
 
-    auto result1 = this->qs->select().execute();
+    auto result1 = this->qs->template order_by<^^Person::name>().limit(2).offset(1).select().execute();
     ASSERT_TRUE(result1.has_value());
     EXPECT_LE(result1.value().size(), 2);
 

--- a/tests/query/test_limit_offset.cpp
+++ b/tests/query/test_limit_offset.cpp
@@ -171,17 +171,17 @@ TYPED_TEST(LimitOffsetTest, ResetClearsLimitOffset) {
 TYPED_TEST(LimitOffsetTest, ReuseLimitOffset) {
     QuerySet<Person, TypeParam> qs;
 
-    // Set ORDER BY + LIMIT/OFFSET once
-    qs.template order_by<^^Person::name>().limit(5).offset(10);
+    // Chain ORDER BY + LIMIT/OFFSET — returns finalized QS by value
+    auto finalized = qs.template order_by<^^Person::name>().limit(5).offset(10);
 
     // First query — names 11-15: Karen, Leo, Mia, Nick, Olivia
-    auto result1 = qs.select().execute();
+    auto result1 = finalized.select().execute();
     ASSERT_TRUE(result1.has_value());
     ASSERT_EQ(result1.value().size(), 5);
     EXPECT_EQ(result1.value().begin()->name, "Karen");
 
-    // Second query reuses same LIMIT/OFFSET
-    auto result2 = qs.select().execute();
+    // Second query reuses same finalized QS
+    auto result2 = finalized.select().execute();
     ASSERT_TRUE(result2.has_value());
     ASSERT_EQ(result2.value().size(), 5);
     EXPECT_EQ(result2.value().begin()->name, "Karen");

--- a/tests/query/test_setop.cpp
+++ b/tests/query/test_setop.cpp
@@ -743,4 +743,54 @@ TYPED_TEST(SetOpTest, AllFourOpsChained) {
     EXPECT_EQ(result->size(), 7);
 }
 
+// ============================================================================
+// Compile-time safety: Finalized QuerySet cannot be used as set-op operand
+// ============================================================================
+
+// is_finalized() compile-time checks
+static_assert(!QuerySet<Person, storm::db::sqlite::Connection>::is_finalized());
+static_assert(QuerySet<Person, storm::db::sqlite::Connection, true>::is_finalized());
+
+// Concepts for compile-time constraint verification
+// (template SFINAE via concepts avoids experimental Clang requires-expression bug)
+template <typename QS, typename Other>
+concept CanUnion = requires(QS qs, Other other) { qs.union_(other); };
+
+template <typename QS, typename Other>
+concept CanUnionAll = requires(QS qs, Other other) { qs.union_all(other); };
+
+template <typename QS, typename Other>
+concept CanExcept = requires(QS qs, Other other) { qs.except_(other); };
+
+template <typename QS, typename Other>
+concept CanIntersect = requires(QS qs, Other other) { qs.intersect_(other); };
+
+template <typename QS>
+concept CanCaptureOperand = requires(QS qs) { qs.capture_operand(); };
+
+using NormalQS    = QuerySet<Person, storm::db::sqlite::Connection>;
+using FinalizedQS = QuerySet<Person, storm::db::sqlite::Connection, true>;
+
+// Finalized QuerySet must NOT have set-op methods
+static_assert(!CanUnion<FinalizedQS, NormalQS>);
+static_assert(!CanUnionAll<FinalizedQS, NormalQS>);
+static_assert(!CanExcept<FinalizedQS, NormalQS>);
+static_assert(!CanIntersect<FinalizedQS, NormalQS>);
+
+// Set-op methods must NOT accept finalized operands
+static_assert(!CanUnion<NormalQS, FinalizedQS>);
+static_assert(!CanUnionAll<NormalQS, FinalizedQS>);
+static_assert(!CanExcept<NormalQS, FinalizedQS>);
+static_assert(!CanIntersect<NormalQS, FinalizedQS>);
+
+// capture_operand() must NOT be callable on finalized QuerySet
+static_assert(!CanCaptureOperand<FinalizedQS>);
+
+// Non-finalized QuerySet MUST still have set-op methods (positive checks)
+static_assert(CanUnion<NormalQS, NormalQS>);
+static_assert(CanUnionAll<NormalQS, NormalQS>);
+static_assert(CanExcept<NormalQS, NormalQS>);
+static_assert(CanIntersect<NormalQS, NormalQS>);
+static_assert(CanCaptureOperand<NormalQS>);
+
 // NOLINTEND(misc-use-internal-linkage,modernize-use-trailing-return-type,readability-named-parameter,readability-convert-member-functions-to-static)

--- a/tests/test_query_runner_base.h
+++ b/tests/test_query_runner_base.h
@@ -94,9 +94,8 @@ template <typename Model, typename ConnType> class QueryRunnerBase {
         }
     }
 
-    // NTTP twin of SelectQueryBenchmarkBase::apply_query_filters()
-    // Tc must have: join_name, where (WhereSpec), order_by (OrderBySpec), limit_value, offset_value
-    template <const auto &Tc> void apply_query_filters() {
+    // Apply WHERE and JOIN filters (mutates qs_ in place)
+    template <const auto &Tc> void apply_where_and_join() {
         if constexpr (!Tc.join_name.empty()) {
             qs_.template join<&Model::sender>();
         }
@@ -104,17 +103,42 @@ template <typename Model, typename ConnType> class QueryRunnerBase {
             qs_.where(build_where_node_expr<0, Tc, Model>());
         else if constexpr (!Tc.where.field.empty())
             apply_where<Tc>();
+    }
+
+    // Return a QuerySet with ORDER BY / LIMIT / OFFSET applied
+    // order_by/limit/offset return finalized QuerySet<T,C,true> by value
+    // When no modifiers: returns qs_ by reference (avoids copy — QuerySet has unique_ptr members)
+    template <const auto &Tc> decltype(auto) qs_with_modifiers() { // NOSONAR(S3776) -- inherent constexpr dispatch
         if constexpr (!Tc.order_by.field.empty()) {
             constexpr auto fi = dispatch_field<Model>(Tc.order_by.field.view());
-            if constexpr (Tc.order_by.asc)
-                qs_.template order_by<fi, true>();
-            else
-                qs_.template order_by<fi, false>();
+            if constexpr (Tc.order_by.asc) {
+                if constexpr (Tc.limit_value >= 0 && Tc.offset_value >= 0)
+                    return qs_.template order_by<fi, true>().limit(Tc.limit_value).offset(Tc.offset_value);
+                else if constexpr (Tc.limit_value >= 0)
+                    return qs_.template order_by<fi, true>().limit(Tc.limit_value);
+                else if constexpr (Tc.offset_value >= 0)
+                    return qs_.template order_by<fi, true>().offset(Tc.offset_value);
+                else
+                    return qs_.template order_by<fi, true>();
+            } else {
+                if constexpr (Tc.limit_value >= 0 && Tc.offset_value >= 0)
+                    return qs_.template order_by<fi, false>().limit(Tc.limit_value).offset(Tc.offset_value);
+                else if constexpr (Tc.limit_value >= 0)
+                    return qs_.template order_by<fi, false>().limit(Tc.limit_value);
+                else if constexpr (Tc.offset_value >= 0)
+                    return qs_.template order_by<fi, false>().offset(Tc.offset_value);
+                else
+                    return qs_.template order_by<fi, false>();
+            }
+        } else if constexpr (Tc.limit_value >= 0 && Tc.offset_value >= 0) {
+            return qs_.limit(Tc.limit_value).offset(Tc.offset_value);
+        } else if constexpr (Tc.limit_value >= 0) {
+            return qs_.limit(Tc.limit_value);
+        } else if constexpr (Tc.offset_value >= 0) {
+            return qs_.offset(Tc.offset_value);
+        } else {
+            return (qs_); // parentheses → returns by reference (no copy)
         }
-        if constexpr (Tc.limit_value >= 0)
-            qs_.limit(Tc.limit_value);
-        if constexpr (Tc.offset_value >= 0)
-            qs_.offset(Tc.offset_value);
     }
 };
 

--- a/tests/test_select_runner.h
+++ b/tests/test_select_runner.h
@@ -44,9 +44,9 @@ template <typename Model, typename ConnType> class SelectRunner : public SelectQ
     }
 
     template <const auto &Tc> void run() { // NOSONAR(S3776) -- inherent constexpr dispatch
-        this->template apply_query_filters<Tc>();
+        this->template apply_where_and_join<Tc>();
         if constexpr (Tc.query_type == "first") {
-            auto r = this->qs_.first().execute();
+            auto r = this->template qs_with_modifiers<Tc>().first().execute();
             ASSERT_TRUE(r.has_value()) << r.error().message();
             EXPECT_EQ(r.value().has_value() ? 1 : 0, Tc.expected.count);
             if constexpr (Tc.expected.count == 1) {
@@ -54,7 +54,7 @@ template <typename Model, typename ConnType> class SelectRunner : public SelectQ
                 verify_first_row<Tc>(r.value().value());
             }
         } else if constexpr (Tc.query_type == "one") {
-            auto r = this->qs_.get().execute();
+            auto r = this->template qs_with_modifiers<Tc>().get().execute();
             if constexpr (Tc.expected.count == 1) {
                 ASSERT_TRUE(r.has_value()) << r.error().message();
                 verify_first_row<Tc>(r.value());
@@ -62,7 +62,7 @@ template <typename Model, typename ConnType> class SelectRunner : public SelectQ
                 EXPECT_FALSE(r.has_value());
             }
         } else {
-            auto result = this->qs_.select().execute();
+            auto result = this->template qs_with_modifiers<Tc>().select().execute();
             ASSERT_TRUE(result.has_value()) << result.error().message();
             EXPECT_EQ(static_cast<int>(result.value().size()), Tc.expected.count);
             if constexpr (Tc.expected.count > 0) {
@@ -79,7 +79,7 @@ template <typename Model, typename ConnType> class SelectRunner : public SelectQ
 template <typename Model, typename ConnType> class AggregateRunner : public SelectQueryRunnerBase<Model, ConnType> {
   public:
     template <const auto &Tc> void run() { // NOSONAR(S3776) -- inherent constexpr dispatch
-        this->template apply_query_filters<Tc>();
+        this->template apply_where_and_join<Tc>();
 
         if constexpr (Tc.query_type == "count") {
             auto r = this->qs_.count().get();
@@ -139,7 +139,7 @@ template <typename Model, typename ConnType> class ChainAggRunner : public Selec
     template <const auto &Tc>
     // NOLINTNEXTLINE(readability-function-cognitive-complexity)
     void run() { // NOSONAR(S3776) -- inherent constexpr dispatch
-        this->template apply_query_filters<Tc>();
+        this->template apply_where_and_join<Tc>();
 
         if constexpr (Tc.chain_len == 2) {
             if constexpr (Tc.aggregations[0].func == "sum" && Tc.aggregations[1].func == "count") {
@@ -299,16 +299,16 @@ template <typename Model, typename ConnType> class ChainAggRunner : public Selec
 template <typename Model, typename ConnType> class DistinctRunner : public SelectQueryRunnerBase<Model, ConnType> {
   public:
     template <const auto &Tc> void run() {
-        this->template apply_query_filters<Tc>();
+        this->template apply_where_and_join<Tc>();
         if constexpr (!Tc.distinct_field2.empty()) {
             constexpr auto fi1 = dispatch_field<Model>(Tc.distinct_field.view());
             constexpr auto fi2 = dispatch_field<Model>(Tc.distinct_field2.view());
-            auto r = this->qs_.template distinct<fi1, fi2>().select();
+            auto r = this->template qs_with_modifiers<Tc>().template distinct<fi1, fi2>().select();
             ASSERT_TRUE(r.has_value()) << r.error().message();
             EXPECT_EQ(static_cast<int>(r.value().size()), Tc.expected.count);
         } else {
             constexpr auto fi = dispatch_field<Model>(Tc.distinct_field.view());
-            auto r = this->qs_.template distinct<fi>().select();
+            auto r = this->template qs_with_modifiers<Tc>().template distinct<fi>().select();
             ASSERT_TRUE(r.has_value()) << r.error().message();
             EXPECT_EQ(static_cast<int>(r.value().size()), Tc.expected.count);
         }
@@ -321,27 +321,28 @@ template <typename Model, typename ConnType> class DistinctRunner : public Selec
 template <typename Model, typename ConnType> class GroupByRunner : public SelectQueryRunnerBase<Model, ConnType> {
   public:
     template <const auto &Tc> void run() { // NOSONAR(S3776) -- inherent constexpr dispatch
-        this->template apply_query_filters<Tc>();
+        this->template apply_where_and_join<Tc>();
+        decltype(auto) qs = this->template qs_with_modifiers<Tc>();
 
         constexpr auto gb_fi = dispatch_field<Model>(Tc.group_by_field.view());
 
         if constexpr (Tc.query_type == "group_count") {
             if constexpr (!Tc.group_by_field2.empty()) {
                 constexpr auto gb_fi2 = dispatch_field<Model>(Tc.group_by_field2.view());
-                auto r = this->qs_.template group_by<gb_fi, gb_fi2>().count().select();
+                auto r = qs.template group_by<gb_fi, gb_fi2>().count().select();
                 ASSERT_TRUE(r.has_value()) << r.error().message();
                 EXPECT_EQ(static_cast<int>(r.value().size()), Tc.expected.count);
             } else {
                 if constexpr (!Tc.having_field.empty()) {
                     constexpr auto hv_fi = dispatch_field<Model>(Tc.having_field.view());
-                    auto r = this->qs_.template group_by<gb_fi>()
+                    auto r = qs.template group_by<gb_fi>()
                                  .having(build_where_expr<hv_fi>(Tc.having_op.view(), Tc.having_value_int))
                                  .count()
                                  .select();
                     ASSERT_TRUE(r.has_value()) << r.error().message();
                     EXPECT_EQ(static_cast<int>(r.value().size()), Tc.expected.count);
                 } else {
-                    auto r = this->qs_.template group_by<gb_fi>().count().select();
+                    auto r = qs.template group_by<gb_fi>().count().select();
                     ASSERT_TRUE(r.has_value()) << r.error().message();
                     EXPECT_EQ(static_cast<int>(r.value().size()), Tc.expected.count);
                     if constexpr (Tc.expected.groups_count > 0) { // NOSONAR(S134) -- constexpr nesting
@@ -362,7 +363,7 @@ template <typename Model, typename ConnType> class GroupByRunner : public Select
 
         } else if constexpr (Tc.query_type == "group_sum") {
             constexpr auto agg_fi = dispatch_field<Model>(Tc.agg_field.view());
-            auto r = this->qs_.template group_by<gb_fi>().template sum<agg_fi>().select();
+            auto r = qs.template group_by<gb_fi>().template sum<agg_fi>().select();
             ASSERT_TRUE(r.has_value()) << r.error().message();
             EXPECT_EQ(static_cast<int>(r.value().size()), Tc.expected.count);
             if constexpr (Tc.expected.groups_count > 0) {
@@ -379,7 +380,7 @@ template <typename Model, typename ConnType> class GroupByRunner : public Select
 
         } else if constexpr (Tc.query_type == "group_avg") {
             constexpr auto agg_fi = dispatch_field<Model>(Tc.agg_field.view());
-            auto r = this->qs_.template group_by<gb_fi>().template avg<agg_fi>().select();
+            auto r = qs.template group_by<gb_fi>().template avg<agg_fi>().select();
             ASSERT_TRUE(r.has_value()) << r.error().message();
             EXPECT_EQ(static_cast<int>(r.value().size()), Tc.expected.count);
             if constexpr (Tc.expected.groups_count > 0) {
@@ -397,7 +398,7 @@ template <typename Model, typename ConnType> class GroupByRunner : public Select
 
         } else if constexpr (Tc.query_type == "group_min") {
             constexpr auto agg_fi = dispatch_field<Model>(Tc.agg_field.view());
-            auto r = this->qs_.template group_by<gb_fi>().template min<agg_fi>().select();
+            auto r = qs.template group_by<gb_fi>().template min<agg_fi>().select();
             ASSERT_TRUE(r.has_value()) << r.error().message();
             EXPECT_EQ(static_cast<int>(r.value().size()), Tc.expected.count);
             if constexpr (Tc.expected.groups_count > 0) {
@@ -415,7 +416,7 @@ template <typename Model, typename ConnType> class GroupByRunner : public Select
 
         } else if constexpr (Tc.query_type == "group_max") {
             constexpr auto agg_fi = dispatch_field<Model>(Tc.agg_field.view());
-            auto r = this->qs_.template group_by<gb_fi>().template max<agg_fi>().select();
+            auto r = qs.template group_by<gb_fi>().template max<agg_fi>().select();
             ASSERT_TRUE(r.has_value()) << r.error().message();
             EXPECT_EQ(static_cast<int>(r.value().size()), Tc.expected.count);
             if constexpr (Tc.expected.groups_count > 0) {


### PR DESCRIPTION
## Summary

- Add `bool Finalized_` template parameter to `QuerySet` — `order_by()`, `limit()`, `offset()` now return `QuerySet<T, ConnType, true>` by value
- Set-op methods (`union_`, `union_all`, `except_`, `intersect_`, `capture_operand`) constrained with `requires (!Finalized_)` — prevents misuse at compile time
- Runtime `assert()` checks removed from `capture_operand()` — now enforced at compile time
- `static_assert` tests verify all compile-time constraints (concept-based for experimental Clang compatibility)
- Test infrastructure updated: `apply_query_filters` split into `apply_where_and_join` + `qs_with_modifiers`

Closes #142

## Test plan

- [x] All 1409 tests pass (debug)
- [x] ASAN+UBSAN clean (1409 tests)
- [x] TSAN clean (1409 tests)
- [x] 100% line coverage
- [x] No benchmark regression (quick)
- [x] static_assert tests verify: finalized QS cannot call set-ops, set-ops reject finalized operands
- [ ] SonarCloud gate passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)