### PR TITLE
feat: add [[nodiscard]] to limit(), offset(), order_by()

### DIFF
--- a/src/orm/queryset.cppm
+++ b/src/orm/queryset.cppm
@@ -128,7 +128,7 @@ export namespace storm {
         // LIMIT clause support - returns finalized QuerySet (prevents use as set-op operand)
         // Usage: queryset.limit(10).select()
         //        queryset.where(age > 25).limit(10).select()
-        constexpr auto limit(int n) -> QuerySet<T, ConnType, true> {
+        [[nodiscard]] constexpr auto limit(int n) -> QuerySet<T, ConnType, true> {
             auto result         = to_finalized();
             result.limit_value_ = n;
             return result;
@@ -137,7 +137,7 @@ export namespace storm {
         // OFFSET clause support - returns finalized QuerySet (prevents use as set-op operand)
         // Usage: queryset.offset(5).select()
         //        queryset.limit(10).offset(5).select()
-        constexpr auto offset(int n) -> QuerySet<T, ConnType, true> {
+        [[nodiscard]] constexpr auto offset(int n) -> QuerySet<T, ConnType, true> {
             auto result          = to_finalized();
             result.offset_value_ = n;
             return result;
@@ -145,7 +145,7 @@ export namespace storm {
 
         // ORDER BY clause support - returns finalized QuerySet (prevents use as set-op operand)
         // Supports single/multiple fields with ASC (default) or DESC direction
-        template <auto... Args> constexpr auto order_by() -> QuerySet<T, ConnType, true> {
+        template <auto... Args> [[nodiscard]] constexpr auto order_by() -> QuerySet<T, ConnType, true> {
             auto result              = to_finalized();
             result.order_by_wrapper_ = orm::statements::make_order_by_wrapper<Args...>();
             return result;

--- a/tests/query/test_setop.cpp
+++ b/tests/query/test_setop.cpp
@@ -786,6 +786,11 @@ static_assert(!CanIntersect<NormalQS, FinalizedQS>);
 // capture_operand() must NOT be callable on finalized QuerySet
 static_assert(!CanCaptureOperand<FinalizedQS>);
 
+// limit/offset/order_by return finalized QS (not void) — [[nodiscard]] makes discard a warning
+static_assert(!std::is_void_v<decltype(std::declval<NormalQS>().limit(1))>);
+static_assert(!std::is_void_v<decltype(std::declval<NormalQS>().offset(1))>);
+static_assert(!std::is_void_v<decltype(std::declval<NormalQS>().template order_by<^^Person::name>())>);
+
 // Non-finalized QuerySet MUST still have set-op methods (positive checks)
 static_assert(CanUnion<NormalQS, NormalQS>);
 static_assert(CanUnionAll<NormalQS, NormalQS>);


### PR DESCRIPTION
## Summary

- Add `[[nodiscard]]` to `limit()`, `offset()`, `order_by()` in `queryset.cppm` — compiler warns if the returned finalized `QuerySet` is discarded
- Add 3 `static_assert` compile-time checks in `test_setop.cpp` verifying these methods return non-void

Closes #144

## Test plan

- [x] All 1409 tests pass (`ctest --preset ninja-debug`)
- [x] No new compiler warnings
- [ ] SonarCloud gate passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)