### PR TITLE
feat: add cookbook, build instructions, fix broken doc links

### DIFF
--- a/docs/COOKBOOK.md
+++ b/docs/COOKBOOK.md
@@ -1,0 +1,202 @@
+# Storm ORM Cookbook
+
+Quick-reference patterns for common Storm ORM operations.
+
+## Setup
+
+```cpp
+import storm;
+using namespace storm;
+
+// Define a model — reflection maps fields to columns automatically
+struct Person {
+    [[storm::primary_key, storm::auto_increment]] int id;
+    std::string name;
+    int age;
+    double salary;
+    bool is_active;
+    std::optional<int> score;
+};
+
+// Connect (thread-local, one per thread)
+QuerySet<Person>::set_default_connection(":memory:");
+QuerySet<Person> qs;
+```
+
+## INSERT
+
+```cpp
+// Single insert (id auto-generated)
+Person p{.name = "Alice", .age = 30, .salary = 75000.0, .is_active = true};
+qs.insert(p);
+
+// Batch insert
+plf::hive<Person> people;
+people.insert({.name = "Bob", .age = 25, .salary = 60000.0, .is_active = true});
+people.insert({.name = "Carol", .age = 35, .salary = 80000.0, .is_active = false});
+qs.insert(people);
+```
+
+## SELECT
+
+```cpp
+// Select all
+auto all = qs.select();
+
+// With WHERE
+auto seniors = qs.where(field<^^Person::age>() > 30).select();
+
+// With ORDER BY + LIMIT + OFFSET
+auto page = qs
+    .where(field<^^Person::is_active>() == true)
+    .order_by<^^Person::name>()
+    .limit(10)
+    .offset(20)
+    .select();
+```
+
+## WHERE Clauses
+
+```cpp
+// Comparison operators
+qs.where(field<^^Person::age>() == 30).select();
+qs.where(field<^^Person::age>() != 30).select();
+qs.where(field<^^Person::age>() > 30).select();
+qs.where(field<^^Person::age>() >= 30).select();
+qs.where(field<^^Person::age>() < 30).select();
+qs.where(field<^^Person::age>() <= 30).select();
+
+// LIKE
+qs.where(field<^^Person::name>().like("A%")).select();
+
+// IN
+qs.where(field<^^Person::age>().in(25, 30, 35)).select();
+
+// BETWEEN
+qs.where(field<^^Person::age>().between(25, 35)).select();
+
+// AND / OR
+qs.where(field<^^Person::age>() > 30 && field<^^Person::is_active>() == true).select();
+qs.where(field<^^Person::age>() < 25 || field<^^Person::age>() > 40).select();
+```
+
+## UPDATE
+
+```cpp
+// Single update
+Person p = /* ... fetched from select ... */;
+p.salary = 85000.0;
+qs.update(p);
+
+// Batch update
+auto people = qs.select();
+for (auto& p : people) { p.salary *= 1.1; }
+qs.update(people);
+```
+
+## DELETE
+
+```cpp
+// Single remove
+qs.remove(p);
+
+// Remove all matching
+auto inactive = qs.where(field<^^Person::is_active>() == false).select();
+qs.remove(inactive);
+
+// Remove all
+qs.remove_all();
+```
+
+## Aggregates
+
+```cpp
+// Scalar aggregates (no GROUP BY) — use .get()
+auto count = qs.count().get();                           // int64_t
+auto total = qs.sum<^^Person::salary>().get();           // int64_t
+auto avg   = qs.avg<^^Person::salary>().get();           // double
+auto lo    = qs.min<^^Person::age>().get();              // int64_t
+auto hi    = qs.max<^^Person::age>().get();              // int64_t
+
+// With WHERE
+auto active_count = qs.where(field<^^Person::is_active>() == true).count().get();
+```
+
+## GROUP BY + HAVING
+
+```cpp
+// Group and count
+auto groups = qs.group_by<^^Person::is_active>().count().select();
+
+// GROUP BY with HAVING
+auto large_groups = qs
+    .group_by<^^Person::age>()
+    .having(field<^^Person::age>() > 30)
+    .count()
+    .select();
+```
+
+## DISTINCT
+
+```cpp
+// Single field
+auto names = qs.distinct<^^Person::name>().select();
+
+// Multi-field
+auto combos = qs.distinct<^^Person::name, ^^Person::age>().select();
+```
+
+## Column Projection (VALUES)
+
+```cpp
+// Single column → hive<T>
+auto names = qs.values<^^Person::name>().select();  // plf::hive<std::string>
+
+// Multiple columns → hive<tuple<...>>
+auto pairs = qs.values<^^Person::name, ^^Person::age>().select();
+// plf::hive<std::tuple<std::string, int>>
+```
+
+## JOIN
+
+```cpp
+struct Message {
+    [[storm::primary_key, storm::auto_increment]] int id;
+    std::string content;
+    [[storm::foreign_key<^^Person::id>]] int sender;
+};
+
+QuerySet<Message> msg_qs;
+auto results = msg_qs.join<Message>().where(...).select();
+```
+
+## Set Operations
+
+```cpp
+QuerySet<Person> qs1, qs2;
+
+// UNION (deduplicated)
+auto combined = qs1.where(field<^^Person::age>() > 30)
+    .union_with(qs2.where(field<^^Person::is_active>() == true))
+    .select();
+
+// UNION ALL (keeps duplicates)
+auto all = qs1.where(...).union_all(qs2.where(...)).select();
+
+// INTERSECT / EXCEPT
+auto common = qs1.where(...).intersect(qs2.where(...)).select();
+auto diff   = qs1.where(...).except_with(qs2.where(...)).select();
+```
+
+## Thread Safety
+
+```cpp
+// Each thread gets its own connection — safe
+void worker() {
+    QuerySet<Person>::set_default_connection(":memory:");
+    QuerySet<Person> qs;
+    qs.where(field<^^Person::age>() > 30).select();
+}
+
+std::jthread t1(worker), t2(worker);
+```

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,8 +6,8 @@ Welcome to Storm ORM - a modern C++26 ORM library using compile-time reflection 
 
 ## Quick Links
 
-- **[Main Project Guide (CLAUDE.md)](../CLAUDE.md)** - Quick start and common tasks
-- **[Benchmarks](../benchmarks/README.md)** - Performance results and benchmark system
+- **[Main Project Guide (CLAUDE.md)](https://github.com/spiritEcosse/storm/blob/develop/CLAUDE.md)** - Quick start and common tasks
+- **[Benchmarks](https://github.com/spiritEcosse/storm/blob/develop/benchmarks/README.md)** - Performance results and benchmark system
 
 ## Features
 
@@ -30,7 +30,7 @@ Welcome to Storm ORM - a modern C++26 ORM library using compile-time reflection 
 
 ## Benchmarks
 
-- **[Benchmark System](../benchmarks/README.md)** - Compile-time benchmark system with size profiles and category filtering
+- **[Benchmark System](https://github.com/spiritEcosse/storm/blob/develop/benchmarks/README.md)** - Compile-time benchmark system with size profiles and category filtering
 - **[JOIN Analysis](benchmarks/JOIN_ANALYSIS.md)** - JOIN performance deep dive
 - **[DISTINCT Analysis](benchmarks/DISTINCT_ANALYSIS.md)** - DISTINCT performance analysis
 

--- a/docs/architecture/DESIGN_DECISIONS.md
+++ b/docs/architecture/DESIGN_DECISIONS.md
@@ -153,7 +153,7 @@ conn.execute("CREATE TABLE Person ("
 
 Unified caching pattern across UPDATE/DELETE/SELECT operations achieves near-raw SQLite performance.
 
-See [Statement Caching Reference](../reference/statement-caching.md) for detailed implementation.
+See [Statement Caching](STATEMENT_CACHING.md) for detailed implementation.
 
 **Performance Impact Examples:**
 - **DELETE**: 947K → 21.6M ops/sec (22.8x speedup, 73% of raw SQLite)
@@ -198,7 +198,7 @@ auto result = message_qs.join<&Message::sender>().select();
 auto result = message_qs.join<&Message::sender, &Message::receiver>().select();
 ```
 
-See [JOIN Performance Analysis](../benchmarks/join-analysis.md) for detailed performance data.
+See [JOIN Performance Analysis](../benchmarks/JOIN_ANALYSIS.md) for detailed performance data.
 
 ## 12. DISTINCT Query Support (Single & Multi-Field)
 
@@ -219,7 +219,7 @@ class DistinctStatement : private BaseStatement<T> {
 };
 ```
 
-See [DISTINCT Analysis](../benchmarks/distinct-analysis.md) for detailed implementation and performance data.
+See [DISTINCT Analysis](../benchmarks/DISTINCT_ANALYSIS.md) for detailed implementation and performance data.
 
 ## Implementation Notes
 

--- a/docs/benchmarks/DISTINCT_ANALYSIS.md
+++ b/docs/benchmarks/DISTINCT_ANALYSIS.md
@@ -164,7 +164,7 @@ Multiple QuerySet instances can safely share the same cached `DistinctQuerySet` 
 - `where_expr_` object (each QuerySet instance has its own)
 - Bound parameters (temporary, overwritten on each bind call)
 
-See [Parameter Binding Safety](../reference/statement-caching.md#parameter-binding-safety-with-shared-cached-statements) for comprehensive explanation and examples.
+See [Statement Caching](../architecture/STATEMENT_CACHING.md) for comprehensive explanation and examples.
 
 ## Future Enhancements
 

--- a/docs/benchmarks/JOIN_ANALYSIS.md
+++ b/docs/benchmarks/JOIN_ANALYSIS.md
@@ -24,7 +24,7 @@ All benchmarks performed on 10,000 rows with 100 iterations in Release builds.
 
 ## Architecture
 
-See [Design Decisions](../architecture/design-decisions.md#11-join-architecture-type-erased-sql-builder-pattern) for detailed architecture.
+See [Design Decisions](../architecture/DESIGN_DECISIONS.md#11-join-architecture-type-erased-sql-builder-pattern) for detailed architecture.
 
 **Key Components:**
 - Abstract base class (`IJoinStatement`) for type erasure
@@ -126,4 +126,4 @@ python3 bench.py --joins --messages=10000  # Custom size
 ./build/release/benchmarks/bench_join --storm-join-1 --raw-join-1 --size=10000
 ```
 
-See [benchmarks/README.md](../../benchmarks/README.md) for comprehensive guide.
+See [benchmarks/README.md](https://github.com/spiritEcosse/storm/blob/develop/benchmarks/README.md) for comprehensive guide.

--- a/docs/development/COMMON_TASKS.md
+++ b/docs/development/COMMON_TASKS.md
@@ -1,5 +1,28 @@
 # Common Development Tasks
 
+## Building and Serving Documentation
+
+Storm uses [MkDocs Material](https://squidfunk.github.io/mkdocs-material/) for hosted documentation.
+
+```bash
+# Install (Arch Linux)
+sudo pacman -S mkdocs-material python-pymdown-extensions
+
+# Install (pip)
+pip install mkdocs-material
+
+# Live preview (http://127.0.0.1:8000)
+mkdocs serve
+
+# Build static site
+mkdocs build
+
+# Build with strict mode (fails on broken links)
+mkdocs build --strict
+```
+
+Documentation auto-deploys to GitHub Pages on push to `develop` when `docs/` or `mkdocs.yml` changes.
+
 ## Adding a New Database Operation
 
 1. Create statement class in `src/orm/statements/` inheriting from `BaseStatement<T>`

--- a/docs/development/PERFORMANCE_TESTING.md
+++ b/docs/development/PERFORMANCE_TESTING.md
@@ -256,4 +256,4 @@ void raw_benchmark(int batch_size) { ... }  // Same decision logic
 ## See Also
 
 - [Adding Features](ADDING_FEATURES.md) - Development workflow
-- [Benchmarks](../../benchmarks/README.md) - Current benchmark results
+- [Benchmarks](https://github.com/spiritEcosse/storm/blob/develop/benchmarks/README.md) - Current benchmark results

--- a/docs/development/TESTING.md
+++ b/docs/development/TESTING.md
@@ -31,7 +31,7 @@
 - DISTINCT queries
 - Batch operations
 
-See [benchmarks/README.md](../../benchmarks/README.md) for detailed benchmark documentation.
+See [benchmarks/README.md](https://github.com/spiritEcosse/storm/blob/develop/benchmarks/README.md) for detailed benchmark documentation.
 
 ## Running Tests
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,6 +40,7 @@ markdown_extensions:
 
 nav:
   - Home: README.md
+  - Cookbook: COOKBOOK.md
   - Architecture:
       - Overview: architecture/OVERVIEW.md
       - Design Decisions: architecture/DESIGN_DECISIONS.md


### PR DESCRIPTION
## Summary
- Add `docs/COOKBOOK.md` with categorized query pattern examples
- Add MkDocs build/serve instructions to `docs/development/COMMON_TASKS.md`
- Fix all 11 broken links across docs (lowercase filenames, out-of-tree references)
- `mkdocs build --strict` now passes with zero warnings

Closes #140

## Test plan
- [x] `mkdocs build --strict` passes with zero warnings
- [ ] Verify cookbook renders correctly on GitHub Pages after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)