### PR TITLE
fix: reset WHERE clause in WhereRepeatedQueries tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,4 @@ jobs:
       - name: Test
         env:
           STORM_PG_CONNSTR: "host=postgres port=5432 dbname=storm_db user=storm_db password=storm_db"
-        run: >
-          ctest --test-dir build/${{ matrix.build_dir }} --output-on-failure --no-tests=error
-          --exclude-regex "AggregateTest.WhereRepeatedQueries<storm::db::sqlite"
+        run: ctest --test-dir build/${{ matrix.build_dir }} --output-on-failure --no-tests=error

--- a/tests/query/test_aggregate.cpp
+++ b/tests/query/test_aggregate.cpp
@@ -399,8 +399,9 @@ TYPED_TEST(AggregateTest, WhereRepeatedQueries) {
 
     // Run same WHERE + aggregate query multiple times (tests caching)
     for (int i = 0; i < 100; ++i) {
+        (*this->qs).reset();
         auto result = this->qs->where(storm::orm::where::field<^^Person::age>() > 30).count().get();
-        ASSERT_TRUE(result.has_value()) << "Iteration " << i << " failed";
+        ASSERT_TRUE(result.has_value()) << "Iteration " << i << " failed: " << result.error().message();
         EXPECT_EQ(result.value(), 13);
     }
 }
@@ -435,11 +436,12 @@ TYPED_TEST(AggregateTest, WhereJoinRepeatedQueries) {
 
     // Run same WHERE + JOIN + aggregate query multiple times (tests caching)
     for (int i = 0; i < 50; ++i) {
+        (*this->msg_qs).reset();
         auto result = this->msg_qs->where(storm::orm::where::field<^^Message::value>() > 20)
                               .template join<&Message::sender>()
                               .count()
                               .get();
-        ASSERT_TRUE(result.has_value()) << "Iteration " << i << " failed";
+        ASSERT_TRUE(result.has_value()) << "Iteration " << i << " failed: " << result.error().message();
         EXPECT_EQ(result.value(), 4); // 30, 40, 50, 60
     }
 }


### PR DESCRIPTION
## Summary
- Fixed `AggregateTest.WhereRepeatedQueries` and `WhereJoinRepeatedQueries` tests that were accumulating WHERE clauses across loop iterations without `.reset()`, creating ever-growing SQL strings that caused failures at ~90 iterations in CI
- Removed the `--exclude-regex` workaround from `.github/workflows/ci.yml`
- Added error message output to assertion failures for better diagnostics

Closes #151

## Test plan
- [x] All 1451 tests pass locally (ninja-debug)
- [x] ASAN+UBSAN clean on affected tests
- [ ] CI passes without the `--exclude-regex` exclusion

🤖 Generated with [Claude Code](https://claude.com/claude-code)