### PR TITLE
feat: make where() return new QuerySet (immutable)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,7 +83,7 @@ cmake/
 ### Branching Rules
 - **GitHub Issue work**: Create and link a feature branch using `gh issue develop <N> --name feature/<N>-<short-description> --base develop --checkout` — this creates the branch, links it to the issue in GitHub, and checks it out in one step.
 - **Create pull request**: After pushing a feature branch, ALWAYS create a PR with `gh pr create --base develop` including `Closes #<N>` in the body to auto-link and auto-close the issue on merge.
-- **After creating a PR**: Wait 30 seconds, then run `/sonarcloud-status`. If there are **zero issues** on new code, immediately merge the PR into `develop` (`gh pr merge --merge`). If there are ANY issues (even minor), fix them all, push, and re-check until zero issues remain before merging.
+- **After creating a PR**: Wait 30 seconds, then run `/sonarcloud-status`. If there are **zero issues** on new code, check CI jobs with `gh pr checks <PR#> --watch`. Only merge after **both** SonarCloud gate AND all CI jobs (ninja-debug, ninja-asan-ubsan, ninja-tsan) pass (`gh pr merge --squash`). If ANY SonarCloud issues or CI failures, fix them all, push, and re-check until clean.
 - **Close issue after merge**: After merging a feature branch into `develop`, ALWAYS close the issue with `gh issue close <N>`. Do NOT wait to be asked.
 - **Switch to develop after merge**: After merging and closing the issue, ALWAYS run `git checkout develop && git pull` to return to the main branch.
 - **Ad-hoc fixes** (no GitHub Issue): Work directly on `develop`.

--- a/benchmarks/operations/select_query_base.hpp
+++ b/benchmarks/operations/select_query_base.hpp
@@ -319,7 +319,7 @@ namespace storm::benchmark {
             }
             if constexpr (WhereCfg::enabled) {
                 auto where_clause = build_where_clause();
-                Base::qs().where(where_clause);
+                Base::qs()        = Base::qs().where(where_clause);
             }
             if constexpr (OrderByCfg::enabled) {
                 // Storm ORM order_by uses boolean: true = ASC (default), false = DESC

--- a/benchmarks/operations/setop.hpp
+++ b/benchmarks/operations/setop.hpp
@@ -92,31 +92,39 @@ namespace storm::benchmark {
         int execute(int iterations) {
             // Build WHERE expressions and set operation builder ONCE (setup cost)
             auto left_where = field<^^Model::age>() < left_threshold_;
-            Base::qs().where(left_where);
+            auto qs_left    = Base::qs().where(left_where);
 
             if constexpr (needs_overlap) {
                 auto right_where = field<^^Model::age>() > right_threshold_;
-                qs_right_.where(right_where);
+                auto qs_r        = qs_right_.where(right_where);
+
+                auto builder = make_builder(qs_left, qs_r);
+                apply_modifiers(builder);
+
+                int total = 0;
+                for (int i = 0; i < iterations; i++) {
+                    auto result = builder.execute();
+                    if (result.has_value()) {
+                        total += static_cast<int>(result.value().size());
+                    }
+                }
+                return total;
             } else {
                 auto right_where = field<^^Model::age>() >= right_threshold_;
-                qs_right_.where(right_where);
-            }
+                auto qs_r        = qs_right_.where(right_where);
 
-            auto builder = make_builder(Base::qs(), qs_right_);
-            apply_modifiers(builder);
+                auto builder = make_builder(qs_left, qs_r);
+                apply_modifiers(builder);
 
-            // Execute in loop — statement caching kicks in after first call
-            int total = 0;
-            for (int i = 0; i < iterations; i++) {
-                auto result = builder.execute();
-                if (result.has_value()) {
-                    total += static_cast<int>(result.value().size());
+                int total = 0;
+                for (int i = 0; i < iterations; i++) {
+                    auto result = builder.execute();
+                    if (result.has_value()) {
+                        total += static_cast<int>(result.value().size());
+                    }
                 }
+                return total;
             }
-
-            Base::qs().reset();
-            qs_right_.reset();
-            return total;
         }
 
         int execute_raw(int iterations) {

--- a/benchmarks/operations/where_operators.hpp
+++ b/benchmarks/operations/where_operators.hpp
@@ -53,16 +53,15 @@ namespace storm::benchmark {
 
         int execute(int iterations) {
             auto where_clause = field<FieldInfo>().like(pattern_);
-            Base::qs().where(where_clause);
+            auto filtered     = Base::qs().where(where_clause);
 
             int total = 0;
             for (int i = 0; i < iterations; i++) {
-                auto result = Base::qs().select().execute();
+                auto result = filtered.select().execute();
                 if (result.has_value()) {
                     total += result.value().size();
                 }
             }
-            Base::qs().reset();
             return total;
         }
 
@@ -144,16 +143,15 @@ namespace storm::benchmark {
 
         int execute(int iterations) {
             auto where_clause = field<FieldInfo>().between(min_value_, max_value_);
-            Base::qs().where(where_clause);
+            auto filtered     = Base::qs().where(where_clause);
 
             int total = 0;
             for (int i = 0; i < iterations; i++) {
-                auto result = Base::qs().select().execute();
+                auto result = filtered.select().execute();
                 if (result.has_value()) {
                     total += result.value().size();
                 }
             }
-            Base::qs().reset();
             return total;
         }
 
@@ -249,16 +247,15 @@ namespace storm::benchmark {
             // Build IN expression using field<>().in(values...)
             // We need to use the runtime API since we have a vector
             auto where_clause = build_in_clause();
-            Base::qs().where(where_clause);
+            auto filtered     = Base::qs().where(where_clause);
 
             int total = 0;
             for (int i = 0; i < iterations; i++) {
-                auto result = Base::qs().select().execute();
+                auto result = filtered.select().execute();
                 if (result.has_value()) {
                     total += result.value().size();
                 }
             }
-            Base::qs().reset();
             return total;
         }
 
@@ -384,16 +381,15 @@ namespace storm::benchmark {
 
         int execute(int iterations) {
             auto where_clause = build_where_clause();
-            Base::qs().where(where_clause);
+            auto filtered     = Base::qs().where(where_clause);
 
             int total = 0;
             for (int i = 0; i < iterations; i++) {
-                auto result = Base::qs().select().execute();
+                auto result = filtered.select().execute();
                 if (result.has_value()) {
                     total += result.value().size();
                 }
             }
-            Base::qs().reset();
             return total;
         }
 

--- a/src/orm/queryset.cppm
+++ b/src/orm/queryset.cppm
@@ -113,16 +113,17 @@ export namespace storm {
         //   queryset.where(field<^^Person::age>() > 25 and field<^^Person::is_active>() == true).select()
         //   queryset.where((field<^^Person::age>() > 25) or (field<^^Person::name>().like("A%"))).select()
         //
-        constexpr auto where(this auto&& self, orm::where::ExpressionVariantPtr expr) -> auto&& { // NOSONAR(cpp:S6189)
-            if (self.where_expr_) {
+        [[nodiscard]] auto where(orm::where::ExpressionVariantPtr expr) const -> QuerySet {
+            auto result = clone_state();
+            if (result.where_expr_) {
                 // Combine with existing expression using AND
-                self.where_expr_ = std::make_shared<orm::where::ExpressionVariant>(
-                        orm::where::LogicalExpr{self.where_expr_, orm::where::LogicalOp::And, expr}
+                result.where_expr_ = std::make_shared<orm::where::ExpressionVariant>(
+                        orm::where::LogicalExpr{result.where_expr_, orm::where::LogicalOp::And, expr}
                 );
             } else {
-                self.where_expr_ = expr;
+                result.where_expr_ = expr;
             }
-            return std::forward<decltype(self)>(self);
+            return result;
         }
 
         // LIMIT clause support - returns finalized QuerySet (prevents use as set-op operand)
@@ -511,6 +512,18 @@ export namespace storm {
 
         // Private constructor for to_finalized() — takes explicit connection
         explicit QuerySet(std::shared_ptr<ConnType> conn) : conn_(std::move(conn)) {}
+
+        // Create a shallow copy carrying query state (where, join, limit, offset, order_by)
+        // Statement caches are NOT copied — they are lazy-init'd on demand via prepare_cached()
+        auto clone_state() const -> QuerySet {
+            QuerySet result(conn_);
+            result.where_expr_       = where_expr_;
+            result.join_stmt_        = join_stmt_;
+            result.limit_value_      = limit_value_;
+            result.offset_value_     = offset_value_;
+            result.order_by_wrapper_ = order_by_wrapper_;
+            return result;
+        }
 
         // Create a finalized copy carrying conn_, where, join, limit, offset, order_by state
         // Statement caches are NOT copied — they are lazy-init'd on demand via prepare_cached()

--- a/tests/crud/test_crud.cpp
+++ b/tests/crud/test_crud.cpp
@@ -425,14 +425,13 @@ template <typename ConnType> class QueryResetTest : public StormTestFixture<Pers
 TYPED_TEST_SUITE(QueryResetTest, DatabaseTypes);
 
 TYPED_TEST(QueryResetTest, ResetClearsAllState) {
-    this->qs->where(storm::orm::where::field<^^Person::age>() > 25);
+    auto filtered = this->qs->where(storm::orm::where::field<^^Person::age>() > 25);
 
-    auto result1 = this->qs->template order_by<^^Person::name>().limit(2).offset(1).select().execute();
+    auto result1 = filtered.template order_by<^^Person::name>().limit(2).offset(1).select().execute();
     ASSERT_TRUE(result1.has_value());
     EXPECT_LE(result1.value().size(), 2);
 
-    this->qs->reset();
-
+    // Original qs is unaffected — no reset needed
     auto result2 = this->qs->select().execute();
     ASSERT_TRUE(result2.has_value());
     EXPECT_EQ(result2.value().size(), 25);
@@ -443,11 +442,12 @@ TYPED_TEST(QueryResetTest, ReuseSameQuerySetMultipleTimes) {
     ASSERT_TRUE(result1.has_value());
     EXPECT_EQ(result1.value().size(), 9);
 
+    // Original qs is unaffected by where() — still returns all rows
     auto result2 = this->qs->select().execute();
     ASSERT_TRUE(result2.has_value());
-    EXPECT_EQ(result2.value().size(), 9);
+    EXPECT_EQ(result2.value().size(), 25);
 
-    this->qs->reset();
+    // Can create a different filter without reset
     auto result3 = this->qs->where(storm::orm::where::field<^^Person::age>() < 35).select().execute();
     ASSERT_TRUE(result3.has_value());
     EXPECT_EQ(result3.value().size(), 14);

--- a/tests/mock_libpq/test_orm_pg_mock_errors.cpp
+++ b/tests/mock_libpq/test_orm_pg_mock_errors.cpp
@@ -1155,6 +1155,24 @@ namespace {
         EXPECT_TRUE(results.value().empty());
     }
 
+    // Covers queryset.cppm lines 296-298: reset() invalidates cached select statement
+    // Covers select.cppm lines 239-244: invalidate_cache() body
+    TEST_F(PgOrmInsertReturningTest, ResetInvalidatesSelectCache) {
+        MockPqConfig::exec_prepared_ntuples(0);
+
+        PgQuerySet qs;
+        // Execute a select to populate select_stmt_ cache
+        auto results = qs.select().execute();
+        ASSERT_TRUE(results.has_value());
+
+        // Reset should invalidate the cached select statement
+        qs.reset();
+
+        // Verify the queryset works correctly after reset
+        auto results2 = qs.select().execute();
+        ASSERT_TRUE(results2.has_value());
+    }
+
     // ============================================================================
     // Concept-based mock connection with failing binds
     // Tests INSERT RETURNING bind error path (insert.cppm line 264-267)

--- a/tests/query/test_aggregate.cpp
+++ b/tests/query/test_aggregate.cpp
@@ -398,8 +398,8 @@ TYPED_TEST(AggregateTest, WhereRepeatedQueries) {
     this->insert_test_data();
 
     // Run same WHERE + aggregate query multiple times (tests caching)
+    // No reset() needed — where() returns a new QuerySet each time
     for (int i = 0; i < 100; ++i) {
-        (*this->qs).reset();
         auto result = this->qs->where(storm::orm::where::field<^^Person::age>() > 30).count().get();
         ASSERT_TRUE(result.has_value()) << "Iteration " << i << " failed: " << result.error().message();
         EXPECT_EQ(result.value(), 13);
@@ -435,8 +435,8 @@ TYPED_TEST(AggregateTest, WhereJoinRepeatedQueries) {
     this->insert_join_test_data();
 
     // Run same WHERE + JOIN + aggregate query multiple times (tests caching)
+    // No reset() needed — where() returns a new QuerySet each time
     for (int i = 0; i < 50; ++i) {
-        (*this->msg_qs).reset();
         auto result = this->msg_qs->where(storm::orm::where::field<^^Message::value>() > 20)
                               .template join<&Message::sender>()
                               .count()

--- a/tests/query/test_where.cpp
+++ b/tests/query/test_where.cpp
@@ -57,34 +57,32 @@ TYPED_TEST(WhereTest, WhereComplexExpression) {
     ASSERT_EQ(people.size(), 18) << "Expected 18 people matching complex condition";
 }
 
-// Test: WHERE state persists after select() - enables query reusability
-TYPED_TEST(WhereTest, WherePreservesStateAfterSelect) {
+// Test: where() returns a new QuerySet; original is unchanged; returned copy is reusable
+TYPED_TEST(WhereTest, WhereReturnsCopyReusable) {
     QuerySet<Person, TypeParam> queryset;
 
-    // Set base filter
-    queryset.where(field<^^Person::age>() >= 25);
+    // where() returns a new QuerySet — original unchanged
+    auto filtered = queryset.where(field<^^Person::age>() >= 25);
 
-    // First query uses the filter
-    auto result1 = queryset.select().execute();
+    auto result1 = filtered.select().execute();
     ASSERT_TRUE(result1.has_value());
     ASSERT_EQ(result1.value().size(), 23) << "Expected 23 people with age >= 25";
 
-    // Second query still has the same filter (state preserved)
-    auto result2 = queryset.select().execute();
+    // Returned copy is reusable (state preserved after select)
+    auto result2 = filtered.select().execute();
     ASSERT_TRUE(result2.has_value());
     ASSERT_EQ(result2.value().size(), 23) << "State should persist after first select()";
 
-    // Add more conditions - they accumulate
-    queryset.where(field<^^Person::age>() < 40);
-    auto result3 = queryset.select().execute();
+    // Chaining further narrows without affecting the original filtered copy
+    auto narrower = filtered.where(field<^^Person::age>() < 40);
+    auto result3  = narrower.select().execute();
     ASSERT_TRUE(result3.has_value());
     ASSERT_EQ(result3.value().size(), 17) << "Expected 17 people with age >= 25 AND age < 40";
 
-    // reset() clears all state
-    queryset.reset();
-    auto result4 = queryset.select().execute();
-    ASSERT_TRUE(result4.has_value());
-    ASSERT_EQ(result4.value().size(), 25) << "After reset() should select all rows";
+    // Original queryset is still unfiltered
+    auto all = queryset.select().execute();
+    ASSERT_TRUE(all.has_value());
+    ASSERT_EQ(all.value().size(), 25) << "Original should be unfiltered";
 }
 
 // Test fixture for WHERE + JOIN operations — templated on database backend
@@ -278,79 +276,138 @@ TYPED_TEST(WhereTest, WhereComposableFilters) {
     EXPECT_EQ(old_a_names.value().size(), 0) << "Expected 0 people (no old people with A names)";
 }
 
-// Test: Reusable base QuerySet pattern
+// Test: Reusable base QuerySet pattern — where() returns independent copies
 TYPED_TEST(WhereTest, ReusableBaseQuerySet) {
     QuerySet<Person, TypeParam> queryset;
 
     // Create a base filtered QuerySet (age >= 25)
-    queryset.where(field<^^Person::age>() >= 25);
+    auto base = queryset.where(field<^^Person::age>() >= 25);
 
     // Reuse base filter multiple times
-    auto result1 = queryset.select().execute();
+    auto result1 = base.select().execute();
     ASSERT_TRUE(result1.has_value());
     ASSERT_EQ(result1.value().size(), 23) << "Expected 23 people with age >= 25";
 
     // Still has base filter on second call
-    auto result2 = queryset.select().execute();
+    auto result2 = base.select().execute();
     ASSERT_TRUE(result2.has_value());
     ASSERT_EQ(result2.value().size(), 23) << "Base filter should persist";
 
-    // Refine the base filter
-    queryset.where(field<^^Person::age>() >= 30);
-    auto adults = queryset.select().execute();
+    // Refine the base filter — creates new copy, base unchanged
+    auto adults = base.where(field<^^Person::age>() >= 30).select().execute();
     ASSERT_TRUE(adults.has_value());
     ASSERT_EQ(adults.value().size(), 16) << "Expected 16 people (age >= 25 AND age >= 30)";
+
+    // Base is still unchanged
+    auto result3 = base.select().execute();
+    ASSERT_TRUE(result3.has_value());
+    ASSERT_EQ(result3.value().size(), 23) << "Base should be unchanged after refinement";
 }
 
-// Test: Building query progressively
+// Test: Building query progressively — each where() returns a narrower copy
 TYPED_TEST(WhereTest, ProgressiveQueryBuilding) {
     QuerySet<Person, TypeParam> queryset;
 
     // Start with broad filter
-    queryset.where(field<^^Person::age>() >= 25);
-    auto result1 = queryset.select().execute();
+    auto q1      = queryset.where(field<^^Person::age>() >= 25);
+    auto result1 = q1.select().execute();
     ASSERT_TRUE(result1.has_value());
     EXPECT_EQ(result1.value().size(), 23) << "23 people have age >= 25";
 
     // Narrow it down
-    queryset.where(field<^^Person::age>() < 35);
-    auto result2 = queryset.select().execute();
+    auto q2      = q1.where(field<^^Person::age>() < 35);
+    auto result2 = q2.select().execute();
     ASSERT_TRUE(result2.has_value());
     EXPECT_EQ(result2.value().size(), 12) << "Expected 12 people (25 <= age < 35)";
 
     // Add another condition (names starting with certain letter)
-    queryset.where(field<^^Person::name>().like("D%"));
-    auto result3 = queryset.select().execute();
+    auto q3      = q2.where(field<^^Person::name>().like("D%"));
+    auto result3 = q3.select().execute();
     ASSERT_TRUE(result3.has_value());
     EXPECT_EQ(result3.value().size(), 1) << "Expected 1 person matching all conditions (Diana)";
     EXPECT_EQ(result3.value().begin()->name, "Diana");
+
+    // All previous stages remain unchanged
+    EXPECT_EQ(q1.select().execute().value().size(), 23);
+    EXPECT_EQ(q2.select().execute().value().size(), 12);
 }
 
-// Test: reset() clears all accumulated conditions
-TYPED_TEST(WhereTest, ResetClearsAllConditions) {
+// Test: chaining where() builds complex filters without mutating the original
+TYPED_TEST(WhereTest, ChainingBuildsComplexFilter) {
     QuerySet<Person, TypeParam> queryset;
 
-    // Build up complex filter
-    queryset.where(field<^^Person::age>() >= 25);
-    queryset.where(field<^^Person::age>() < 40);
-    queryset.where(field<^^Person::name>().like("D%"));
+    // Build up complex filter via chaining
+    auto filtered = queryset.where(field<^^Person::age>() >= 25)
+                            .where(field<^^Person::age>() < 40)
+                            .where(field<^^Person::name>().like("D%"));
 
-    auto filtered = queryset.select().execute();
-    ASSERT_TRUE(filtered.has_value());
-    EXPECT_EQ(filtered.value().size(), 1) << "Complex filter should match Diana only";
-    EXPECT_EQ(filtered.value().begin()->name, "Diana");
+    auto result = filtered.select().execute();
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result.value().size(), 1) << "Complex filter should match Diana only";
+    EXPECT_EQ(result.value().begin()->name, "Diana");
 
-    // Reset and verify clean slate
-    queryset.reset();
+    // Original is unchanged
     auto all_people = queryset.select().execute();
     ASSERT_TRUE(all_people.has_value());
-    EXPECT_EQ(all_people.value().size(), 25) << "After reset() should get all rows";
+    EXPECT_EQ(all_people.value().size(), 25) << "Original should have all rows";
 
-    // Can build new filter after reset
-    queryset.where(field<^^Person::age>() == 25);
-    auto age25 = queryset.select().execute();
+    // Can create a different filter from the same base
+    auto age25 = queryset.where(field<^^Person::age>() == 25).select().execute();
     ASSERT_TRUE(age25.has_value());
-    EXPECT_EQ(age25.value().size(), 3) << "New filter after reset works (Alice, Grace, Karen)";
+    EXPECT_EQ(age25.value().size(), 3) << "Different filter from same base (Alice, Grace, Karen)";
+}
+
+// Test: where() does not mutate the original QuerySet (returns new copy)
+TYPED_TEST(WhereTest, WhereDoesNotMutateOriginal) {
+    QuerySet<Person, TypeParam> queryset;
+
+    // Call where() — original should be unchanged
+    auto filtered = queryset.where(field<^^Person::age>() > 30);
+    auto all      = queryset.select().execute();
+    ASSERT_TRUE(all.has_value());
+    EXPECT_EQ(all.value().size(), 25) << "Original QuerySet must not be mutated by where()";
+
+    // The returned copy should have the filter
+    auto result = filtered.select().execute();
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result.value().size(), 13) << "Returned QuerySet should have the WHERE filter";
+}
+
+// Test: where() in a loop works without reset()
+TYPED_TEST(WhereTest, WhereInLoopWithoutReset) {
+    QuerySet<Person, TypeParam> queryset;
+
+    for (int i = 0; i < 10; ++i) {
+        auto result = queryset.where(field<^^Person::age>() > 30).count().get();
+        ASSERT_TRUE(result.has_value()) << "Iteration " << i << " failed: " << result.error().message();
+        EXPECT_EQ(result.value(), 13) << "Each iteration should return 13 (no accumulation)";
+    }
+
+    // Original should still be unfiltered
+    auto all = queryset.select().execute();
+    ASSERT_TRUE(all.has_value());
+    EXPECT_EQ(all.value().size(), 25) << "Original QuerySet must remain unfiltered after loop";
+}
+
+// Test: chaining where() returns progressively narrowed copies
+TYPED_TEST(WhereTest, WhereChainingReturnsNewCopies) {
+    QuerySet<Person, TypeParam> queryset;
+
+    auto q1 = queryset.where(field<^^Person::age>() >= 25);
+    auto q2 = q1.where(field<^^Person::age>() < 35);
+
+    // Original, q1, q2 should all be independent
+    auto all = queryset.select().execute();
+    ASSERT_TRUE(all.has_value());
+    EXPECT_EQ(all.value().size(), 25) << "Original unchanged";
+
+    auto r1 = q1.select().execute();
+    ASSERT_TRUE(r1.has_value());
+    EXPECT_EQ(r1.value().size(), 23) << "q1: age >= 25";
+
+    auto r2 = q2.select().execute();
+    ASSERT_TRUE(r2.has_value());
+    EXPECT_EQ(r2.value().size(), 12) << "q2: age >= 25 AND age < 35";
 }
 
 // ============================================================================

--- a/tests/test_query_runner_base.h
+++ b/tests/test_query_runner_base.h
@@ -46,51 +46,51 @@ template <typename Model, typename ConnType> class QueryRunnerBase {
 
         if constexpr (Tc.where.op == "LIKE") {
             constexpr auto fi = dispatch_field<Model>(Tc.where.field.view());
-            qs_.where(field<fi>().like(Tc.where.value_str.view()));
+            qs_ = qs_.where(field<fi>().like(Tc.where.value_str.view()));
 
         } else if constexpr (Tc.where.op == "BETWEEN") {
             constexpr auto fi = dispatch_field<Model>(Tc.where.field.view());
-            qs_.where(field<fi>().between(Tc.where.value_int, Tc.where.value_int2));
+            qs_ = qs_.where(field<fi>().between(Tc.where.value_int, Tc.where.value_int2));
 
         } else if constexpr (Tc.where.op == "IN") {
             constexpr auto fi = dispatch_field<Model>(Tc.where.field.view());
             constexpr size_t n = Tc.where.value_list_count;
             [&]<size_t... J>(std::index_sequence<J...>) {
-                qs_.where(field<fi>().in(Tc.where.value_list[J]...));
+                qs_ = qs_.where(field<fi>().in(Tc.where.value_list[J]...));
             }(std::make_index_sequence<n>{});
 
         } else if constexpr (!Tc.where.field3.empty()) {
             constexpr auto fi1 = dispatch_field<Model>(Tc.where.field.view());
             constexpr auto fi2 = dispatch_field<Model>(Tc.where.field2.view());
             constexpr auto fi3 = dispatch_field<Model>(Tc.where.field3.view());
-            qs_.where(field<fi1>() > Tc.where.value_int && field<fi2>() > Tc.where.value_dbl2 &&
-                      field<fi3>() == Tc.where.value_bool3);
+            qs_ = qs_.where(field<fi1>() > Tc.where.value_int && field<fi2>() > Tc.where.value_dbl2 &&
+                            field<fi3>() == Tc.where.value_bool3);
 
         } else if constexpr (!Tc.where.field2.empty() && Tc.where.logic == "AND") {
             constexpr auto fi1 = dispatch_field<Model>(Tc.where.field.view());
             constexpr auto fi2 = dispatch_field<Model>(Tc.where.field2.view());
-            qs_.where(field<fi1>() > Tc.where.value_int && field<fi2>() == Tc.where.value_bool2);
+            qs_ = qs_.where(field<fi1>() > Tc.where.value_int && field<fi2>() == Tc.where.value_bool2);
 
         } else if constexpr (!Tc.where.field2.empty() && Tc.where.logic == "OR") {
             constexpr auto fi1 = dispatch_field<Model>(Tc.where.field.view());
             constexpr auto fi2 = dispatch_field<Model>(Tc.where.field2.view());
-            qs_.where(field<fi1>() < Tc.where.value_int || field<fi2>() > Tc.where.value_int_2);
+            qs_ = qs_.where(field<fi1>() < Tc.where.value_int || field<fi2>() > Tc.where.value_int_2);
 
         } else if constexpr (!Tc.where.value_str.empty()) {
             constexpr auto fi = dispatch_field<Model>(Tc.where.field.view());
-            qs_.where(build_where_expr<fi>(Tc.where.op.view(), Tc.where.value_str.view()));
+            qs_ = qs_.where(build_where_expr<fi>(Tc.where.op.view(), Tc.where.value_str.view()));
 
         } else if constexpr (Tc.where.value_dbl != 0.0) {
             constexpr auto fi = dispatch_field<Model>(Tc.where.field.view());
-            qs_.where(build_where_expr<fi>(Tc.where.op.view(), Tc.where.value_dbl));
+            qs_ = qs_.where(build_where_expr<fi>(Tc.where.op.view(), Tc.where.value_dbl));
 
         } else if constexpr (Tc.where.value_bool) {
             constexpr auto fi = dispatch_field<Model>(Tc.where.field.view());
-            qs_.where(build_where_expr<fi>(Tc.where.op.view(), Tc.where.value_bool));
+            qs_ = qs_.where(build_where_expr<fi>(Tc.where.op.view(), Tc.where.value_bool));
 
         } else {
             constexpr auto fi = dispatch_field<Model>(Tc.where.field.view());
-            qs_.where(build_where_expr<fi>(Tc.where.op.view(), Tc.where.value_int));
+            qs_ = qs_.where(build_where_expr<fi>(Tc.where.op.view(), Tc.where.value_int));
         }
     }
 
@@ -100,7 +100,7 @@ template <typename Model, typename ConnType> class QueryRunnerBase {
             qs_.template join<&Model::sender>();
         }
         if constexpr (Tc.where_node_count > 0)
-            qs_.where(build_where_node_expr<0, Tc, Model>());
+            qs_ = qs_.where(build_where_node_expr<0, Tc, Model>());
         else if constexpr (!Tc.where.field.empty())
             apply_where<Tc>();
     }


### PR DESCRIPTION
## Summary
- `where()` now returns a new `QuerySet` by value instead of mutating in-place (Django-style immutability)
- Prevents silent condition accumulation bugs when reusing a QuerySet in loops
- Added `clone_state()` private helper that copies query state without statement caches
- Added mock PG test for `reset()` + `invalidate_cache()` to maintain 100% line coverage

Closes #153

## Test plan
- [x] All 1457 tests pass
- [x] 100.0% line coverage maintained
- [x] ASAN clean
- [x] Immutability tests: `WhereDoesNotMutateOriginal`, `WhereInLoopWithoutReset`, `WhereChainingReturnsNewCopies`
- [x] Existing WHERE/YAML tests updated to capture return value
- [x] Benchmarks updated to use new pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)