### PR TITLE
perf: fix WHERE int comparison benchmark fairness (#157)

### DIFF
--- a/benchmarks/operations/first_get.hpp
+++ b/benchmarks/operations/first_get.hpp
@@ -64,7 +64,7 @@ namespace storm::benchmark {
             if (!db)
                 return 0;
 
-            std::string sql = "SELECT id, name, age, is_active, salary FROM Person";
+            std::string sql = "SELECT id, name, age, is_active, salary, score FROM Person";
 
             if constexpr (WhereCfg::enabled) {
                 constexpr std::string_view where_field = std::meta::identifier_of(WhereCfg::field_info);
@@ -100,6 +100,9 @@ namespace storm::benchmark {
                     obj.age       = sqlite3_column_int(stmt, 2);
                     obj.is_active = sqlite3_column_int(stmt, 3) != 0;
                     obj.salary    = sqlite3_column_double(stmt, 4);
+                    if (sqlite3_column_type(stmt, 5) != SQLITE_NULL) {
+                        obj.score = sqlite3_column_int(stmt, 5);
+                    }
                     result.emplace(std::move(obj));
                 }
                 if (result.has_value()) {
@@ -159,7 +162,7 @@ namespace storm::benchmark {
                 return 0;
 
             // get() uses LIMIT 2 internally to detect multiple rows
-            std::string sql = "SELECT id, name, age, is_active, salary FROM Person";
+            std::string sql = "SELECT id, name, age, is_active, salary, score FROM Person";
 
             if constexpr (WhereCfg::enabled) {
                 constexpr std::string_view where_field = std::meta::identifier_of(WhereCfg::field_info);
@@ -195,6 +198,9 @@ namespace storm::benchmark {
                         obj.age       = sqlite3_column_int(stmt, 2);
                         obj.is_active = sqlite3_column_int(stmt, 3) != 0;
                         obj.salary    = sqlite3_column_double(stmt, 4);
+                        if (sqlite3_column_type(stmt, 5) != SQLITE_NULL) {
+                            obj.score = sqlite3_column_int(stmt, 5);
+                        }
                     }
                     row_count++;
                 }

--- a/benchmarks/operations/select.hpp
+++ b/benchmarks/operations/select.hpp
@@ -209,7 +209,7 @@ namespace storm::benchmark {
                 }
             } else {
                 // Basic SELECT query
-                sql = "SELECT id, name, age, is_active, salary FROM Person";
+                sql = "SELECT id, name, age, is_active, salary, score FROM Person";
 
                 if constexpr (WhereCfg::enabled) {
                     constexpr std::string_view where_field = std::meta::identifier_of(WhereCfg::field_info);
@@ -234,7 +234,7 @@ namespace storm::benchmark {
             return sql;
         }
 
-        // Extract row for basic SELECT (Person model)
+        // Extract row for basic SELECT (Person model) — must match Storm's column list
         __attribute__((always_inline)) static BaseModel extract_row_basic(sqlite3_stmt* stmt) {
             BaseModel obj;
             obj.id        = sqlite3_column_int64(stmt, 0);
@@ -242,6 +242,9 @@ namespace storm::benchmark {
             obj.age       = sqlite3_column_int(stmt, 2);
             obj.is_active = sqlite3_column_int(stmt, 3) != 0;
             obj.salary    = sqlite3_column_double(stmt, 4);
+            if (sqlite3_column_type(stmt, 5) != SQLITE_NULL) {
+                obj.score = sqlite3_column_int(stmt, 5);
+            }
             return obj;
         }
 
@@ -513,7 +516,7 @@ namespace storm::benchmark {
             constexpr std::string_view field1 = std::meta::identifier_of(OrderByFieldInfo1);
             constexpr std::string_view field2 = std::meta::identifier_of(OrderByFieldInfo2);
 
-            std::string sql = "SELECT id, name, age, is_active, salary FROM Person ORDER BY ";
+            std::string sql = "SELECT id, name, age, is_active, salary, score FROM Person ORDER BY ";
             sql += field1;
             sql += (Dir1 == OrderDirection::DESC) ? " DESC, " : " ASC, ";
             sql += field2;
@@ -546,6 +549,9 @@ namespace storm::benchmark {
             obj.age       = sqlite3_column_int(stmt, 2);
             obj.is_active = sqlite3_column_int(stmt, 3) != 0;
             obj.salary    = sqlite3_column_double(stmt, 4);
+            if (sqlite3_column_type(stmt, 5) != SQLITE_NULL) {
+                obj.score = sqlite3_column_int(stmt, 5);
+            }
             return obj;
         }
     };
@@ -631,7 +637,7 @@ namespace storm::benchmark {
                 return 0;
 
             // Build SQL with variadic fold expression
-            std::string sql   = "SELECT id, name, age, is_active, salary FROM Person GROUP BY ";
+            std::string sql   = "SELECT id, name, age, is_active, salary, score FROM Person GROUP BY ";
             bool        first = true;
             ((sql += (first ? (first = false, "") : ", "),
               sql += std::string(std::meta::identifier_of(GroupByFieldInfos))),
@@ -664,6 +670,9 @@ namespace storm::benchmark {
             obj.age       = sqlite3_column_int(stmt, 2);
             obj.is_active = sqlite3_column_int(stmt, 3) != 0;
             obj.salary    = sqlite3_column_double(stmt, 4);
+            if (sqlite3_column_type(stmt, 5) != SQLITE_NULL) {
+                obj.score = sqlite3_column_int(stmt, 5);
+            }
             return obj;
         }
     };

--- a/benchmarks/operations/select_query_base.hpp
+++ b/benchmarks/operations/select_query_base.hpp
@@ -407,7 +407,8 @@ namespace storm::benchmark {
                         .name      = std::format("Person{}", i),
                         .age       = 20 + (i % 50),
                         .is_active = (i % 2 == 0),
-                        .salary    = 30000.0 + (i * 1000.0)
+                        .salary    = 30000.0 + (i * 1000.0),
+                        .score     = (i % 3 == 0) ? std::optional<int>(60 + (i % 40)) : std::nullopt
                 };
             }
         }

--- a/benchmarks/operations/setop.hpp
+++ b/benchmarks/operations/setop.hpp
@@ -154,6 +154,9 @@ namespace storm::benchmark {
                     obj.age       = sqlite3_column_int(stmt, 2);
                     obj.is_active = sqlite3_column_int(stmt, 3) != 0;
                     obj.salary    = sqlite3_column_double(stmt, 4);
+                    if (sqlite3_column_type(stmt, 5) != SQLITE_NULL) {
+                        obj.score = sqlite3_column_int(stmt, 5);
+                    }
                     results.push_back(std::move(obj));
                 }
                 total += static_cast<int>(results.size());
@@ -211,12 +214,12 @@ namespace storm::benchmark {
         }
 
         std::string build_raw_sql() const {
-            std::string sql = "SELECT id, name, age, is_active, salary FROM Person WHERE age < ?";
+            std::string sql = "SELECT id, name, age, is_active, salary, score FROM Person WHERE age < ?";
             sql += op_sql();
             if constexpr (needs_overlap) {
-                sql += "SELECT id, name, age, is_active, salary FROM Person WHERE age > ?";
+                sql += "SELECT id, name, age, is_active, salary, score FROM Person WHERE age > ?";
             } else {
-                sql += "SELECT id, name, age, is_active, salary FROM Person WHERE age >= ?";
+                sql += "SELECT id, name, age, is_active, salary, score FROM Person WHERE age >= ?";
             }
             if constexpr (WithOrderBy) {
                 sql += " ORDER BY age ASC";

--- a/benchmarks/operations/where_operators.hpp
+++ b/benchmarks/operations/where_operators.hpp
@@ -71,8 +71,9 @@ namespace storm::benchmark {
                 return 0;
 
             constexpr std::string_view field_name = std::meta::identifier_of(FieldInfo);
-            std::string                sql =
-                    std::format("SELECT id, name, age, is_active, salary FROM Person WHERE {} LIKE ?", field_name);
+            std::string                sql        = std::format(
+                    "SELECT id, name, age, is_active, salary, score FROM Person WHERE {} LIKE ?", field_name
+            );
 
             sqlite3_stmt* stmt = nullptr;
             sqlite3_prepare_v2(db, sql.c_str(), -1, &stmt, nullptr);
@@ -100,6 +101,9 @@ namespace storm::benchmark {
             obj.age       = sqlite3_column_int(stmt, 2);
             obj.is_active = sqlite3_column_int(stmt, 3) != 0;
             obj.salary    = sqlite3_column_double(stmt, 4);
+            if (sqlite3_column_type(stmt, 5) != SQLITE_NULL) {
+                obj.score = sqlite3_column_int(stmt, 5);
+            }
             return obj;
         }
     };
@@ -162,7 +166,7 @@ namespace storm::benchmark {
 
             constexpr std::string_view field_name = std::meta::identifier_of(FieldInfo);
             std::string                sql        = std::format(
-                    "SELECT id, name, age, is_active, salary FROM Person WHERE {} BETWEEN ? AND ?", field_name
+                    "SELECT id, name, age, is_active, salary, score FROM Person WHERE {} BETWEEN ? AND ?", field_name
             );
 
             sqlite3_stmt* stmt = nullptr;
@@ -199,6 +203,9 @@ namespace storm::benchmark {
             obj.age       = sqlite3_column_int(stmt, 2);
             obj.is_active = sqlite3_column_int(stmt, 3) != 0;
             obj.salary    = sqlite3_column_double(stmt, 4);
+            if (sqlite3_column_type(stmt, 5) != SQLITE_NULL) {
+                obj.score = sqlite3_column_int(stmt, 5);
+            }
             return obj;
         }
     };
@@ -268,7 +275,7 @@ namespace storm::benchmark {
 
             // Build SQL with placeholders
             std::string sql =
-                    std::format("SELECT id, name, age, is_active, salary FROM Person WHERE {} IN (", field_name);
+                    std::format("SELECT id, name, age, is_active, salary, score FROM Person WHERE {} IN (", field_name);
             for (size_t i = 0; i < values_.size(); i++) {
                 if (i > 0)
                     sql += ", ";
@@ -309,6 +316,9 @@ namespace storm::benchmark {
             obj.age       = sqlite3_column_int(stmt, 2);
             obj.is_active = sqlite3_column_int(stmt, 3) != 0;
             obj.salary    = sqlite3_column_double(stmt, 4);
+            if (sqlite3_column_type(stmt, 5) != SQLITE_NULL) {
+                obj.score = sqlite3_column_int(stmt, 5);
+            }
             return obj;
         }
 
@@ -405,7 +415,7 @@ namespace storm::benchmark {
             constexpr const char*      logic_op    = IsAnd ? "AND" : "OR";
 
             std::string sql = std::format(
-                    "SELECT id, name, age, is_active, salary FROM Person WHERE {} {} ? {} {} {} ?",
+                    "SELECT id, name, age, is_active, salary, score FROM Person WHERE {} {} ? {} {} {} ?",
                     field_name1,
                     op_sql1,
                     logic_op,
@@ -456,6 +466,9 @@ namespace storm::benchmark {
             obj.age       = sqlite3_column_int(stmt, 2);
             obj.is_active = sqlite3_column_int(stmt, 3) != 0;
             obj.salary    = sqlite3_column_double(stmt, 4);
+            if (sqlite3_column_type(stmt, 5) != SQLITE_NULL) {
+                obj.score = sqlite3_column_int(stmt, 5);
+            }
             return obj;
         }
 

--- a/src/orm/utilities.cppm
+++ b/src/orm/utilities.cppm
@@ -163,8 +163,9 @@ export namespace storm::orm::utilities {
                         return false;
                     }
                 } else {
-                    auto c = static_cast<unsigned char>(sv[i]);
-                    if (std::isxdigit(c) == 0) {
+                    auto c      = sv[i];
+                    bool is_hex = (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
+                    if (!is_hex) {
                         return false;
                     }
                 }


### PR DESCRIPTION
## Summary
- Fixed unfair raw SQLite benchmark that selected 5 columns while Storm ORM selects all 6 (missing `score` optional column)
- Added `score` extraction with NULL handling to all raw benchmark functions across 5 files
- Fixed compiler crash in `utilities.cppm` caused by `std::isxdigit()` in C++26 module (replaced with inline hex check)

## Results
| Benchmark | Before | After |
|---|---|---|
| `where_int_comparison_gt` | 81.5% | **97.5%** |
| All other WHERE benchmarks | - | 95-111% |
| All other categories | - | No regressions |

## Test plan
- [x] All 1715 tests pass (debug)
- [x] ASAN+UBSAN clean (1715/1715)
- [x] TSAN clean (1715/1715)
- [x] Thorough benchmark run confirms ≥95% on all WHERE benchmarks
- [x] Quick full benchmark run confirms no regressions

Closes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)