### PR TITLE
refactor: unify connection passing to shared_ptr (#173)

### DIFF
--- a/src/orm/queryset.cppm
+++ b/src/orm/queryset.cppm
@@ -314,7 +314,7 @@ export namespace storm {
             requires(sizeof...(GroupFieldInfos) > 0)
         auto group_by() {
             return orm::statements::GroupByBuilder<T, ConnType, GroupFieldInfos...>{
-                    conn_.get(), where_expr_, join_stmt_, limit_value_, offset_value_, order_by_wrapper_
+                    conn_, where_expr_, join_stmt_, limit_value_, offset_value_, order_by_wrapper_
             };
         }
         // =====================================================================
@@ -374,7 +374,7 @@ export namespace storm {
                     ConnType,
                     orm::statements::NoGroupBy,
                     orm::statements::AggregateOp<orm::statements::AggregateType::SUM, FieldInfos...>>;
-            return StmtType{conn_.get(), where_expr_, join_stmt_};
+            return StmtType{conn_, where_expr_, join_stmt_};
         }
 
         // COUNT aggregate (defaults to COUNT(*) if no fields)
@@ -389,7 +389,7 @@ export namespace storm {
                     ConnType,
                     orm::statements::NoGroupBy,
                     orm::statements::AggregateOp<orm::statements::AggregateType::COUNT, FieldInfos...>>;
-            return StmtType{conn_.get(), where_expr_, join_stmt_};
+            return StmtType{conn_, where_expr_, join_stmt_};
         }
 
         // AVG aggregate (multi-field: AVG(f1 + f2 + ...))
@@ -403,7 +403,7 @@ export namespace storm {
                     ConnType,
                     orm::statements::NoGroupBy,
                     orm::statements::AggregateOp<orm::statements::AggregateType::AVG, FieldInfos...>>;
-            return StmtType{conn_.get(), where_expr_, join_stmt_};
+            return StmtType{conn_, where_expr_, join_stmt_};
         }
 
         // MIN aggregate (multi-field: MIN(f1 + f2 + ...))
@@ -417,7 +417,7 @@ export namespace storm {
                     ConnType,
                     orm::statements::NoGroupBy,
                     orm::statements::AggregateOp<orm::statements::AggregateType::MIN, FieldInfos...>>;
-            return StmtType{conn_.get(), where_expr_, join_stmt_};
+            return StmtType{conn_, where_expr_, join_stmt_};
         }
 
         // MAX aggregate (multi-field: MAX(f1 + f2 + ...))
@@ -431,7 +431,7 @@ export namespace storm {
                     ConnType,
                     orm::statements::NoGroupBy,
                     orm::statements::AggregateOp<orm::statements::AggregateType::MAX, FieldInfos...>>;
-            return StmtType{conn_.get(), where_expr_, join_stmt_};
+            return StmtType{conn_, where_expr_, join_stmt_};
         }
 
         // COUNT(DISTINCT field) aggregate
@@ -445,7 +445,7 @@ export namespace storm {
                     ConnType,
                     orm::statements::NoGroupBy,
                     orm::statements::AggregateOp<orm::statements::AggregateType::COUNT_DISTINCT, FieldInfo>>;
-            return StmtType{conn_.get(), where_expr_, join_stmt_};
+            return StmtType{conn_, where_expr_, join_stmt_};
         }
 
         // Static methods for connection management

--- a/src/orm/queryset.cppm
+++ b/src/orm/queryset.cppm
@@ -314,7 +314,7 @@ export namespace storm {
             requires(sizeof...(GroupFieldInfos) > 0)
         auto group_by() {
             return orm::statements::GroupByBuilder<T, ConnType, GroupFieldInfos...>{
-                    conn_, where_expr_, join_stmt_, limit_value_, offset_value_, order_by_wrapper_
+                    {conn_, where_expr_, join_stmt_, limit_value_, offset_value_, order_by_wrapper_, nullptr}
             };
         }
         // =====================================================================
@@ -374,7 +374,7 @@ export namespace storm {
                     ConnType,
                     orm::statements::NoGroupBy,
                     orm::statements::AggregateOp<orm::statements::AggregateType::SUM, FieldInfos...>>;
-            return StmtType{conn_, where_expr_, join_stmt_};
+            return StmtType{{conn_, where_expr_, join_stmt_, {}, {}, {}, nullptr}};
         }
 
         // COUNT aggregate (defaults to COUNT(*) if no fields)
@@ -389,7 +389,7 @@ export namespace storm {
                     ConnType,
                     orm::statements::NoGroupBy,
                     orm::statements::AggregateOp<orm::statements::AggregateType::COUNT, FieldInfos...>>;
-            return StmtType{conn_, where_expr_, join_stmt_};
+            return StmtType{{conn_, where_expr_, join_stmt_, {}, {}, {}, nullptr}};
         }
 
         // AVG aggregate (multi-field: AVG(f1 + f2 + ...))
@@ -403,7 +403,7 @@ export namespace storm {
                     ConnType,
                     orm::statements::NoGroupBy,
                     orm::statements::AggregateOp<orm::statements::AggregateType::AVG, FieldInfos...>>;
-            return StmtType{conn_, where_expr_, join_stmt_};
+            return StmtType{{conn_, where_expr_, join_stmt_, {}, {}, {}, nullptr}};
         }
 
         // MIN aggregate (multi-field: MIN(f1 + f2 + ...))
@@ -417,7 +417,7 @@ export namespace storm {
                     ConnType,
                     orm::statements::NoGroupBy,
                     orm::statements::AggregateOp<orm::statements::AggregateType::MIN, FieldInfos...>>;
-            return StmtType{conn_, where_expr_, join_stmt_};
+            return StmtType{{conn_, where_expr_, join_stmt_, {}, {}, {}, nullptr}};
         }
 
         // MAX aggregate (multi-field: MAX(f1 + f2 + ...))
@@ -431,7 +431,7 @@ export namespace storm {
                     ConnType,
                     orm::statements::NoGroupBy,
                     orm::statements::AggregateOp<orm::statements::AggregateType::MAX, FieldInfos...>>;
-            return StmtType{conn_, where_expr_, join_stmt_};
+            return StmtType{{conn_, where_expr_, join_stmt_, {}, {}, {}, nullptr}};
         }
 
         // COUNT(DISTINCT field) aggregate
@@ -445,7 +445,7 @@ export namespace storm {
                     ConnType,
                     orm::statements::NoGroupBy,
                     orm::statements::AggregateOp<orm::statements::AggregateType::COUNT_DISTINCT, FieldInfo>>;
-            return StmtType{conn_, where_expr_, join_stmt_};
+            return StmtType{{conn_, where_expr_, join_stmt_, {}, {}, {}, nullptr}};
         }
 
         // Static methods for connection management

--- a/src/orm/statements/aggregate.cppm
+++ b/src/orm/statements/aggregate.cppm
@@ -84,6 +84,17 @@ export namespace storm::orm::statements {
         // LCOV_EXCL_STOP
     };
 
+    // Common parameter bundle for AggregateStatement and GroupByBuilder
+    template <typename ConnType> struct AggregateParams {
+        std::shared_ptr<ConnType>           conn;
+        orm::where::ExpressionVariantPtr    where_expr;
+        std::optional<JoinStatementWrapper> join_stmt;
+        std::optional<int>                  limit;
+        std::optional<int>                  offset;
+        std::optional<OrderByWrapper>       order_by_wrapper;
+        orm::where::ExpressionVariantPtr    having_expr;
+    };
+
     // ============================================================================
     // Compile-time SQL Building Utilities
     // ============================================================================
@@ -194,36 +205,26 @@ export namespace storm::orm::statements {
       public:
         using ResultType = std::conditional_t<HasGroupBy, plf::hive<GroupedTuple>, decltype(deduce_simple_type())>;
 
-        explicit AggregateStatement(
-                std::shared_ptr<ConnType>                  conn,
-                orm::where::ExpressionVariantPtr           where_expr       = nullptr,
-                const std::optional<JoinStatementWrapper>& join_stmt        = std::nullopt,
-                const std::optional<int>&                  limit            = std::nullopt,
-                const std::optional<int>&                  offset           = std::nullopt,
-                const std::optional<OrderByWrapper>&       order_by_wrapper = std::nullopt,
-                orm::where::ExpressionVariantPtr           having_expr      = nullptr
-        )
-            : conn_(std::move(conn))
-            , where_expr_(std::move(where_expr))
-            , join_stmt_(join_stmt)
-            , limit_(limit)
-            , offset_(offset)
-            , order_by_wrapper_(order_by_wrapper)
-            , having_expr_(std::move(having_expr)) {}
+        explicit AggregateStatement(AggregateParams<ConnType> p)
+            : conn_(std::move(p.conn))
+            , where_expr_(std::move(p.where_expr))
+            , join_stmt_(std::move(p.join_stmt))
+            , limit_(p.limit)
+            , offset_(p.offset)
+            , order_by_wrapper_(std::move(p.order_by_wrapper))
+            , having_expr_(std::move(p.having_expr)) {}
 
         // HAVING clause - only available when GROUP BY is present
         auto having(orm::where::ExpressionVariantPtr expr)
             requires HasGroupBy
         {
-            return AggregateStatement<T, ConnType, GroupFields, Ops...>{
-                    conn_, where_expr_, join_stmt_, limit_, offset_, order_by_wrapper_, std::move(expr)
-            };
+            return AggregateStatement<T, ConnType, GroupFields, Ops...>{make_params(std::move(expr))};
         }
 
         // Chaining methods (only for non-GROUP BY queries building aggregates)
         template <std::meta::info... FieldInfos> auto sum() {
             return AggregateStatement<T, ConnType, GroupFields, Ops..., AggregateOp<AggregateType::SUM, FieldInfos...>>{
-                    conn_, where_expr_, join_stmt_, limit_, offset_, order_by_wrapper_, having_expr_
+                    make_params()
             };
         }
 
@@ -233,26 +234,24 @@ export namespace storm::orm::statements {
                     ConnType,
                     GroupFields,
                     Ops...,
-                    AggregateOp<AggregateType::COUNT, FieldInfos...>>{
-                    conn_, where_expr_, join_stmt_, limit_, offset_, order_by_wrapper_, having_expr_
-            };
+                    AggregateOp<AggregateType::COUNT, FieldInfos...>>{make_params()};
         }
 
         template <std::meta::info... FieldInfos> auto avg() {
             return AggregateStatement<T, ConnType, GroupFields, Ops..., AggregateOp<AggregateType::AVG, FieldInfos...>>{
-                    conn_, where_expr_, join_stmt_, limit_, offset_, order_by_wrapper_, having_expr_
+                    make_params()
             };
         }
 
         template <std::meta::info... FieldInfos> auto min() {
             return AggregateStatement<T, ConnType, GroupFields, Ops..., AggregateOp<AggregateType::MIN, FieldInfos...>>{
-                    conn_, where_expr_, join_stmt_, limit_, offset_, order_by_wrapper_, having_expr_
+                    make_params()
             };
         }
 
         template <std::meta::info... FieldInfos> auto max() {
             return AggregateStatement<T, ConnType, GroupFields, Ops..., AggregateOp<AggregateType::MAX, FieldInfos...>>{
-                    conn_, where_expr_, join_stmt_, limit_, offset_, order_by_wrapper_, having_expr_
+                    make_params()
             };
         }
 
@@ -612,6 +611,14 @@ export namespace storm::orm::statements {
             return prepare_bind_extract(sql);
         }
 
+        auto make_params() -> AggregateParams<ConnType> {
+            return {conn_, where_expr_, join_stmt_, limit_, offset_, order_by_wrapper_, having_expr_};
+        }
+
+        auto make_params(orm::where::ExpressionVariantPtr having) -> AggregateParams<ConnType> {
+            return {conn_, where_expr_, join_stmt_, limit_, offset_, order_by_wrapper_, std::move(having)};
+        }
+
         std::shared_ptr<ConnType>           conn_;
         orm::where::ExpressionVariantPtr    where_expr_;
         std::optional<JoinStatementWrapper> join_stmt_;
@@ -634,61 +641,59 @@ export namespace storm::orm::statements {
         using GBFields = GroupByFields<GroupFieldInfos...>;
 
       public:
-        explicit GroupByBuilder(
-                std::shared_ptr<ConnType>                  conn,
-                orm::where::ExpressionVariantPtr           where_expr       = nullptr,
-                const std::optional<JoinStatementWrapper>& join_stmt        = std::nullopt,
-                const std::optional<int>&                  limit            = std::nullopt,
-                const std::optional<int>&                  offset           = std::nullopt,
-                const std::optional<OrderByWrapper>&       order_by_wrapper = std::nullopt,
-                orm::where::ExpressionVariantPtr           having_expr      = nullptr
-        )
-            : conn_(std::move(conn))
-            , where_expr_(std::move(where_expr))
-            , join_stmt_(join_stmt)
-            , limit_(limit)
-            , offset_(offset)
-            , order_by_wrapper_(order_by_wrapper)
-            , having_expr_(std::move(having_expr)) {}
+        explicit GroupByBuilder(AggregateParams<ConnType> p)
+            : conn_(std::move(p.conn))
+            , where_expr_(std::move(p.where_expr))
+            , join_stmt_(std::move(p.join_stmt))
+            , limit_(p.limit)
+            , offset_(p.offset)
+            , order_by_wrapper_(std::move(p.order_by_wrapper))
+            , having_expr_(std::move(p.having_expr)) {}
 
         // HAVING clause - stores expression and returns new GroupByBuilder
         auto having(orm::where::ExpressionVariantPtr expr) {
-            return GroupByBuilder<T, ConnType, GroupFieldInfos...>{
-                    conn_, where_expr_, join_stmt_, limit_, offset_, order_by_wrapper_, std::move(expr)
-            };
+            return GroupByBuilder<T, ConnType, GroupFieldInfos...>{make_params(std::move(expr))};
         }
 
         template <std::meta::info... FieldInfos> auto count() {
             return AggregateStatement<T, ConnType, GBFields, AggregateOp<AggregateType::COUNT, FieldInfos...>>{
-                    conn_, where_expr_, join_stmt_, limit_, offset_, order_by_wrapper_, having_expr_
+                    make_params()
             };
         }
 
         template <std::meta::info... FieldInfos> auto sum() {
             return AggregateStatement<T, ConnType, GBFields, AggregateOp<AggregateType::SUM, FieldInfos...>>{
-                    conn_, where_expr_, join_stmt_, limit_, offset_, order_by_wrapper_, having_expr_
+                    make_params()
             };
         }
 
         template <std::meta::info... FieldInfos> auto avg() {
             return AggregateStatement<T, ConnType, GBFields, AggregateOp<AggregateType::AVG, FieldInfos...>>{
-                    conn_, where_expr_, join_stmt_, limit_, offset_, order_by_wrapper_, having_expr_
+                    make_params()
             };
         }
 
         template <std::meta::info... FieldInfos> auto min() {
             return AggregateStatement<T, ConnType, GBFields, AggregateOp<AggregateType::MIN, FieldInfos...>>{
-                    conn_, where_expr_, join_stmt_, limit_, offset_, order_by_wrapper_, having_expr_
+                    make_params()
             };
         }
 
         template <std::meta::info... FieldInfos> auto max() {
             return AggregateStatement<T, ConnType, GBFields, AggregateOp<AggregateType::MAX, FieldInfos...>>{
-                    conn_, where_expr_, join_stmt_, limit_, offset_, order_by_wrapper_, having_expr_
+                    make_params()
             };
         }
 
       private:
+        auto make_params() -> AggregateParams<ConnType> {
+            return {conn_, where_expr_, join_stmt_, limit_, offset_, order_by_wrapper_, having_expr_};
+        }
+
+        auto make_params(orm::where::ExpressionVariantPtr having) -> AggregateParams<ConnType> {
+            return {conn_, where_expr_, join_stmt_, limit_, offset_, order_by_wrapper_, std::move(having)};
+        }
+
         std::shared_ptr<ConnType>           conn_;
         orm::where::ExpressionVariantPtr    where_expr_;
         std::optional<JoinStatementWrapper> join_stmt_;

--- a/src/orm/statements/aggregate.cppm
+++ b/src/orm/statements/aggregate.cppm
@@ -641,66 +641,37 @@ export namespace storm::orm::statements {
         using GBFields = GroupByFields<GroupFieldInfos...>;
 
       public:
-        explicit GroupByBuilder(AggregateParams<ConnType> p)
-            : conn_(std::move(p.conn))
-            , where_expr_(std::move(p.where_expr))
-            , join_stmt_(std::move(p.join_stmt))
-            , limit_(p.limit)
-            , offset_(p.offset)
-            , order_by_wrapper_(std::move(p.order_by_wrapper))
-            , having_expr_(std::move(p.having_expr)) {}
+        explicit GroupByBuilder(AggregateParams<ConnType> p) : params_(std::move(p)) {}
 
         // HAVING clause - stores expression and returns new GroupByBuilder
         auto having(orm::where::ExpressionVariantPtr expr) {
-            return GroupByBuilder<T, ConnType, GroupFieldInfos...>{make_params(std::move(expr))};
+            auto p        = params_;
+            p.having_expr = std::move(expr);
+            return GroupByBuilder<T, ConnType, GroupFieldInfos...>{std::move(p)};
         }
 
         template <std::meta::info... FieldInfos> auto count() {
-            return AggregateStatement<T, ConnType, GBFields, AggregateOp<AggregateType::COUNT, FieldInfos...>>{
-                    make_params()
-            };
+            return AggregateStatement<T, ConnType, GBFields, AggregateOp<AggregateType::COUNT, FieldInfos...>>{params_};
         }
 
         template <std::meta::info... FieldInfos> auto sum() {
-            return AggregateStatement<T, ConnType, GBFields, AggregateOp<AggregateType::SUM, FieldInfos...>>{
-                    make_params()
-            };
+            return AggregateStatement<T, ConnType, GBFields, AggregateOp<AggregateType::SUM, FieldInfos...>>{params_};
         }
 
         template <std::meta::info... FieldInfos> auto avg() {
-            return AggregateStatement<T, ConnType, GBFields, AggregateOp<AggregateType::AVG, FieldInfos...>>{
-                    make_params()
-            };
+            return AggregateStatement<T, ConnType, GBFields, AggregateOp<AggregateType::AVG, FieldInfos...>>{params_};
         }
 
         template <std::meta::info... FieldInfos> auto min() {
-            return AggregateStatement<T, ConnType, GBFields, AggregateOp<AggregateType::MIN, FieldInfos...>>{
-                    make_params()
-            };
+            return AggregateStatement<T, ConnType, GBFields, AggregateOp<AggregateType::MIN, FieldInfos...>>{params_};
         }
 
         template <std::meta::info... FieldInfos> auto max() {
-            return AggregateStatement<T, ConnType, GBFields, AggregateOp<AggregateType::MAX, FieldInfos...>>{
-                    make_params()
-            };
+            return AggregateStatement<T, ConnType, GBFields, AggregateOp<AggregateType::MAX, FieldInfos...>>{params_};
         }
 
       private:
-        auto make_params() -> AggregateParams<ConnType> {
-            return {conn_, where_expr_, join_stmt_, limit_, offset_, order_by_wrapper_, having_expr_};
-        }
-
-        auto make_params(orm::where::ExpressionVariantPtr having) -> AggregateParams<ConnType> {
-            return {conn_, where_expr_, join_stmt_, limit_, offset_, order_by_wrapper_, std::move(having)};
-        }
-
-        std::shared_ptr<ConnType>           conn_;
-        orm::where::ExpressionVariantPtr    where_expr_;
-        std::optional<JoinStatementWrapper> join_stmt_;
-        std::optional<int>                  limit_;
-        std::optional<int>                  offset_;
-        std::optional<OrderByWrapper>       order_by_wrapper_;
-        orm::where::ExpressionVariantPtr    having_expr_;
+        AggregateParams<ConnType> params_;
     };
 
 } // namespace storm::orm::statements

--- a/src/orm/statements/aggregate.cppm
+++ b/src/orm/statements/aggregate.cppm
@@ -195,7 +195,7 @@ export namespace storm::orm::statements {
         using ResultType = std::conditional_t<HasGroupBy, plf::hive<GroupedTuple>, decltype(deduce_simple_type())>;
 
         explicit AggregateStatement(
-                ConnType*                                  conn,
+                std::shared_ptr<ConnType>                  conn,
                 orm::where::ExpressionVariantPtr           where_expr       = nullptr,
                 const std::optional<JoinStatementWrapper>& join_stmt        = std::nullopt,
                 const std::optional<int>&                  limit            = std::nullopt,
@@ -203,7 +203,7 @@ export namespace storm::orm::statements {
                 const std::optional<OrderByWrapper>&       order_by_wrapper = std::nullopt,
                 orm::where::ExpressionVariantPtr           having_expr      = nullptr
         )
-            : conn_(conn)
+            : conn_(std::move(conn))
             , where_expr_(std::move(where_expr))
             , join_stmt_(join_stmt)
             , limit_(limit)
@@ -555,7 +555,7 @@ export namespace storm::orm::statements {
                 static thread_local Statement* tl_stmt = nullptr;
                 static thread_local void*      tl_conn = nullptr;
 
-                if (tl_conn == static_cast<void*>(conn_) && tl_stmt != nullptr) [[likely]] {
+                if (tl_conn == static_cast<void*>(conn_.get()) && tl_stmt != nullptr) [[likely]] {
                     // Fast path: reuse cached pointer, just reset
                     tl_stmt->reset();
                 } else {
@@ -565,7 +565,7 @@ export namespace storm::orm::statements {
                         return std::unexpected(prepare_result.error());
                     }
                     tl_stmt = *prepare_result;
-                    tl_conn = static_cast<void*>(conn_);
+                    tl_conn = static_cast<void*>(conn_.get());
                     // prepare_cached already called reset()
                 }
 
@@ -612,7 +612,7 @@ export namespace storm::orm::statements {
             return prepare_bind_extract(sql);
         }
 
-        ConnType*                           conn_;
+        std::shared_ptr<ConnType>           conn_;
         orm::where::ExpressionVariantPtr    where_expr_;
         std::optional<JoinStatementWrapper> join_stmt_;
         std::optional<int>                  limit_;
@@ -635,7 +635,7 @@ export namespace storm::orm::statements {
 
       public:
         explicit GroupByBuilder(
-                ConnType*                                  conn,
+                std::shared_ptr<ConnType>                  conn,
                 orm::where::ExpressionVariantPtr           where_expr       = nullptr,
                 const std::optional<JoinStatementWrapper>& join_stmt        = std::nullopt,
                 const std::optional<int>&                  limit            = std::nullopt,
@@ -643,7 +643,7 @@ export namespace storm::orm::statements {
                 const std::optional<OrderByWrapper>&       order_by_wrapper = std::nullopt,
                 orm::where::ExpressionVariantPtr           having_expr      = nullptr
         )
-            : conn_(conn)
+            : conn_(std::move(conn))
             , where_expr_(std::move(where_expr))
             , join_stmt_(join_stmt)
             , limit_(limit)
@@ -689,7 +689,7 @@ export namespace storm::orm::statements {
         }
 
       private:
-        ConnType*                           conn_;
+        std::shared_ptr<ConnType>           conn_;
         orm::where::ExpressionVariantPtr    where_expr_;
         std::optional<JoinStatementWrapper> join_stmt_;
         std::optional<int>                  limit_;

--- a/src/orm/statements/insert.cppm
+++ b/src/orm/statements/insert.cppm
@@ -503,7 +503,7 @@ export namespace storm::orm::statements {
         // NOTE: Transaction wrapper required - multiple INSERT statements need atomicity
         [[nodiscard]] auto execute_chunked_bulk_custom(std::span<const T> objects, size_t custom_bulk_size)
                 -> std::expected<void, Error> {
-            auto txn = TransactionGuard<ConnType>::begin(*conn_);
+            auto txn = TransactionGuard<ConnType>::begin(conn_);
             if (!txn) {
                 return std::unexpected(txn.error());
             }
@@ -567,7 +567,7 @@ export namespace storm::orm::statements {
         // Execute chunked bulk INSERT ... RETURNING — multiple chunks with transaction
         [[nodiscard]] auto execute_chunked_bulk_returning(std::span<const T> objects, size_t custom_bulk_size)
                 -> std::expected<std::vector<int64_t>, Error> {
-            auto txn = TransactionGuard<ConnType>::begin(*conn_);
+            auto txn = TransactionGuard<ConnType>::begin(conn_);
             if (!txn) {
                 return std::unexpected(txn.error());
             }

--- a/src/orm/statements/remove.cppm
+++ b/src/orm/statements/remove.cppm
@@ -286,7 +286,7 @@ export namespace storm::orm::statements {
             }
 
             // Strategy 3: Chunked IN clause (800+ rows) - RAII transaction guard
-            auto txn = TransactionGuard<ConnType>::begin(*conn_);
+            auto txn = TransactionGuard<ConnType>::begin(conn_);
             if (!txn) {
                 return std::unexpected(txn.error());
             }

--- a/src/orm/statements/update.cppm
+++ b/src/orm/statements/update.cppm
@@ -207,7 +207,7 @@ export namespace storm::orm::statements {
             }
 
             // Multiple objects - use RAII transaction guard
-            auto txn = TransactionGuard<ConnType>::begin(*conn_);
+            auto txn = TransactionGuard<ConnType>::begin(conn_);
             if (!txn) {
                 return std::unexpected(txn.error());
             }

--- a/src/orm/transaction.cppm
+++ b/src/orm/transaction.cppm
@@ -5,6 +5,7 @@ module;
 export module storm_orm_transaction;
 
 import <expected>;
+import <memory>;
 
 export namespace storm::orm::utilities {
 
@@ -13,7 +14,7 @@ export namespace storm::orm::utilities {
     // ============================================================================
     //
     // Usage:
-    //   auto txn = TransactionGuard<ConnType>::begin(*conn_);
+    //   auto txn = TransactionGuard<ConnType>::begin(conn_);
     //   if (!txn) return std::unexpected(txn.error());
     //
     //   auto result = do_work();
@@ -27,34 +28,33 @@ export namespace storm::orm::utilities {
     template <typename ConnType> class TransactionGuard {
         using Error = typename ConnType::Error;
 
-        ConnType* conn_;
-        bool      committed_ = false;
+        std::shared_ptr<ConnType> conn_;
+        bool                      committed_ = false;
 
-        explicit TransactionGuard(ConnType* conn) noexcept : conn_(conn) {}
+        explicit TransactionGuard(std::shared_ptr<ConnType> conn) noexcept : conn_(std::move(conn)) {}
 
       public:
         // Factory method - begins transaction, returns expected
-        [[nodiscard]] static auto begin(ConnType& conn) noexcept -> std::expected<TransactionGuard, Error> {
-            if (auto result = conn.execute("BEGIN TRANSACTION"); !result) {
+        [[nodiscard]] static auto begin(std::shared_ptr<ConnType> conn) noexcept
+                -> std::expected<TransactionGuard, Error> {
+            if (auto result = conn->execute("BEGIN TRANSACTION"); !result) {
                 return std::unexpected(result.error());
             }
-            return TransactionGuard(&conn);
+            return TransactionGuard(std::move(conn));
         }
 
         // Move-only (no copying)
         TransactionGuard(const TransactionGuard&)                    = delete;
         auto operator=(const TransactionGuard&) -> TransactionGuard& = delete;
 
-        TransactionGuard(TransactionGuard&& other) noexcept : conn_(other.conn_), committed_(other.committed_) {
-            other.conn_ = nullptr; // Prevent double-rollback
-        }
+        TransactionGuard(TransactionGuard&& other) noexcept
+            : conn_(std::move(other.conn_)), committed_(other.committed_) {}
 
         auto operator=(TransactionGuard&& other) noexcept -> TransactionGuard& {
             if (this != &other) {
                 rollback_if_needed();
-                conn_       = other.conn_;
-                committed_  = other.committed_;
-                other.conn_ = nullptr;
+                conn_      = std::move(other.conn_);
+                committed_ = other.committed_;
             }
             return *this;
         }
@@ -66,7 +66,7 @@ export namespace storm::orm::utilities {
 
         // Explicit commit - must be called for successful transaction
         [[nodiscard]] auto commit() noexcept -> std::expected<void, Error> {
-            if (conn_ == nullptr || committed_) {
+            if (!conn_ || committed_) {
                 return {}; // Already committed or moved-from
             }
 

--- a/tests/mock_sqlite/test_orm_mock_errors.cpp
+++ b/tests/mock_sqlite/test_orm_mock_errors.cpp
@@ -2122,7 +2122,7 @@ namespace {
         // Covers line 396-397: commit() when committed_ == true
         auto conn_result = db::sqlite::Connection::open(":memory:");
         ASSERT_TRUE(conn_result.has_value());
-        auto& conn = *conn_result;
+        auto conn = std::make_shared<db::sqlite::Connection>(std::move(*conn_result));
 
         using TxnGuard = storm::orm::utilities::TransactionGuard<db::sqlite::Connection>;
 
@@ -2142,7 +2142,7 @@ namespace {
         // Covers line 396-397: commit() when conn_ == nullptr (moved-from) // NOSONAR(cpp:S125)
         auto conn_result = db::sqlite::Connection::open(":memory:");
         ASSERT_TRUE(conn_result.has_value());
-        auto& conn = *conn_result;
+        auto conn = std::make_shared<db::sqlite::Connection>(std::move(*conn_result));
 
         using TxnGuard = storm::orm::utilities::TransactionGuard<db::sqlite::Connection>;
 
@@ -2165,7 +2165,7 @@ namespace {
         // Covers lines 400-402: commit() when COMMIT execution fails
         auto conn_result = db::sqlite::Connection::open(":memory:");
         ASSERT_TRUE(conn_result.has_value());
-        auto& conn = *conn_result;
+        auto conn = std::make_shared<db::sqlite::Connection>(std::move(*conn_result));
 
         using TxnGuard = storm::orm::utilities::TransactionGuard<db::sqlite::Connection>;
 


### PR DESCRIPTION
## Summary
- Replace raw `ConnType*` with `std::shared_ptr<ConnType>` in `AggregateStatement`, `GroupByBuilder`, and `TransactionGuard`
- All ORM statement types now consistently use `shared_ptr` for connection passing
- Pool internals correctly keep raw pointers (internal bookkeeping under mutex, public API already returns `shared_ptr`)

## Benchmark results
No performance regression — aggregate/group_by/insert/update all within normal 94-121% efficiency range vs raw SQLite.

## Test plan
- [x] 1789/1789 tests pass (debug)
- [x] ASAN+UBSAN clean
- [x] TSAN clean
- [x] Release benchmarks: AGGREGATE, GROUP_BY, INSERT, UPDATE — no regression

Closes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)