### PR TITLE
test: add sql() and SQL verification tests for all statement types

### DIFF
--- a/src/orm/statements/aggregate.cppm
+++ b/src/orm/statements/aggregate.cppm
@@ -255,6 +255,28 @@ export namespace storm::orm::statements {
             };
         }
 
+        // Return the SQL that would be executed (for testing/debugging)
+        [[nodiscard]] auto sql() -> std::string
+            requires(NumOps > 0)
+        {
+            std::string result;
+            if (join_stmt_.has_value()) {
+                result = build_join_sql();
+            } else {
+                result = base_sql_;
+            }
+            if (where_expr_) {
+                insert_where_clause(result);
+            }
+            if constexpr (HasGroupBy) {
+                if (having_expr_) {
+                    insert_having_clause(result);
+                }
+            }
+            append_modifiers(result);
+            return result;
+        }
+
         // Scalar aggregate: no GROUP BY → returns single value via .get()
         [[nodiscard]] __attribute__((always_inline)) auto get() -> std::expected<ResultType, Error>
             requires(NumOps > 0 && !HasGroupBy)

--- a/src/orm/statements/insert.cppm
+++ b/src/orm/statements/insert.cppm
@@ -243,6 +243,9 @@ export namespace storm::orm::statements {
             [[nodiscard]] auto to_sql() -> std::expected<std::string, Error> {
                 return stmt.to_sql(obj);
             }
+            [[nodiscard]] static auto sql() -> std::string {
+                return insert_returning_sql_string;
+            }
         };
 
         struct VoidQuery {
@@ -253,6 +256,9 @@ export namespace storm::orm::statements {
             }
             [[nodiscard]] auto to_sql() -> std::expected<std::string, Error> {
                 return stmt.to_sql_no_returning(obj);
+            }
+            [[nodiscard]] static auto sql() -> std::string {
+                return insert_sql_string;
             }
         };
 
@@ -266,6 +272,9 @@ export namespace storm::orm::statements {
             [[nodiscard]] auto to_sql() -> std::expected<std::string, Error> {
                 return stmt.to_sql(objects);
             }
+            [[nodiscard]] auto sql() -> std::string {
+                return std::string(get_bulk_insert_sql(objects.size()));
+            }
         };
 
         struct BulkReturningQuery {
@@ -278,6 +287,9 @@ export namespace storm::orm::statements {
             }
             [[nodiscard]] auto to_sql() -> std::expected<std::string, Error> { // NOSONAR(cpp:S1659)
                 return stmt.to_sql_returning(objects);
+            }
+            [[nodiscard]] auto sql() -> std::string { // NOSONAR(cpp:S1659)
+                return std::string(get_bulk_insert_returning_sql(objects.size()));
             }
         };
 

--- a/src/orm/statements/remove.cppm
+++ b/src/orm/statements/remove.cppm
@@ -201,6 +201,9 @@ export namespace storm::orm::statements {
             [[nodiscard]] auto to_sql() -> std::expected<std::string, Error> {
                 return stmt.to_sql(obj);
             }
+            [[nodiscard]] static auto sql() -> std::string {
+                return single_delete_sql_string;
+            }
         };
 
         struct BulkQuery {
@@ -212,6 +215,9 @@ export namespace storm::orm::statements {
             [[nodiscard]] auto to_sql() -> std::expected<std::string, Error> {
                 return stmt.to_sql(objects);
             }
+            [[nodiscard]] auto sql() -> std::string {
+                return std::string(get_bulk_delete_sql(objects.size()));
+            }
         };
 
         struct DeleteAllQuery {
@@ -220,6 +226,9 @@ export namespace storm::orm::statements {
                 return stmt.execute_all();
             }
             [[nodiscard]] auto to_sql() -> std::string {
+                return delete_all_sql_string;
+            }
+            [[nodiscard]] static auto sql() -> std::string {
                 return delete_all_sql_string;
             }
         };

--- a/src/orm/statements/select.cppm
+++ b/src/orm/statements/select.cppm
@@ -79,6 +79,24 @@ export namespace storm::orm::statements {
 
         explicit SelectStatement(std::shared_ptr<ConnType> conn) : conn_(std::move(conn)) {}
 
+        // Build SQL string without preparing or binding (for testing/debugging)
+        [[nodiscard]] static auto build_sql(
+                const std::optional<JoinStatementWrapper>& join_wrapper,
+                const orm::where::ExpressionVariantPtr&    where_expr,
+                const std::optional<int>&                  limit,
+                const std::optional<int>&                  offset,
+                const std::optional<OrderByWrapper>&       order_by_wrapper
+        ) -> std::string {
+            std::string sql = join_wrapper ? join_wrapper->get_complete_sql() : std::string(get_select_sql());
+            if (where_expr) {
+                sql += " WHERE ";
+                sql += orm::where::to_sql(*where_expr);
+            }
+            Base::template append_order_by<ConnType>(sql, order_by_wrapper);
+            Base::template append_limit_offset<ConnType>(sql, limit, offset);
+            return sql;
+        }
+
         // Returns the SQL that would be executed by select()
         [[nodiscard]] auto
         to_sql(std::optional<JoinStatementWrapper>     join_wrapper     = std::nullopt,
@@ -87,13 +105,7 @@ export namespace storm::orm::statements {
                const std::optional<int>&               offset           = std::nullopt,
                const std::optional<OrderByWrapper>&    order_by_wrapper = std::nullopt)
                 -> std::expected<std::string, Error> {
-            std::string sql = join_wrapper ? join_wrapper->get_complete_sql() : std::string(get_select_sql());
-            if (where_expr) {
-                sql += " WHERE ";
-                sql += orm::where::to_sql(*where_expr);
-            }
-            Base::template append_order_by<ConnType>(sql, order_by_wrapper);
-            Base::template append_limit_offset<ConnType>(sql, limit, offset);
+            std::string sql = build_sql(join_wrapper, where_expr, limit, offset, order_by_wrapper);
 
             auto stmt_result = conn_->prepare_cached(sql);
             if (!stmt_result) {
@@ -160,6 +172,15 @@ export namespace storm::orm::statements {
                                 this->offset_value,
                                 this->order_by_wrapper);
             }
+            [[nodiscard]] auto sql() -> std::string {
+                return build_sql(
+                        this->join_wrapper,
+                        this->where_expr,
+                        this->limit_value,
+                        this->offset_value,
+                        this->order_by_wrapper
+                );
+            }
         };
 
         struct FirstQuery : QueryBase {
@@ -180,6 +201,12 @@ export namespace storm::orm::statements {
                 return this->stmt
                         .to_sql_first(this->join_wrapper, this->where_expr, this->offset_value, this->order_by_wrapper);
             }
+            [[nodiscard]] auto sql() -> std::string {
+                std::optional<int> const limit_one = 1;
+                return build_sql(
+                        this->join_wrapper, this->where_expr, limit_one, this->offset_value, this->order_by_wrapper
+                );
+            }
         };
 
         struct GetQuery : QueryBase {
@@ -199,6 +226,12 @@ export namespace storm::orm::statements {
             [[nodiscard]] auto to_sql() -> std::expected<std::string, Error> {
                 return this->stmt
                         .to_sql_get(this->join_wrapper, this->where_expr, this->offset_value, this->order_by_wrapper);
+            }
+            [[nodiscard]] auto sql() -> std::string {
+                std::optional<int> const limit_two = 2;
+                return build_sql(
+                        this->join_wrapper, this->where_expr, limit_two, this->offset_value, this->order_by_wrapper
+                );
             }
         };
 

--- a/src/orm/statements/setop.cppm
+++ b/src/orm/statements/setop.cppm
@@ -109,6 +109,11 @@ export namespace storm::orm::statements {
             return execute_query_loop(cached_stmt_);
         }
 
+        // Return the SQL template without preparing/binding (for testing/debugging)
+        [[nodiscard]] auto sql() -> std::string {
+            return build_combined_sql();
+        }
+
         [[nodiscard]] auto to_sql() -> std::expected<std::string, Error> {
             if (!cached_stmt_) {
                 auto prepare_result = prepare_statement();

--- a/src/orm/statements/update.cppm
+++ b/src/orm/statements/update.cppm
@@ -142,6 +142,9 @@ export namespace storm::orm::statements {
             [[nodiscard]] auto to_sql() -> std::expected<std::string, Error> {
                 return stmt.to_sql(obj);
             }
+            [[nodiscard]] static auto sql() -> std::string {
+                return update_sql_string;
+            }
         };
 
         struct BulkQuery {
@@ -152,6 +155,9 @@ export namespace storm::orm::statements {
             }
             [[nodiscard]] auto to_sql() -> std::expected<std::string, Error> {
                 return stmt.to_sql(objects);
+            }
+            [[nodiscard]] static auto sql() -> std::string {
+                return update_sql_string;
             }
         };
 

--- a/tests/query/test_sql_verify.cpp
+++ b/tests/query/test_sql_verify.cpp
@@ -1,0 +1,569 @@
+#include <gtest/gtest.h>
+#include "test_db_helpers.h"
+
+// NOLINTBEGIN(misc-use-internal-linkage,modernize-use-trailing-return-type,readability-named-parameter,readability-convert-member-functions-to-static)
+
+import storm;
+import <string>;
+import <vector>;
+import <expected>;
+import <format>;
+import <optional>;
+import <span>;
+
+using namespace storm;
+using namespace storm::orm::where;
+
+#include "test_models.h" // NOSONAR cpp:S954
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+// Returns "ASC" or "ASC NULLS FIRST" depending on backend
+template <typename ConnType> constexpr auto order_asc() -> std::string_view {
+    if constexpr (storm::test::is_postgresql<ConnType>()) {
+        return "ASC NULLS FIRST";
+    } else {
+        return "ASC";
+    }
+}
+
+template <typename ConnType> constexpr auto order_desc() -> std::string_view {
+    if constexpr (storm::test::is_postgresql<ConnType>()) {
+        return "DESC NULLS LAST";
+    } else {
+        return "DESC";
+    }
+}
+
+// Returns "LIMIT ALL" for PostgreSQL, "LIMIT -1" for SQLite (unlimited with offset)
+template <typename ConnType> constexpr auto limit_all() -> std::string_view {
+    if constexpr (storm::test::is_postgresql<ConnType>()) {
+        return "LIMIT ALL";
+    } else {
+        return "LIMIT -1";
+    }
+}
+
+// ============================================================================
+// Fixture — no data needed, SQL verification is structural only
+// ============================================================================
+
+template <typename ConnType> class SqlVerifyTest : public StormTestFixture<Person, ConnType, Message> {};
+
+TYPED_TEST_SUITE(SqlVerifyTest, DatabaseTypes);
+
+// ============================================================================
+// SELECT sql()
+// ============================================================================
+
+TYPED_TEST(SqlVerifyTest, SelectSimple) {
+    QuerySet<Person, TypeParam> qs;
+    auto                        sql = qs.select().sql();
+    EXPECT_EQ(
+            sql,
+            "SELECT id, name, age, salary, is_active, years_experience, department, score, nickname, avatar FROM Person"
+    );
+}
+
+TYPED_TEST(SqlVerifyTest, SelectWithWhere) {
+    QuerySet<Person, TypeParam> qs;
+    auto                        sql = qs.where(field<^^Person::age>() > 30).select().sql();
+    EXPECT_EQ(
+            sql,
+            "SELECT id, name, age, salary, is_active, years_experience, department, score, nickname, avatar"
+            " FROM Person WHERE age > ?"
+    );
+}
+
+TYPED_TEST(SqlVerifyTest, SelectWithJoin) {
+    QuerySet<Message, TypeParam> qs;
+    auto                         sql = qs.template join<&Message::sender>().select().sql();
+    EXPECT_EQ(
+            sql,
+            "SELECT t1.id, t1.content, t1.value, t2.id, t2.name, t2.age, t2.salary,"
+            " t2.is_active, t2.years_experience, t2.department, t2.score, t2.nickname, t2.avatar"
+            " FROM Message t1 INNER JOIN Person t2 ON t2.id = t1.sender_id"
+    );
+}
+
+TYPED_TEST(SqlVerifyTest, SelectWithJoinAndWhere) {
+    QuerySet<Message, TypeParam> qs;
+    auto sql = qs.template join<&Message::sender>().where(field<^^Message::value>() > 10).select().sql();
+    EXPECT_EQ(
+            sql,
+            "SELECT t1.id, t1.content, t1.value, t2.id, t2.name, t2.age, t2.salary,"
+            " t2.is_active, t2.years_experience, t2.department, t2.score, t2.nickname, t2.avatar"
+            " FROM Message t1 INNER JOIN Person t2 ON t2.id = t1.sender_id WHERE value > ?"
+    );
+}
+
+TYPED_TEST(SqlVerifyTest, SelectWithOrderBy) {
+    QuerySet<Person, TypeParam> qs;
+    auto                        sql = qs.template order_by<^^Person::name>().select().sql();
+    EXPECT_EQ(
+            sql,
+            std::format(
+                    "SELECT id, name, age, salary, is_active, years_experience, department, score, nickname, avatar"
+                    " FROM Person ORDER BY name {}",
+                    order_asc<TypeParam>()
+            )
+    );
+}
+
+TYPED_TEST(SqlVerifyTest, SelectWithOrderByDesc) {
+    QuerySet<Person, TypeParam> qs;
+    auto                        sql = qs.template order_by<^^Person::age, false>().select().sql();
+    EXPECT_EQ(
+            sql,
+            std::format(
+                    "SELECT id, name, age, salary, is_active, years_experience, department, score, nickname, avatar"
+                    " FROM Person ORDER BY age {}",
+                    order_desc<TypeParam>()
+            )
+    );
+}
+
+TYPED_TEST(SqlVerifyTest, SelectWithLimitOffset) {
+    QuerySet<Person, TypeParam> qs;
+    auto                        sql = qs.limit(10).offset(5).select().sql();
+    EXPECT_EQ(
+            sql,
+            "SELECT id, name, age, salary, is_active, years_experience, department, score, nickname, avatar"
+            " FROM Person LIMIT 10 OFFSET 5"
+    );
+}
+
+TYPED_TEST(SqlVerifyTest, SelectWithOffsetOnly) {
+    QuerySet<Person, TypeParam> qs;
+    auto                        sql = qs.offset(5).select().sql();
+    EXPECT_EQ(
+            sql,
+            std::format(
+                    "SELECT id, name, age, salary, is_active, years_experience, department, score, nickname, avatar"
+                    " FROM Person {} OFFSET 5",
+                    limit_all<TypeParam>()
+            )
+    );
+}
+
+TYPED_TEST(SqlVerifyTest, SelectFullCombo) {
+    QuerySet<Message, TypeParam> qs;
+    auto                         sql = qs.template join<&Message::sender>()
+                       .where(field<^^Message::value>() > 10)
+                       .template order_by<^^Message::content>()
+                       .limit(5)
+                       .offset(2)
+                       .select()
+                       .sql();
+    EXPECT_EQ(
+            sql,
+            std::format(
+                    "SELECT t1.id, t1.content, t1.value, t2.id, t2.name, t2.age, t2.salary,"
+                    " t2.is_active, t2.years_experience, t2.department, t2.score, t2.nickname, t2.avatar"
+                    " FROM Message t1 INNER JOIN Person t2 ON t2.id = t1.sender_id"
+                    " WHERE value > ? ORDER BY content {} LIMIT 5 OFFSET 2",
+                    order_asc<TypeParam>()
+            )
+    );
+}
+
+// ============================================================================
+// first().sql() and get().sql()
+// ============================================================================
+
+TYPED_TEST(SqlVerifyTest, FirstSimple) {
+    QuerySet<Person, TypeParam> qs;
+    auto                        sql = qs.first().sql();
+    EXPECT_EQ(
+            sql,
+            "SELECT id, name, age, salary, is_active, years_experience, department, score, nickname, avatar"
+            " FROM Person LIMIT 1"
+    );
+}
+
+TYPED_TEST(SqlVerifyTest, FirstWithWhere) {
+    QuerySet<Person, TypeParam> qs;
+    auto                        sql = qs.where(field<^^Person::age>() > 30).first().sql();
+    EXPECT_EQ(
+            sql,
+            "SELECT id, name, age, salary, is_active, years_experience, department, score, nickname, avatar"
+            " FROM Person WHERE age > ? LIMIT 1"
+    );
+}
+
+TYPED_TEST(SqlVerifyTest, GetSimple) {
+    QuerySet<Person, TypeParam> qs;
+    auto                        sql = qs.get().sql();
+    EXPECT_EQ(
+            sql,
+            "SELECT id, name, age, salary, is_active, years_experience, department, score, nickname, avatar"
+            " FROM Person LIMIT 2"
+    );
+}
+
+TYPED_TEST(SqlVerifyTest, GetWithWhere) {
+    QuerySet<Person, TypeParam> qs;
+    auto                        sql = qs.where(field<^^Person::id>() == 1).get().sql();
+    EXPECT_EQ(
+            sql,
+            "SELECT id, name, age, salary, is_active, years_experience, department, score, nickname, avatar"
+            " FROM Person WHERE id = ? LIMIT 2"
+    );
+}
+
+// ============================================================================
+// INSERT sql()
+// ============================================================================
+
+TYPED_TEST(SqlVerifyTest, InsertSingleReturning) {
+    QuerySet<Person, TypeParam> qs;
+    Person const                p{};
+    auto                        sql = qs.insert(p).sql();
+    EXPECT_EQ(
+            sql,
+            "INSERT INTO Person (name, age, salary, is_active, years_experience, department, score, nickname, avatar)"
+            " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING id"
+    );
+}
+
+TYPED_TEST(SqlVerifyTest, InsertSingleNoReturning) {
+    QuerySet<Person, TypeParam> qs;
+    Person const                p{};
+    auto                        sql = qs.template insert<storm::orm::statements::ReturnId::No>(p).sql();
+    EXPECT_EQ(
+            sql,
+            "INSERT INTO Person (name, age, salary, is_active, years_experience, department, score, nickname, avatar)"
+            " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)"
+    );
+}
+
+TYPED_TEST(SqlVerifyTest, InsertBulk) {
+    QuerySet<Person, TypeParam>   qs;
+    std::array<Person, 3> const   people{};
+    std::span<const Person> const span{people};
+    auto                          sql = qs.insert(span).sql();
+    EXPECT_EQ(
+            sql,
+            "INSERT INTO Person (name, age, salary, is_active, years_experience, department, score, nickname, avatar)"
+            " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?), (?, ?, ?, ?, ?, ?, ?, ?, ?), (?, ?, ?, ?, ?, ?, ?, ?, ?)"
+    );
+}
+
+TYPED_TEST(SqlVerifyTest, InsertBulkReturning) {
+    QuerySet<Person, TypeParam>   qs;
+    std::array<Person, 2> const   people{};
+    std::span<const Person> const span{people};
+    auto                          sql = qs.template insert<storm::orm::statements::ReturnId::Yes>(span).sql();
+    EXPECT_EQ(
+            sql,
+            "INSERT INTO Person (name, age, salary, is_active, years_experience, department, score, nickname, avatar)"
+            " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?), (?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING id"
+    );
+}
+
+// ============================================================================
+// INSERT sql() with SimpleRecord (fewer fields)
+// ============================================================================
+
+TYPED_TEST(SqlVerifyTest, InsertSimpleRecord) {
+    QuerySet<SimpleRecord, TypeParam> qs;
+    SimpleRecord const                r{};
+    auto                              sql = qs.insert(r).sql();
+    EXPECT_EQ(sql, "INSERT INTO SimpleRecord (name, value) VALUES (?, ?) RETURNING id");
+}
+
+// ============================================================================
+// INSERT sql() with FK model
+// ============================================================================
+
+TYPED_TEST(SqlVerifyTest, InsertMessageWithFK) {
+    QuerySet<Message, TypeParam> qs;
+    Message const                m{};
+    auto                         sql = qs.insert(m).sql();
+    EXPECT_EQ(sql, "INSERT INTO Message (content, value, sender_id) VALUES (?, ?, ?) RETURNING id");
+}
+
+// ============================================================================
+// UPDATE sql()
+// ============================================================================
+
+TYPED_TEST(SqlVerifyTest, UpdateSingle) {
+    QuerySet<Person, TypeParam> qs;
+    Person const                p{};
+    auto                        sql = qs.update(p).sql();
+    EXPECT_EQ(
+            sql,
+            "UPDATE Person SET name=?, age=?, salary=?, is_active=?, years_experience=?,"
+            " department=?, score=?, nickname=?, avatar=? WHERE id = ?"
+    );
+}
+
+TYPED_TEST(SqlVerifyTest, UpdateBulk) {
+    QuerySet<Person, TypeParam>   qs;
+    std::array<Person, 3> const   people{};
+    std::span<const Person> const span{people};
+    auto                          sql = qs.update(span).sql();
+    EXPECT_EQ(
+            sql,
+            "UPDATE Person SET name=?, age=?, salary=?, is_active=?, years_experience=?,"
+            " department=?, score=?, nickname=?, avatar=? WHERE id = ?"
+    );
+}
+
+TYPED_TEST(SqlVerifyTest, UpdateMessageWithFK) {
+    QuerySet<Message, TypeParam> qs;
+    Message const                m{};
+    auto                         sql = qs.update(m).sql();
+    EXPECT_EQ(sql, "UPDATE Message SET content=?, value=?, sender_id=? WHERE id = ?");
+}
+
+// ============================================================================
+// DELETE sql()
+// ============================================================================
+
+TYPED_TEST(SqlVerifyTest, DeleteSingle) {
+    QuerySet<Person, TypeParam> qs;
+    Person const                p{};
+    auto                        sql = qs.remove(p).sql();
+    EXPECT_EQ(sql, "DELETE FROM Person WHERE id = ?");
+}
+
+TYPED_TEST(SqlVerifyTest, DeleteBulk) {
+    QuerySet<Person, TypeParam>   qs;
+    std::array<Person, 3> const   people{};
+    std::span<const Person> const span{people};
+    auto                          sql = qs.remove(span).sql();
+    EXPECT_EQ(sql, "DELETE FROM Person WHERE id IN (?,?,?)");
+}
+
+TYPED_TEST(SqlVerifyTest, DeleteAll) {
+    QuerySet<Person, TypeParam> qs;
+    auto                        sql = qs.remove_all().sql();
+    EXPECT_EQ(sql, "DELETE FROM Person");
+}
+
+TYPED_TEST(SqlVerifyTest, DeleteSimpleRecord) {
+    QuerySet<SimpleRecord, TypeParam> qs;
+    SimpleRecord const                r{};
+    auto                              sql = qs.remove(r).sql();
+    EXPECT_EQ(sql, "DELETE FROM SimpleRecord WHERE id = ?");
+}
+
+// ============================================================================
+// AGGREGATE sql()
+// ============================================================================
+
+TYPED_TEST(SqlVerifyTest, AggregateCountSimple) {
+    QuerySet<Person, TypeParam> qs;
+    auto                        sql = qs.count().sql();
+    EXPECT_EQ(sql, "SELECT COUNT(*) FROM Person");
+}
+
+TYPED_TEST(SqlVerifyTest, AggregateCountWithWhere) {
+    QuerySet<Person, TypeParam> qs;
+    auto                        sql = qs.where(field<^^Person::age>() > 30).count().sql();
+    EXPECT_EQ(sql, "SELECT COUNT(*) FROM Person WHERE age > ?");
+}
+
+TYPED_TEST(SqlVerifyTest, AggregateSumField) {
+    QuerySet<Person, TypeParam> qs;
+    auto                        sql = qs.template sum<^^Person::salary>().sql();
+    EXPECT_EQ(sql, "SELECT SUM(salary) FROM Person");
+}
+
+TYPED_TEST(SqlVerifyTest, AggregateAvgField) {
+    QuerySet<Person, TypeParam> qs;
+    auto                        sql = qs.template avg<^^Person::age>().sql();
+    EXPECT_EQ(sql, "SELECT AVG(age) FROM Person");
+}
+
+TYPED_TEST(SqlVerifyTest, AggregateMinField) {
+    QuerySet<Person, TypeParam> qs;
+    auto                        sql = qs.template min<^^Person::age>().sql();
+    EXPECT_EQ(sql, "SELECT MIN(age) FROM Person");
+}
+
+TYPED_TEST(SqlVerifyTest, AggregateMaxField) {
+    QuerySet<Person, TypeParam> qs;
+    auto                        sql = qs.template max<^^Person::salary>().sql();
+    EXPECT_EQ(sql, "SELECT MAX(salary) FROM Person");
+}
+
+TYPED_TEST(SqlVerifyTest, AggregateChainedOps) {
+    QuerySet<Person, TypeParam> qs;
+    auto                        sql = qs.template sum<^^Person::age>().template count<>().sql();
+    EXPECT_EQ(sql, "SELECT SUM(age), COUNT(*) FROM Person");
+}
+
+TYPED_TEST(SqlVerifyTest, AggregateCountWithJoin) {
+    QuerySet<Message, TypeParam> qs;
+    auto                         sql = qs.template join<&Message::sender>().count().sql();
+    EXPECT_EQ(sql, "SELECT COUNT(*) FROM Message t1 INNER JOIN Person t2 ON t2.id = t1.sender_id");
+}
+
+TYPED_TEST(SqlVerifyTest, AggregateCountWithJoinAndWhere) {
+    QuerySet<Message, TypeParam> qs;
+    auto sql = qs.template join<&Message::sender>().where(field<^^Message::value>() > 10).count().sql();
+    EXPECT_EQ(sql, "SELECT COUNT(*) FROM Message t1 INNER JOIN Person t2 ON t2.id = t1.sender_id WHERE value > ?");
+}
+
+// ============================================================================
+// GROUP BY sql()
+// ============================================================================
+
+TYPED_TEST(SqlVerifyTest, GroupByCount) {
+    QuerySet<Person, TypeParam> qs;
+    auto                        sql = qs.template group_by<^^Person::department>().template count<>().sql();
+    EXPECT_EQ(sql, "SELECT department, COUNT(*) FROM Person GROUP BY department");
+}
+
+TYPED_TEST(SqlVerifyTest, GroupBySum) {
+    QuerySet<Person, TypeParam> qs;
+    auto sql = qs.template group_by<^^Person::department>().template sum<^^Person::salary>().sql();
+    EXPECT_EQ(sql, "SELECT department, SUM(salary) FROM Person GROUP BY department");
+}
+
+TYPED_TEST(SqlVerifyTest, GroupByWithWhere) {
+    QuerySet<Person, TypeParam> qs;
+    auto                        sql = qs.where(field<^^Person::is_active>() == true)
+                       .template group_by<^^Person::department>()
+                       .template count<>()
+                       .sql();
+    EXPECT_EQ(sql, "SELECT department, COUNT(*) FROM Person WHERE is_active = ? GROUP BY department");
+}
+
+TYPED_TEST(SqlVerifyTest, GroupByWithHaving) {
+    QuerySet<Person, TypeParam> qs;
+    auto                        sql = qs.template group_by<^^Person::department>()
+                       .template count<>()
+                       .having(field<^^Person::department>() == "Engineering")
+                       .sql();
+    EXPECT_EQ(sql, "SELECT department, COUNT(*) FROM Person GROUP BY department HAVING department = ?");
+}
+
+TYPED_TEST(SqlVerifyTest, GroupByWithWhereAndHaving) {
+    QuerySet<Person, TypeParam> qs;
+    auto                        sql = qs.where(field<^^Person::age>() > 25)
+                       .template group_by<^^Person::department>()
+                       .template count<>()
+                       .having(field<^^Person::department>() == "Engineering")
+                       .sql();
+    EXPECT_EQ(sql, "SELECT department, COUNT(*) FROM Person WHERE age > ? GROUP BY department HAVING department = ?");
+}
+
+TYPED_TEST(SqlVerifyTest, GroupByWithOrderBy) {
+    QuerySet<Person, TypeParam> qs;
+    auto                        sql = qs.template order_by<^^Person::department>()
+                       .template group_by<^^Person::department>()
+                       .template count<>()
+                       .sql();
+    EXPECT_EQ(
+            sql,
+            std::format(
+                    "SELECT department, COUNT(*) FROM Person GROUP BY department ORDER BY department {}",
+                    order_asc<TypeParam>()
+            )
+    );
+}
+
+TYPED_TEST(SqlVerifyTest, GroupByWithLimitOffset) {
+    QuerySet<Person, TypeParam> qs;
+    auto sql = qs.limit(3).offset(1).template group_by<^^Person::department>().template count<>().sql();
+    EXPECT_EQ(sql, "SELECT department, COUNT(*) FROM Person GROUP BY department LIMIT 3 OFFSET 1");
+}
+
+TYPED_TEST(SqlVerifyTest, GroupByMultiField) {
+    QuerySet<Person, TypeParam> qs;
+    auto sql = qs.template group_by<^^Person::department, ^^Person::is_active>().template count<>().sql();
+    EXPECT_EQ(sql, "SELECT department, is_active, COUNT(*) FROM Person GROUP BY department, is_active");
+}
+
+TYPED_TEST(SqlVerifyTest, GroupByWithJoin) {
+    QuerySet<Message, TypeParam> qs;
+    auto sql = qs.template join<&Message::sender>().template group_by<^^Message::content>().template count<>().sql();
+    EXPECT_EQ(
+            sql,
+            "SELECT content, COUNT(*) FROM Message t1 INNER JOIN Person t2 ON t2.id = t1.sender_id"
+            " GROUP BY content"
+    );
+}
+
+// ============================================================================
+// SET OPERATION sql()
+// ============================================================================
+
+TYPED_TEST(SqlVerifyTest, UnionSimple) {
+    QuerySet<Person, TypeParam> qs1;
+    QuerySet<Person, TypeParam> qs2;
+    auto sql = qs1.where(field<^^Person::age>() > 40).union_(qs2.where(field<^^Person::age>() < 25)).sql();
+    EXPECT_EQ(
+            sql,
+            "SELECT id, name, age, salary, is_active, years_experience, department, score, nickname, avatar"
+            " FROM Person WHERE age > ? UNION "
+            "SELECT id, name, age, salary, is_active, years_experience, department, score, nickname, avatar"
+            " FROM Person WHERE age < ?"
+    );
+}
+
+TYPED_TEST(SqlVerifyTest, UnionAllSimple) {
+    QuerySet<Person, TypeParam> qs1;
+    QuerySet<Person, TypeParam> qs2;
+    auto sql = qs1.where(field<^^Person::age>() > 40).union_all(qs2.where(field<^^Person::age>() < 25)).sql();
+    EXPECT_EQ(
+            sql,
+            "SELECT id, name, age, salary, is_active, years_experience, department, score, nickname, avatar"
+            " FROM Person WHERE age > ? UNION ALL "
+            "SELECT id, name, age, salary, is_active, years_experience, department, score, nickname, avatar"
+            " FROM Person WHERE age < ?"
+    );
+}
+
+TYPED_TEST(SqlVerifyTest, ExceptSimple) {
+    QuerySet<Person, TypeParam> qs1;
+    QuerySet<Person, TypeParam> qs2;
+    auto                        sql = qs1.except_(qs2.where(field<^^Person::age>() < 25)).sql();
+    EXPECT_EQ(
+            sql,
+            "SELECT id, name, age, salary, is_active, years_experience, department, score, nickname, avatar"
+            " FROM Person EXCEPT "
+            "SELECT id, name, age, salary, is_active, years_experience, department, score, nickname, avatar"
+            " FROM Person WHERE age < ?"
+    );
+}
+
+TYPED_TEST(SqlVerifyTest, IntersectSimple) {
+    QuerySet<Person, TypeParam> qs1;
+    QuerySet<Person, TypeParam> qs2;
+    auto sql = qs1.where(field<^^Person::age>() > 30).intersect_(qs2.where(field<^^Person::is_active>() == true)).sql();
+    EXPECT_EQ(
+            sql,
+            "SELECT id, name, age, salary, is_active, years_experience, department, score, nickname, avatar"
+            " FROM Person WHERE age > ? INTERSECT "
+            "SELECT id, name, age, salary, is_active, years_experience, department, score, nickname, avatar"
+            " FROM Person WHERE is_active = ?"
+    );
+}
+
+TYPED_TEST(SqlVerifyTest, SetOpWithOrderByAndLimit) {
+    QuerySet<Person, TypeParam> qs1;
+    QuerySet<Person, TypeParam> qs2;
+    auto                        sql = qs1.where(field<^^Person::age>() > 40)
+                       .union_(qs2.where(field<^^Person::age>() < 25))
+                       .template order_by<^^Person::name>()
+                       .limit(10)
+                       .sql();
+    EXPECT_EQ(
+            sql,
+            std::format(
+                    "SELECT id, name, age, salary, is_active, years_experience, department, score, nickname, avatar"
+                    " FROM Person WHERE age > ? UNION "
+                    "SELECT id, name, age, salary, is_active, years_experience, department, score, nickname, avatar"
+                    " FROM Person WHERE age < ? ORDER BY name {} LIMIT 10",
+                    order_asc<TypeParam>()
+            )
+    );
+}
+
+// NOLINTEND(misc-use-internal-linkage,modernize-use-trailing-return-type,readability-named-parameter,readability-convert-member-functions-to-static)


### PR DESCRIPTION
## Summary
- Add lightweight `sql()` method to all statement types (SELECT, INSERT, UPDATE, DELETE, Aggregate, SetOp) that returns the SQL template with `?` placeholders — no database interaction needed
- Add 49 SQL verification tests covering all combinations: simple, WHERE, JOIN, ORDER BY, LIMIT/OFFSET, full combo, and backend-aware (PostgreSQL NULLS FIRST/LAST, LIMIT ALL)
- Refactor `SelectStatement::to_sql()` to reuse new `build_sql()` to avoid duplication

Closes #174

## Test plan
- [x] All 1887 tests pass (including 98 new SqlVerify tests across both backends)
- [x] ASAN+UBSAN clean
- [x] TSAN clean
- [x] No performance regression (benchmarks verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)