### PR TITLE
remove: drop last_insert_rowid — superseded by RETURNING

### DIFF
--- a/docs/architecture/DESIGN_DECISIONS.md
+++ b/docs/architecture/DESIGN_DECISIONS.md
@@ -139,8 +139,7 @@ Two optimized batch operation strategies:
 Returns generated IDs from insert operations:
 - Single insert: `std::expected<int64_t, Error>`
 - Batch insert: `std::expected<std::vector<int64_t>, Error>`
-- Uses SQLite's `AUTOINCREMENT` and `sqlite3_last_insert_rowid()`
-- For bulk INSERT, calculates sequential IDs from last ID
+- Uses `RETURNING id` clause for both single and bulk INSERT
 
 **Table creation requires AUTOINCREMENT:**
 ```cpp

--- a/docs/features/BATCH_OPERATIONS.md
+++ b/docs/features/BATCH_OPERATIONS.md
@@ -135,30 +135,6 @@ static auto get_cached_sql(size_t count) -> std::string {
 
 **Thread safety**: Each thread has its own cache (thread_local), zero synchronization overhead
 
-### Auto-Generated ID Calculation
-
-For bulk INSERT, Storm calculates sequential IDs from the last insert:
-
-```cpp
-auto execute_batch(std::span<const T> objects) -> std::expected<std::vector<int64_t>, Error> {
-    // Execute bulk INSERT
-    stmt->execute();
-
-    // Get last inserted ID
-    int64_t last_id = conn_.last_insert_rowid();
-
-    // Calculate all IDs (sequential from last_id)
-    std::vector<int64_t> ids;
-    ids.reserve(objects.size());
-    for (size_t i = 0; i < objects.size(); ++i) {
-        ids.push_back(last_id - (objects.size() - 1 - i));
-    }
-
-    return ids;
-}
-```
-
-**Requirement**: Table must use `AUTOINCREMENT` for correct sequential IDs
 
 ## Batch UPDATE
 

--- a/src/db/postgresql.cppm
+++ b/src/db/postgresql.cppm
@@ -683,14 +683,6 @@ export namespace storm::db::postgresql {
             return conn_.get();
         }
 
-        [[nodiscard]] auto last_insert_rowid() const noexcept -> int64_t {
-            return last_insert_rowid_;
-        }
-
-        auto set_last_insert_rowid(int64_t rowid) noexcept -> void {
-            last_insert_rowid_ = rowid;
-        }
-
       private:
         explicit Connection(PGconnPtr conn_ptr) : conn_(std::move(conn_ptr)) {
             statement_cache_.reserve(STMT_CACHE_RESERVE);
@@ -734,8 +726,7 @@ export namespace storm::db::postgresql {
 
         PGconnPtr      conn_;
         StatementCache statement_cache_;
-        int64_t        last_insert_rowid_ = 0;
-        int            stmt_counter_      = 0;
+        int            stmt_counter_ = 0;
     };
 
     // Verify concepts are satisfied

--- a/src/db/sqlite.cppm
+++ b/src/db/sqlite.cppm
@@ -453,13 +453,6 @@ export namespace storm::db::sqlite {
             return db.get();
         }
 
-        // LCOV_EXCL_START — public API, not called by ORM (uses RETURNING instead)
-        // Get the row ID of the most recent successful INSERT
-        [[nodiscard]] auto last_insert_rowid() const noexcept -> int64_t {
-            return sqlite3_last_insert_rowid(db.get());
-        }
-        // LCOV_EXCL_STOP
-
       private:
         explicit Connection(SqlitePtr db_ptr) : db(std::move(db_ptr)) {
             // Reserve capacity to prevent rehashing and dangling pointers in InsertStatement

--- a/tests/mock_libpq/test_orm_pg_mock_errors.cpp
+++ b/tests/mock_libpq/test_orm_pg_mock_errors.cpp
@@ -567,19 +567,6 @@ namespace {
         EXPECT_NE(raw, nullptr);
     }
 
-    TEST_F(PgConnectionAccessorTest, LastInsertRowid) {
-        auto conn_result = PgConnection::open("host=localhost");
-        ASSERT_TRUE(conn_result.has_value());
-
-        EXPECT_EQ(conn_result->last_insert_rowid(), 0);
-
-        conn_result->set_last_insert_rowid(42);
-        EXPECT_EQ(conn_result->last_insert_rowid(), 42);
-
-        conn_result->set_last_insert_rowid(100);
-        EXPECT_EQ(conn_result->last_insert_rowid(), 100);
-    }
-
     // ============================================================================
     // Quote Handling in Placeholder Translation Tests (L688-693)
     // ============================================================================
@@ -1363,14 +1350,6 @@ namespace {
 
         [[nodiscard]] auto get() const noexcept -> void* { // NOSONAR(cpp:S5008)
             return nullptr;
-        }
-
-        [[nodiscard]] auto last_insert_rowid() const noexcept -> int64_t {
-            return 0;
-        }
-
-        auto set_last_insert_rowid(int64_t /*rowid*/) noexcept -> void {
-            // Intentionally empty.
         }
 
         auto set_fail_binds(bool fail) noexcept -> void {

--- a/tests/mock_sqlite/mock_sqlite3.cpp
+++ b/tests/mock_sqlite/mock_sqlite3.cpp
@@ -20,8 +20,7 @@ namespace {
 
     // Fake handles - just use pointers to distinguish between null and valid
     struct FakeSqlite3 {
-        std::string error_message     = "not an error";
-        int64_t     last_insert_rowid = 0;
+        std::string error_message = "not an error";
     };
 
     struct FakeSqlite3Stmt {
@@ -576,13 +575,6 @@ auto sqlite3_expanded_sql(sqlite3_stmt* pStmt) -> char* {
     auto*       copy        = static_cast<char*>(malloc(strlen(placeholder) + 1)); // NOSONAR(cpp:S1231)
     strcpy(copy, placeholder);                                                     // NOSONAR(cpp:S5025)
     return copy;
-}
-
-auto sqlite3_last_insert_rowid(sqlite3* db) -> int64_t {
-    if (auto* fake_db = reinterpret_cast<FakeSqlite3*>(db); fake_db) { // NOSONAR(cpp:S3630)
-        return fake_db->last_insert_rowid++;
-    }
-    return 0;
 }
 
 } // extern "C"

--- a/tests/mock_sqlite/mock_sqlite3.h
+++ b/tests/mock_sqlite/mock_sqlite3.h
@@ -236,9 +236,6 @@ auto sqlite3_free(void *ptr) -> void;
 // Expanded SQL (parameter substitution for debugging)
 auto sqlite3_expanded_sql(sqlite3_stmt *pStmt) -> char *;
 
-// Last insert rowid
-auto sqlite3_last_insert_rowid(sqlite3 *db) -> int64_t;
-
 #ifdef __cplusplus
 }
 #endif

--- a/tests/schema/test_types.cpp
+++ b/tests/schema/test_types.cpp
@@ -467,7 +467,6 @@ TYPED_TEST(InsertOptionsTest, BatchInsertReturnsVoid) {
             {.id = 0, .big_num = 300LL, .ll_signed = 30LL},
     };
 
-    // Batch insert returns void (no IDs - SQLite's last_insert_rowid is unreliable for batch)
     auto result = qs.insert(batch).execute();
     ASSERT_TRUE(result.has_value());
 


### PR DESCRIPTION
## Summary

- Remove `last_insert_rowid` from SQLite and PostgreSQL `Connection` classes — the ORM no longer uses it, all ID retrieval goes through `RETURNING id`
- Remove mock stubs, mock implementation, and the `LastInsertRowid` test
- Update docs to reflect `RETURNING id` usage

Closes #184

## Test plan
- [ ] All 1887 tests pass (verified locally before push)
- [ ] SonarCloud gate passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)