### PR TITLE
refactor: enable trailing return type syntax

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,7 +2,7 @@
 # Clang-Tidy configuration for Storm ORM
 # Comprehensive checks for C++26 ORM project
 #
-# Categories enabled: bugprone, cert, concurrency, cppcoreguidelines, misc, modernize, performance, readability
+# Categories enabled: bugprone, cert, concurrency, cppcoreguidelines, misc, performance, readability
 # Excluded categories: android, fuchsia, llvm, abseil, google, objc, etc. (platform/library-specific)
 #
 # Exclusion policy:
@@ -34,7 +34,6 @@ Checks: >
   -cppcoreguidelines-pro-type-reinterpret-cast,
   misc-*,
   -misc-include-cleaner,
-  modernize-*,
   performance-*,
   -performance-enum-size,
   readability-*

--- a/benchmarks/main.cpp
+++ b/benchmarks/main.cpp
@@ -50,7 +50,7 @@ namespace {
         bool        thorough_mode = false; // 1.5x iterations for regression testing
     };
 
-    void print_help(const char* prog) {
+    auto print_help(const char* prog) -> void {
         std::cout << "Storm ORM Benchmark System\n\n";
         std::cout << "Usage: " << prog << " [options]\n\n";
         std::cout << "Options:\n";

--- a/benchmarks/operations/aggregate.hpp
+++ b/benchmarks/operations/aggregate.hpp
@@ -42,7 +42,7 @@ namespace storm::benchmark {
     enum class AggregateOp { Count, CountField, CountDistinct, Sum, Avg, Min, Max };
 
     // Get aggregate operation name for display
-    constexpr std::string_view aggregate_op_name(AggregateOp op) {
+    constexpr auto aggregate_op_name(AggregateOp op) -> std::string_view {
         using enum AggregateOp;
         switch (op) {
         case Count:
@@ -125,7 +125,7 @@ namespace storm::benchmark {
         // ====================================================================
         // print_info - Uses shared footer from base class
         // ====================================================================
-        void print_info() const {
+        auto print_info() const -> void {
             std::cout << "Operation: " << aggregate_op_name(Op);
 
             if constexpr (Op != AggregateOp::Count) {
@@ -162,12 +162,12 @@ namespace storm::benchmark {
 
       public:
         // For compatibility with execute_with_filters
-        int execute_iteration() {
+        auto execute_iteration() -> int {
             auto result = create_aggregate_stmt().select().execute();
             return (result.has_value() && result.value() >= 0) ? 1 : 0;
         }
 
-        int execute(int iterations) {
+        auto execute(int iterations) -> int {
             // Create aggregate statement ONCE (like raw prepares statement once)
             // then call execute() in the loop - matches fair benchmark pattern
             Base::apply_query_filters();
@@ -186,7 +186,7 @@ namespace storm::benchmark {
         // execute_raw - Raw SQLite aggregate query
         // ====================================================================
       private:
-        static std::string build_aggregate_sql() {
+        static auto build_aggregate_sql() -> std::string {
             std::string sql = "SELECT ";
 
             // Build aggregate function
@@ -250,7 +250,7 @@ namespace storm::benchmark {
         }
 
       public:
-        int execute_raw(int iterations) {
+        auto execute_raw(int iterations) -> int {
             sqlite3* db = get_db<Model>();
             if (!db)
                 return 0;

--- a/benchmarks/operations/base.hpp
+++ b/benchmarks/operations/base.hpp
@@ -24,7 +24,7 @@ namespace storm::benchmark {
     // ========================================================================
     // get_db: Helper to get raw sqlite3* from default connection
     // ========================================================================
-    template <typename Model> sqlite3* get_db() {
+    template <typename Model> auto get_db() -> sqlite3* {
         auto& conn = storm::QuerySet<Model>::get_default_connection();
         return conn->get();
     }
@@ -38,7 +38,7 @@ namespace storm::benchmark {
 
     // INSERT operation specialization
     template <> struct OperationDispatcher<OperationType::Insert> {
-        static constexpr std::string_view name() {
+        static constexpr auto name() -> std::string_view {
             return "INSERT";
         }
 
@@ -49,7 +49,7 @@ namespace storm::benchmark {
 
     // UPDATE operation specialization
     template <> struct OperationDispatcher<OperationType::UpdatePK> {
-        static constexpr std::string_view name() {
+        static constexpr auto name() -> std::string_view {
             return "UPDATE by PK";
         }
 
@@ -60,7 +60,7 @@ namespace storm::benchmark {
 
     // DELETE operation specialization (for future use)
     template <> struct OperationDispatcher<OperationType::Delete> {
-        static constexpr std::string_view name() {
+        static constexpr auto name() -> std::string_view {
             return "DELETE";
         }
 
@@ -71,7 +71,7 @@ namespace storm::benchmark {
 
     // SELECT operation specialization
     template <> struct OperationDispatcher<OperationType::Select> {
-        static constexpr std::string_view name() {
+        static constexpr auto name() -> std::string_view {
             return "SELECT WHERE";
         }
     };
@@ -86,16 +86,16 @@ namespace storm::benchmark {
 
       protected:
         // Accessor methods for derived classes
-        QuerySet<Model>& qs() {
+        auto qs() -> QuerySet<Model>& {
             return qs_;
         }
-        const QuerySet<Model>& qs() const {
+        auto qs() const -> const QuerySet<Model>& {
             return qs_;
         }
-        std::vector<Model>& data() {
+        auto data() -> std::vector<Model>& {
             return data_;
         }
-        const std::vector<Model>& data() const {
+        auto data() const -> const std::vector<Model>& {
             return data_;
         }
         auto batch_size() const -> int {
@@ -115,13 +115,13 @@ namespace storm::benchmark {
 
         // Default model creation - derived classes can override via static method hiding
         // index parameter allows generating varied data (useful for SELECT WHERE benchmarks)
-        static Model create_model([[maybe_unused]] int index = 0) {
+        static auto create_model([[maybe_unused]] int index = 0) -> Model {
             return Model{.id = 0, .name = "BenchmarkPerson", .age = 30, .is_active = true, .salary = 50000.0};
         }
 
         // Bind model fields to statement (name, age, is_active, salary)
         // idx is 1-based SQLite parameter index, incremented after each bind
-        static void bind_model_fields(sqlite3_stmt* stmt, const Model& p, int& idx) {
+        static auto bind_model_fields(sqlite3_stmt* stmt, const Model& p, int& idx) -> void {
             sqlite3_bind_text(stmt, idx++, p.name.c_str(), -1, SQLITE_TRANSIENT);
             sqlite3_bind_int(stmt, idx++, p.age);
             sqlite3_bind_int(stmt, idx++, p.is_active ? 1 : 0);
@@ -129,7 +129,7 @@ namespace storm::benchmark {
         }
 
         // Execute statement, reset, return success count
-        static int step_and_reset(sqlite3_stmt* stmt, [[maybe_unused]] sqlite3* db, int rows) {
+        static auto step_and_reset(sqlite3_stmt* stmt, [[maybe_unused]] sqlite3* db, int rows) -> int {
             if (sqlite3_step(stmt) == SQLITE_DONE) {
                 sqlite3_reset(stmt);
                 return rows;
@@ -191,7 +191,7 @@ namespace storm::benchmark {
         // ====================================================================
         // Unified print_info() with compile-time operation name
         // ====================================================================
-        template <OperationType Op> void print_info_unified() const {
+        template <OperationType Op> auto print_info_unified() const -> void {
             constexpr std::string_view op_name = OperationDispatcher<Op>::name();
             if (batch_size_ == 1)
                 std::cout << "Operation: " << op_name << " (single row)\n";
@@ -203,7 +203,7 @@ namespace storm::benchmark {
         // Unified execute() with compile-time operation dispatch
         // Runtime batch size check (same as Storm ORM for fair comparison)
         // ====================================================================
-        template <OperationType Op> int execute_unified(int iterations) {
+        template <OperationType Op> auto execute_unified(int iterations) -> int {
             int total = 0;
             if (batch_size_ == 1) {
                 for (int i = 0; i < iterations; i++) {

--- a/benchmarks/operations/delete.hpp
+++ b/benchmarks/operations/delete.hpp
@@ -32,18 +32,18 @@ namespace storm::benchmark {
         explicit DeleteBenchmark(int batch_size = 1) : Base(batch_size) {}
 
         // Use unified print_info with compile-time operation name
-        void print_info() const {
+        auto print_info() const -> void {
             Base::template print_info_unified<OperationType::Delete>();
         }
 
-        void prepare(int iterations) {
+        auto prepare(int iterations) -> void {
             // Clear table, generate data, insert to get IDs
             Base::prepare_with_insert(iterations);
         }
 
         // DELETE needs special handling: re-insert data before each batch iteration
         // because after one DELETE, all rows are gone
-        int execute(int iterations) {
+        auto execute(int iterations) -> int {
             int total = 0;
             // Runtime check - same as Storm ORM
             if (Base::batch_size() == 1) {
@@ -65,7 +65,7 @@ namespace storm::benchmark {
 
       private:
         // Build DELETE SQL with IN clause for bulk operations
-        static std::string sql_delete_batch(size_t count) {
+        static auto sql_delete_batch(size_t count) -> std::string {
             if (count == 1) {
                 return "DELETE FROM Person WHERE id = ?";
             }
@@ -80,14 +80,14 @@ namespace storm::benchmark {
         }
 
         // Bind IDs for IN clause
-        static void bind_ids(sqlite3_stmt* stmt, const Model* data, size_t count, int idx = 1) {
+        static auto bind_ids(sqlite3_stmt* stmt, const Model* data, size_t count, int idx = 1) -> void {
             for (size_t i = 0; i < count; i++) {
                 sqlite3_bind_int64(stmt, idx++, data[i].id);
             }
         }
 
         // Helper: Execute single-row deletes
-        int execute_single_row(sqlite3_stmt* stmt, int iterations) {
+        auto execute_single_row(sqlite3_stmt* stmt, int iterations) -> int {
             int total = 0;
             for (int i = 0; i < iterations; i++) {
                 sqlite3_bind_int64(stmt, 1, Base::data()[i].id);
@@ -104,7 +104,7 @@ namespace storm::benchmark {
 
         // Helper: Execute large batch using chunked IN clauses with transaction
         // (matches Storm ORM's execute_chunked strategy)
-        int execute_chunked_batch(sqlite3* db, int iterations) {
+        auto execute_chunked_batch(sqlite3* db, int iterations) -> int {
             int total = 0;
 
             // Pre-prepare statements for each unique chunk size we'll need
@@ -164,7 +164,7 @@ namespace storm::benchmark {
 
         // Runtime check for bulk SQL strategy (matches Storm ORM's logic)
         // Returns true if batch should use bulk IN clause, false for individual deletes
-        bool should_use_bulk_sql() const {
+        auto should_use_bulk_sql() const -> bool {
             // max_bulk_size = 999 / fields_per_row = 999 for DELETE (1 field per row)
             constexpr size_t max_bulk_size   = 999 / Base::fields_per_row;
             constexpr size_t bulk_sweet_spot = std::max(size_t(50), max_bulk_size / 2);
@@ -187,7 +187,7 @@ namespace storm::benchmark {
         }
 
         // Helper: Re-insert data using Storm ORM (not timed - just setup)
-        void reinsert_data() {
+        auto reinsert_data() -> void {
             if (auto insert_result = Base::qs().insert(Base::data()).execute(); !insert_result.has_value()) {
                 return;
             }
@@ -211,7 +211,7 @@ namespace storm::benchmark {
         }
 
       public:
-        int execute_raw(int iterations) {
+        auto execute_raw(int iterations) -> int {
             sqlite3* db = get_db<Model>();
             if (!db)
                 return 0;

--- a/benchmarks/operations/distinct.hpp
+++ b/benchmarks/operations/distinct.hpp
@@ -93,7 +93,7 @@ namespace storm::benchmark {
         // ====================================================================
         // print_info - Uses shared footer from base class
         // ====================================================================
-        void print_info() const {
+        auto print_info() const -> void {
             constexpr std::string_view distinct_field = std::meta::identifier_of(DistinctFieldInfo);
             std::cout << "Operation: SELECT DISTINCT " << distinct_field;
             Base::print_info_footer();
@@ -102,12 +102,12 @@ namespace storm::benchmark {
         // ====================================================================
         // execute - Storm ORM DISTINCT using base class helpers
         // ====================================================================
-        int execute_iteration() {
+        auto execute_iteration() -> int {
             auto results = Base::qs().template distinct<DistinctFieldInfo>().select();
             return results.value().size();
         }
 
-        int execute(int iterations) {
+        auto execute(int iterations) -> int {
             return Base::execute_with_filters(iterations);
         }
 
@@ -116,7 +116,7 @@ namespace storm::benchmark {
         // ====================================================================
       private:
         // Build DISTINCT SQL string based on enabled features
-        static std::string build_distinct_sql() {
+        static auto build_distinct_sql() -> std::string {
             constexpr std::string_view distinct_field = std::meta::identifier_of(DistinctFieldInfo);
             std::string                sql;
 
@@ -156,7 +156,7 @@ namespace storm::benchmark {
         }
 
       public:
-        int execute_raw(int iterations) {
+        auto execute_raw(int iterations) -> int {
             sqlite3* db = get_db<BaseModel>();
             if (db == nullptr)
                 return 0;
@@ -269,23 +269,23 @@ namespace storm::benchmark {
             requires(!WhereCfg::enabled)
             : Base(dataset_size) {}
 
-        void print_info() const {
+        auto print_info() const -> void {
             constexpr std::string_view field1 = std::meta::identifier_of(DistinctFieldInfo1);
             constexpr std::string_view field2 = std::meta::identifier_of(DistinctFieldInfo2);
             std::cout << "Operation: SELECT DISTINCT " << field1 << ", " << field2;
             Base::print_info_footer();
         }
 
-        int execute_iteration() {
+        auto execute_iteration() -> int {
             auto results = Base::qs().template distinct<DistinctFieldInfo1, DistinctFieldInfo2>().select();
             return results.value().size();
         }
 
-        int execute(int iterations) {
+        auto execute(int iterations) -> int {
             return Base::execute_with_filters(iterations);
         }
 
-        int execute_raw(int iterations) {
+        auto execute_raw(int iterations) -> int {
             sqlite3* db = get_db<BaseModel>();
             if (db == nullptr)
                 return 0;
@@ -325,7 +325,8 @@ namespace storm::benchmark {
         }
 
       private:
-        template <typename T> __attribute__((always_inline)) static T extract_column(sqlite3_stmt* stmt, int col) {
+        template <typename T>
+        __attribute__((always_inline)) static auto extract_column(sqlite3_stmt* stmt, int col) -> T {
             if constexpr (std::is_same_v<T, std::string>) {
                 auto text = reinterpret_cast<const char*>(sqlite3_column_text(stmt, col));
                 return text != nullptr ? T(text) : T{};
@@ -380,7 +381,7 @@ namespace storm::benchmark {
             requires(!WhereCfg::enabled)
             : Base(dataset_size) {}
 
-        void print_info() const {
+        auto print_info() const -> void {
             constexpr std::string_view field1 = std::meta::identifier_of(DistinctFieldInfo1);
             constexpr std::string_view field2 = std::meta::identifier_of(DistinctFieldInfo2);
             constexpr std::string_view field3 = std::meta::identifier_of(DistinctFieldInfo3);
@@ -388,17 +389,17 @@ namespace storm::benchmark {
             Base::print_info_footer();
         }
 
-        int execute_iteration() {
+        auto execute_iteration() -> int {
             auto results =
                     Base::qs().template distinct<DistinctFieldInfo1, DistinctFieldInfo2, DistinctFieldInfo3>().select();
             return results.value().size();
         }
 
-        int execute(int iterations) {
+        auto execute(int iterations) -> int {
             return Base::execute_with_filters(iterations);
         }
 
-        int execute_raw(int iterations) {
+        auto execute_raw(int iterations) -> int {
             sqlite3* db = get_db<BaseModel>();
             if (db == nullptr)
                 return 0;
@@ -443,7 +444,8 @@ namespace storm::benchmark {
         }
 
       private:
-        template <typename T> __attribute__((always_inline)) static T extract_column(sqlite3_stmt* stmt, int col) {
+        template <typename T>
+        __attribute__((always_inline)) static auto extract_column(sqlite3_stmt* stmt, int col) -> T {
             if constexpr (std::is_same_v<T, std::string>) {
                 auto text = reinterpret_cast<const char*>(sqlite3_column_text(stmt, col));
                 return text != nullptr ? T(text) : T{};
@@ -494,25 +496,25 @@ namespace storm::benchmark {
             requires(!WhereCfg::enabled)
             : Base(dataset_size) {}
 
-        void print_info() const {
+        auto print_info() const -> void {
             constexpr std::string_view distinct_field = std::meta::identifier_of(DistinctFieldInfo);
             std::cout << "Operation: SELECT DISTINCT " << distinct_field;
             // ORDER BY is printed by base class print_info_footer()
             Base::print_info_footer();
         }
 
-        int execute_iteration() {
+        auto execute_iteration() -> int {
             // NOTE: Storm ORM handles ORDER BY via the base class apply_query_filters()
             // which was already called, so just call distinct().select()
             auto results = Base::qs().template distinct<DistinctFieldInfo>().select();
             return results.value().size();
         }
 
-        int execute(int iterations) {
+        auto execute(int iterations) -> int {
             return Base::execute_with_filters(iterations);
         }
 
-        int execute_raw(int iterations) {
+        auto execute_raw(int iterations) -> int {
             sqlite3* db = get_db<BaseModel>();
             if (db == nullptr)
                 return 0;

--- a/benchmarks/operations/first_get.hpp
+++ b/benchmarks/operations/first_get.hpp
@@ -45,21 +45,21 @@ namespace storm::benchmark {
             requires(WhereCfg::enabled)
             : Base(value, dataset_size) {}
 
-        void print_info() const {
+        auto print_info() const -> void {
             std::cout << "Operation: FIRST";
             Base::print_info_footer();
         }
 
-        int execute_iteration() {
+        auto execute_iteration() -> int {
             auto result = Base::qs().first().execute();
             return (result.has_value() && result.value().has_value()) ? 1 : 0;
         }
 
-        int execute(int iterations) {
+        auto execute(int iterations) -> int {
             return Base::execute_with_filters(iterations);
         }
 
-        int execute_raw(int iterations) {
+        auto execute_raw(int iterations) -> int {
             sqlite3* db = get_db<BaseModel>();
             if (!db)
                 return 0;
@@ -142,21 +142,21 @@ namespace storm::benchmark {
             requires(WhereCfg::enabled)
             : Base(value, dataset_size) {}
 
-        void print_info() const {
+        auto print_info() const -> void {
             std::cout << "Operation: GET";
             Base::print_info_footer();
         }
 
-        int execute_iteration() {
+        auto execute_iteration() -> int {
             auto result = Base::qs().get().execute();
             return result.has_value() ? 1 : 0;
         }
 
-        int execute(int iterations) {
+        auto execute(int iterations) -> int {
             return Base::execute_with_filters(iterations);
         }
 
-        int execute_raw(int iterations) {
+        auto execute_raw(int iterations) -> int {
             sqlite3* db = get_db<BaseModel>();
             if (!db)
                 return 0;

--- a/benchmarks/operations/insert.hpp
+++ b/benchmarks/operations/insert.hpp
@@ -22,17 +22,17 @@ namespace storm::benchmark {
         using Base = DataBenchmarkBase<InsertBenchmark<Model>, Model, 4>;
 
         // Build single-row INSERT SQL with RETURNING (matches Storm ORM behavior)
-        static std::string sql_insert_single_returning() {
+        static auto sql_insert_single_returning() -> std::string {
             return "INSERT INTO Person (name, age, is_active, salary) VALUES (?, ?, ?, ?) RETURNING id";
         }
 
         // Build single-row INSERT SQL without RETURNING (faster path)
-        static std::string sql_insert_single() {
+        static auto sql_insert_single() -> std::string {
             return "INSERT INTO Person (name, age, is_active, salary) VALUES (?, ?, ?, ?)";
         }
 
         // Build multi-row INSERT SQL for bulk operations
-        static std::string sql_insert_batch(size_t count) {
+        static auto sql_insert_batch(size_t count) -> std::string {
             std::string sql = "INSERT INTO Person (id, name, age, is_active, salary) VALUES ";
             for (size_t i = 0; i < count; i++) {
                 if (i > 0)
@@ -43,7 +43,7 @@ namespace storm::benchmark {
         }
 
         // Bind a range of models starting at parameter index `idx`
-        static void bind_rows(sqlite3_stmt* stmt, const Model* data, size_t count, int idx = 1) {
+        static auto bind_rows(sqlite3_stmt* stmt, const Model* data, size_t count, int idx = 1) -> void {
             for (size_t i = 0; i < count; i++) {
                 int local_idx = idx;
                 Base::bind_model_fields(stmt, data[i], local_idx);
@@ -56,20 +56,20 @@ namespace storm::benchmark {
         explicit InsertBenchmark(int batch_size = 1) : Base(batch_size) {}
 
         // Use unified print_info with compile-time operation name
-        void print_info() const {
+        auto print_info() const -> void {
             Base::template print_info_unified<OperationType::Insert>();
         }
 
         // Use unified execute with compile-time operation binding
-        int execute(int iterations) {
+        auto execute(int iterations) -> int {
             return Base::template execute_unified<OperationType::Insert>(iterations);
         }
 
-        void print_info_no_return() const {
+        auto print_info_no_return() const -> void {
             std::cout << "Operation: INSERT (no return, single row)\n";
         }
 
-        int execute_no_return(int iterations) {
+        auto execute_no_return(int iterations) -> int {
             int total = 0;
             for (int i = 0; i < iterations; i++) {
                 Base::qs().template insert<storm::orm::statements::ReturnId::No>(Base::data()[i]).execute();
@@ -79,7 +79,7 @@ namespace storm::benchmark {
         }
 
         // Helper: Prepare statements for unique chunk sizes (reduces nesting)
-        void prepare_chunk_statements(sqlite3* db, std::unordered_map<size_t, sqlite3_stmt*>& stmts) {
+        auto prepare_chunk_statements(sqlite3* db, std::unordered_map<size_t, sqlite3_stmt*>& stmts) -> void {
             for (size_t off = 0; off < Base::data().size(); off += Base::max_bulk) {
                 size_t chunk = std::min(Base::max_bulk, Base::data().size() - off);
                 if (stmts.contains(chunk))
@@ -92,7 +92,7 @@ namespace storm::benchmark {
         }
 
         // Helper: Execute one batch iteration (reduces nesting)
-        int execute_batch_iteration(sqlite3* db, const std::unordered_map<size_t, sqlite3_stmt*>& stmts) {
+        auto execute_batch_iteration(sqlite3* db, const std::unordered_map<size_t, sqlite3_stmt*>& stmts) -> int {
             int total = 0;
             for (size_t off = 0; off < Base::data().size(); off += Base::max_bulk) {
                 size_t chunk = std::min(Base::max_bulk, Base::data().size() - off);
@@ -106,7 +106,7 @@ namespace storm::benchmark {
             return total;
         }
 
-        int execute_raw(int iterations) {
+        auto execute_raw(int iterations) -> int {
             sqlite3* db = get_db<Model>();
             if (!db)
                 return 0;
@@ -166,7 +166,7 @@ namespace storm::benchmark {
         }
 
         // Raw SQLite INSERT without RETURNING — fair comparison for insert_no_return
-        int execute_raw_no_return(int iterations) {
+        auto execute_raw_no_return(int iterations) -> int {
             sqlite3* db = get_db<Model>();
             if (!db)
                 return 0;
@@ -198,15 +198,15 @@ namespace storm::benchmark {
       public:
         explicit InsertNoReturnBenchmark(int batch_size = 1) : Base(batch_size) {}
 
-        void print_info() const {
+        auto print_info() const -> void {
             Base::print_info_no_return();
         }
 
-        int execute(int iterations) {
+        auto execute(int iterations) -> int {
             return Base::execute_no_return(iterations);
         }
 
-        int execute_raw(int iterations) {
+        auto execute_raw(int iterations) -> int {
             return Base::execute_raw_no_return(iterations);
         }
     };

--- a/benchmarks/operations/select.hpp
+++ b/benchmarks/operations/select.hpp
@@ -152,7 +152,7 @@ namespace storm::benchmark {
         // ====================================================================
         // print_info - Uses shared footer from base class
         // ====================================================================
-        void print_info() const {
+        auto print_info() const -> void {
             std::cout << "Operation: SELECT";
             Base::print_info_footer();
         }
@@ -160,12 +160,12 @@ namespace storm::benchmark {
         // ====================================================================
         // execute - Storm ORM SELECT using base class helpers
         // ====================================================================
-        int execute_iteration() {
+        auto execute_iteration() -> int {
             auto results = Base::qs().select().execute();
             return results.value().size();
         }
 
-        int execute(int iterations) {
+        auto execute(int iterations) -> int {
             return Base::execute_with_filters(iterations);
         }
 
@@ -174,7 +174,7 @@ namespace storm::benchmark {
         // ====================================================================
       private:
         // Helper to get JOIN keyword based on JoinType
-        static constexpr const char* get_join_keyword() {
+        static constexpr auto get_join_keyword() -> const char* {
             if constexpr (!JoinCfg::enabled) {
                 return "";
             } else if constexpr (JoinCfg::join_type == JoinType::Left) {
@@ -187,7 +187,7 @@ namespace storm::benchmark {
         }
 
         // Build SQL string based on enabled features
-        static std::string build_select_sql() {
+        static auto build_select_sql() -> std::string {
             std::string sql;
 
             if constexpr (JoinCfg::enabled) {
@@ -235,7 +235,7 @@ namespace storm::benchmark {
         }
 
         // Extract row for basic SELECT (Person model) — must match Storm's column list
-        __attribute__((always_inline)) static BaseModel extract_row_basic(sqlite3_stmt* stmt) {
+        __attribute__((always_inline)) static auto extract_row_basic(sqlite3_stmt* stmt) -> BaseModel {
             BaseModel obj;
             obj.id        = sqlite3_column_int64(stmt, 0);
             obj.name      = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 1));
@@ -249,7 +249,7 @@ namespace storm::benchmark {
         }
 
         // Extract row for JOIN SELECT (FKMessage model with joined User)
-        __attribute__((always_inline)) static BaseModel extract_row_join(sqlite3_stmt* stmt)
+        __attribute__((always_inline)) static auto extract_row_join(sqlite3_stmt* stmt) -> BaseModel
             requires(JoinCfg::enabled)
         {
             BaseModel obj;
@@ -270,7 +270,7 @@ namespace storm::benchmark {
         }
 
       public:
-        int execute_raw(int iterations) {
+        auto execute_raw(int iterations) -> int {
             sqlite3* db = get_db<BaseModel>();
             if (!db)
                 return 0;
@@ -478,7 +478,7 @@ namespace storm::benchmark {
             requires(!WhereCfg::enabled)
             : Base(dataset_size) {}
 
-        void print_info() const {
+        auto print_info() const -> void {
             constexpr std::string_view field1   = std::meta::identifier_of(OrderByFieldInfo1);
             constexpr std::string_view field2   = std::meta::identifier_of(OrderByFieldInfo2);
             constexpr const char*      dir1_str = (Dir1 == OrderDirection::ASC) ? "ASC" : "DESC";
@@ -488,7 +488,7 @@ namespace storm::benchmark {
             Base::print_info_footer();
         }
 
-        int execute_iteration() {
+        auto execute_iteration() -> int {
             // Use Storm ORM's multi-field order_by syntax
             // Convert OrderDirection to bool: ASC=true, DESC=false
             constexpr bool asc1 = (Dir1 == OrderDirection::ASC);
@@ -500,7 +500,7 @@ namespace storm::benchmark {
             return results.value().size();
         }
 
-        int execute(int iterations) {
+        auto execute(int iterations) -> int {
             int total = 0;
             for (int i = 0; i < iterations; i++) {
                 total += execute_iteration();
@@ -508,7 +508,7 @@ namespace storm::benchmark {
             return total;
         }
 
-        int execute_raw(int iterations) {
+        auto execute_raw(int iterations) -> int {
             sqlite3* db = get_db<BaseModel>();
             if (db == nullptr)
                 return 0;
@@ -542,7 +542,7 @@ namespace storm::benchmark {
         }
 
       private:
-        __attribute__((always_inline)) static BaseModel extract_row_basic(sqlite3_stmt* stmt) {
+        __attribute__((always_inline)) static auto extract_row_basic(sqlite3_stmt* stmt) -> BaseModel {
             BaseModel obj;
             obj.id        = sqlite3_column_int64(stmt, 0);
             obj.name      = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 1));
@@ -609,21 +609,21 @@ namespace storm::benchmark {
       public:
         explicit constexpr GroupByMultiFieldBenchmark(int dataset_size = 1000) : Base(dataset_size) {}
 
-        void print_info() const {
+        auto print_info() const -> void {
             std::cout << "Operation: SELECT GROUP BY ";
             bool first = true;
             ((std::cout << (first ? (first = false, "") : ", ") << std::meta::identifier_of(GroupByFieldInfos)), ...);
             Base::print_info_footer();
         }
 
-        int execute_iteration() {
+        auto execute_iteration() -> int {
             Base::qs().template group_by<GroupByFieldInfos...>();
             auto results = Base::qs().select().execute();
             Base::qs().reset();
             return results.value().size();
         }
 
-        int execute(int iterations) {
+        auto execute(int iterations) -> int {
             int total = 0;
             for (int i = 0; i < iterations; i++) {
                 total += execute_iteration();
@@ -631,7 +631,7 @@ namespace storm::benchmark {
             return total;
         }
 
-        int execute_raw(int iterations) {
+        auto execute_raw(int iterations) -> int {
             sqlite3* db = get_db<BaseModel>();
             if (db == nullptr)
                 return 0;
@@ -663,7 +663,7 @@ namespace storm::benchmark {
         }
 
       private:
-        __attribute__((always_inline)) static BaseModel extract_row_basic(sqlite3_stmt* stmt) {
+        __attribute__((always_inline)) static auto extract_row_basic(sqlite3_stmt* stmt) -> BaseModel {
             BaseModel obj;
             obj.id        = sqlite3_column_int64(stmt, 0);
             obj.name      = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 1));
@@ -686,7 +686,7 @@ namespace storm::benchmark {
     // ========================================================================
     enum class GroupByAggOp { Count, Sum, Avg, Min, Max };
 
-    static consteval const char* agg_op_name(GroupByAggOp op) {
+    static consteval auto agg_op_name(GroupByAggOp op) -> const char* {
         using enum GroupByAggOp;
         switch (op) {
         case Count:
@@ -703,7 +703,7 @@ namespace storm::benchmark {
         return ""; // unreachable: all enum values handled above
     }
 
-    static consteval const char* agg_op_sql(GroupByAggOp op) {
+    static consteval auto agg_op_sql(GroupByAggOp op) -> const char* {
         using enum GroupByAggOp;
         switch (op) {
         case Count:
@@ -740,7 +740,7 @@ namespace storm::benchmark {
       public:
         explicit constexpr GroupByAggregateBenchmark(int dataset_size = 1000) : Base(dataset_size) {}
 
-        void print_info() const {
+        auto print_info() const -> void {
             using enum GroupByAggOp;
             constexpr std::string_view group_field_name = std::meta::identifier_of(GroupByFieldInfo);
             if constexpr (AggOp == Count) {
@@ -753,7 +753,7 @@ namespace storm::benchmark {
             std::cout << "\n  Dataset: " << Base::batch_size() << " rows\n";
         }
 
-        int execute_iteration() {
+        auto execute_iteration() -> int {
             using enum GroupByAggOp;
             if constexpr (AggOp == Count) {
                 auto result = Base::qs().template group_by<GroupByFieldInfo>().count().select();
@@ -777,7 +777,7 @@ namespace storm::benchmark {
             }
         }
 
-        int execute(int iterations) {
+        auto execute(int iterations) -> int {
             int total = 0;
             for (int i = 0; i < iterations; i++) {
                 total += execute_iteration();
@@ -785,7 +785,7 @@ namespace storm::benchmark {
             return total;
         }
 
-        int execute_raw(int iterations) {
+        auto execute_raw(int iterations) -> int {
             sqlite3* db = get_db<BaseModel>();
             if (db == nullptr)
                 return 0;
@@ -872,7 +872,7 @@ namespace storm::benchmark {
       public:
         explicit constexpr GroupByHavingAggregateBenchmark(int dataset_size = 1000) : Base(dataset_size) {}
 
-        void print_info() const {
+        auto print_info() const -> void {
             constexpr std::string_view group_field_name  = std::meta::identifier_of(GroupByFieldInfo);
             constexpr std::string_view having_field_name = std::meta::identifier_of(HavingFieldInfo);
             if constexpr (AggOp == GroupByAggOp::Count) {
@@ -887,7 +887,7 @@ namespace storm::benchmark {
             std::cout << "\n  Dataset: " << Base::batch_size() << " rows\n";
         }
 
-        int execute_iteration() {
+        auto execute_iteration() -> int {
             auto having_expr = storm::orm::where::field<HavingFieldInfo>() > HavingValue;
             if constexpr (AggOp == GroupByAggOp::Count) {
                 auto result = Base::qs().template group_by<GroupByFieldInfo>().having(having_expr).count().select();
@@ -923,7 +923,7 @@ namespace storm::benchmark {
             }
         }
 
-        int execute(int iterations) {
+        auto execute(int iterations) -> int {
             int total = 0;
             for (int i = 0; i < iterations; i++) {
                 total += execute_iteration();
@@ -931,7 +931,7 @@ namespace storm::benchmark {
             return total;
         }
 
-        int execute_raw(int iterations) {
+        auto execute_raw(int iterations) -> int {
             sqlite3* db = get_db<BaseModel>();
             if (db == nullptr)
                 return 0;
@@ -1078,12 +1078,12 @@ namespace storm::benchmark {
       public:
         explicit SelectMultiFKJoinBenchmark(int dataset_size) : dataset_size_(dataset_size) {}
 
-        void print_info() const {
+        auto print_info() const -> void {
             std::cout << "Operation: SELECT + Multi-FK INNER JOIN (sender + receiver)\n";
             std::cout << "  Dataset: " << dataset_size_ << " rows\n";
         }
 
-        void prepare([[maybe_unused]] int iterations) {
+        auto prepare([[maybe_unused]] int iterations) -> void {
             sqlite3* db = get_db<BaseModel>();
             if (!db)
                 return;
@@ -1139,7 +1139,7 @@ namespace storm::benchmark {
             }
         }
 
-        int execute(int iterations) {
+        auto execute(int iterations) -> int {
             // JOIN on both sender AND receiver FK fields
             qs_.template join<&BaseModel::sender, &BaseModel::receiver>();
 
@@ -1152,7 +1152,7 @@ namespace storm::benchmark {
             return total;
         }
 
-        int execute_raw(int iterations) {
+        auto execute_raw(int iterations) -> int {
             sqlite3* db = get_db<BaseModel>();
             if (!db)
                 return 0;

--- a/benchmarks/operations/select_query_base.hpp
+++ b/benchmarks/operations/select_query_base.hpp
@@ -173,7 +173,7 @@ namespace storm::benchmark {
     // ========================================================================
     // Field dispatcher - compile-time field lookup by name
     // ========================================================================
-    template <typename Model> consteval std::meta::info dispatch_field(std::string_view field_name) {
+    template <typename Model> consteval auto dispatch_field(std::string_view field_name) -> std::meta::info {
         constexpr auto model_info = ^^Model;
 
         for (std::meta::info member :
@@ -245,14 +245,14 @@ namespace storm::benchmark {
         typename RelatedQSHelper<JoinCfg, std::monostate>::type related_qs_{};
 
         // Accessor for where_value_ from derived classes
-        const WhereValueType& where_value() const {
+        auto where_value() const -> const WhereValueType& {
             return where_value_;
         }
 
         // ====================================================================
         // print_info helpers - shared formatting for WHERE/JOIN/dataset
         // ====================================================================
-        void print_where_suffix() const {
+        auto print_where_suffix() const -> void {
             if constexpr (WhereCfg::enabled) {
                 constexpr std::string_view field_name = std::meta::identifier_of(WhereCfg::field_info);
                 constexpr std::string_view op_str     = WhereCfg::op.view();
@@ -260,7 +260,7 @@ namespace storm::benchmark {
             }
         }
 
-        void print_join_suffix() const {
+        auto print_join_suffix() const -> void {
             if constexpr (JoinCfg::enabled) {
                 if constexpr (JoinCfg::join_type == JoinType::Left) {
                     std::cout << " + LEFT JOIN";
@@ -272,7 +272,7 @@ namespace storm::benchmark {
             }
         }
 
-        void print_limit_offset_suffix() const {
+        auto print_limit_offset_suffix() const -> void {
             if constexpr (LimitOffsetCfg::enabled) {
                 if constexpr (LimitOffsetCfg::limit_value > 0) {
                     std::cout << " LIMIT " << LimitOffsetCfg::limit_value;
@@ -283,7 +283,7 @@ namespace storm::benchmark {
             }
         }
 
-        void print_order_by_suffix() const {
+        auto print_order_by_suffix() const -> void {
             if constexpr (OrderByCfg::enabled) {
                 constexpr std::string_view field_name = std::meta::identifier_of(OrderByCfg::field_info);
                 std::cout << " ORDER BY " << field_name;
@@ -298,14 +298,14 @@ namespace storm::benchmark {
             }
         }
 
-        void print_group_by_suffix() const {
+        auto print_group_by_suffix() const -> void {
             if constexpr (GroupByCfg::enabled) {
                 constexpr std::string_view field_name = std::meta::identifier_of(GroupByCfg::field_info);
                 std::cout << " GROUP BY " << field_name;
             }
         }
 
-        void print_info_footer() const {
+        auto print_info_footer() const -> void {
             print_where_suffix();
             print_join_suffix();
             print_group_by_suffix();
@@ -318,7 +318,7 @@ namespace storm::benchmark {
         // ====================================================================
         // execute helpers - shared JOIN/WHERE application and loop structure
         // ====================================================================
-        void apply_query_filters() {
+        auto apply_query_filters() -> void {
             if constexpr (JoinCfg::enabled) {
                 // Dispatch to correct JOIN method based on join_type
                 if constexpr (JoinCfg::join_type == JoinType::Left) {
@@ -364,7 +364,7 @@ namespace storm::benchmark {
         }
 
         // CRTP execute helper - derived class provides execute_iteration()
-        int execute_with_filters(int iterations) {
+        auto execute_with_filters(int iterations) -> int {
             apply_query_filters();
             int total = 0;
             for (int i = 0; i < iterations; i++) {
@@ -393,7 +393,7 @@ namespace storm::benchmark {
         // ====================================================================
         // create_model - Generate varied data for WHERE clause testing
         // ====================================================================
-        static BaseModel create_model(int index = 0) {
+        static auto create_model(int index = 0) -> BaseModel {
             int i = index + 1;
 
             if constexpr (JoinCfg::enabled) {
@@ -416,7 +416,7 @@ namespace storm::benchmark {
         // ====================================================================
         // prepare - Feature-aware data preparation
         // ====================================================================
-        void prepare(int iterations) {
+        auto prepare(int iterations) -> void {
             if constexpr (JoinCfg::enabled) {
                 prepare_join_data(iterations);
             } else {
@@ -426,7 +426,7 @@ namespace storm::benchmark {
 
       protected:
         // Prepare data for JOIN benchmarks (creates related records + FK references)
-        void prepare_join_data([[maybe_unused]] int iterations) {
+        auto prepare_join_data([[maybe_unused]] int iterations) -> void {
             if constexpr (JoinCfg::enabled) {
                 sqlite3* db = get_db<BaseModel>();
                 if (!db)
@@ -512,7 +512,7 @@ namespace storm::benchmark {
         }
 
         // Bind WHERE value to prepared statement
-        void bind_where_value(sqlite3_stmt* stmt) const
+        auto bind_where_value(sqlite3_stmt* stmt) const -> void
             requires(WhereCfg::enabled)
         {
             using V = typename WhereCfg::value_type;
@@ -535,7 +535,7 @@ namespace storm::benchmark {
         // ====================================================================
         // ORDER BY SQL helpers for raw SQLite benchmarks
         // ====================================================================
-        static void append_order_by_sql(std::string& sql) {
+        static auto append_order_by_sql(std::string& sql) -> void {
             if constexpr (OrderByCfg::enabled) {
                 constexpr std::string_view field_name = std::meta::identifier_of(OrderByCfg::field_info);
                 sql += " ORDER BY ";
@@ -554,7 +554,7 @@ namespace storm::benchmark {
         // ====================================================================
         // LIMIT/OFFSET SQL helpers for raw SQLite benchmarks
         // ====================================================================
-        static void append_limit_offset_sql(std::string& sql) {
+        static auto append_limit_offset_sql(std::string& sql) -> void {
             if constexpr (LimitOffsetCfg::enabled) {
                 if constexpr (LimitOffsetCfg::limit_value > 0) {
                     sql += " LIMIT ";
@@ -573,7 +573,7 @@ namespace storm::benchmark {
         // ====================================================================
         // GROUP BY SQL helpers for raw SQLite benchmarks
         // ====================================================================
-        static void append_group_by_sql(std::string& sql) {
+        static auto append_group_by_sql(std::string& sql) -> void {
             if constexpr (GroupByCfg::enabled) {
                 constexpr std::string_view field_name = std::meta::identifier_of(GroupByCfg::field_info);
                 sql += " GROUP BY ";

--- a/benchmarks/operations/setop.hpp
+++ b/benchmarks/operations/setop.hpp
@@ -55,7 +55,7 @@ namespace storm::benchmark {
             }
         }
 
-        static Model create_model(int index = 0) {
+        static auto create_model(int index = 0) -> Model {
             int i = index + 1;
             return Model{
                     .id        = 0,
@@ -66,11 +66,11 @@ namespace storm::benchmark {
             };
         }
 
-        void prepare(int iterations) {
+        auto prepare(int iterations) -> void {
             Base::prepare_with_insert(iterations);
         }
 
-        void print_info() const {
+        auto print_info() const -> void {
             std::cout << "Operation: SELECT " << op_name();
             if constexpr (WithOrderBy) {
                 std::cout << " + ORDER BY";
@@ -89,7 +89,7 @@ namespace storm::benchmark {
             std::cout << "  Dataset: " << Base::batch_size() << " rows\n";
         }
 
-        int execute(int iterations) {
+        auto execute(int iterations) -> int {
             // Build WHERE expressions and set operation builder ONCE (setup cost)
             auto left_where = field<^^Model::age>() < left_threshold_;
             auto qs_left    = Base::qs().where(left_where);
@@ -127,7 +127,7 @@ namespace storm::benchmark {
             }
         }
 
-        int execute_raw(int iterations) {
+        auto execute_raw(int iterations) -> int {
             sqlite3* db = get_db<Model>();
             if (!db)
                 return 0;
@@ -167,7 +167,7 @@ namespace storm::benchmark {
         }
 
       private:
-        static constexpr const char* op_name() {
+        static constexpr auto op_name() -> const char* {
             using enum SetOpBenchType;
             if constexpr (OpType == Union)
                 return "UNION";
@@ -179,7 +179,7 @@ namespace storm::benchmark {
                 return "INTERSECT";
         }
 
-        static constexpr const char* op_sql() {
+        static constexpr auto op_sql() -> const char* {
             using enum SetOpBenchType;
             if constexpr (OpType == Union)
                 return " UNION ";
@@ -204,7 +204,7 @@ namespace storm::benchmark {
             }
         }
 
-        template <typename Builder> void apply_modifiers(Builder& builder) {
+        template <typename Builder> auto apply_modifiers(Builder& builder) -> void {
             if constexpr (WithOrderBy) {
                 builder.template order_by<^^Model::age, true>();
             }
@@ -213,7 +213,7 @@ namespace storm::benchmark {
             }
         }
 
-        std::string build_raw_sql() const {
+        auto build_raw_sql() const -> std::string {
             std::string sql = "SELECT id, name, age, is_active, salary, score FROM Person WHERE age < ?";
             sql += op_sql();
             if constexpr (needs_overlap) {

--- a/benchmarks/operations/update.hpp
+++ b/benchmarks/operations/update.hpp
@@ -29,11 +29,11 @@ namespace storm::benchmark {
         explicit UpdateBenchmark(int batch_size = 1) : Base(batch_size) {}
 
         // Use unified print_info with compile-time operation name
-        void print_info() const {
+        auto print_info() const -> void {
             Base::template print_info_unified<OperationType::UpdatePK>();
         }
 
-        void prepare(int iterations) {
+        auto prepare(int iterations) -> void {
             // 1. Clear table, generate data, insert to get IDs
             Base::prepare_with_insert(iterations);
 
@@ -47,13 +47,13 @@ namespace storm::benchmark {
         }
 
         // Use unified execute with compile-time operation binding
-        int execute(int iterations) {
+        auto execute(int iterations) -> int {
             return Base::template execute_unified<OperationType::UpdatePK>(iterations);
         }
 
       private:
         // Helper: Bind model fields for UPDATE (name, age, is_active, salary, id)
-        static void bind_update_fields(sqlite3_stmt* stmt, const Model& p) {
+        static auto bind_update_fields(sqlite3_stmt* stmt, const Model& p) -> void {
             int idx = 1;
             sqlite3_bind_text(stmt, idx++, p.name.c_str(), -1, SQLITE_TRANSIENT);
             sqlite3_bind_int(stmt, idx++, p.age);
@@ -63,7 +63,7 @@ namespace storm::benchmark {
         }
 
         // Helper: Execute single-row updates
-        int execute_single_row(sqlite3_stmt* stmt, int iterations) {
+        auto execute_single_row(sqlite3_stmt* stmt, int iterations) -> int {
             int total = 0;
             for (int i = 0; i < iterations; i++) {
                 bind_update_fields(stmt, Base::data()[i]);
@@ -76,7 +76,7 @@ namespace storm::benchmark {
         }
 
         // Helper: Execute batch updates with transaction
-        int execute_batch(sqlite3_stmt* stmt, int iterations) {
+        auto execute_batch(sqlite3_stmt* stmt, int iterations) -> int {
             int total = 0;
             for (int iter = 0; iter < iterations; iter++) {
                 sqlite3_exec(sqlite3_db_handle(stmt), "BEGIN TRANSACTION", nullptr, nullptr, nullptr);
@@ -93,7 +93,7 @@ namespace storm::benchmark {
         }
 
       public:
-        int execute_raw(int iterations) {
+        auto execute_raw(int iterations) -> int {
             sqlite3* db = get_db<Model>();
             if (!db)
                 return 0;

--- a/benchmarks/operations/where_operators.hpp
+++ b/benchmarks/operations/where_operators.hpp
@@ -30,7 +30,7 @@ namespace storm::benchmark {
         explicit constexpr WhereLikeBenchmark(std::string pattern, int dataset_size = 1000)
             : Base(dataset_size), pattern_(std::move(pattern)) {}
 
-        static Model create_model(int index = 0) {
+        static auto create_model(int index = 0) -> Model {
             int i = index + 1;
             return Model{
                     .id        = 0,
@@ -41,17 +41,17 @@ namespace storm::benchmark {
             };
         }
 
-        void prepare(int iterations) {
+        auto prepare(int iterations) -> void {
             Base::prepare_with_insert(iterations);
         }
 
-        void print_info() const {
+        auto print_info() const -> void {
             constexpr std::string_view field_name = std::meta::identifier_of(FieldInfo);
             std::cout << "SELECT (WHERE LIKE): " << field_name << " LIKE '" << pattern_ << "'\n";
             std::cout << "  Dataset: " << Base::batch_size() << " rows\n";
         }
 
-        int execute(int iterations) {
+        auto execute(int iterations) -> int {
             auto where_clause = field<FieldInfo>().like(pattern_);
             auto filtered     = Base::qs().where(where_clause);
 
@@ -65,7 +65,7 @@ namespace storm::benchmark {
             return total;
         }
 
-        int execute_raw(int iterations) {
+        auto execute_raw(int iterations) -> int {
             sqlite3* db = get_db<Model>();
             if (!db)
                 return 0;
@@ -94,7 +94,7 @@ namespace storm::benchmark {
         }
 
       private:
-        __attribute__((always_inline)) static Model extract_row(sqlite3_stmt* stmt) {
+        __attribute__((always_inline)) static auto extract_row(sqlite3_stmt* stmt) -> Model {
             Model obj;
             obj.id        = sqlite3_column_int64(stmt, 0);
             obj.name      = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 1));
@@ -123,7 +123,7 @@ namespace storm::benchmark {
         explicit constexpr WhereBetweenBenchmark(ValueType min_val, ValueType max_val, int dataset_size = 1000)
             : Base(dataset_size), min_value_(min_val), max_value_(max_val) {}
 
-        static Model create_model(int index = 0) {
+        static auto create_model(int index = 0) -> Model {
             int i = index + 1;
             return Model{
                     .id        = 0,
@@ -134,18 +134,18 @@ namespace storm::benchmark {
             };
         }
 
-        void prepare(int iterations) {
+        auto prepare(int iterations) -> void {
             Base::prepare_with_insert(iterations);
         }
 
-        void print_info() const {
+        auto print_info() const -> void {
             constexpr std::string_view field_name = std::meta::identifier_of(FieldInfo);
             std::cout << "SELECT (WHERE BETWEEN): " << field_name << " BETWEEN " << min_value_ << " AND " << max_value_
                       << "\n";
             std::cout << "  Dataset: " << Base::batch_size() << " rows\n";
         }
 
-        int execute(int iterations) {
+        auto execute(int iterations) -> int {
             auto where_clause = field<FieldInfo>().between(min_value_, max_value_);
             auto filtered     = Base::qs().where(where_clause);
 
@@ -159,7 +159,7 @@ namespace storm::benchmark {
             return total;
         }
 
-        int execute_raw(int iterations) {
+        auto execute_raw(int iterations) -> int {
             sqlite3* db = get_db<Model>();
             if (!db)
                 return 0;
@@ -196,7 +196,7 @@ namespace storm::benchmark {
         }
 
       private:
-        __attribute__((always_inline)) static Model extract_row(sqlite3_stmt* stmt) {
+        __attribute__((always_inline)) static auto extract_row(sqlite3_stmt* stmt) -> Model {
             Model obj;
             obj.id        = sqlite3_column_int64(stmt, 0);
             obj.name      = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 1));
@@ -223,7 +223,7 @@ namespace storm::benchmark {
         explicit WhereInBenchmark(std::vector<ValueType> values, int dataset_size = 1000)
             : Base(dataset_size), values_(std::move(values)) {}
 
-        static Model create_model(int index = 0) {
+        static auto create_model(int index = 0) -> Model {
             int i = index + 1;
             return Model{
                     .id        = 0,
@@ -234,11 +234,11 @@ namespace storm::benchmark {
             };
         }
 
-        void prepare(int iterations) {
+        auto prepare(int iterations) -> void {
             Base::prepare_with_insert(iterations);
         }
 
-        void print_info() const {
+        auto print_info() const -> void {
             constexpr std::string_view field_name = std::meta::identifier_of(FieldInfo);
             std::cout << "SELECT (WHERE IN): " << field_name << " IN (";
             for (size_t i = 0; i < values_.size(); i++) {
@@ -250,7 +250,7 @@ namespace storm::benchmark {
             std::cout << "  Dataset: " << Base::batch_size() << " rows\n";
         }
 
-        int execute(int iterations) {
+        auto execute(int iterations) -> int {
             // Build IN expression using field<>().in(values...)
             // We need to use the runtime API since we have a vector
             auto where_clause = build_in_clause();
@@ -266,7 +266,7 @@ namespace storm::benchmark {
             return total;
         }
 
-        int execute_raw(int iterations) {
+        auto execute_raw(int iterations) -> int {
             sqlite3* db = get_db<Model>();
             if (!db)
                 return 0;
@@ -309,7 +309,7 @@ namespace storm::benchmark {
             return total;
         }
 
-        __attribute__((always_inline)) static Model extract_row(sqlite3_stmt* stmt) {
+        __attribute__((always_inline)) static auto extract_row(sqlite3_stmt* stmt) -> Model {
             Model obj;
             obj.id        = sqlite3_column_int64(stmt, 0);
             obj.name      = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 1));
@@ -362,7 +362,7 @@ namespace storm::benchmark {
         explicit constexpr WhereAndOrBenchmark(ValueType1 value1, ValueType2 value2, int dataset_size = 1000)
             : Base(dataset_size), value1_(value1), value2_(value2) {}
 
-        static Model create_model(int index = 0) {
+        static auto create_model(int index = 0) -> Model {
             int i = index + 1;
             return Model{
                     .id        = 0,
@@ -373,11 +373,11 @@ namespace storm::benchmark {
             };
         }
 
-        void prepare(int iterations) {
+        auto prepare(int iterations) -> void {
             Base::prepare_with_insert(iterations);
         }
 
-        void print_info() const {
+        auto print_info() const -> void {
             constexpr std::string_view field_name1 = std::meta::identifier_of(FieldInfo1);
             constexpr std::string_view field_name2 = std::meta::identifier_of(FieldInfo2);
             constexpr std::string_view op_str1     = Op1.view();
@@ -389,7 +389,7 @@ namespace storm::benchmark {
             std::cout << "  Dataset: " << Base::batch_size() << " rows\n";
         }
 
-        int execute(int iterations) {
+        auto execute(int iterations) -> int {
             auto where_clause = build_where_clause();
             auto filtered     = Base::qs().where(where_clause);
 
@@ -403,7 +403,7 @@ namespace storm::benchmark {
             return total;
         }
 
-        int execute_raw(int iterations) {
+        auto execute_raw(int iterations) -> int {
             sqlite3* db = get_db<Model>();
             if (!db)
                 return 0;
@@ -459,7 +459,7 @@ namespace storm::benchmark {
         }
 
       private:
-        __attribute__((always_inline)) static Model extract_row(sqlite3_stmt* stmt) {
+        __attribute__((always_inline)) static auto extract_row(sqlite3_stmt* stmt) -> Model {
             Model obj;
             obj.id        = sqlite3_column_int64(stmt, 0);
             obj.name      = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 1));
@@ -472,7 +472,7 @@ namespace storm::benchmark {
             return obj;
         }
 
-        static constexpr std::string_view get_sql_op(std::string_view op) {
+        static constexpr auto get_sql_op(std::string_view op) -> std::string_view {
             if (op == ">")
                 return ">";
             if (op == ">=")
@@ -547,7 +547,7 @@ namespace storm::benchmark {
       public:
         explicit constexpr WhereIsNullBenchmark(int dataset_size = 1000) : Base(dataset_size) {}
 
-        static Model create_model(int index = 0) {
+        static auto create_model(int index = 0) -> Model {
             int i = index + 1;
             return Model{
                     .id        = 0,
@@ -559,18 +559,18 @@ namespace storm::benchmark {
             };
         }
 
-        void prepare(int iterations) {
+        auto prepare(int iterations) -> void {
             Base::prepare_with_insert(iterations);
         }
 
-        void print_info() const {
+        auto print_info() const -> void {
             constexpr std::string_view field_name = std::meta::identifier_of(FieldInfo);
             constexpr const char*      null_str   = IsNull ? "IS NULL" : "IS NOT NULL";
             std::cout << "SELECT (WHERE " << null_str << "): " << field_name << " " << null_str << "\n";
             std::cout << "  Dataset: " << Base::batch_size() << " rows\n";
         }
 
-        int execute(int iterations) {
+        auto execute(int iterations) -> int {
             auto where_clause = [] {
                 if constexpr (IsNull)
                     return field<FieldInfo>().is_null();
@@ -589,7 +589,7 @@ namespace storm::benchmark {
             return total;
         }
 
-        int execute_raw(int iterations) {
+        auto execute_raw(int iterations) -> int {
             sqlite3* db = get_db<Model>();
             if (!db)
                 return 0;
@@ -618,7 +618,7 @@ namespace storm::benchmark {
         }
 
       private:
-        __attribute__((always_inline)) static Model extract_row(sqlite3_stmt* stmt) {
+        __attribute__((always_inline)) static auto extract_row(sqlite3_stmt* stmt) -> Model {
             Model obj;
             obj.id        = sqlite3_column_int64(stmt, 0);
             obj.name      = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 1));

--- a/benchmarks/parser.hpp
+++ b/benchmarks/parser.hpp
@@ -14,14 +14,14 @@
 namespace storm::benchmark {
 
     // Helper: Skip whitespace
-    constexpr void skip_whitespace(std::string_view json, size_t& pos) {
+    constexpr auto skip_whitespace(std::string_view json, size_t& pos) -> void {
         while (pos < json.size() && (json[pos] == ' ' || json[pos] == '\n' || json[pos] == '\r' || json[pos] == '\t')) {
             pos++;
         }
     }
 
     // Helper: Skip specific character with whitespace
-    constexpr void skip_char(std::string_view json, size_t& pos, char c) {
+    constexpr auto skip_char(std::string_view json, size_t& pos, char c) -> void {
         skip_whitespace(json, pos);
         if (pos < json.size() && json[pos] == c) {
             pos++;
@@ -29,7 +29,7 @@ namespace storm::benchmark {
     }
 
     // Parse int
-    constexpr int parse_int(std::string_view json, size_t& pos) {
+    constexpr auto parse_int(std::string_view json, size_t& pos) -> int {
         skip_whitespace(json, pos);
 
         int  result   = 0;
@@ -49,7 +49,7 @@ namespace storm::benchmark {
     }
 
     // Parse double
-    constexpr double parse_double(std::string_view json, size_t& pos) {
+    constexpr auto parse_double(std::string_view json, size_t& pos) -> double {
         skip_whitespace(json, pos);
 
         double result   = 0.0;
@@ -81,7 +81,7 @@ namespace storm::benchmark {
     }
 
     // Parse bool
-    constexpr bool parse_bool(std::string_view json, size_t& pos) {
+    constexpr auto parse_bool(std::string_view json, size_t& pos) -> bool {
         skip_whitespace(json, pos);
 
         if (pos + 4 <= json.size() && json.substr(pos, 4) == "true") {
@@ -97,7 +97,7 @@ namespace storm::benchmark {
     }
 
     // Parse string into ConstexprString
-    template <size_t N> constexpr ConstexprString<N> parse_string(std::string_view json, size_t& pos) {
+    template <size_t N> constexpr auto parse_string(std::string_view json, size_t& pos) -> ConstexprString<N> {
         skip_whitespace(json, pos);
 
         ConstexprString<N> result;
@@ -123,7 +123,7 @@ namespace storm::benchmark {
     }
 
     // Skip a JSON value (string, number, bool, null)
-    constexpr void skip_value(std::string_view json, size_t& pos) {
+    constexpr auto skip_value(std::string_view json, size_t& pos) -> void {
         skip_whitespace(json, pos);
 
         if (pos >= json.size())
@@ -150,12 +150,12 @@ namespace storm::benchmark {
     }
 
     // Parse key name from JSON (returns the key string)
-    constexpr ConstexprString<64> parse_key(std::string_view json, size_t& pos) {
+    constexpr auto parse_key(std::string_view json, size_t& pos) -> ConstexprString<64> {
         return parse_string<64>(json, pos);
     }
 
     // Helper: Parse JSON array of integers into WhereClause (reduces nesting in main parser)
-    constexpr void parse_int_array_into_where(WhereClause& where, std::string_view json, size_t& pos) {
+    constexpr auto parse_int_array_into_where(WhereClause& where, std::string_view json, size_t& pos) -> void {
         skip_whitespace(json, pos);
         if (pos >= json.size() || json[pos] != '[') {
             return;
@@ -272,7 +272,7 @@ namespace storm::benchmark {
     }
 
     // Parse single benchmark test object from flat JSON
-    constexpr BenchmarkTest parse_test_object(std::string_view json, size_t& pos) {
+    constexpr auto parse_test_object(std::string_view json, size_t& pos) -> BenchmarkTest {
         BenchmarkTest test;
         skip_char(json, pos, '{');
 
@@ -299,7 +299,7 @@ namespace storm::benchmark {
     }
 
     // Helper: Skip to end of JSON object (reduces nesting depth)
-    constexpr void skip_json_object(std::string_view json, size_t& pos) {
+    constexpr auto skip_json_object(std::string_view json, size_t& pos) -> void {
         int brace_depth = 0;
         while (pos < json.size()) {
             if (json[pos] == '{')
@@ -316,7 +316,7 @@ namespace storm::benchmark {
     }
 
     // Count tests in JSON array (needed for std::array size)
-    constexpr size_t count_tests(std::string_view json) {
+    constexpr auto count_tests(std::string_view json) -> size_t {
         size_t count = 0;
         size_t pos   = 0;
 
@@ -344,7 +344,7 @@ namespace storm::benchmark {
     }
 
     // Parse entire JSON array
-    template <size_t N> constexpr std::array<BenchmarkTest, N> parse_tests(std::string_view json) {
+    template <size_t N> constexpr auto parse_tests(std::string_view json) -> std::array<BenchmarkTest, N> {
         std::array<BenchmarkTest, N> tests{};
 
         size_t pos = 0;

--- a/benchmarks/runner.hpp
+++ b/benchmarks/runner.hpp
@@ -307,7 +307,8 @@ namespace storm::benchmark {
         // Operation handlers - one function per operation type
         // Clean, simple, easy to add new operations
 
-        template <typename Model, auto& test> static void run_where_operation(BenchmarkRunner& runner, int iterations) {
+        template <typename Model, auto& test>
+        static auto run_where_operation(BenchmarkRunner& runner, int iterations) -> void {
             constexpr std::string_view field_name   = test.where.field.view();
             constexpr auto             op_str       = test.where.op;
             constexpr int              value        = test.where.value_int;
@@ -323,7 +324,7 @@ namespace storm::benchmark {
         }
 
         template <typename Model, auto& test>
-        static void run_insert_operation(BenchmarkRunner& runner, int iterations) {
+        static auto run_insert_operation(BenchmarkRunner& runner, int iterations) -> void {
             constexpr auto profile_str = test.size_profile.view();
             constexpr auto profile     = sizes::profile_from_string(profile_str);
 
@@ -346,7 +347,7 @@ namespace storm::benchmark {
         }
 
         template <typename Model, auto& test>
-        static void run_insert_no_return_operation(BenchmarkRunner& runner, int iterations) {
+        static auto run_insert_no_return_operation(BenchmarkRunner& runner, int iterations) -> void {
             constexpr auto profile_str = test.size_profile.view();
             constexpr auto profile     = sizes::profile_from_string(profile_str);
 
@@ -366,7 +367,7 @@ namespace storm::benchmark {
         }
 
         template <typename Model, auto& test>
-        static void run_delete_pk_operation(BenchmarkRunner& runner, int iterations) {
+        static auto run_delete_pk_operation(BenchmarkRunner& runner, int iterations) -> void {
             constexpr auto profile_str = test.size_profile.view();
             constexpr auto profile     = sizes::profile_from_string(profile_str);
 
@@ -383,7 +384,7 @@ namespace storm::benchmark {
         }
 
         template <typename Model, auto& test>
-        static void run_update_pk_operation(BenchmarkRunner& runner, int iterations) {
+        static auto run_update_pk_operation(BenchmarkRunner& runner, int iterations) -> void {
             constexpr auto profile_str = test.size_profile.view();
             constexpr auto profile     = sizes::profile_from_string(profile_str);
 
@@ -406,7 +407,7 @@ namespace storm::benchmark {
         }
 
         template <typename Model, auto& test>
-        static void run_select_operation(BenchmarkRunner& runner, int iterations) {
+        static auto run_select_operation(BenchmarkRunner& runner, int iterations) -> void {
             constexpr auto profile_str = test.size_profile.view();
             constexpr auto profile     = sizes::profile_from_string(profile_str);
 
@@ -424,7 +425,7 @@ namespace storm::benchmark {
         }
 
         template <typename Model, auto& test>
-        static void run_select_join_operation(BenchmarkRunner& runner, int iterations) {
+        static auto run_select_join_operation(BenchmarkRunner& runner, int iterations) -> void {
             constexpr auto profile_str = test.size_profile.view();
             constexpr auto profile     = sizes::profile_from_string(profile_str);
 
@@ -450,7 +451,7 @@ namespace storm::benchmark {
         }
 
         template <typename Model, auto& test>
-        static void run_select_where_join_operation(BenchmarkRunner& runner, int iterations) {
+        static auto run_select_where_join_operation(BenchmarkRunner& runner, int iterations) -> void {
             constexpr std::string_view field_name = test.where.field.view();
             constexpr auto             op_str     = test.where.op;
             constexpr int              value      = test.where.value_int;
@@ -488,7 +489,7 @@ namespace storm::benchmark {
         // ====================================================================
 
         template <typename Model, auto& test>
-        static void run_select_left_join_operation(BenchmarkRunner& runner, int iterations) {
+        static auto run_select_left_join_operation(BenchmarkRunner& runner, int iterations) -> void {
             constexpr auto profile_str = test.size_profile.view();
             constexpr auto profile     = sizes::profile_from_string(profile_str);
 
@@ -513,7 +514,7 @@ namespace storm::benchmark {
         }
 
         template <typename Model, auto& test>
-        static void run_select_left_join_where_operation(BenchmarkRunner& runner, int iterations) {
+        static auto run_select_left_join_where_operation(BenchmarkRunner& runner, int iterations) -> void {
             constexpr std::string_view field_name = test.where.field.view();
             constexpr auto             op_str     = test.where.op;
             constexpr int              value      = test.where.value_int;
@@ -551,7 +552,7 @@ namespace storm::benchmark {
         // ====================================================================
 
         template <typename Model, auto& test>
-        static void run_select_right_join_operation(BenchmarkRunner& runner, int iterations) {
+        static auto run_select_right_join_operation(BenchmarkRunner& runner, int iterations) -> void {
             constexpr auto profile_str = test.size_profile.view();
             constexpr auto profile     = sizes::profile_from_string(profile_str);
 
@@ -576,7 +577,7 @@ namespace storm::benchmark {
         }
 
         template <typename Model, auto& test>
-        static void run_select_right_join_where_operation(BenchmarkRunner& runner, int iterations) {
+        static auto run_select_right_join_where_operation(BenchmarkRunner& runner, int iterations) -> void {
             constexpr std::string_view field_name = test.where.field.view();
             constexpr auto             op_str     = test.where.op;
             constexpr int              value      = test.where.value_int;
@@ -614,7 +615,7 @@ namespace storm::benchmark {
         // ====================================================================
 
         template <typename Model, auto& test>
-        static void run_select_multi_fk_join_operation(BenchmarkRunner& runner, int iterations) {
+        static auto run_select_multi_fk_join_operation(BenchmarkRunner& runner, int iterations) -> void {
             constexpr auto profile_str = test.size_profile.view();
             constexpr auto profile     = sizes::profile_from_string(profile_str);
 
@@ -639,7 +640,7 @@ namespace storm::benchmark {
         // ====================================================================
 
         template <typename Model, auto& test>
-        static void run_aggregate_count_operation(BenchmarkRunner& runner, int iterations) {
+        static auto run_aggregate_count_operation(BenchmarkRunner& runner, int iterations) -> void {
             constexpr auto profile_str = test.size_profile.view();
             constexpr auto profile     = sizes::profile_from_string(profile_str);
 
@@ -662,7 +663,7 @@ namespace storm::benchmark {
         }
 
         template <typename Model, auto& test>
-        static void run_aggregate_count_field_operation(BenchmarkRunner& runner, int iterations) {
+        static auto run_aggregate_count_field_operation(BenchmarkRunner& runner, int iterations) -> void {
             constexpr std::string_view field_name  = test.aggregate_field.view();
             constexpr auto             field_info  = dispatch_field<Model>(field_name);
             constexpr auto             profile_str = test.size_profile.view();
@@ -683,7 +684,7 @@ namespace storm::benchmark {
         }
 
         template <typename Model, auto& test>
-        static void run_aggregate_count_distinct_operation(BenchmarkRunner& runner, int iterations) {
+        static auto run_aggregate_count_distinct_operation(BenchmarkRunner& runner, int iterations) -> void {
             constexpr std::string_view field_name  = test.aggregate_field.view();
             constexpr auto             field_info  = dispatch_field<Model>(field_name);
             constexpr auto             profile_str = test.size_profile.view();
@@ -706,7 +707,7 @@ namespace storm::benchmark {
         }
 
         template <typename Model, auto& test>
-        static void run_aggregate_sum_operation(BenchmarkRunner& runner, int iterations) {
+        static auto run_aggregate_sum_operation(BenchmarkRunner& runner, int iterations) -> void {
             constexpr std::string_view field_name  = test.aggregate_field.view();
             constexpr auto             field_info  = dispatch_field<Model>(field_name);
             constexpr auto             profile_str = test.size_profile.view();
@@ -725,7 +726,7 @@ namespace storm::benchmark {
         }
 
         template <typename Model, auto& test>
-        static void run_aggregate_avg_operation(BenchmarkRunner& runner, int iterations) {
+        static auto run_aggregate_avg_operation(BenchmarkRunner& runner, int iterations) -> void {
             constexpr std::string_view field_name  = test.aggregate_field.view();
             constexpr auto             field_info  = dispatch_field<Model>(field_name);
             constexpr auto             profile_str = test.size_profile.view();
@@ -744,7 +745,7 @@ namespace storm::benchmark {
         }
 
         template <typename Model, auto& test>
-        static void run_aggregate_min_operation(BenchmarkRunner& runner, int iterations) {
+        static auto run_aggregate_min_operation(BenchmarkRunner& runner, int iterations) -> void {
             constexpr std::string_view field_name  = test.aggregate_field.view();
             constexpr auto             field_info  = dispatch_field<Model>(field_name);
             constexpr auto             profile_str = test.size_profile.view();
@@ -763,7 +764,7 @@ namespace storm::benchmark {
         }
 
         template <typename Model, auto& test>
-        static void run_aggregate_max_operation(BenchmarkRunner& runner, int iterations) {
+        static auto run_aggregate_max_operation(BenchmarkRunner& runner, int iterations) -> void {
             constexpr std::string_view field_name  = test.aggregate_field.view();
             constexpr auto             field_info  = dispatch_field<Model>(field_name);
             constexpr auto             profile_str = test.size_profile.view();
@@ -786,7 +787,7 @@ namespace storm::benchmark {
         // ====================================================================
 
         template <typename Model, auto& test>
-        static void run_distinct_operation(BenchmarkRunner& runner, int iterations) {
+        static auto run_distinct_operation(BenchmarkRunner& runner, int iterations) -> void {
             constexpr std::string_view field_name  = test.distinct_field.view();
             constexpr auto             field_info  = dispatch_field<Model>(field_name);
             constexpr auto             profile_str = test.size_profile.view();
@@ -809,7 +810,7 @@ namespace storm::benchmark {
         }
 
         template <typename Model, auto& test>
-        static void run_distinct_where_operation(BenchmarkRunner& runner, int iterations) {
+        static auto run_distinct_where_operation(BenchmarkRunner& runner, int iterations) -> void {
             constexpr std::string_view distinct_field_name = test.distinct_field.view();
             constexpr auto             distinct_field_info = dispatch_field<Model>(distinct_field_name);
             constexpr std::string_view where_field_name    = test.where.field.view();
@@ -844,7 +845,7 @@ namespace storm::benchmark {
         }
 
         template <typename Model, auto& test>
-        static void run_distinct_join_operation(BenchmarkRunner& runner, int iterations) {
+        static auto run_distinct_join_operation(BenchmarkRunner& runner, int iterations) -> void {
             constexpr std::string_view distinct_field_name = test.distinct_field.view();
             constexpr auto             distinct_field_info = dispatch_field<FKMessage>(distinct_field_name);
             constexpr auto             profile_str         = test.size_profile.view();
@@ -871,7 +872,7 @@ namespace storm::benchmark {
         }
 
         template <typename Model, auto& test>
-        static void run_distinct_where_join_operation(BenchmarkRunner& runner, int iterations) {
+        static auto run_distinct_where_join_operation(BenchmarkRunner& runner, int iterations) -> void {
             constexpr std::string_view distinct_field_name = test.distinct_field.view();
             constexpr auto             distinct_field_info = dispatch_field<FKMessage>(distinct_field_name);
             constexpr std::string_view where_field_name    = test.where.field.view();
@@ -920,7 +921,7 @@ namespace storm::benchmark {
         // ====================================================================
 
         template <typename Model, auto& test>
-        static void run_distinct_multi_2_operation(BenchmarkRunner& runner, int iterations) {
+        static auto run_distinct_multi_2_operation(BenchmarkRunner& runner, int iterations) -> void {
             constexpr std::string_view field_name1  = test.distinct_field.view();
             constexpr std::string_view field_name2  = test.distinct_field2.view();
             constexpr auto             field_info1  = dispatch_field<Model>(field_name1);
@@ -934,7 +935,7 @@ namespace storm::benchmark {
         }
 
         template <typename Model, auto& test>
-        static void run_distinct_multi_3_operation(BenchmarkRunner& runner, int iterations) {
+        static auto run_distinct_multi_3_operation(BenchmarkRunner& runner, int iterations) -> void {
             constexpr std::string_view field_name1  = test.distinct_field.view();
             constexpr std::string_view field_name2  = test.distinct_field2.view();
             constexpr std::string_view field_name3  = test.distinct_field3.view();
@@ -954,7 +955,7 @@ namespace storm::benchmark {
         // ====================================================================
 
         template <typename Model, auto& test>
-        static void run_distinct_order_by_asc_operation(BenchmarkRunner& runner, int iterations) {
+        static auto run_distinct_order_by_asc_operation(BenchmarkRunner& runner, int iterations) -> void {
             constexpr std::string_view distinct_field_name = test.distinct_field.view();
             constexpr std::string_view order_field_name    = test.order_by_field.view();
             constexpr auto             distinct_field_info = dispatch_field<Model>(distinct_field_name);
@@ -968,7 +969,7 @@ namespace storm::benchmark {
         }
 
         template <typename Model, auto& test>
-        static void run_distinct_order_by_desc_operation(BenchmarkRunner& runner, int iterations) {
+        static auto run_distinct_order_by_desc_operation(BenchmarkRunner& runner, int iterations) -> void {
             constexpr std::string_view distinct_field_name = test.distinct_field.view();
             constexpr std::string_view order_field_name    = test.order_by_field.view();
             constexpr auto             distinct_field_info = dispatch_field<Model>(distinct_field_name);
@@ -986,7 +987,7 @@ namespace storm::benchmark {
         // ====================================================================
 
         template <typename Model, auto& test>
-        static void run_select_limit_operation(BenchmarkRunner& runner, int iterations) {
+        static auto run_select_limit_operation(BenchmarkRunner& runner, int iterations) -> void {
             constexpr int dataset_size = test.dataset_size;
             constexpr int limit_value  = test.limit_value;
             runner.run_benchmark(
@@ -995,7 +996,7 @@ namespace storm::benchmark {
         }
 
         template <typename Model, auto& test>
-        static void run_select_offset_operation(BenchmarkRunner& runner, int iterations) {
+        static auto run_select_offset_operation(BenchmarkRunner& runner, int iterations) -> void {
             constexpr int dataset_size = test.dataset_size;
             constexpr int offset_value = test.offset_value;
             runner.run_benchmark(
@@ -1004,7 +1005,7 @@ namespace storm::benchmark {
         }
 
         template <typename Model, auto& test>
-        static void run_select_limit_offset_operation(BenchmarkRunner& runner, int iterations) {
+        static auto run_select_limit_offset_operation(BenchmarkRunner& runner, int iterations) -> void {
             constexpr int dataset_size = test.dataset_size;
             constexpr int limit_value  = test.limit_value;
             constexpr int offset_value = test.offset_value;
@@ -1016,7 +1017,7 @@ namespace storm::benchmark {
         }
 
         template <typename Model, auto& test>
-        static void run_select_where_limit_operation(BenchmarkRunner& runner, int iterations) {
+        static auto run_select_where_limit_operation(BenchmarkRunner& runner, int iterations) -> void {
             constexpr std::string_view field_name   = test.where.field.view();
             constexpr auto             op_str       = test.where.op;
             constexpr int              value        = test.where.value_int;
@@ -1031,7 +1032,7 @@ namespace storm::benchmark {
         }
 
         template <typename Model, auto& test>
-        static void run_select_join_limit_operation(BenchmarkRunner& runner, int iterations) {
+        static auto run_select_join_limit_operation(BenchmarkRunner& runner, int iterations) -> void {
             constexpr int dataset_size = test.dataset_size;
             constexpr int limit_value  = test.limit_value;
             runner.run_benchmark(
@@ -1042,7 +1043,7 @@ namespace storm::benchmark {
         }
 
         template <typename Model, auto& test>
-        static void run_select_join_limit_offset_operation(BenchmarkRunner& runner, int iterations) {
+        static auto run_select_join_limit_offset_operation(BenchmarkRunner& runner, int iterations) -> void {
             constexpr int dataset_size = test.dataset_size;
             constexpr int limit_value  = test.limit_value;
             constexpr int offset_value = test.offset_value;
@@ -1060,7 +1061,7 @@ namespace storm::benchmark {
         // ====================================================================
 
         template <typename Model, auto& test>
-        static void run_select_order_by_asc_operation(BenchmarkRunner& runner, int iterations) {
+        static auto run_select_order_by_asc_operation(BenchmarkRunner& runner, int iterations) -> void {
             constexpr std::string_view field_name   = test.order_by_field.view();
             constexpr auto             field_info   = dispatch_field<Model>(field_name);
             constexpr int              dataset_size = test.dataset_size;
@@ -1070,7 +1071,7 @@ namespace storm::benchmark {
         }
 
         template <typename Model, auto& test>
-        static void run_select_order_by_desc_operation(BenchmarkRunner& runner, int iterations) {
+        static auto run_select_order_by_desc_operation(BenchmarkRunner& runner, int iterations) -> void {
             constexpr std::string_view field_name   = test.order_by_field.view();
             constexpr auto             field_info   = dispatch_field<Model>(field_name);
             constexpr int              dataset_size = test.dataset_size;
@@ -1080,7 +1081,7 @@ namespace storm::benchmark {
         }
 
         template <typename Model, auto& test>
-        static void run_select_order_by_where_operation(BenchmarkRunner& runner, int iterations) {
+        static auto run_select_order_by_where_operation(BenchmarkRunner& runner, int iterations) -> void {
             constexpr std::string_view order_field_name = test.order_by_field.view();
             constexpr auto             order_field_info = dispatch_field<Model>(order_field_name);
             constexpr std::string_view where_field_name = test.where.field.view();
@@ -1118,7 +1119,7 @@ namespace storm::benchmark {
         }
 
         template <typename Model, auto& test>
-        static void run_select_order_by_limit_operation(BenchmarkRunner& runner, int iterations) {
+        static auto run_select_order_by_limit_operation(BenchmarkRunner& runner, int iterations) -> void {
             constexpr std::string_view field_name   = test.order_by_field.view();
             constexpr auto             field_info   = dispatch_field<Model>(field_name);
             constexpr int              dataset_size = test.dataset_size;
@@ -1154,7 +1155,7 @@ namespace storm::benchmark {
         }
 
         template <typename Model, auto& test>
-        static void run_select_order_by_collate_operation(BenchmarkRunner& runner, int iterations) {
+        static auto run_select_order_by_collate_operation(BenchmarkRunner& runner, int iterations) -> void {
             constexpr std::string_view field_name   = test.order_by_field.view();
             constexpr auto             field_info   = dispatch_field<Model>(field_name);
             constexpr int              dataset_size = test.dataset_size;
@@ -1177,7 +1178,7 @@ namespace storm::benchmark {
         }
 
         template <typename Model, auto& test>
-        static void run_select_order_by_collate_where_operation(BenchmarkRunner& runner, int iterations) {
+        static auto run_select_order_by_collate_where_operation(BenchmarkRunner& runner, int iterations) -> void {
             constexpr auto order_field_info = dispatch_field<Model>(test.order_by_field.view());
             constexpr auto where_field_info = dispatch_field<Model>(test.where.field.view());
             constexpr auto op_str           = test.where.op;
@@ -1206,7 +1207,7 @@ namespace storm::benchmark {
         // ====================================================================
 
         template <typename Model, auto& test>
-        static void run_order_by_multi_2_asc_operation(BenchmarkRunner& runner, int iterations) {
+        static auto run_order_by_multi_2_asc_operation(BenchmarkRunner& runner, int iterations) -> void {
             constexpr std::string_view field_name1  = test.order_by_field.view();
             constexpr std::string_view field_name2  = test.order_by_field2.view();
             constexpr auto             field_info1  = dispatch_field<Model>(field_name1);
@@ -1220,7 +1221,7 @@ namespace storm::benchmark {
         }
 
         template <typename Model, auto& test>
-        static void run_order_by_multi_2_desc_operation(BenchmarkRunner& runner, int iterations) {
+        static auto run_order_by_multi_2_desc_operation(BenchmarkRunner& runner, int iterations) -> void {
             constexpr std::string_view field_name1  = test.order_by_field.view();
             constexpr std::string_view field_name2  = test.order_by_field2.view();
             constexpr auto             field_info1  = dispatch_field<Model>(field_name1);
@@ -1234,7 +1235,7 @@ namespace storm::benchmark {
         }
 
         template <typename Model, auto& test>
-        static void run_order_by_multi_2_mixed_operation(BenchmarkRunner& runner, int iterations) {
+        static auto run_order_by_multi_2_mixed_operation(BenchmarkRunner& runner, int iterations) -> void {
             constexpr std::string_view field_name1  = test.order_by_field.view();
             constexpr std::string_view field_name2  = test.order_by_field2.view();
             constexpr auto             field_info1  = dispatch_field<Model>(field_name1);
@@ -1252,7 +1253,7 @@ namespace storm::benchmark {
         // ====================================================================
 
         template <typename Model, auto& test>
-        static void run_group_by_operation(BenchmarkRunner& runner, int iterations) {
+        static auto run_group_by_operation(BenchmarkRunner& runner, int iterations) -> void {
             constexpr std::string_view field_name   = test.group_by_field.view();
             constexpr auto             field_info   = dispatch_field<Model>(field_name);
             constexpr int              dataset_size = test.dataset_size;
@@ -1262,7 +1263,7 @@ namespace storm::benchmark {
         }
 
         template <typename Model, auto& test>
-        static void run_group_by_where_operation(BenchmarkRunner& runner, int iterations) {
+        static auto run_group_by_where_operation(BenchmarkRunner& runner, int iterations) -> void {
             constexpr std::string_view group_field_name = test.group_by_field.view();
             constexpr auto             group_field_info = dispatch_field<Model>(group_field_name);
             constexpr std::string_view where_field_name = test.where.field.view();
@@ -1280,7 +1281,7 @@ namespace storm::benchmark {
         }
 
         template <typename Model, auto& test>
-        static void run_group_by_multi_2_operation(BenchmarkRunner& runner, int iterations) {
+        static auto run_group_by_multi_2_operation(BenchmarkRunner& runner, int iterations) -> void {
             constexpr std::string_view field_name1  = test.group_by_field.view();
             constexpr std::string_view field_name2  = test.group_by_field2.view();
             constexpr auto             field_info1  = dispatch_field<Model>(field_name1);
@@ -1294,7 +1295,7 @@ namespace storm::benchmark {
         }
 
         template <typename Model, auto& test>
-        static void run_group_by_with_count_operation(BenchmarkRunner& runner, int iterations) {
+        static auto run_group_by_with_count_operation(BenchmarkRunner& runner, int iterations) -> void {
             constexpr std::string_view field_name   = test.group_by_field.view();
             constexpr auto             field_info   = dispatch_field<Model>(field_name);
             constexpr int              dataset_size = test.dataset_size;
@@ -1304,7 +1305,7 @@ namespace storm::benchmark {
         }
 
         template <typename Model, auto& test>
-        static void run_group_by_with_sum_operation(BenchmarkRunner& runner, int iterations) {
+        static auto run_group_by_with_sum_operation(BenchmarkRunner& runner, int iterations) -> void {
             constexpr std::string_view group_field_name = test.group_by_field.view();
             constexpr std::string_view agg_field_name   = test.aggregate_field.view();
             constexpr auto             group_field_info = dispatch_field<Model>(group_field_name);
@@ -1318,7 +1319,7 @@ namespace storm::benchmark {
         }
 
         template <typename Model, auto& test>
-        static void run_group_by_with_avg_operation(BenchmarkRunner& runner, int iterations) {
+        static auto run_group_by_with_avg_operation(BenchmarkRunner& runner, int iterations) -> void {
             constexpr std::string_view group_field_name = test.group_by_field.view();
             constexpr std::string_view agg_field_name   = test.aggregate_field.view();
             constexpr auto             group_field_info = dispatch_field<Model>(group_field_name);
@@ -1332,7 +1333,7 @@ namespace storm::benchmark {
         }
 
         template <typename Model, auto& test>
-        static void run_group_by_with_min_operation(BenchmarkRunner& runner, int iterations) {
+        static auto run_group_by_with_min_operation(BenchmarkRunner& runner, int iterations) -> void {
             constexpr std::string_view group_field_name = test.group_by_field.view();
             constexpr std::string_view agg_field_name   = test.aggregate_field.view();
             constexpr auto             group_field_info = dispatch_field<Model>(group_field_name);
@@ -1346,7 +1347,7 @@ namespace storm::benchmark {
         }
 
         template <typename Model, auto& test>
-        static void run_group_by_with_max_operation(BenchmarkRunner& runner, int iterations) {
+        static auto run_group_by_with_max_operation(BenchmarkRunner& runner, int iterations) -> void {
             constexpr std::string_view group_field_name = test.group_by_field.view();
             constexpr std::string_view agg_field_name   = test.aggregate_field.view();
             constexpr auto             group_field_info = dispatch_field<Model>(group_field_name);
@@ -1364,7 +1365,7 @@ namespace storm::benchmark {
         // ====================================================================
 
         template <typename Model, auto& test>
-        static void run_group_by_having_count_operation(BenchmarkRunner& runner, int iterations) {
+        static auto run_group_by_having_count_operation(BenchmarkRunner& runner, int iterations) -> void {
             constexpr std::string_view group_field_name  = test.group_by_field.view();
             constexpr std::string_view having_field_name = test.having_field.view();
             constexpr auto             group_field_info  = dispatch_field<Model>(group_field_name);
@@ -1381,7 +1382,7 @@ namespace storm::benchmark {
         }
 
         template <typename Model, auto& test>
-        static void run_group_by_having_sum_operation(BenchmarkRunner& runner, int iterations) {
+        static auto run_group_by_having_sum_operation(BenchmarkRunner& runner, int iterations) -> void {
             constexpr std::string_view group_field_name  = test.group_by_field.view();
             constexpr std::string_view agg_field_name    = test.aggregate_field.view();
             constexpr std::string_view having_field_name = test.having_field.view();
@@ -1407,7 +1408,7 @@ namespace storm::benchmark {
         // ====================================================================
 
         template <typename Model, auto& test>
-        static void run_where_like_operation(BenchmarkRunner& runner, int iterations) {
+        static auto run_where_like_operation(BenchmarkRunner& runner, int iterations) -> void {
             constexpr std::string_view field_name   = test.where.field.view();
             constexpr auto             field_info   = dispatch_field<Model>(field_name);
             constexpr int              dataset_size = test.dataset_size;
@@ -1420,7 +1421,7 @@ namespace storm::benchmark {
         }
 
         template <typename Model, auto& test>
-        static void run_where_between_operation(BenchmarkRunner& runner, int iterations) {
+        static auto run_where_between_operation(BenchmarkRunner& runner, int iterations) -> void {
             constexpr std::string_view field_name   = test.where.field.view();
             constexpr auto             field_info   = dispatch_field<Model>(field_name);
             constexpr int              dataset_size = test.dataset_size;
@@ -1434,7 +1435,7 @@ namespace storm::benchmark {
         }
 
         template <typename Model, auto& test>
-        static void run_where_in_operation(BenchmarkRunner& runner, int iterations) {
+        static auto run_where_in_operation(BenchmarkRunner& runner, int iterations) -> void {
             constexpr std::string_view field_name   = test.where.field.view();
             constexpr auto             field_info   = dispatch_field<Model>(field_name);
             constexpr int              dataset_size = test.dataset_size;
@@ -1454,7 +1455,7 @@ namespace storm::benchmark {
         }
 
         template <typename Model, auto& test>
-        static void run_where_and_operation(BenchmarkRunner& runner, int iterations) {
+        static auto run_where_and_operation(BenchmarkRunner& runner, int iterations) -> void {
             constexpr std::string_view field_name1  = test.where.field.view();
             constexpr auto             field_info1  = dispatch_field<Model>(field_name1);
             constexpr auto             op1          = test.where.op;
@@ -1475,7 +1476,7 @@ namespace storm::benchmark {
         }
 
         template <typename Model, auto& test>
-        static void run_where_or_operation(BenchmarkRunner& runner, int iterations) {
+        static auto run_where_or_operation(BenchmarkRunner& runner, int iterations) -> void {
             constexpr std::string_view field_name1  = test.where.field.view();
             constexpr auto             field_info1  = dispatch_field<Model>(field_name1);
             constexpr auto             op1          = test.where.op;
@@ -1499,7 +1500,7 @@ namespace storm::benchmark {
         // IS NULL / IS NOT NULL operations
         // ====================================================================
         template <typename Model, auto& test>
-        static void run_where_is_null_operation(BenchmarkRunner& runner, int iterations) {
+        static auto run_where_is_null_operation(BenchmarkRunner& runner, int iterations) -> void {
             constexpr std::string_view field_name   = test.where.field.view();
             constexpr auto             field_info   = dispatch_field<Model>(field_name);
             constexpr int              dataset_size = test.dataset_size;
@@ -1509,7 +1510,7 @@ namespace storm::benchmark {
         }
 
         template <typename Model, auto& test>
-        static void run_where_is_not_null_operation(BenchmarkRunner& runner, int iterations) {
+        static auto run_where_is_not_null_operation(BenchmarkRunner& runner, int iterations) -> void {
             constexpr std::string_view field_name   = test.where.field.view();
             constexpr auto             field_info   = dispatch_field<Model>(field_name);
             constexpr int              dataset_size = test.dataset_size;
@@ -1521,7 +1522,8 @@ namespace storm::benchmark {
         // ====================================================================
         // FIRST operations
         // ====================================================================
-        template <typename Model, auto& test> static void run_first_operation(BenchmarkRunner& runner, int iterations) {
+        template <typename Model, auto& test>
+        static auto run_first_operation(BenchmarkRunner& runner, int iterations) -> void {
             constexpr auto profile_str = test.size_profile.view();
             constexpr auto profile     = sizes::profile_from_string(profile_str);
 
@@ -1538,7 +1540,7 @@ namespace storm::benchmark {
         }
 
         template <typename Model, auto& test>
-        static void run_first_where_operation(BenchmarkRunner& runner, int iterations) {
+        static auto run_first_where_operation(BenchmarkRunner& runner, int iterations) -> void {
             constexpr std::string_view field_name   = test.where.field.view();
             constexpr auto             field_info   = dispatch_field<Model>(field_name);
             constexpr auto             op           = test.where.op;
@@ -1555,7 +1557,7 @@ namespace storm::benchmark {
         // GET operations
         // ====================================================================
         template <typename Model, auto& test>
-        static void run_get_where_operation(BenchmarkRunner& runner, int iterations) {
+        static auto run_get_where_operation(BenchmarkRunner& runner, int iterations) -> void {
             constexpr std::string_view field_name   = test.where.field.view();
             constexpr auto             field_info   = dispatch_field<Model>(field_name);
             constexpr auto             op           = test.where.op;
@@ -1573,7 +1575,7 @@ namespace storm::benchmark {
         // ====================================================================
 
         template <typename Model, auto& test, SetOpBenchType OpType, bool WithOrderBy = false, bool WithLimit = false>
-        static void run_setop_operation_impl(BenchmarkRunner& runner, int iterations) {
+        static auto run_setop_operation_impl(BenchmarkRunner& runner, int iterations) -> void {
             constexpr auto profile_str = test.size_profile.view();
             constexpr auto profile     = sizes::profile_from_string(profile_str);
 
@@ -1616,32 +1618,32 @@ namespace storm::benchmark {
         }
 
         template <typename Model, auto& test>
-        static void run_setop_union_operation(BenchmarkRunner& runner, int iterations) {
+        static auto run_setop_union_operation(BenchmarkRunner& runner, int iterations) -> void {
             run_setop_operation_impl<Model, test, SetOpBenchType::Union>(runner, iterations);
         }
 
         template <typename Model, auto& test>
-        static void run_setop_union_all_operation(BenchmarkRunner& runner, int iterations) {
+        static auto run_setop_union_all_operation(BenchmarkRunner& runner, int iterations) -> void {
             run_setop_operation_impl<Model, test, SetOpBenchType::UnionAll>(runner, iterations);
         }
 
         template <typename Model, auto& test>
-        static void run_setop_except_operation(BenchmarkRunner& runner, int iterations) {
+        static auto run_setop_except_operation(BenchmarkRunner& runner, int iterations) -> void {
             run_setop_operation_impl<Model, test, SetOpBenchType::Except>(runner, iterations);
         }
 
         template <typename Model, auto& test>
-        static void run_setop_intersect_operation(BenchmarkRunner& runner, int iterations) {
+        static auto run_setop_intersect_operation(BenchmarkRunner& runner, int iterations) -> void {
             run_setop_operation_impl<Model, test, SetOpBenchType::Intersect>(runner, iterations);
         }
 
         template <typename Model, auto& test>
-        static void run_setop_union_order_by_operation(BenchmarkRunner& runner, int iterations) {
+        static auto run_setop_union_order_by_operation(BenchmarkRunner& runner, int iterations) -> void {
             run_setop_operation_impl<Model, test, SetOpBenchType::Union, true>(runner, iterations);
         }
 
         template <typename Model, auto& test>
-        static void run_setop_union_limit_operation(BenchmarkRunner& runner, int iterations) {
+        static auto run_setop_union_limit_operation(BenchmarkRunner& runner, int iterations) -> void {
             run_setop_operation_impl<Model, test, SetOpBenchType::Union, false, true>(runner, iterations);
         }
 

--- a/benchmarks/schema.hpp
+++ b/benchmarks/schema.hpp
@@ -32,11 +32,11 @@ namespace storm::benchmark {
             data[len] = '\0';
         }
 
-        constexpr std::string_view view() const {
+        constexpr auto view() const -> std::string_view {
             return std::string_view(data.data(), len);
         }
 
-        constexpr const char* c_str() const {
+        constexpr auto c_str() const -> const char* {
             return data.data();
         }
 

--- a/benchmarks/sizes.hpp
+++ b/benchmarks/sizes.hpp
@@ -55,7 +55,7 @@ namespace storm::benchmark::sizes {
 
     // Calculate iterations inversely proportional to batch size
     // Larger batches get fewer iterations to maintain consistent total work
-    constexpr int iterations_for_batch(int size) {
+    constexpr auto iterations_for_batch(int size) -> int {
         if (size <= 1)
             return 10000;
         if (size <= 10)
@@ -74,7 +74,7 @@ namespace storm::benchmark::sizes {
     }
 
     // Calculate iterations inversely proportional to dataset size
-    constexpr int iterations_for_dataset(int size) {
+    constexpr auto iterations_for_dataset(int size) -> int {
         if (size <= 100)
             return 10000;
         if (size <= 1000)
@@ -85,7 +85,7 @@ namespace storm::benchmark::sizes {
     }
 
     // Calculate iterations for aggregate operations
-    constexpr int iterations_for_aggregate(int size) {
+    constexpr auto iterations_for_aggregate(int size) -> int {
         if (size <= 1000)
             return 10000;
         if (size <= 10000)
@@ -106,7 +106,7 @@ namespace storm::benchmark::sizes {
     };
 
     // Convert string to SizeProfile
-    constexpr SizeProfile profile_from_string(std::string_view str) {
+    constexpr auto profile_from_string(std::string_view str) -> SizeProfile {
         using enum SizeProfile;
         if (str == "batch_standard")
             return BatchStandard;

--- a/benchmarks/timing_trace.hpp
+++ b/benchmarks/timing_trace.hpp
@@ -76,24 +76,24 @@ namespace storm::benchmark {
             bool                                        enabled_ = false;
 
           public:
-            static TraceContext& instance() {
+            static auto instance() -> TraceContext& {
                 static thread_local TraceContext ctx;
                 return ctx;
             }
 
-            void set_enabled(bool enabled) {
+            auto set_enabled(bool enabled) -> void {
                 enabled_ = enabled;
             }
-            bool is_enabled() const {
+            auto is_enabled() const -> bool {
                 return enabled_;
             }
 
-            void reset() {
+            auto reset() -> void {
                 entries_.clear();
                 order_.clear();
             }
 
-            void start(const char* name) {
+            auto start(const char* name) -> void {
                 if (!enabled_)
                     return;
                 auto& entry = entries_[name];
@@ -104,7 +104,7 @@ namespace storm::benchmark {
                 entry.start_time = now_ns();
             }
 
-            void end(const char* name) {
+            auto end(const char* name) -> void {
                 if (!enabled_)
                     return;
                 auto it = entries_.find(name);
@@ -115,7 +115,7 @@ namespace storm::benchmark {
                 }
             }
 
-            void report(int iterations = 1) {
+            auto report(int iterations = 1) -> void {
                 if (entries_.empty())
                     return;
 
@@ -154,7 +154,7 @@ namespace storm::benchmark {
             }
 
           private:
-            static uint64_t now_ns() {
+            static auto now_ns() -> uint64_t {
                 return std::chrono::duration_cast<std::chrono::nanoseconds>(
                                std::chrono::high_resolution_clock::now().time_since_epoch()
                 )

--- a/scripts/run_clang_tidy.sh
+++ b/scripts/run_clang_tidy.sh
@@ -135,9 +135,8 @@ is_cpp26_module_file() {
     # they parse successfully and never reach this function's "known skip" path.
     case "$file" in
         tests/*|benchmarks/*|fuzz/*) return 0 ;;
+        *) return 1 ;;
     esac
-
-    return 1
 }
 export -f is_cpp26_module_file
 

--- a/scripts/run_clang_tidy.sh
+++ b/scripts/run_clang_tidy.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Run clang-tidy on staged files (git diff --cached)
-# Usage: ./run_clang_tidy.sh [--fix] [-j N]
+# Usage: ./run_clang_tidy.sh [--fix] [--all] [-j N]
 #
 # Prerequisites:
 #   - Release build with compile_commands.json: cmake --preset ninja-release
@@ -8,6 +8,7 @@
 #
 # Options:
 #   --fix   Apply suggested fixes automatically (use with caution)
+#   --all   Check ALL C++ source files (not just staged files)
 #   -j N    Number of parallel jobs (default: all cores)
 
 set -e
@@ -30,12 +31,17 @@ CLANG_TIDY_CONFIG=".clang-tidy"
 
 # Parse arguments
 FIX_FLAG=""
+CHECK_ALL=false
 JOBS=$(nproc)
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --fix)
             FIX_FLAG="-fix"
+            shift
+            ;;
+        --all)
+            CHECK_ALL=true
             shift
             ;;
         -j)
@@ -69,7 +75,11 @@ echo "🔍 Running clang-tidy using .clang-tidy configuration..."
 echo "   Config file: $CLANG_TIDY_CONFIG"
 echo "   Build directory: $BUILD_DIR"
 echo "   Parallel jobs: $JOBS"
-echo "   Scope: staged files (git diff --cached)"
+if [[ "$CHECK_ALL" == true ]]; then
+    echo "   Scope: ALL C++ source files"
+else
+    echo "   Scope: staged files (git diff --cached)"
+fi
 if [[ -n "$FIX_FLAG" ]]; then
     echo "   Mode: AUTO-FIX enabled"
 else
@@ -77,14 +87,24 @@ else
 fi
 echo ""
 
-# Collect staged C++ source files
-FILES=$(git diff --cached --name-only 2>/dev/null \
-    | grep -E '\.(cpp|cppm)$' \
-    | grep -v 'third_party' \
-    | sort)
+# Collect C++ source files
+if [[ "$CHECK_ALL" == true ]]; then
+    FILES=$(find src tests benchmarks \( -name '*.cpp' -o -name '*.cppm' -o -name '*.h' -o -name '*.hpp' \) 2>/dev/null \
+        | grep -v 'third_party' \
+        | sort)
+else
+    FILES=$(git diff --cached --name-only 2>/dev/null \
+        | grep -E '\.(cpp|cppm|h|hpp)$' \
+        | grep -v 'third_party' \
+        | sort)
+fi
 
 if [[ -z "$FILES" ]]; then
-    echo "✅ No staged C++ files — clang-tidy skipped"
+    if [[ "$CHECK_ALL" == true ]]; then
+        echo "✅ No C++ files found — clang-tidy skipped"
+    else
+        echo "✅ No staged C++ files — clang-tidy skipped"
+    fi
     exit 0
 fi
 
@@ -109,20 +129,13 @@ is_cpp26_module_file() {
         return 0
     fi
 
-    # All test files import Storm modules
-    if [[ "$file" == tests/*.cpp ]]; then
-        return 0
-    fi
-
-    # All benchmark files import Storm modules
-    if [[ "$file" == benchmarks/*.cpp ]]; then
-        return 0
-    fi
-
-    # All fuzz harnesses import Storm modules
-    if [[ "$file" == fuzz/*.cpp ]]; then
-        return 0
-    fi
+    # All files under tests/, benchmarks/, fuzz/ use C++26 modules/reflection
+    # (directly or transitively via includes like <meta>, std::meta::info, etc.)
+    # Exception: mock files that don't use modules are handled by the caller —
+    # they parse successfully and never reach this function's "known skip" path.
+    case "$file" in
+        tests/*|benchmarks/*|fuzz/*) return 0 ;;
+    esac
 
     return 1
 }

--- a/tests/query/test_aggregate.cpp
+++ b/tests/query/test_aggregate.cpp
@@ -41,7 +41,7 @@ template <typename ConnType> class AggregateTest : public StormTestFixture<Perso
     }
 
     // Helper to insert PEOPLE_25 + MESSAGES_8 with FK safety (query back IDs for PG)
-    void insert_join_test_data() {
+    auto insert_join_test_data() -> void {
         ASSERT_TRUE((storm::test::batch_insert<Person, ConnType>(
                 std::vector<Person>(storm::test::PEOPLE_25.begin(), storm::test::PEOPLE_25.end())
         )));

--- a/tests/test_db_helpers.h
+++ b/tests/test_db_helpers.h
@@ -51,7 +51,7 @@ inline std::string current_test_schema; // NOLINT // NOSONAR(cpp:S5421)
 
 // Check if the backend is available (PG requires STORM_PG_CONNSTR set and server reachable;
 // SQLite is always available)
-template <typename ConnType> bool backend_available() {
+template <typename ConnType> auto backend_available() -> bool {
     if constexpr (std::is_same_v<ConnType, storm::db::postgresql::Connection>) {
         const char *connstr = std::getenv("STORM_PG_CONNSTR");
         if (!connstr)
@@ -94,7 +94,7 @@ template <typename ConnType> auto pg_schema_init(auto &conn) -> void {
 
 // End test isolation. For PG: drops the per-process schema (instant cleanup).
 // For SQLite: no-op (:memory: is destroyed with the connection).
-template <typename ConnType> void rollback_test_txn(auto &conn) {
+template <typename ConnType> auto rollback_test_txn(auto &conn) -> void {
     if constexpr (std::is_same_v<ConnType, storm::db::postgresql::Connection>) {
         if (!detail::current_test_schema.empty()) {
             (void)conn->execute(std::format("DROP SCHEMA IF EXISTS {} CASCADE", detail::current_test_schema));
@@ -107,12 +107,12 @@ template <typename ConnType> void rollback_test_txn(auto &conn) {
 }
 
 // Check if we're running against PostgreSQL
-template <typename ConnType> constexpr bool is_postgresql() {
+template <typename ConnType> constexpr auto is_postgresql() -> bool {
     return std::is_same_v<ConnType, storm::db::postgresql::Connection>;
 }
 
 // Check if we're running against SQLite
-template <typename ConnType> constexpr bool is_sqlite() {
+template <typename ConnType> constexpr auto is_sqlite() -> bool {
     return std::is_same_v<ConnType, storm::db::sqlite::Connection>;
 }
 

--- a/tests/test_models.h
+++ b/tests/test_models.h
@@ -126,13 +126,14 @@ template <typename T, typename ConnType> inline auto ensure_table(auto &conn) {
 
 // Variadic helper — creates tables for all given model types.
 // Returns true only if all tables were created successfully.
-template <typename ConnType, typename... Models> inline bool ensure_tables(const std::shared_ptr<ConnType> &conn) {
+template <typename ConnType, typename... Models>
+inline auto ensure_tables(const std::shared_ptr<ConnType> &conn) -> bool {
     return (ensure_table<Models, ConnType>(conn).has_value() && ...);
 }
 
 // Populates join test data: 3 Persons + 5 Messages with sender FKs.
 // Used by DistinctTest, ValuesTest, and AggregateTest fixtures.
-template <typename ConnType> inline void populate_join_test_data() {
+template <typename ConnType> inline auto populate_join_test_data() -> void {
     storm::QuerySet<Person, ConnType> person_qs;
     std::vector<Person> const people = {
         {.name = "Alice", .age = 30},
@@ -161,30 +162,34 @@ template <typename ConnType> inline void populate_join_test_data() {
 // Model record generators -- used by InsertRunner/UpdateRunner/RemoveRunner
 // ============================================================================
 
-template <typename Model> Model make_record(int i) = delete;
-template <> inline Person make_record<Person>(int i) {
+template <typename Model> auto make_record(int i) -> Model = delete;
+template <> inline auto make_record<Person>(int i) -> Person {
     return {.name = std::format("P{}", i + 1),
             .age = 20 + (i % 50),
             .salary = 1000.0 * (i + 1),
             .is_active = (i % 2 == 0),
             .years_experience = i % 30};
 }
-template <> inline SimpleRecord make_record<SimpleRecord>(int i) { return {0, std::format("R{}", i), i}; }
-template <> inline Message make_record<Message>(int i) { return {.content = std::format("M{}", i), .value = i}; }
+template <> inline auto make_record<SimpleRecord>(int i) -> SimpleRecord { return {0, std::format("R{}", i), i}; }
+template <> inline auto make_record<Message>(int i) -> Message {
+    return {.content = std::format("M{}", i), .value = i};
+}
 
-template <typename Model> Model make_updated_record(const Model &) = delete;
-template <> inline Person make_updated_record<Person>(const Person &p) {
+template <typename Model> auto make_updated_record(const Model &) -> Model = delete;
+template <> inline auto make_updated_record<Person>(const Person &p) -> Person {
     Person u = p;
     u.name = std::format("Updated{}", p.id);
     return u;
 }
-template <> inline SimpleRecord make_updated_record<SimpleRecord>(const SimpleRecord &r) {
+template <> inline auto make_updated_record<SimpleRecord>(const SimpleRecord &r) -> SimpleRecord {
     return {r.id, std::format("Updated{}", r.id), r.value * 2};
 }
 
-template <typename Model> bool is_original_record(const Model &) = delete;
-template <> inline bool is_original_record<Person>(const Person &p) { return p.name.starts_with("P"); }
-template <> inline bool is_original_record<SimpleRecord>(const SimpleRecord &r) { return r.name.starts_with("R"); }
+template <typename Model> auto is_original_record(const Model &) -> bool = delete;
+template <> inline auto is_original_record<Person>(const Person &p) -> bool { return p.name.starts_with("P"); }
+template <> inline auto is_original_record<SimpleRecord>(const SimpleRecord &r) -> bool {
+    return r.name.starts_with("R");
+}
 
 // ---------------------------------------------------------------------------
 // Unified seed dataset — ONE shared 25-row Person + 8-row Message dataset.

--- a/tests/test_parser.hpp
+++ b/tests/test_parser.hpp
@@ -36,17 +36,17 @@ namespace storm::test {
         }
     }
 
-    constexpr void skip_ws(std::string_view j, size_t& p) {
+    constexpr auto skip_ws(std::string_view j, size_t& p) -> void {
         skip_ws(j.data(), j.size(), p);
     }
 
-    constexpr void skip_char(std::string_view j, size_t& p, char c) {
+    constexpr auto skip_char(std::string_view j, size_t& p, char c) -> void {
         skip_ws(j, p);
         if (p < j.size() && j.data()[p] == c)
             ++p;
     }
 
-    constexpr int parse_int(std::string_view j, size_t& p) {
+    constexpr auto parse_int(std::string_view j, size_t& p) -> int {
         skip_ws(j, p);
         const char*  ptr = j.data();
         const size_t sz  = j.size();
@@ -61,7 +61,7 @@ namespace storm::test {
         return neg ? -v : v;
     }
 
-    constexpr double parse_double(std::string_view j, size_t& p) {
+    constexpr auto parse_double(std::string_view j, size_t& p) -> double {
         skip_ws(j, p);
         const char*  ptr = j.data();
         const size_t sz  = j.size();
@@ -84,7 +84,7 @@ namespace storm::test {
         return neg ? -v : v;
     }
 
-    constexpr bool parse_bool(std::string_view j, size_t& p) {
+    constexpr auto parse_bool(std::string_view j, size_t& p) -> bool {
         skip_ws(j, p);
         const char*  ptr = j.data();
         const size_t sz  = j.size();
@@ -100,7 +100,7 @@ namespace storm::test {
         return false;
     }
 
-    template <size_t N> constexpr ConstexprString<N> parse_str(std::string_view j, size_t& p) {
+    template <size_t N> constexpr auto parse_str(std::string_view j, size_t& p) -> ConstexprString<N> {
         skip_ws(j, p);
         const char*        ptr = j.data();
         const size_t       sz  = j.size();
@@ -119,7 +119,7 @@ namespace storm::test {
         return r;
     }
 
-    constexpr void skip_object(std::string_view j, size_t& p) {
+    constexpr auto skip_object(std::string_view j, size_t& p) -> void {
         const char*  ptr   = j.data();
         const size_t sz    = j.size();
         int          depth = 0;
@@ -135,7 +135,7 @@ namespace storm::test {
         }
     }
 
-    constexpr void skip_array(std::string_view j, size_t& p) {
+    constexpr auto skip_array(std::string_view j, size_t& p) -> void {
         const char*  ptr   = j.data();
         const size_t sz    = j.size();
         int          depth = 0;
@@ -150,7 +150,7 @@ namespace storm::test {
         }
     }
 
-    constexpr void skip_value(std::string_view j, size_t& p) { // NOSONAR(S3776) -- consteval JSON parser
+    constexpr auto skip_value(std::string_view j, size_t& p) -> void { // NOSONAR(S3776) -- consteval JSON parser
         skip_ws(j, p);
         const char*  ptr = j.data();
         const size_t sz  = j.size();
@@ -179,7 +179,7 @@ namespace storm::test {
         }
     }
 
-    constexpr size_t count_objects(std::string_view j) {
+    constexpr auto count_objects(std::string_view j) -> size_t {
         size_t n = 0;
         size_t p = 0;
         skip_char(j, p, '[');
@@ -202,7 +202,8 @@ namespace storm::test {
 
     // Zero-alloc key comparison directly from JSON buffer.
     template <size_t M>
-    constexpr bool jkey_eq(const char* json_ptr, size_t key_start, size_t key_len, const char (&lit)[M]) noexcept {
+    constexpr auto jkey_eq(const char* json_ptr, size_t key_start, size_t key_len, const char (&lit)[M]) noexcept
+            -> bool {
         constexpr size_t len = M - 1;
         if (key_len != len)
             return false;
@@ -217,7 +218,8 @@ namespace storm::test {
         size_t len   = 0;
     };
 
-    constexpr JsonKeyRef parse_key_ref(const char* ptr, size_t sz, size_t& p) { // NOSONAR — ptr+sz needed for consteval
+    constexpr auto parse_key_ref(const char* ptr, size_t sz, size_t& p)
+            -> JsonKeyRef { // NOSONAR — ptr+sz needed for consteval
         skip_ws(ptr, sz, p);
         JsonKeyRef ref;
         if (p < sz && ptr[p] == '"') {
@@ -234,7 +236,7 @@ namespace storm::test {
 
     // Detect JSON value type and parse into the appropriate where.value_* field.
     // Checks the first non-whitespace character: " = string, t/f = bool, [ = array, else number.
-    constexpr bool is_number_with_dot(std::string_view j, size_t p) {
+    constexpr auto is_number_with_dot(std::string_view j, size_t p) -> bool {
         const char*  ptr = j.data();
         const size_t sz  = j.size();
         while (p < sz) {
@@ -249,7 +251,7 @@ namespace storm::test {
     }
 
     template <size_t MaxLen>
-    constexpr size_t parse_int_array(std::string_view j, size_t& p, std::array<int, MaxLen>& out) {
+    constexpr auto parse_int_array(std::string_view j, size_t& p, std::array<int, MaxLen>& out) -> size_t {
         skip_ws(j, p);
         const char*  ptr = j.data();
         const size_t sz  = j.size();
@@ -273,7 +275,7 @@ namespace storm::test {
     }
 
     template <size_t MaxLen>
-    constexpr size_t parse_double_array(std::string_view j, size_t& p, std::array<double, MaxLen>& out) {
+    constexpr auto parse_double_array(std::string_view j, size_t& p, std::array<double, MaxLen>& out) -> size_t {
         skip_ws(j, p);
         const char*  ptr = j.data();
         const size_t sz  = j.size();
@@ -298,7 +300,7 @@ namespace storm::test {
 
     // In-place array parser — calls parse_fn(j, p, arr[i]) to avoid copy overhead.
     template <typename T, size_t N, typename ParseIntoFn>
-    constexpr std::array<T, N> parse_array_into(std::string_view j, ParseIntoFn parse_fn) {
+    constexpr auto parse_array_into(std::string_view j, ParseIntoFn parse_fn) -> std::array<T, N> {
         std::array<T, N> arr{};
         size_t           p   = 0;
         const char*      ptr = j.data();
@@ -317,7 +319,7 @@ namespace storm::test {
     }
 
     // Helper: check for end-of-object '}'.  Returns true (and advances p) if found.
-    constexpr bool at_object_end(const char* ptr, size_t sz, size_t& p) {
+    constexpr auto at_object_end(const char* ptr, size_t sz, size_t& p) -> bool {
         skip_ws(ptr, sz, p);
         if (p < sz && ptr[p] == '}') {
             ++p;
@@ -327,7 +329,7 @@ namespace storm::test {
     }
 
     // Helper: parse key and skip colon.  Returns the key reference.
-    constexpr JsonKeyRef parse_key_and_colon(const char* ptr, size_t sz, size_t& p) {
+    constexpr auto parse_key_and_colon(const char* ptr, size_t sz, size_t& p) -> JsonKeyRef {
         auto kr = parse_key_ref(ptr, sz, p);
         skip_ws(ptr, sz, p);
         if (p < sz && ptr[p] == ':')
@@ -336,7 +338,7 @@ namespace storm::test {
     }
 
     // Helper: skip trailing comma after a value inside an object/array.
-    constexpr void skip_comma(const char* ptr, size_t sz, size_t& p) {
+    constexpr auto skip_comma(const char* ptr, size_t sz, size_t& p) -> void {
         skip_ws(ptr, sz, p);
         if (p < sz && ptr[p] == ',')
             ++p;
@@ -442,7 +444,7 @@ namespace storm::test {
         TypedValueKind      kind = TypedValueKind::Int;
     };
 
-    constexpr TypedValue parse_typed_value(std::string_view j, size_t& p) {
+    constexpr auto parse_typed_value(std::string_view j, size_t& p) -> TypedValue {
         using enum TypedValueKind;
         skip_ws(j, p);
         const char* ptr = j.data();
@@ -464,7 +466,7 @@ namespace storm::test {
     }
 
     // Assign typed value into primary where fields.
-    constexpr void assign_where_value(WhereSpec& w, const TypedValue& tv) {
+    constexpr auto assign_where_value(WhereSpec& w, const TypedValue& tv) -> void {
         using enum TypedValueKind;
         if (tv.kind == Bool)
             w.value_bool = tv.b;
@@ -477,7 +479,7 @@ namespace storm::test {
     }
 
     // Assign typed value into secondary where fields (value2).
-    constexpr void assign_where_value2(WhereSpec& w, const TypedValue& tv) {
+    constexpr auto assign_where_value2(WhereSpec& w, const TypedValue& tv) -> void {
         using enum TypedValueKind;
         if (tv.kind == Bool)
             w.value_bool2 = tv.b;
@@ -503,7 +505,8 @@ namespace storm::test {
     }
 
     // Parse len-6 keys inside "where" object.
-    constexpr void parse_where_key6(std::string_view j, size_t& p, const char* ptr, JsonKeyRef kr, WhereSpec& w) {
+    constexpr auto parse_where_key6(std::string_view j, size_t& p, const char* ptr, JsonKeyRef kr, WhereSpec& w)
+            -> void {
         if (jkey_eq(ptr, kr.start, kr.len, "field2"))
             w.field2 = parse_str<32>(j, p);
         else if (jkey_eq(ptr, kr.start, kr.len, "field3"))
@@ -523,7 +526,7 @@ namespace storm::test {
     }
 
     // Parse "where": { field, op, value, upper, values, field2, op2, value2, field3, value3, logic }
-    constexpr void parse_where_into(std::string_view j, size_t& p, WhereSpec& w) { // NOSONAR(S3776)
+    constexpr auto parse_where_into(std::string_view j, size_t& p, WhereSpec& w) -> void { // NOSONAR(S3776)
         const char*  ptr = j.data();
         const size_t sz  = j.size();
         skip_char(j, p, '{');
@@ -560,7 +563,7 @@ namespace storm::test {
     }
 
     // Parse "order_by": { field, asc }
-    constexpr void parse_order_by_into(std::string_view j, size_t& p, OrderBySpec& ob) {
+    constexpr auto parse_order_by_into(std::string_view j, size_t& p, OrderBySpec& ob) -> void {
         const char*  ptr = j.data();
         const size_t sz  = j.size();
         skip_char(j, p, '{');
@@ -579,7 +582,7 @@ namespace storm::test {
     }
 
     // Parse "first": { name, age, salary, is_active, years_experience, department, content, value }
-    constexpr void parse_first_row_into(std::string_view j, size_t& p, FirstRowSpec& f) { // NOSONAR(S3776)
+    constexpr auto parse_first_row_into(std::string_view j, size_t& p, FirstRowSpec& f) -> void { // NOSONAR(S3776)
         const char*  ptr = j.data();
         const size_t sz  = j.size();
         skip_char(j, p, '{');
@@ -655,7 +658,7 @@ namespace storm::test {
 
     // Parse "expected": { count, int_val, dbl_val, unchanged, remaining, first,
     //                     groups_count, group_keys, group_agg_int, group_agg_dbl }
-    constexpr void parse_expected_into(std::string_view j, size_t& p, ExpectedSpec& e) { // NOSONAR(S3776)
+    constexpr auto parse_expected_into(std::string_view j, size_t& p, ExpectedSpec& e) -> void { // NOSONAR(S3776)
         const char*  ptr = j.data();
         const size_t sz  = j.size();
         skip_char(j, p, '{');
@@ -748,7 +751,7 @@ namespace storm::test {
     }
 
     // Parse nested "result": { type, value } inside a ChainAggSpec.
-    constexpr void parse_chain_result_into(std::string_view j, size_t& p, ChainAggSpec& spec) {
+    constexpr auto parse_chain_result_into(std::string_view j, size_t& p, ChainAggSpec& spec) -> void {
         const char*  ptr = j.data();
         const size_t sz  = j.size();
         skip_char(j, p, '{');
@@ -767,7 +770,7 @@ namespace storm::test {
     }
 
     // Parse a single ChainAggSpec: { func, field, result: { type, value } }
-    constexpr ChainAggSpec parse_chain_agg_spec(std::string_view j, size_t& p) {
+    constexpr auto parse_chain_agg_spec(std::string_view j, size_t& p) -> ChainAggSpec {
         ChainAggSpec spec;
         const char*  ptr = j.data();
         const size_t sz  = j.size();
@@ -948,7 +951,8 @@ namespace storm::test {
     //     remove_count,update_count
     // 14: distinct_field,group_by_field
     // 15: distinct_field2,group_by_field2,having_value_int
-    constexpr void parse_unified_case_into(std::string_view j, size_t& p, UnifiedTestCase& tc) { // NOSONAR(S3776)
+    constexpr auto parse_unified_case_into(std::string_view j, size_t& p, UnifiedTestCase& tc)
+            -> void { // NOSONAR(S3776)
         const char*  ptr = j.data();
         const size_t sz  = j.size();
         skip_char(j, p, '{');

--- a/tests/test_query_dispatch.h
+++ b/tests/test_query_dispatch.h
@@ -28,7 +28,7 @@ namespace storm::test {
 // Field dispatcher — resolves a field name string to its consteval meta::info
 // ============================================================================
 
-template <typename Model> consteval std::meta::info dispatch_field(std::string_view field_name) {
+template <typename Model> consteval auto dispatch_field(std::string_view field_name) -> std::meta::info {
     for (std::meta::info member :
          std::meta::nonstatic_data_members_of(^^Model, std::meta::access_context::unchecked())) {
         if (std::meta::identifier_of(member) == field_name) {

--- a/tests/test_query_runner_base.h
+++ b/tests/test_query_runner_base.h
@@ -41,7 +41,7 @@ template <typename Model, typename ConnType> class QueryRunnerBase {
 
     // NTTP twin of SelectQueryBenchmarkBase::build_where_clause()
     // Tc must have a WhereSpec-compatible `where` member.
-    template <const auto &Tc> void apply_where() {
+    template <const auto &Tc> auto apply_where() -> void {
         using storm::orm::where::field;
 
         if constexpr (Tc.where.op == "is_null") {
@@ -103,7 +103,7 @@ template <typename Model, typename ConnType> class QueryRunnerBase {
     }
 
     // Apply WHERE and JOIN filters (mutates qs_ in place)
-    template <const auto &Tc> void apply_where_and_join() {
+    template <const auto &Tc> auto apply_where_and_join() -> void {
         if constexpr (!Tc.join_name.empty()) {
             qs_.template join<&Model::sender>();
         }

--- a/tests/test_select_runner.h
+++ b/tests/test_select_runner.h
@@ -24,7 +24,7 @@ template <typename Model, typename ConnType> class SelectRunner : public SelectQ
     // Verify first-row fields specified in the expected.first spec.
     // Uses `if constexpr (requires { ... })` to guard model-specific field access.
     template <const auto &Tc, typename Row>
-    void verify_first_row(const Row &row) { // NOSONAR(S3776) -- constexpr dispatch
+    auto verify_first_row(const Row &row) -> void { // NOSONAR(S3776) -- constexpr dispatch
         if constexpr (Tc.expected.first.has_name && requires { row.name; })
             EXPECT_EQ(row.name, std::string(Tc.expected.first.name.view()));
         if constexpr (Tc.expected.first.has_age && requires { row.age; })
@@ -43,7 +43,7 @@ template <typename Model, typename ConnType> class SelectRunner : public SelectQ
             EXPECT_EQ(row.value, Tc.expected.first.value);
     }
 
-    template <const auto &Tc> void run() { // NOSONAR(S3776) -- inherent constexpr dispatch
+    template <const auto &Tc> auto run() -> void { // NOSONAR(S3776) -- inherent constexpr dispatch
         this->template apply_where_and_join<Tc>();
         if constexpr (Tc.query_type == "first") {
             auto r = this->template qs_with_modifiers<Tc>().first().execute();
@@ -78,7 +78,7 @@ template <typename Model, typename ConnType> class SelectRunner : public SelectQ
 // ---------------------------------------------------------------------------
 template <typename Model, typename ConnType> class AggregateRunner : public SelectQueryRunnerBase<Model, ConnType> {
   public:
-    template <const auto &Tc> void run() { // NOSONAR(S3776) -- inherent constexpr dispatch
+    template <const auto &Tc> auto run() -> void { // NOSONAR(S3776) -- inherent constexpr dispatch
         this->template apply_where_and_join<Tc>();
 
         if constexpr (Tc.query_type == "count") {
@@ -138,7 +138,7 @@ template <typename Model, typename ConnType> class ChainAggRunner : public Selec
   public:
     template <const auto &Tc>
     // NOLINTNEXTLINE(readability-function-cognitive-complexity)
-    void run() { // NOSONAR(S3776) -- inherent constexpr dispatch
+    auto run() -> void { // NOSONAR(S3776) -- inherent constexpr dispatch
         this->template apply_where_and_join<Tc>();
 
         if constexpr (Tc.chain_len == 2) {
@@ -298,7 +298,7 @@ template <typename Model, typename ConnType> class ChainAggRunner : public Selec
 // ---------------------------------------------------------------------------
 template <typename Model, typename ConnType> class DistinctRunner : public SelectQueryRunnerBase<Model, ConnType> {
   public:
-    template <const auto &Tc> void run() {
+    template <const auto &Tc> auto run() -> void {
         this->template apply_where_and_join<Tc>();
         if constexpr (!Tc.distinct_field2.empty()) {
             constexpr auto fi1 = dispatch_field<Model>(Tc.distinct_field.view());
@@ -320,7 +320,7 @@ template <typename Model, typename ConnType> class DistinctRunner : public Selec
 // ---------------------------------------------------------------------------
 template <typename Model, typename ConnType> class GroupByRunner : public SelectQueryRunnerBase<Model, ConnType> {
   public:
-    template <const auto &Tc> void run() { // NOSONAR(S3776) -- inherent constexpr dispatch
+    template <const auto &Tc> auto run() -> void { // NOSONAR(S3776) -- inherent constexpr dispatch
         this->template apply_where_and_join<Tc>();
         decltype(auto) qs = this->template qs_with_modifiers<Tc>();
 

--- a/tests/test_write_runner.h
+++ b/tests/test_write_runner.h
@@ -18,7 +18,7 @@ namespace storm::test {
 // ---------------------------------------------------------------------------
 template <typename Model, typename ConnType> class InsertRunner : public QueryRunnerBase<Model, ConnType> {
   public:
-    template <const auto &Tc> void run() {
+    template <const auto &Tc> auto run() -> void {
         if constexpr (Tc.query_type == "insert_one") {
             auto r = this->qs_.insert(make_record<Model>(0)).execute();
             ASSERT_TRUE(r.has_value()) << r.error().message();
@@ -45,7 +45,7 @@ template <typename Model, typename ConnType> class InsertRunner : public QueryRu
 // ---------------------------------------------------------------------------
 template <typename Model, typename ConnType> class UpdateRunner : public QueryRunnerBase<Model, ConnType> {
   public:
-    template <const auto &Tc> void run() {
+    template <const auto &Tc> auto run() -> void {
         // Seed initial dataset
         std::vector<Model> initial;
         initial.reserve(static_cast<size_t>(Tc.dataset_size));
@@ -88,7 +88,7 @@ template <typename Model, typename ConnType> class UpdateRunner : public QueryRu
 // ---------------------------------------------------------------------------
 template <typename Model, typename ConnType> class RemoveRunner : public QueryRunnerBase<Model, ConnType> {
   public:
-    template <const auto &Tc> void run() {
+    template <const auto &Tc> auto run() -> void {
         if constexpr (Tc.query_type == "remove_all") {
             // Seed dataset_size records, then remove all
             std::vector<Model> initial;

--- a/tests/test_yaml_register.h
+++ b/tests/test_yaml_register.h
@@ -29,7 +29,7 @@ template <size_t I, typename Fixture, typename ConnType> class YamlTestInstance 
 // The factory returns Fixture* (not YamlTestInstance*) so GTest sees a single
 // fixture type for the whole suite -- avoids "different fixture class" errors.
 template <const auto &Tests, typename Fixture, typename ConnType>
-void register_for_backend(const char *suite, const char *backend) {
+auto register_for_backend(const char *suite, const char *backend) -> void {
     static const std::string suite_name = std::string(suite) + "/" + backend;
     [suite_ptr = suite_name.c_str()]<size_t... I>(std::index_sequence<I...>) {
         (..., ::testing::RegisterTest(
@@ -44,7 +44,8 @@ void register_for_backend(const char *suite, const char *backend) {
 
 // Convenience: register for both SQLite and PostgreSQL.
 // Returns true so callers can assign to [[maybe_unused]] const bool for static init.
-template <const auto &Tests, template <typename> class FixtureTpl> bool register_both_backends(const char *suite) {
+template <const auto &Tests, template <typename> class FixtureTpl>
+auto register_both_backends(const char *suite) -> bool {
     using sqlite_t = storm::db::sqlite::Connection;
     using pg_t = storm::db::postgresql::Connection;
     register_for_backend<Tests, FixtureTpl<sqlite_t>, sqlite_t>(suite, "SQLite");


### PR DESCRIPTION
## Summary
- Convert ~335 function signatures from traditional to trailing return type syntax across 27 files (benchmarks, tests, headers)
- Remove `modernize-*` from `.clang-tidy` — clang-tidy can't enforce on C++26 module files yet (#113)
- Add `--all` flag to `run_clang_tidy.sh` to check all C++ files (`.cpp`, `.cppm`, `.h`, `.hpp`), not just staged

Closes #69

## Test plan
- [x] All 1887 tests pass (ninja-debug)
- [x] ASAN+UBSAN clean (ninja-asan-ubsan)
- [x] TSAN clean (ninja-tsan)
- [x] Release build compiles (benchmarks included)
- [x] Pre-commit hook passes (clang-format, clang-tidy, tests, 100% coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)