### PR TITLE
refactor: share compile-time SQL and models between tests and benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ Testing
 *.pyc
 __pycache__
 tests/test_cases/*.json
+.zed
 
 # Benchmark executables
 benchmarks/bench_sqlite

--- a/benchmarks/models.hpp
+++ b/benchmarks/models.hpp
@@ -3,26 +3,23 @@
 /**
  * Benchmark Models
  *
- * Defines all models used in benchmarks.
- * This file must be included before runner.hpp to provide complete types.
+ * Person comes from shared/models.h (single source of truth).
+ * User and FKMessage are benchmark-specific (JOIN benchmarks with 2 FKs).
+ *
+ * This file must be included after `import storm;` to provide complete types.
  */
 
 import storm;
-import <optional>;
+
+// Shared model structs — used by both tests and benchmarks
+#include "../shared/models.h"
 
 namespace storm::benchmark {
 
-    // Test model for basic operations (INSERT, UPDATE, DELETE, SELECT WHERE)
-    struct Person {
-        [[= storm::meta::FieldAttr::primary]] int id;
-        std::string                               name;
-        int                                       age;
-        bool                                      is_active;
-        double                                    salary;
-        std::optional<int>                        score;
-    };
+    // Bring shared Person into benchmark namespace
+    using ::Person;
 
-    // Test models for JOIN operations
+    // Benchmark-specific models for JOIN tests (2 FK relationships)
     struct User {
         [[= storm::meta::FieldAttr::primary]] int id;
         std::string                               name;

--- a/benchmarks/operations/aggregate.hpp
+++ b/benchmarks/operations/aggregate.hpp
@@ -186,67 +186,88 @@ namespace storm::benchmark {
         // execute_raw - Raw SQLite aggregate query
         // ====================================================================
       private:
-        static auto build_aggregate_sql() -> std::string {
-            std::string sql = "SELECT ";
-
-            // Build aggregate function
-            if constexpr (Op == AggregateOp::Count) {
-                sql += "COUNT(*)";
-            } else if constexpr (Op == AggregateOp::CountField) {
-                constexpr std::string_view field_name = std::meta::identifier_of(FieldInfo);
-                sql += "COUNT(";
-                sql += field_name;
-                sql += ")";
-            } else if constexpr (Op == AggregateOp::CountDistinct) {
-                constexpr std::string_view field_name = std::meta::identifier_of(FieldInfo);
-                sql += "COUNT(DISTINCT ";
-                sql += field_name;
-                sql += ")";
-            } else if constexpr (Op == AggregateOp::Sum) {
-                constexpr std::string_view field_name = std::meta::identifier_of(FieldInfo);
-                sql += "SUM(";
-                sql += field_name;
-                sql += ")";
-            } else if constexpr (Op == AggregateOp::Avg) {
-                constexpr std::string_view field_name = std::meta::identifier_of(FieldInfo);
-                sql += "AVG(";
-                sql += field_name;
-                sql += ")";
-            } else if constexpr (Op == AggregateOp::Min) {
-                constexpr std::string_view field_name = std::meta::identifier_of(FieldInfo);
-                sql += "MIN(";
-                sql += field_name;
-                sql += ")";
-            } else if constexpr (Op == AggregateOp::Max) {
-                constexpr std::string_view field_name = std::meta::identifier_of(FieldInfo);
-                sql += "MAX(";
-                sql += field_name;
-                sql += ")";
-            }
-
-            // Build FROM clause
+        // Build aggregate SQL — ORM-generated for non-JOIN, manual for JOIN
+        auto build_aggregate_sql() const -> std::string {
             if constexpr (JoinCfg::enabled) {
-                sql += " FROM FKMessage fm INNER JOIN User u ON fm.sender_id = u.id";
-            } else {
-                sql += " FROM Person";
-            }
-
-            // Build WHERE clause if configured
-            if constexpr (WhereCfg::enabled) {
-                constexpr std::string_view where_field = std::meta::identifier_of(WhereCfg::field_info);
-                constexpr std::string_view op_str      = WhereCfg::op.view();
-
-                sql += " WHERE ";
-                if constexpr (JoinCfg::enabled) {
-                    sql += "u."; // Assume WHERE is on joined table for JOIN benchmarks
+                // JOIN uses custom aliases (fm/u) — keep manual
+                std::string sql = "SELECT ";
+                if constexpr (Op == AggregateOp::Count) {
+                    sql += "COUNT(*)";
+                } else {
+                    constexpr std::string_view field_name = std::meta::identifier_of(FieldInfo);
+                    if constexpr (Op == AggregateOp::CountField) {
+                        sql += "COUNT(";
+                        sql += field_name;
+                        sql += ")";
+                    } else if constexpr (Op == AggregateOp::CountDistinct) {
+                        sql += "COUNT(DISTINCT ";
+                        sql += field_name;
+                        sql += ")";
+                    } else if constexpr (Op == AggregateOp::Sum) {
+                        sql += "SUM(";
+                        sql += field_name;
+                        sql += ")";
+                    } else if constexpr (Op == AggregateOp::Avg) {
+                        sql += "AVG(";
+                        sql += field_name;
+                        sql += ")";
+                    } else if constexpr (Op == AggregateOp::Min) {
+                        sql += "MIN(";
+                        sql += field_name;
+                        sql += ")";
+                    } else if constexpr (Op == AggregateOp::Max) {
+                        sql += "MAX(";
+                        sql += field_name;
+                        sql += ")";
+                    }
                 }
-                sql += std::string(where_field);
-                sql += " ";
-                sql += std::string(op_str);
-                sql += " ?";
+                sql += " FROM FKMessage fm INNER JOIN User u ON fm.sender_id = u.id";
+                if constexpr (WhereCfg::enabled) {
+                    constexpr std::string_view where_field = std::meta::identifier_of(WhereCfg::field_info);
+                    constexpr std::string_view op_str      = WhereCfg::op.view();
+                    sql += " WHERE u.";
+                    sql += std::string(where_field);
+                    sql += " ";
+                    sql += std::string(op_str);
+                    sql += " ?";
+                }
+                return sql;
+            } else {
+                // SQL from ORM — single source of truth
+                QuerySet<Model> qs_tmp;
+                if constexpr (WhereCfg::enabled) {
+                    qs_tmp = qs_tmp.where(Base::build_where_clause());
+                }
+                if constexpr (Op == AggregateOp::Count) {
+                    return qs_tmp.count().sql();
+                } else if constexpr (Op == AggregateOp::CountField) {
+                    return qs_tmp.template count<FieldInfo>().sql();
+                } else if constexpr (Op == AggregateOp::CountDistinct) {
+                    // ORM doesn't have count_distinct — keep manual
+                    constexpr std::string_view field_name = std::meta::identifier_of(FieldInfo);
+                    std::string                sql        = "SELECT COUNT(DISTINCT ";
+                    sql += field_name;
+                    sql += std::format(") FROM {}", std::meta::identifier_of(^^Model));
+                    if constexpr (WhereCfg::enabled) {
+                        constexpr std::string_view where_field = std::meta::identifier_of(WhereCfg::field_info);
+                        constexpr std::string_view op_str      = WhereCfg::op.view();
+                        sql += " WHERE ";
+                        sql += std::string(where_field);
+                        sql += " ";
+                        sql += std::string(op_str);
+                        sql += " ?";
+                    }
+                    return sql;
+                } else if constexpr (Op == AggregateOp::Sum) {
+                    return qs_tmp.template sum<FieldInfo>().sql();
+                } else if constexpr (Op == AggregateOp::Avg) {
+                    return qs_tmp.template avg<FieldInfo>().sql();
+                } else if constexpr (Op == AggregateOp::Min) {
+                    return qs_tmp.template min<FieldInfo>().sql();
+                } else if constexpr (Op == AggregateOp::Max) {
+                    return qs_tmp.template max<FieldInfo>().sql();
+                }
             }
-
-            return sql;
         }
 
       public:

--- a/benchmarks/operations/base.hpp
+++ b/benchmarks/operations/base.hpp
@@ -11,13 +11,12 @@
  * - Unified execute() with compile-time operation dispatch
  */
 
-#include <sqlite3.h>
+#include "../raw_helpers.hpp"
+#include <format>
 #include <plf_hive/plf_hive.h>
 #include <iostream>
 #include <string_view>
 #include <vector>
-
-import storm;
 
 namespace storm::benchmark {
 
@@ -78,7 +77,8 @@ namespace storm::benchmark {
 
     // CRTP base class for data-driven benchmarks (Insert, UpdateByPK)
     // BatchSize is now a runtime parameter for fair comparison with Storm ORM
-    template <typename Derived, typename Model, size_t FieldsPerRow = 4> class DataBenchmarkBase {
+    template <typename Derived, typename Model, size_t FieldsPerRow = non_pk_field_count<Model>()>
+    class DataBenchmarkBase {
       private:
         QuerySet<Model>    qs_;
         std::vector<Model> data_;
@@ -115,17 +115,13 @@ namespace storm::benchmark {
 
         // Default model creation - derived classes can override via static method hiding
         // index parameter allows generating varied data (useful for SELECT WHERE benchmarks)
-        static auto create_model([[maybe_unused]] int index = 0) -> Model {
-            return Model{.id = 0, .name = "BenchmarkPerson", .age = 30, .is_active = true, .salary = 50000.0};
-        }
-
-        // Bind model fields to statement (name, age, is_active, salary)
-        // idx is 1-based SQLite parameter index, incremented after each bind
-        static auto bind_model_fields(sqlite3_stmt* stmt, const Model& p, int& idx) -> void {
-            sqlite3_bind_text(stmt, idx++, p.name.c_str(), -1, SQLITE_TRANSIENT);
-            sqlite3_bind_int(stmt, idx++, p.age);
-            sqlite3_bind_int(stmt, idx++, p.is_active ? 1 : 0);
-            sqlite3_bind_double(stmt, idx++, p.salary);
+        static auto create_model(int index = 0) -> Model {
+            return Model{
+                    .name      = std::format("Person{}", index),
+                    .age       = 20 + (index % 50),
+                    .salary    = 30000.0 + (index * 1000.0),
+                    .is_active = (index % 2 == 0)
+            };
         }
 
         // Execute statement, reset, return success count
@@ -157,7 +153,8 @@ namespace storm::benchmark {
         auto prepare_with_insert(int iterations) -> void {
             // 1. Clear table using raw SQLite
             if (sqlite3* db = get_db<Model>()) {
-                sqlite3_exec(db, "DELETE FROM Person", nullptr, nullptr, nullptr);
+                auto delete_sql = std::format("DELETE FROM {}", std::meta::identifier_of(^^Model));
+                sqlite3_exec(db, delete_sql.c_str(), nullptr, nullptr, nullptr);
             }
 
             // 2. Generate test data

--- a/benchmarks/operations/delete.hpp
+++ b/benchmarks/operations/delete.hpp
@@ -64,19 +64,13 @@ namespace storm::benchmark {
         }
 
       private:
-        // Build DELETE SQL with IN clause for bulk operations
+        // SQL from ORM — single source of truth
         static auto sql_delete_batch(size_t count) -> std::string {
             if (count == 1) {
-                return "DELETE FROM Person WHERE id = ?";
+                return storm::QuerySet<Model>().remove(Model{}).sql();
             }
-            std::string sql = "DELETE FROM Person WHERE id IN (";
-            for (size_t i = 0; i < count; i++) {
-                if (i > 0)
-                    sql += ",";
-                sql += "?";
-            }
-            sql += ")";
-            return sql;
+            std::vector<Model> batch(count);
+            return storm::QuerySet<Model>().remove(batch).sql();
         }
 
         // Bind IDs for IN clause

--- a/benchmarks/operations/distinct.hpp
+++ b/benchmarks/operations/distinct.hpp
@@ -115,14 +115,12 @@ namespace storm::benchmark {
         // execute_raw - Raw SQLite DISTINCT with compile-time feature dispatch
         // ====================================================================
       private:
-        // Build DISTINCT SQL string based on enabled features
-        static auto build_distinct_sql() -> std::string {
-            constexpr std::string_view distinct_field = std::meta::identifier_of(DistinctFieldInfo);
-            std::string                sql;
-
+        // Build DISTINCT SQL string — ORM-generated for non-JOIN, manual for JOIN
+        auto build_distinct_sql() const -> std::string {
             if constexpr (JoinCfg::enabled) {
-                // DISTINCT + JOIN query
-                sql = "SELECT DISTINCT fm.";
+                // JOIN uses custom aliases (fm/u) — keep manual
+                constexpr std::string_view distinct_field = std::meta::identifier_of(DistinctFieldInfo);
+                std::string                sql            = "SELECT DISTINCT fm.";
                 sql += distinct_field;
                 sql += " FROM FKMessage fm INNER JOIN User u ON fm.sender_id = u.id";
 
@@ -135,24 +133,15 @@ namespace storm::benchmark {
                     sql += std::string(op_str);
                     sql += " ?";
                 }
+                return sql;
             } else {
-                // Basic DISTINCT query
-                sql = "SELECT DISTINCT ";
-                sql += distinct_field;
-                sql += " FROM Person";
-
+                // SQL from ORM — single source of truth
+                QuerySet<BaseModel> qs_tmp;
                 if constexpr (WhereCfg::enabled) {
-                    constexpr std::string_view where_field = std::meta::identifier_of(WhereCfg::field_info);
-                    constexpr std::string_view op_str      = WhereCfg::op.view();
-                    sql += " WHERE ";
-                    sql += std::string(where_field);
-                    sql += " ";
-                    sql += std::string(op_str);
-                    sql += " ?";
+                    qs_tmp = qs_tmp.where(Base::build_where_clause());
                 }
+                return qs_tmp.template distinct<DistinctFieldInfo>().sql();
             }
-
-            return sql;
         }
 
       public:
@@ -290,14 +279,8 @@ namespace storm::benchmark {
             if (db == nullptr)
                 return 0;
 
-            constexpr std::string_view field1 = std::meta::identifier_of(DistinctFieldInfo1);
-            constexpr std::string_view field2 = std::meta::identifier_of(DistinctFieldInfo2);
-
-            std::string sql = "SELECT DISTINCT ";
-            sql += field1;
-            sql += ", ";
-            sql += field2;
-            sql += " FROM Person";
+            // SQL from ORM — single source of truth
+            std::string sql = QuerySet<BaseModel>().template distinct<DistinctFieldInfo1, DistinctFieldInfo2>().sql();
 
             sqlite3_stmt* stmt = nullptr;
             if (sqlite3_prepare_v2(db, sql.c_str(), -1, &stmt, nullptr) != SQLITE_OK) {
@@ -404,17 +387,10 @@ namespace storm::benchmark {
             if (db == nullptr)
                 return 0;
 
-            constexpr std::string_view field1 = std::meta::identifier_of(DistinctFieldInfo1);
-            constexpr std::string_view field2 = std::meta::identifier_of(DistinctFieldInfo2);
-            constexpr std::string_view field3 = std::meta::identifier_of(DistinctFieldInfo3);
-
-            std::string sql = "SELECT DISTINCT ";
-            sql += field1;
-            sql += ", ";
-            sql += field2;
-            sql += ", ";
-            sql += field3;
-            sql += " FROM Person";
+            // SQL from ORM — single source of truth
+            std::string sql = QuerySet<BaseModel>()
+                                      .template distinct<DistinctFieldInfo1, DistinctFieldInfo2, DistinctFieldInfo3>()
+                                      .sql();
 
             sqlite3_stmt* stmt = nullptr;
             if (sqlite3_prepare_v2(db, sql.c_str(), -1, &stmt, nullptr) != SQLITE_OK) {
@@ -519,18 +495,10 @@ namespace storm::benchmark {
             if (db == nullptr)
                 return 0;
 
-            constexpr std::string_view distinct_field = std::meta::identifier_of(DistinctFieldInfo);
-            constexpr std::string_view order_field    = std::meta::identifier_of(OrderByFieldInfo);
-
-            std::string sql = "SELECT DISTINCT ";
-            sql += distinct_field;
-            sql += " FROM Person ORDER BY ";
-            sql += order_field;
-            if constexpr (Dir == OrderDirection::DESC) {
-                sql += " DESC";
-            } else {
-                sql += " ASC";
-            }
+            // SQL from ORM — single source of truth
+            constexpr bool asc    = (Dir == OrderDirection::ASC);
+            auto           qs_tmp = QuerySet<BaseModel>().template order_by<OrderByFieldInfo, asc>();
+            std::string    sql    = qs_tmp.template distinct<DistinctFieldInfo>().sql();
 
             sqlite3_stmt* stmt = nullptr;
             if (sqlite3_prepare_v2(db, sql.c_str(), -1, &stmt, nullptr) != SQLITE_OK) {

--- a/benchmarks/operations/first_get.hpp
+++ b/benchmarks/operations/first_get.hpp
@@ -64,20 +64,12 @@ namespace storm::benchmark {
             if (!db)
                 return 0;
 
-            std::string sql = "SELECT id, name, age, is_active, salary, score FROM Person";
-
+            // SQL from ORM — single source of truth
+            QuerySet<BaseModel> qs_tmp;
             if constexpr (WhereCfg::enabled) {
-                constexpr std::string_view where_field = std::meta::identifier_of(WhereCfg::field_info);
-                constexpr std::string_view op_str      = WhereCfg::op.view();
-                sql += " WHERE ";
-                sql += std::string(where_field);
-                sql += " ";
-                sql += std::string(op_str);
-                sql += " ?";
+                qs_tmp = qs_tmp.where(Base::build_where_clause());
             }
-
-            Base::append_order_by_sql(sql);
-            sql += " LIMIT 1";
+            std::string sql = qs_tmp.first().sql();
 
             sqlite3_stmt* stmt = nullptr;
             if (sqlite3_prepare_v2(db, sql.c_str(), -1, &stmt, nullptr) != SQLITE_OK) {
@@ -91,19 +83,9 @@ namespace storm::benchmark {
             int total = 0;
             for (int i = 0; i < iterations; i++) {
                 sqlite3_reset(stmt);
-                // Fair comparison: wrap result in std::optional like Storm's first()
                 std::optional<BaseModel> result;
                 if (sqlite3_step(stmt) == SQLITE_ROW) {
-                    BaseModel obj;
-                    obj.id        = sqlite3_column_int64(stmt, 0);
-                    obj.name      = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 1));
-                    obj.age       = sqlite3_column_int(stmt, 2);
-                    obj.is_active = sqlite3_column_int(stmt, 3) != 0;
-                    obj.salary    = sqlite3_column_double(stmt, 4);
-                    if (sqlite3_column_type(stmt, 5) != SQLITE_NULL) {
-                        obj.score = sqlite3_column_int(stmt, 5);
-                    }
-                    result.emplace(std::move(obj));
+                    result.emplace(storm::benchmark::extract_row<BaseModel>(stmt));
                 }
                 if (result.has_value()) {
                     total++;
@@ -161,20 +143,12 @@ namespace storm::benchmark {
             if (!db)
                 return 0;
 
-            // get() uses LIMIT 2 internally to detect multiple rows
-            std::string sql = "SELECT id, name, age, is_active, salary, score FROM Person";
-
+            // SQL from ORM — single source of truth (get() uses LIMIT 2 internally)
+            QuerySet<BaseModel> qs_tmp;
             if constexpr (WhereCfg::enabled) {
-                constexpr std::string_view where_field = std::meta::identifier_of(WhereCfg::field_info);
-                constexpr std::string_view op_str      = WhereCfg::op.view();
-                sql += " WHERE ";
-                sql += std::string(where_field);
-                sql += " ";
-                sql += std::string(op_str);
-                sql += " ?";
+                qs_tmp = qs_tmp.where(Base::build_where_clause());
             }
-
-            sql += " LIMIT 2";
+            std::string sql = qs_tmp.get().sql();
 
             sqlite3_stmt* stmt = nullptr;
             if (sqlite3_prepare_v2(db, sql.c_str(), -1, &stmt, nullptr) != SQLITE_OK) {
@@ -193,14 +167,7 @@ namespace storm::benchmark {
                 BaseModel obj;
                 while (sqlite3_step(stmt) == SQLITE_ROW) {
                     if (row_count == 0) {
-                        obj.id        = sqlite3_column_int64(stmt, 0);
-                        obj.name      = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 1));
-                        obj.age       = sqlite3_column_int(stmt, 2);
-                        obj.is_active = sqlite3_column_int(stmt, 3) != 0;
-                        obj.salary    = sqlite3_column_double(stmt, 4);
-                        if (sqlite3_column_type(stmt, 5) != SQLITE_NULL) {
-                            obj.score = sqlite3_column_int(stmt, 5);
-                        }
+                        obj = storm::benchmark::extract_row<BaseModel>(stmt);
                     }
                     row_count++;
                 }

--- a/benchmarks/operations/insert.hpp
+++ b/benchmarks/operations/insert.hpp
@@ -4,51 +4,52 @@
  * INSERT Benchmark
  *
  * Tests INSERT performance for single and batch operations.
- * Inherits from DataBenchmarkBase with 4 fields (id is auto-increment).
+ * Inherits from DataBenchmarkBase.
  *
  * FAIR COMPARISON: Both Storm ORM and raw SQLite now use RUNTIME checks
  * for batch size decisions. No compile-time advantages for raw SQLite.
+ *
+ * Note: Person has a UNIQUE constraint on name, so the table must be
+ * cleared before each iteration to avoid constraint violations.
  */
 
 #include "base.hpp"
-#include <sqlite3.h>
 #include <algorithm>
 #include <unordered_map>
 #include <iostream>
 
 namespace storm::benchmark {
 
-    template <typename Model> class InsertBenchmark : public DataBenchmarkBase<InsertBenchmark<Model>, Model, 4> {
-        using Base = DataBenchmarkBase<InsertBenchmark<Model>, Model, 4>;
+    template <typename Model> class InsertBenchmark : public DataBenchmarkBase<InsertBenchmark<Model>, Model> {
+        using Base = DataBenchmarkBase<InsertBenchmark<Model>, Model>;
 
-        // Build single-row INSERT SQL with RETURNING (matches Storm ORM behavior)
+        // SQL from ORM: single-row INSERT with RETURNING
         static auto sql_insert_single_returning() -> std::string {
-            return "INSERT INTO Person (name, age, is_active, salary) VALUES (?, ?, ?, ?) RETURNING id";
+            return storm::QuerySet<Model>().insert(Model{}).sql();
         }
 
-        // Build single-row INSERT SQL without RETURNING (faster path)
+        // SQL from ORM: single-row INSERT without RETURNING
         static auto sql_insert_single() -> std::string {
-            return "INSERT INTO Person (name, age, is_active, salary) VALUES (?, ?, ?, ?)";
+            return storm::QuerySet<Model>().template insert<storm::orm::statements::ReturnId::No>(Model{}).sql();
         }
 
-        // Build multi-row INSERT SQL for bulk operations
+        // SQL from ORM: multi-row INSERT for bulk operations
         static auto sql_insert_batch(size_t count) -> std::string {
-            std::string sql = "INSERT INTO Person (id, name, age, is_active, salary) VALUES ";
-            for (size_t i = 0; i < count; i++) {
-                if (i > 0)
-                    sql += ", ";
-                sql += "(NULL, ?, ?, ?, ?)";
-            }
-            return sql;
+            std::vector<Model> batch(count);
+            return storm::QuerySet<Model>().insert(batch).sql();
         }
 
         // Bind a range of models starting at parameter index `idx`
         static auto bind_rows(sqlite3_stmt* stmt, const Model* data, size_t count, int idx = 1) -> void {
             for (size_t i = 0; i < count; i++) {
-                int local_idx = idx;
-                Base::bind_model_fields(stmt, data[i], local_idx);
-                idx = local_idx;
+                bind_non_pk_fields(stmt, data[i], idx);
             }
+        }
+
+        // Clear table — needed before each insert iteration due to UNIQUE constraint on name
+        static auto clear_table(sqlite3* db) -> void {
+            auto sql = std::format("DELETE FROM {}", std::meta::identifier_of(^^Model));
+            sqlite3_exec(db, sql.c_str(), nullptr, nullptr, nullptr);
         }
 
       public:
@@ -60,9 +61,24 @@ namespace storm::benchmark {
             Base::template print_info_unified<OperationType::Insert>();
         }
 
-        // Use unified execute with compile-time operation binding
+        // ORM execute — clear table before each iteration for fair comparison
         auto execute(int iterations) -> int {
-            return Base::template execute_unified<OperationType::Insert>(iterations);
+            sqlite3* db    = get_db<Model>();
+            int      total = 0;
+            if (Base::batch_size() == 1) {
+                for (int i = 0; i < iterations; i++) {
+                    OperationDispatcher<OperationType::Insert>::call(Base::qs(), Base::data()[i]).execute();
+                    total++;
+                }
+            } else {
+                for (int i = 0; i < iterations; i++) {
+                    if (db)
+                        clear_table(db);
+                    OperationDispatcher<OperationType::Insert>::call(Base::qs(), Base::data()).execute();
+                    total += Base::data().size();
+                }
+            }
+            return total;
         }
 
         auto print_info_no_return() const -> void {
@@ -115,7 +131,8 @@ namespace storm::benchmark {
 
             // Runtime check - FAIR comparison with Storm ORM
             if (Base::batch_size() == 1) {
-                // Single-row: use INSERT ... RETURNING to match Storm ORM behavior
+                // Single-row: clear once, each row has unique name
+                clear_table(db);
                 std::string sql = sql_insert_single_returning();
 
                 sqlite3_stmt* stmt = nullptr;
@@ -124,7 +141,7 @@ namespace storm::benchmark {
 
                 for (int i = 0; i < iterations; i++) {
                     int idx = 1;
-                    Base::bind_model_fields(stmt, Base::data()[i], idx);
+                    bind_non_pk_fields(stmt, Base::data()[i], idx);
                     if (sqlite3_step(stmt) == SQLITE_ROW) {
                         [[maybe_unused]] int64_t id = sqlite3_column_int64(stmt, 0);
                         total++;
@@ -133,7 +150,7 @@ namespace storm::benchmark {
                 }
                 sqlite3_finalize(stmt);
             } else if (static_cast<size_t>(Base::batch_size()) <= Base::bulk_threshold) {
-                // Small batch: one prepared statement
+                // Small batch: clear before each iteration
                 size_t      rows_per_stmt = std::min(Base::max_bulk, Base::data().size());
                 std::string sql           = sql_insert_batch(rows_per_stmt);
 
@@ -142,18 +159,19 @@ namespace storm::benchmark {
                     return 0;
 
                 for (int i = 0; i < iterations; i++) {
+                    clear_table(db);
                     bind_rows(stmt, &Base::data()[0], rows_per_stmt);
                     total += Base::step_and_reset(stmt, db, rows_per_stmt);
                 }
                 sqlite3_finalize(stmt);
             }
-            // Large batch: chunked with transaction
+            // Large batch: chunked with transaction — clear before each iteration
             else {
-                // Prepare statements for each unique chunk size
                 std::unordered_map<size_t, sqlite3_stmt*> stmts;
                 prepare_chunk_statements(db, stmts);
 
                 for (int iter = 0; iter < iterations; iter++) {
+                    clear_table(db);
                     sqlite3_exec(db, "BEGIN TRANSACTION", nullptr, nullptr, nullptr);
                     total += execute_batch_iteration(db, stmts);
                     sqlite3_exec(db, "COMMIT", nullptr, nullptr, nullptr);
@@ -171,6 +189,8 @@ namespace storm::benchmark {
             if (!db)
                 return 0;
 
+            clear_table(db);
+
             int         total = 0;
             std::string sql   = sql_insert_single();
 
@@ -180,7 +200,7 @@ namespace storm::benchmark {
 
             for (int i = 0; i < iterations; i++) {
                 int idx = 1;
-                Base::bind_model_fields(stmt, Base::data()[i], idx);
+                bind_non_pk_fields(stmt, Base::data()[i], idx);
                 if (sqlite3_step(stmt) == SQLITE_DONE) {
                     total++;
                 }

--- a/benchmarks/operations/select.hpp
+++ b/benchmarks/operations/select.hpp
@@ -186,15 +186,13 @@ namespace storm::benchmark {
             }
         }
 
-        // Build SQL string based on enabled features
-        static auto build_select_sql() -> std::string {
-            std::string sql;
-
+        // Build SQL string using ORM .sql() for non-JOIN, manual for JOIN
+        auto build_select_sql() const -> std::string {
             if constexpr (JoinCfg::enabled) {
-                // JOIN query
-                sql = "SELECT fm.id, fm.sender_id, fm.receiver_id, fm.text, "
-                      "u.id, u.name, u.age "
-                      "FROM FKMessage fm ";
+                // JOIN query — ORM uses t1/t2 aliases; keep manual SQL for benchmark
+                std::string sql = "SELECT fm.id, fm.sender_id, fm.receiver_id, fm.text, "
+                                  "u.id, u.name, u.age "
+                                  "FROM FKMessage fm ";
                 sql += get_join_keyword();
                 sql += " User u ON fm.sender_id = u.id";
 
@@ -207,45 +205,55 @@ namespace storm::benchmark {
                     sql += std::string(op_str);
                     sql += " ?";
                 }
+                Base::append_group_by_sql(sql);
+                Base::append_order_by_sql(sql);
+                Base::append_limit_offset_sql(sql);
+                return sql;
             } else {
-                // Basic SELECT query
-                sql = "SELECT id, name, age, is_active, salary, score FROM Person";
-
+                // Non-JOIN: use ORM .sql() — single source of truth
+                QuerySet<BaseModel> qs;
                 if constexpr (WhereCfg::enabled) {
-                    constexpr std::string_view where_field = std::meta::identifier_of(WhereCfg::field_info);
-                    constexpr std::string_view op_str      = WhereCfg::op.view();
-                    sql += " WHERE ";
-                    sql += std::string(where_field);
-                    sql += " ";
-                    sql += std::string(op_str);
-                    sql += " ?";
+                    constexpr std::string_view op_str = WhereCfg::op.view();
+                    if constexpr (op_str == ">") {
+                        qs = qs.where(field<WhereCfg::field_info>() > Base::where_value_);
+                    } else if constexpr (op_str == ">=") {
+                        qs = qs.where(field<WhereCfg::field_info>() >= Base::where_value_);
+                    } else if constexpr (op_str == "<") {
+                        qs = qs.where(field<WhereCfg::field_info>() < Base::where_value_);
+                    } else if constexpr (op_str == "<=") {
+                        qs = qs.where(field<WhereCfg::field_info>() <= Base::where_value_);
+                    } else if constexpr (op_str == "==") {
+                        qs = qs.where(field<WhereCfg::field_info>() == Base::where_value_);
+                    } else if constexpr (op_str == "!=") {
+                        qs = qs.where(field<WhereCfg::field_info>() != Base::where_value_);
+                    }
                 }
+                if constexpr (OrderByCfg::enabled) {
+                    if constexpr (requires { OrderByCfg::collation; }) {
+                        if constexpr (OrderByCfg::direction == OrderDirection::DESC) {
+                            qs.template order_by<OrderByCfg::field_info, OrderByCfg::collation, false>();
+                        } else {
+                            qs.template order_by<OrderByCfg::field_info, OrderByCfg::collation, true>();
+                        }
+                    } else if constexpr (OrderByCfg::direction == OrderDirection::DESC) {
+                        qs.template order_by<OrderByCfg::field_info, false>();
+                    } else {
+                        qs.template order_by<OrderByCfg::field_info, true>();
+                    }
+                }
+                if constexpr (GroupByCfg::enabled) {
+                    qs.template group_by<GroupByCfg::field_info>();
+                }
+                if constexpr (LimitOffsetCfg::enabled) {
+                    if constexpr (LimitOffsetCfg::limit_value > 0) {
+                        qs.limit(LimitOffsetCfg::limit_value);
+                    }
+                    if constexpr (LimitOffsetCfg::offset_value > 0) {
+                        qs.offset(LimitOffsetCfg::offset_value);
+                    }
+                }
+                return qs.select().sql();
             }
-
-            // Append GROUP BY if configured (must come before ORDER BY)
-            Base::append_group_by_sql(sql);
-
-            // Append ORDER BY if configured (must come before LIMIT/OFFSET)
-            Base::append_order_by_sql(sql);
-
-            // Append LIMIT/OFFSET if configured
-            Base::append_limit_offset_sql(sql);
-
-            return sql;
-        }
-
-        // Extract row for basic SELECT (Person model) — must match Storm's column list
-        __attribute__((always_inline)) static auto extract_row_basic(sqlite3_stmt* stmt) -> BaseModel {
-            BaseModel obj;
-            obj.id        = sqlite3_column_int64(stmt, 0);
-            obj.name      = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 1));
-            obj.age       = sqlite3_column_int(stmt, 2);
-            obj.is_active = sqlite3_column_int(stmt, 3) != 0;
-            obj.salary    = sqlite3_column_double(stmt, 4);
-            if (sqlite3_column_type(stmt, 5) != SQLITE_NULL) {
-                obj.score = sqlite3_column_int(stmt, 5);
-            }
-            return obj;
         }
 
         // Extract row for JOIN SELECT (FKMessage model with joined User)
@@ -296,7 +304,7 @@ namespace storm::benchmark {
                     if constexpr (JoinCfg::enabled) {
                         results.insert(extract_row_join(stmt));
                     } else {
-                        results.insert(extract_row_basic(stmt));
+                        results.insert(storm::benchmark::extract_row<BaseModel>(stmt));
                     }
                 }
                 total_rows += results.size();
@@ -516,11 +524,12 @@ namespace storm::benchmark {
             constexpr std::string_view field1 = std::meta::identifier_of(OrderByFieldInfo1);
             constexpr std::string_view field2 = std::meta::identifier_of(OrderByFieldInfo2);
 
-            std::string sql = "SELECT id, name, age, is_active, salary, score FROM Person ORDER BY ";
-            sql += field1;
-            sql += (Dir1 == OrderDirection::DESC) ? " DESC, " : " ASC, ";
-            sql += field2;
-            sql += (Dir2 == OrderDirection::DESC) ? " DESC" : " ASC";
+            // SQL from ORM — single source of truth
+            QuerySet<BaseModel> qs;
+            constexpr bool      asc1 = (Dir1 == OrderDirection::ASC);
+            constexpr bool      asc2 = (Dir2 == OrderDirection::ASC);
+            qs.template order_by<OrderByFieldInfo1, asc1, OrderByFieldInfo2, asc2>();
+            std::string sql = qs.select().sql();
 
             sqlite3_stmt* stmt = nullptr;
             if (sqlite3_prepare_v2(db, sql.c_str(), -1, &stmt, nullptr) != SQLITE_OK) {
@@ -532,27 +541,13 @@ namespace storm::benchmark {
                 sqlite3_reset(stmt);
                 plf::hive<BaseModel> results;
                 while (sqlite3_step(stmt) == SQLITE_ROW) {
-                    results.insert(extract_row_basic(stmt));
+                    results.insert(storm::benchmark::extract_row<BaseModel>(stmt));
                 }
                 total_rows += results.size();
             }
 
             sqlite3_finalize(stmt);
             return total_rows;
-        }
-
-      private:
-        __attribute__((always_inline)) static auto extract_row_basic(sqlite3_stmt* stmt) -> BaseModel {
-            BaseModel obj;
-            obj.id        = sqlite3_column_int64(stmt, 0);
-            obj.name      = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 1));
-            obj.age       = sqlite3_column_int(stmt, 2);
-            obj.is_active = sqlite3_column_int(stmt, 3) != 0;
-            obj.salary    = sqlite3_column_double(stmt, 4);
-            if (sqlite3_column_type(stmt, 5) != SQLITE_NULL) {
-                obj.score = sqlite3_column_int(stmt, 5);
-            }
-            return obj;
         }
     };
 
@@ -636,12 +631,10 @@ namespace storm::benchmark {
             if (db == nullptr)
                 return 0;
 
-            // Build SQL with variadic fold expression
-            std::string sql   = "SELECT id, name, age, is_active, salary, score FROM Person GROUP BY ";
-            bool        first = true;
-            ((sql += (first ? (first = false, "") : ", "),
-              sql += std::string(std::meta::identifier_of(GroupByFieldInfos))),
-             ...);
+            // SQL from ORM — single source of truth
+            QuerySet<BaseModel> qs;
+            qs.template group_by<GroupByFieldInfos...>();
+            std::string sql = qs.select().sql();
 
             sqlite3_stmt* stmt = nullptr;
             if (sqlite3_prepare_v2(db, sql.c_str(), -1, &stmt, nullptr) != SQLITE_OK) {
@@ -653,27 +646,13 @@ namespace storm::benchmark {
                 sqlite3_reset(stmt);
                 plf::hive<BaseModel> results;
                 while (sqlite3_step(stmt) == SQLITE_ROW) {
-                    results.insert(extract_row_basic(stmt));
+                    results.insert(storm::benchmark::extract_row<BaseModel>(stmt));
                 }
                 total_rows += results.size();
             }
 
             sqlite3_finalize(stmt);
             return total_rows;
-        }
-
-      private:
-        __attribute__((always_inline)) static auto extract_row_basic(sqlite3_stmt* stmt) -> BaseModel {
-            BaseModel obj;
-            obj.id        = sqlite3_column_int64(stmt, 0);
-            obj.name      = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 1));
-            obj.age       = sqlite3_column_int(stmt, 2);
-            obj.is_active = sqlite3_column_int(stmt, 3) != 0;
-            obj.salary    = sqlite3_column_double(stmt, 4);
-            if (sqlite3_column_type(stmt, 5) != SQLITE_NULL) {
-                obj.score = sqlite3_column_int(stmt, 5);
-            }
-            return obj;
         }
     };
 
@@ -790,22 +769,22 @@ namespace storm::benchmark {
             if (db == nullptr)
                 return 0;
 
-            constexpr std::string_view group_field_name = std::meta::identifier_of(GroupByFieldInfo);
-
-            // Build SQL: SELECT group_field, AGG_FUNC(...) FROM table GROUP BY group_field
-            std::string sql = "SELECT ";
-            sql += group_field_name;
-            sql += ", ";
-            if constexpr (AggOp == GroupByAggOp::Count) {
-                sql += "COUNT(*)";
-            } else {
-                constexpr std::string_view agg_field_name = std::meta::identifier_of(AggregateFieldInfo);
-                sql += agg_op_sql(AggOp);
-                sql += agg_field_name;
-                sql += ")";
-            }
-            sql += " FROM Person GROUP BY ";
-            sql += group_field_name;
+            // SQL from ORM — single source of truth
+            auto build_group_sql = [&]() -> std::string {
+                auto gb = QuerySet<BaseModel>().template group_by<GroupByFieldInfo>();
+                if constexpr (AggOp == GroupByAggOp::Count) {
+                    return gb.count().sql();
+                } else if constexpr (AggOp == GroupByAggOp::Sum) {
+                    return gb.template sum<AggregateFieldInfo>().sql();
+                } else if constexpr (AggOp == GroupByAggOp::Avg) {
+                    return gb.template avg<AggregateFieldInfo>().sql();
+                } else if constexpr (AggOp == GroupByAggOp::Min) {
+                    return gb.template min<AggregateFieldInfo>().sql();
+                } else if constexpr (AggOp == GroupByAggOp::Max) {
+                    return gb.template max<AggregateFieldInfo>().sql();
+                }
+            };
+            std::string sql = build_group_sql();
 
             sqlite3_stmt* stmt = nullptr;
             if (sqlite3_prepare_v2(db, sql.c_str(), -1, &stmt, nullptr) != SQLITE_OK) {
@@ -936,25 +915,22 @@ namespace storm::benchmark {
             if (db == nullptr)
                 return 0;
 
-            constexpr std::string_view group_field_name  = std::meta::identifier_of(GroupByFieldInfo);
-            constexpr std::string_view having_field_name = std::meta::identifier_of(HavingFieldInfo);
-
-            std::string sql = "SELECT ";
-            sql += group_field_name;
-            sql += ", ";
-            if constexpr (AggOp == GroupByAggOp::Count) {
-                sql += "COUNT(*)";
-            } else {
-                constexpr std::string_view agg_field_name = std::meta::identifier_of(AggregateFieldInfo);
-                sql += agg_op_sql(AggOp);
-                sql += agg_field_name;
-                sql += ")";
-            }
-            sql += " FROM Person GROUP BY ";
-            sql += group_field_name;
-            sql += " HAVING ";
-            sql += having_field_name;
-            sql += " > ?";
+            // SQL from ORM — single source of truth
+            auto build_having_sql = [&]() -> std::string {
+                auto gb = QuerySet<BaseModel>().template group_by<GroupByFieldInfo>();
+                if constexpr (AggOp == GroupByAggOp::Count) {
+                    return gb.count().having(field<HavingFieldInfo>() > HavingValue).sql();
+                } else if constexpr (AggOp == GroupByAggOp::Sum) {
+                    return gb.template sum<AggregateFieldInfo>().having(field<HavingFieldInfo>() > HavingValue).sql();
+                } else if constexpr (AggOp == GroupByAggOp::Avg) {
+                    return gb.template avg<AggregateFieldInfo>().having(field<HavingFieldInfo>() > HavingValue).sql();
+                } else if constexpr (AggOp == GroupByAggOp::Min) {
+                    return gb.template min<AggregateFieldInfo>().having(field<HavingFieldInfo>() > HavingValue).sql();
+                } else if constexpr (AggOp == GroupByAggOp::Max) {
+                    return gb.template max<AggregateFieldInfo>().having(field<HavingFieldInfo>() > HavingValue).sql();
+                }
+            };
+            std::string sql = build_having_sql();
 
             sqlite3_stmt* stmt = nullptr;
             if (sqlite3_prepare_v2(db, sql.c_str(), -1, &stmt, nullptr) != SQLITE_OK) {

--- a/benchmarks/operations/select_query_base.hpp
+++ b/benchmarks/operations/select_query_base.hpp
@@ -403,11 +403,10 @@ namespace storm::benchmark {
             } else {
                 // For basic SELECT WHERE, create Person-like model
                 return BaseModel{
-                        .id        = 0,
                         .name      = std::format("Person{}", i),
                         .age       = 20 + (i % 50),
-                        .is_active = (i % 2 == 0),
                         .salary    = 30000.0 + (i * 1000.0),
+                        .is_active = (i % 2 == 0),
                         .score     = (i % 3 == 0) ? std::optional<int>(60 + (i % 40)) : std::nullopt
                 };
             }

--- a/benchmarks/operations/setop.hpp
+++ b/benchmarks/operations/setop.hpp
@@ -214,12 +214,14 @@ namespace storm::benchmark {
         }
 
         auto build_raw_sql() const -> std::string {
-            std::string sql = "SELECT id, name, age, is_active, salary, score FROM Person WHERE age < ?";
+            // Column list from ORM — single source of truth
+            std::string base = QuerySet<Model>().select().sql();
+            std::string sql  = base + " WHERE age < ?";
             sql += op_sql();
             if constexpr (needs_overlap) {
-                sql += "SELECT id, name, age, is_active, salary, score FROM Person WHERE age > ?";
+                sql += base + " WHERE age > ?";
             } else {
-                sql += "SELECT id, name, age, is_active, salary, score FROM Person WHERE age >= ?";
+                sql += base + " WHERE age >= ?";
             }
             if constexpr (WithOrderBy) {
                 sql += " ORDER BY age ASC";

--- a/benchmarks/operations/update.hpp
+++ b/benchmarks/operations/update.hpp
@@ -21,8 +21,10 @@
 
 namespace storm::benchmark {
 
-    template <typename Model> class UpdateBenchmark : public DataBenchmarkBase<UpdateBenchmark<Model>, Model, 5> {
-        using Base = DataBenchmarkBase<UpdateBenchmark<Model>, Model, 5>;
+    // FieldsPerRow for UPDATE = non-PK fields + 1 (PK in WHERE clause)
+    template <typename Model>
+    class UpdateBenchmark : public DataBenchmarkBase<UpdateBenchmark<Model>, Model, non_pk_field_count<Model>() + 1> {
+        using Base = DataBenchmarkBase<UpdateBenchmark<Model>, Model, non_pk_field_count<Model>() + 1>;
 
       public:
         // Constructor with runtime batch size
@@ -38,8 +40,9 @@ namespace storm::benchmark {
             Base::prepare_with_insert(iterations);
 
             // 2. Modify data fields for update test (change values so UPDATE actually does work)
-            for (auto& obj : Base::data()) {
-                obj.name      = "UpdatedPerson";
+            for (size_t i = 0; i < Base::data().size(); i++) {
+                auto& obj     = Base::data()[i];
+                obj.name      = std::format("Updated{}", i);
                 obj.age       = obj.age + 5;
                 obj.salary    = obj.salary * 1.1;
                 obj.is_active = !obj.is_active;
@@ -52,21 +55,17 @@ namespace storm::benchmark {
         }
 
       private:
-        // Helper: Bind model fields for UPDATE (name, age, is_active, salary, id)
-        static auto bind_update_fields(sqlite3_stmt* stmt, const Model& p) -> void {
+        // Bind model fields for UPDATE: non-PK fields + PK at end (WHERE id=?)
+        static auto bind_update_fields_raw(sqlite3_stmt* stmt, const Model& p) -> void {
             int idx = 1;
-            sqlite3_bind_text(stmt, idx++, p.name.c_str(), -1, SQLITE_TRANSIENT);
-            sqlite3_bind_int(stmt, idx++, p.age);
-            sqlite3_bind_int(stmt, idx++, p.is_active ? 1 : 0);
-            sqlite3_bind_double(stmt, idx++, p.salary);
-            sqlite3_bind_int64(stmt, idx++, p.id);
+            storm::benchmark::bind_update_fields(stmt, p, idx);
         }
 
         // Helper: Execute single-row updates
         auto execute_single_row(sqlite3_stmt* stmt, int iterations) -> int {
             int total = 0;
             for (int i = 0; i < iterations; i++) {
-                bind_update_fields(stmt, Base::data()[i]);
+                bind_update_fields_raw(stmt, Base::data()[i]);
                 if (sqlite3_step(stmt) == SQLITE_DONE) {
                     total++;
                 }
@@ -81,7 +80,7 @@ namespace storm::benchmark {
             for (int iter = 0; iter < iterations; iter++) {
                 sqlite3_exec(sqlite3_db_handle(stmt), "BEGIN TRANSACTION", nullptr, nullptr, nullptr);
                 for (const auto& p : Base::data()) {
-                    bind_update_fields(stmt, p);
+                    bind_update_fields_raw(stmt, p);
                     if (sqlite3_step(stmt) == SQLITE_DONE) {
                         total++;
                     }
@@ -98,8 +97,8 @@ namespace storm::benchmark {
             if (!db)
                 return 0;
 
-            // Raw SQLite UPDATE SQL: "UPDATE Person SET name=?, age=?, is_active=?, salary=? WHERE id=?"
-            const std::string sql = "UPDATE Person SET name=?, age=?, is_active=?, salary=? WHERE id=?";
+            // SQL from ORM — single source of truth
+            const std::string sql = storm::QuerySet<Model>().update(Model{}).sql();
 
             sqlite3_stmt* stmt = nullptr;
             if (sqlite3_prepare_v2(db, sql.c_str(), -1, &stmt, nullptr) != SQLITE_OK)

--- a/benchmarks/operations/where_operators.hpp
+++ b/benchmarks/operations/where_operators.hpp
@@ -33,11 +33,10 @@ namespace storm::benchmark {
         static auto create_model(int index = 0) -> Model {
             int i = index + 1;
             return Model{
-                    .id        = 0,
                     .name      = std::format("Person{}", i),
                     .age       = 20 + (i % 50),
-                    .is_active = (i % 2 == 0),
-                    .salary    = 30000.0 + (i * 1000.0)
+                    .salary    = 30000.0 + (i * 1000.0),
+                    .is_active = (i % 2 == 0)
             };
         }
 
@@ -70,10 +69,9 @@ namespace storm::benchmark {
             if (!db)
                 return 0;
 
-            constexpr std::string_view field_name = std::meta::identifier_of(FieldInfo);
-            std::string                sql        = std::format(
-                    "SELECT id, name, age, is_active, salary, score FROM Person WHERE {} LIKE ?", field_name
-            );
+            // SQL from ORM — single source of truth
+            QuerySet<Model> qs_tmp;
+            std::string     sql = qs_tmp.where(field<FieldInfo>().like(pattern_)).select().sql();
 
             sqlite3_stmt* stmt = nullptr;
             sqlite3_prepare_v2(db, sql.c_str(), -1, &stmt, nullptr);
@@ -84,27 +82,13 @@ namespace storm::benchmark {
                 sqlite3_reset(stmt);
                 plf::hive<Model> results;
                 while (sqlite3_step(stmt) == SQLITE_ROW) {
-                    results.insert(extract_row(stmt));
+                    results.insert(storm::benchmark::extract_row<Model>(stmt));
                 }
                 total += results.size();
             }
 
             sqlite3_finalize(stmt);
             return total;
-        }
-
-      private:
-        __attribute__((always_inline)) static auto extract_row(sqlite3_stmt* stmt) -> Model {
-            Model obj;
-            obj.id        = sqlite3_column_int64(stmt, 0);
-            obj.name      = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 1));
-            obj.age       = sqlite3_column_int(stmt, 2);
-            obj.is_active = sqlite3_column_int(stmt, 3) != 0;
-            obj.salary    = sqlite3_column_double(stmt, 4);
-            if (sqlite3_column_type(stmt, 5) != SQLITE_NULL) {
-                obj.score = sqlite3_column_int(stmt, 5);
-            }
-            return obj;
         }
     };
 
@@ -126,11 +110,10 @@ namespace storm::benchmark {
         static auto create_model(int index = 0) -> Model {
             int i = index + 1;
             return Model{
-                    .id        = 0,
                     .name      = std::format("Person{}", i),
                     .age       = 20 + (i % 50),
-                    .is_active = (i % 2 == 0),
-                    .salary    = 30000.0 + (i * 1000.0)
+                    .salary    = 30000.0 + (i * 1000.0),
+                    .is_active = (i % 2 == 0)
             };
         }
 
@@ -164,10 +147,9 @@ namespace storm::benchmark {
             if (!db)
                 return 0;
 
-            constexpr std::string_view field_name = std::meta::identifier_of(FieldInfo);
-            std::string                sql        = std::format(
-                    "SELECT id, name, age, is_active, salary, score FROM Person WHERE {} BETWEEN ? AND ?", field_name
-            );
+            // SQL from ORM — single source of truth
+            QuerySet<Model> qs_tmp;
+            std::string     sql = qs_tmp.where(field<FieldInfo>().between(min_value_, max_value_)).select().sql();
 
             sqlite3_stmt* stmt = nullptr;
             sqlite3_prepare_v2(db, sql.c_str(), -1, &stmt, nullptr);
@@ -186,27 +168,13 @@ namespace storm::benchmark {
                 sqlite3_reset(stmt);
                 plf::hive<Model> results;
                 while (sqlite3_step(stmt) == SQLITE_ROW) {
-                    results.insert(extract_row(stmt));
+                    results.insert(storm::benchmark::extract_row<Model>(stmt));
                 }
                 total += results.size();
             }
 
             sqlite3_finalize(stmt);
             return total;
-        }
-
-      private:
-        __attribute__((always_inline)) static auto extract_row(sqlite3_stmt* stmt) -> Model {
-            Model obj;
-            obj.id        = sqlite3_column_int64(stmt, 0);
-            obj.name      = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 1));
-            obj.age       = sqlite3_column_int(stmt, 2);
-            obj.is_active = sqlite3_column_int(stmt, 3) != 0;
-            obj.salary    = sqlite3_column_double(stmt, 4);
-            if (sqlite3_column_type(stmt, 5) != SQLITE_NULL) {
-                obj.score = sqlite3_column_int(stmt, 5);
-            }
-            return obj;
         }
     };
 
@@ -226,11 +194,10 @@ namespace storm::benchmark {
         static auto create_model(int index = 0) -> Model {
             int i = index + 1;
             return Model{
-                    .id        = 0,
                     .name      = std::format("Person{}", i),
                     .age       = 20 + (i % 50),
-                    .is_active = (i % 2 == 0),
-                    .salary    = 30000.0 + (i * 1000.0)
+                    .salary    = 30000.0 + (i * 1000.0),
+                    .is_active = (i % 2 == 0)
             };
         }
 
@@ -271,17 +238,9 @@ namespace storm::benchmark {
             if (!db)
                 return 0;
 
-            constexpr std::string_view field_name = std::meta::identifier_of(FieldInfo);
-
-            // Build SQL with placeholders
-            std::string sql =
-                    std::format("SELECT id, name, age, is_active, salary, score FROM Person WHERE {} IN (", field_name);
-            for (size_t i = 0; i < values_.size(); i++) {
-                if (i > 0)
-                    sql += ", ";
-                sql += "?";
-            }
-            sql += ")";
+            // SQL from ORM — single source of truth
+            QuerySet<Model> qs_tmp;
+            std::string     sql = qs_tmp.where(build_in_clause()).select().sql();
 
             sqlite3_stmt* stmt = nullptr;
             sqlite3_prepare_v2(db, sql.c_str(), -1, &stmt, nullptr);
@@ -300,26 +259,13 @@ namespace storm::benchmark {
                 sqlite3_reset(stmt);
                 plf::hive<Model> results;
                 while (sqlite3_step(stmt) == SQLITE_ROW) {
-                    results.insert(extract_row(stmt));
+                    results.insert(storm::benchmark::extract_row<Model>(stmt));
                 }
                 total += results.size();
             }
 
             sqlite3_finalize(stmt);
             return total;
-        }
-
-        __attribute__((always_inline)) static auto extract_row(sqlite3_stmt* stmt) -> Model {
-            Model obj;
-            obj.id        = sqlite3_column_int64(stmt, 0);
-            obj.name      = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 1));
-            obj.age       = sqlite3_column_int(stmt, 2);
-            obj.is_active = sqlite3_column_int(stmt, 3) != 0;
-            obj.salary    = sqlite3_column_double(stmt, 4);
-            if (sqlite3_column_type(stmt, 5) != SQLITE_NULL) {
-                obj.score = sqlite3_column_int(stmt, 5);
-            }
-            return obj;
         }
 
         // Helper to build IN clause from vector
@@ -365,11 +311,10 @@ namespace storm::benchmark {
         static auto create_model(int index = 0) -> Model {
             int i = index + 1;
             return Model{
-                    .id        = 0,
                     .name      = std::format("Person{}", i),
                     .age       = 20 + (i % 50),
-                    .is_active = (i % 2 == 0),
-                    .salary    = 30000.0 + (i * 1000.0)
+                    .salary    = 30000.0 + (i * 1000.0),
+                    .is_active = (i % 2 == 0)
             };
         }
 
@@ -414,62 +359,30 @@ namespace storm::benchmark {
             constexpr std::string_view op_sql2     = get_sql_op(Op2.view());
             constexpr const char*      logic_op    = IsAnd ? "AND" : "OR";
 
-            std::string sql = std::format(
-                    "SELECT id, name, age, is_active, salary, score FROM Person WHERE {} {} ? {} {} {} ?",
-                    field_name1,
-                    op_sql1,
-                    logic_op,
-                    field_name2,
-                    op_sql2
-            );
+            // Column list from ORM, WHERE clause appended manually (operator dispatch complexity)
+            std::string sql = QuerySet<Model>().select().sql();
+            sql += std::format(" WHERE {} {} ? {} {} {} ?", field_name1, op_sql1, logic_op, field_name2, op_sql2);
 
             sqlite3_stmt* stmt = nullptr;
             sqlite3_prepare_v2(db, sql.c_str(), -1, &stmt, nullptr);
 
-            // Bind first value
-            if constexpr (std::is_same_v<ValueType1, int>) {
-                sqlite3_bind_int(stmt, 1, value1_);
-            } else if constexpr (std::is_same_v<ValueType1, double>) {
-                sqlite3_bind_double(stmt, 1, value1_);
-            } else if constexpr (std::is_same_v<ValueType1, bool>) {
-                sqlite3_bind_int(stmt, 1, value1_ ? 1 : 0);
-            }
-
-            // Bind second value
-            if constexpr (std::is_same_v<ValueType2, int>) {
-                sqlite3_bind_int(stmt, 2, value2_);
-            } else if constexpr (std::is_same_v<ValueType2, double>) {
-                sqlite3_bind_double(stmt, 2, value2_);
-            } else if constexpr (std::is_same_v<ValueType2, bool>) {
-                sqlite3_bind_int(stmt, 2, value2_ ? 1 : 0);
-            }
+            // Bind values using shared helpers
+            int idx = 1;
+            bind_value(stmt, idx++, value1_);
+            bind_value(stmt, idx++, value2_);
 
             int total = 0;
             for (int i = 0; i < iterations; i++) {
                 sqlite3_reset(stmt);
                 plf::hive<Model> results;
                 while (sqlite3_step(stmt) == SQLITE_ROW) {
-                    results.insert(extract_row(stmt));
+                    results.insert(storm::benchmark::extract_row<Model>(stmt));
                 }
                 total += results.size();
             }
 
             sqlite3_finalize(stmt);
             return total;
-        }
-
-      private:
-        __attribute__((always_inline)) static auto extract_row(sqlite3_stmt* stmt) -> Model {
-            Model obj;
-            obj.id        = sqlite3_column_int64(stmt, 0);
-            obj.name      = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 1));
-            obj.age       = sqlite3_column_int(stmt, 2);
-            obj.is_active = sqlite3_column_int(stmt, 3) != 0;
-            obj.salary    = sqlite3_column_double(stmt, 4);
-            if (sqlite3_column_type(stmt, 5) != SQLITE_NULL) {
-                obj.score = sqlite3_column_int(stmt, 5);
-            }
-            return obj;
         }
 
         static constexpr auto get_sql_op(std::string_view op) -> std::string_view {
@@ -550,11 +463,10 @@ namespace storm::benchmark {
         static auto create_model(int index = 0) -> Model {
             int i = index + 1;
             return Model{
-                    .id        = 0,
                     .name      = std::format("Person{}", i),
                     .age       = 20 + (i % 50),
-                    .is_active = (i % 2 == 0),
                     .salary    = 30000.0 + (i * 1000.0),
+                    .is_active = (i % 2 == 0),
                     .score     = (i % 2 == 0) ? std::optional<int>(50 + i) : std::nullopt
             };
         }
@@ -594,11 +506,14 @@ namespace storm::benchmark {
             if (!db)
                 return 0;
 
-            constexpr std::string_view field_name = std::meta::identifier_of(FieldInfo);
-            constexpr const char*      null_str   = IsNull ? "IS NULL" : "IS NOT NULL";
-            std::string                sql        = std::format(
-                    "SELECT id, name, age, is_active, salary, score FROM Person WHERE {} {}", field_name, null_str
-            );
+            // SQL from ORM — single source of truth
+            QuerySet<Model> qs_tmp;
+            std::string     sql;
+            if constexpr (IsNull) {
+                sql = qs_tmp.where(field<FieldInfo>().is_null()).select().sql();
+            } else {
+                sql = qs_tmp.where(field<FieldInfo>().is_not_null()).select().sql();
+            }
 
             sqlite3_stmt* stmt = nullptr;
             sqlite3_prepare_v2(db, sql.c_str(), -1, &stmt, nullptr);
@@ -608,27 +523,13 @@ namespace storm::benchmark {
                 sqlite3_reset(stmt);
                 plf::hive<Model> results;
                 while (sqlite3_step(stmt) == SQLITE_ROW) {
-                    results.insert(extract_row(stmt));
+                    results.insert(storm::benchmark::extract_row<Model>(stmt));
                 }
                 total += results.size();
             }
 
             sqlite3_finalize(stmt);
             return total;
-        }
-
-      private:
-        __attribute__((always_inline)) static auto extract_row(sqlite3_stmt* stmt) -> Model {
-            Model obj;
-            obj.id        = sqlite3_column_int64(stmt, 0);
-            obj.name      = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 1));
-            obj.age       = sqlite3_column_int(stmt, 2);
-            obj.is_active = sqlite3_column_int(stmt, 3) != 0;
-            obj.salary    = sqlite3_column_double(stmt, 4);
-            if (sqlite3_column_type(stmt, 5) != SQLITE_NULL) {
-                obj.score = sqlite3_column_int(stmt, 5);
-            }
-            return obj;
         }
     };
 

--- a/benchmarks/raw_helpers.hpp
+++ b/benchmarks/raw_helpers.hpp
@@ -1,0 +1,244 @@
+#pragma once
+
+/**
+ * Reflection-based raw SQLite helpers for benchmarks.
+ *
+ * Provides generic extract_row<T>() and bind_fields<T>() that work with
+ * any ORM model, eliminating per-model manual column mapping.
+ * Used by the raw SQLite benchmark path (not the Storm ORM path).
+ */
+
+#include <sqlite3.h>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <meta>
+#include <optional>
+#include <string>
+#include <type_traits>
+#include <vector>
+
+import storm;
+
+namespace storm::benchmark {
+
+    // ========================================================================
+    // FK field detection (mirrors ORM's BaseStatement::is_fk_field)
+    // ========================================================================
+    consteval auto is_fk_field(std::meta::info member) -> bool {
+        auto field_attr = std::meta::annotation_of_type<storm::meta::FieldAttr>(member);
+        return field_attr.has_value() && field_attr.value() == storm::meta::FieldAttr::fk;
+    }
+
+    consteval auto is_pk_field(std::meta::info member) -> bool {
+        auto field_attr = std::meta::annotation_of_type<storm::meta::FieldAttr>(member);
+        return field_attr.has_value() && field_attr.value() == storm::meta::FieldAttr::primary;
+    }
+
+    // Find primary key member of a type
+    template <typename T> consteval auto find_pk_member() -> std::meta::info {
+        for (auto m : std::meta::nonstatic_data_members_of(^^T, std::meta::access_context::unchecked())) {
+            if (is_pk_field(m))
+                return m;
+        }
+        std::unreachable();
+    }
+
+    // ========================================================================
+    // Consteval member accessors — avoid storing full members vector as constexpr local
+    // ========================================================================
+    template <typename T> consteval auto member_count() -> size_t {
+        return std::meta::nonstatic_data_members_of(^^T, std::meta::access_context::unchecked()).size();
+    }
+
+    template <typename T, size_t I> consteval auto get_member() -> std::meta::info {
+        return std::meta::nonstatic_data_members_of(^^T, std::meta::access_context::unchecked())[I];
+    }
+
+    // ========================================================================
+    // Type traits
+    // ========================================================================
+    template <typename T> struct is_optional : std::false_type {};
+    template <typename T> struct is_optional<std::optional<T>> : std::true_type {};
+    template <typename T> constexpr bool is_optional_v = is_optional<T>::value;
+
+    template <typename T> struct is_vector_uint8 : std::false_type {};
+    template <> struct is_vector_uint8<std::vector<uint8_t>> : std::true_type {};
+    template <typename T> constexpr bool is_vector_uint8_v = is_vector_uint8<T>::value;
+
+    template <typename T> struct is_vector_byte : std::false_type {};
+    template <> struct is_vector_byte<std::vector<std::byte>> : std::true_type {};
+    template <typename T> constexpr bool is_vector_byte_v = is_vector_byte<T>::value;
+
+    // ========================================================================
+    // extract_value<T> — extract a single column from sqlite3_stmt*
+    // ========================================================================
+    template <typename T> __attribute__((always_inline)) inline auto extract_value(sqlite3_stmt* stmt, int col) -> T {
+        if constexpr (is_optional_v<T>) {
+            using Inner = typename T::value_type;
+            if (sqlite3_column_type(stmt, col) == SQLITE_NULL) {
+                return std::nullopt;
+            }
+            return T{extract_value<Inner>(stmt, col)};
+        } else if constexpr (std::is_same_v<T, bool>) {
+            return sqlite3_column_int(stmt, col) != 0;
+        } else if constexpr (std::is_same_v<T, int>) {
+            return sqlite3_column_int(stmt, col);
+        } else if constexpr (std::is_same_v<T, int64_t> || std::is_same_v<T, long long>) {
+            return static_cast<T>(sqlite3_column_int64(stmt, col));
+        } else if constexpr (std::is_same_v<T, unsigned int> || std::is_same_v<T, short> ||
+                             std::is_same_v<T, unsigned short>) {
+            return static_cast<T>(sqlite3_column_int(stmt, col));
+        } else if constexpr (std::is_same_v<T, double>) {
+            return sqlite3_column_double(stmt, col);
+        } else if constexpr (std::is_same_v<T, float>) {
+            return static_cast<float>(sqlite3_column_double(stmt, col));
+        } else if constexpr (std::is_same_v<T, std::string>) {
+            const auto* text = reinterpret_cast<const char*>(sqlite3_column_text(stmt, col));
+            return text ? std::string(text) : std::string{};
+        } else if constexpr (is_vector_uint8_v<T>) {
+            const auto* blob = static_cast<const uint8_t*>(sqlite3_column_blob(stmt, col));
+            int         len  = sqlite3_column_bytes(stmt, col);
+            return blob ? T(blob, blob + len) : T{};
+        } else if constexpr (is_vector_byte_v<T>) {
+            const auto* blob = static_cast<const std::byte*>(sqlite3_column_blob(stmt, col));
+            int         len  = sqlite3_column_bytes(stmt, col);
+            return blob ? T(blob, blob + len) : T{};
+        } else {
+            static_assert(sizeof(T) == 0, "Unsupported type for extract_value");
+        }
+    }
+
+    // ========================================================================
+    // extract_row<T> — extract all columns into a model using reflection
+    // ========================================================================
+    template <typename T> __attribute__((always_inline)) inline auto extract_row(sqlite3_stmt* stmt) -> T {
+        T obj{};
+
+        [&]<size_t... Is>(std::index_sequence<Is...>) {
+            (([]<size_t I>(sqlite3_stmt* s, T& o) __attribute__((always_inline)) {
+                 constexpr auto member = get_member<T, I>();
+                 using FieldType       = std::remove_cvref_t<decltype(o.[:member:])>;
+
+                 if constexpr (is_fk_field(member)) {
+                     o.[:member:]           = FieldType{};
+                     constexpr auto fk_pk   = find_pk_member<FieldType>();
+                     using PKType           = std::remove_cvref_t<decltype(o.[:member:].[:fk_pk:])>;
+                     o.[:member:].[:fk_pk:] = extract_value<PKType>(s, I);
+                 } else {
+                     o.[:member:] = extract_value<FieldType>(s, I);
+                 }
+             }.template operator()<Is>(stmt, obj)),
+             ...);
+        }(std::make_index_sequence<member_count<T>()>{});
+
+        return obj;
+    }
+
+    // ========================================================================
+    // bind_value — bind a single value to sqlite3_stmt*
+    // ========================================================================
+    __attribute__((always_inline)) inline auto bind_value(sqlite3_stmt* stmt, int idx, int val) -> void {
+        sqlite3_bind_int(stmt, idx, val);
+    }
+    __attribute__((always_inline)) inline auto bind_value(sqlite3_stmt* stmt, int idx, int64_t val) -> void {
+        sqlite3_bind_int64(stmt, idx, val);
+    }
+    __attribute__((always_inline)) inline auto bind_value(sqlite3_stmt* stmt, int idx, double val) -> void {
+        sqlite3_bind_double(stmt, idx, val);
+    }
+    __attribute__((always_inline)) inline auto bind_value(sqlite3_stmt* stmt, int idx, float val) -> void {
+        sqlite3_bind_double(stmt, idx, static_cast<double>(val));
+    }
+    __attribute__((always_inline)) inline auto bind_value(sqlite3_stmt* stmt, int idx, bool val) -> void {
+        sqlite3_bind_int(stmt, idx, val ? 1 : 0);
+    }
+    __attribute__((always_inline)) inline auto bind_value(sqlite3_stmt* stmt, int idx, const std::string& val) -> void {
+        sqlite3_bind_text(stmt, idx, val.c_str(), -1, SQLITE_TRANSIENT);
+    }
+    __attribute__((always_inline)) inline auto bind_value(sqlite3_stmt* stmt, int idx, unsigned int val) -> void {
+        sqlite3_bind_int(stmt, idx, static_cast<int>(val));
+    }
+    __attribute__((always_inline)) inline auto bind_value(sqlite3_stmt* stmt, int idx, long long val) -> void {
+        sqlite3_bind_int64(stmt, idx, val);
+    }
+    __attribute__((always_inline)) inline auto bind_value(sqlite3_stmt* stmt, int idx, const std::vector<uint8_t>& val)
+            -> void {
+        sqlite3_bind_blob(stmt, idx, val.data(), static_cast<int>(val.size()), SQLITE_TRANSIENT);
+    }
+    __attribute__((always_inline)) inline auto
+    bind_value(sqlite3_stmt* stmt, int idx, const std::vector<std::byte>& val) -> void {
+        sqlite3_bind_blob(stmt, idx, val.data(), static_cast<int>(val.size()), SQLITE_TRANSIENT);
+    }
+
+    // ========================================================================
+    // bind_field — bind a single struct field (handles optional + FK)
+    // ========================================================================
+    template <std::meta::info Member, typename T>
+    __attribute__((always_inline)) inline auto bind_field(sqlite3_stmt* stmt, const T& obj, int& idx) -> void {
+        using FieldType = std::remove_cvref_t<decltype(obj.[:Member:])>;
+
+        if constexpr (is_fk_field(Member)) {
+            constexpr auto fk_pk = find_pk_member<FieldType>();
+            bind_value(stmt, idx++, obj.[:Member:].[:fk_pk:]);
+        } else if constexpr (is_optional_v<FieldType>) {
+            if (obj.[:Member:].has_value()) {
+                bind_value(stmt, idx++, obj.[:Member:].value());
+            } else {
+                sqlite3_bind_null(stmt, idx++);
+            }
+        } else {
+            bind_value(stmt, idx++, obj.[:Member:]);
+        }
+    }
+
+    // ========================================================================
+    // bind_non_pk_fields<T> — bind all non-PK fields for INSERT
+    // ========================================================================
+    template <typename T>
+    __attribute__((always_inline)) inline auto bind_non_pk_fields(sqlite3_stmt* stmt, const T& obj, int& idx) -> void {
+        [&]<size_t... Is>(std::index_sequence<Is...>) {
+            (([]<size_t I>(sqlite3_stmt* s, const T& o, int& i) __attribute__((always_inline)) {
+                 constexpr auto member = get_member<T, I>();
+                 if constexpr (!is_pk_field(member)) {
+                     bind_field<member>(s, o, i);
+                 }
+             }.template operator()<Is>(stmt, obj, idx)),
+             ...);
+        }(std::make_index_sequence<member_count<T>()>{});
+    }
+
+    // ========================================================================
+    // bind_all_fields<T> — bind all fields including PK (for UPDATE WHERE id=?)
+    // ========================================================================
+    template <typename T>
+    __attribute__((always_inline)) inline auto bind_all_fields(sqlite3_stmt* stmt, const T& obj, int& idx) -> void {
+        [&]<size_t... Is>(std::index_sequence<Is...>) {
+            ((bind_field<get_member<T, Is>()>(stmt, obj, idx)), ...);
+        }(std::make_index_sequence<member_count<T>()>{});
+    }
+
+    // ========================================================================
+    // bind_update_fields<T> — bind non-PK fields + PK at end (for UPDATE SET ... WHERE id=?)
+    // ========================================================================
+    template <typename T>
+    __attribute__((always_inline)) inline auto bind_update_fields(sqlite3_stmt* stmt, const T& obj, int& idx) -> void {
+        bind_non_pk_fields(stmt, obj, idx);
+        constexpr auto pk = find_pk_member<T>();
+        bind_value(stmt, idx++, obj.[:pk:]);
+    }
+
+    // ========================================================================
+    // non_pk_field_count<T> — count of non-PK fields (for INSERT placeholder count)
+    // ========================================================================
+    template <typename T> consteval auto non_pk_field_count() -> size_t {
+        size_t count   = 0;
+        auto   members = std::meta::nonstatic_data_members_of(^^T, std::meta::access_context::unchecked());
+        for (auto m : members) {
+            if (!is_pk_field(m))
+                ++count;
+        }
+        return count;
+    }
+
+} // namespace storm::benchmark

--- a/scripts/run_clang_tidy.sh
+++ b/scripts/run_clang_tidy.sh
@@ -134,7 +134,7 @@ is_cpp26_module_file() {
     # Exception: mock files that don't use modules are handled by the caller —
     # they parse successfully and never reach this function's "known skip" path.
     case "$file" in
-        tests/*|benchmarks/*|fuzz/*) return 0 ;;
+        tests/*|benchmarks/*|fuzz/*|shared/*) return 0 ;;
         *) return 1 ;;
     esac
 }

--- a/shared/models.h
+++ b/shared/models.h
@@ -1,0 +1,152 @@
+#pragma once
+
+/**
+ * @file models.h
+ * @brief Shared model structs used by both tests and benchmarks.
+ *
+ * IMPORTANT: Include this file AFTER `import storm;` — the
+ * [[= storm::meta::FieldAttr::*]] attributes require the storm module.
+ */
+
+#include <array>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <vector>
+
+// =============================================================================
+// Section 1: Core models (no FK dependencies)
+// =============================================================================
+
+// Shared Person model — covers id/name/age tests, salary/experience aggregates,
+// is_active ordering, optional score/nickname, and avatar BLOB.
+struct Person {
+    [[= storm::meta::FieldAttr::primary]] int id{};
+    [[= storm::meta::FieldAttr::unique]] std::string name;
+    int age{};
+    double salary{};
+    bool is_active{};
+    int years_experience{};
+    [[= storm::meta::FieldAttr::indexed]] std::string department;
+    std::optional<int> score;
+    std::optional<std::string> nickname;
+    std::vector<uint8_t> avatar;
+};
+
+// Composite indexes for Person — specialize the trait after struct definition
+template <> struct storm::Indexes<Person> {
+    using type = std::tuple<storm::Index<^^Person::department, ^^Person::age>,
+                            storm::UniqueIndex<^^Person::name, ^^Person::department>>;
+};
+
+// Shared simple record — covers batch/transaction/update/reset tests needing {id, name, value}.
+struct SimpleRecord {
+    [[= storm::meta::FieldAttr::primary]] int id{};
+    std::string name;
+    int value{};
+};
+
+// Shared Message model — covers FK join tests. Sender is a Person.
+struct Message {
+    [[= storm::meta::FieldAttr::primary]] int id{};
+    std::string content;
+    int value{};
+    [[= storm::meta::FieldAttr::fk]] Person sender;
+};
+
+// =============================================================================
+// Section 2: Type coverage structs (no FK dependencies)
+// =============================================================================
+
+// Enum type for testing enum field support
+enum class Color : int { Red = 0, Green = 1, Blue = 2 };
+
+// Extended types model — covers all supported SQLite column types.
+struct ExtendedTypes {
+    [[= storm::meta::FieldAttr::primary]] int id{};
+    int64_t big_num{};
+    double precise{};
+    float approx{};
+    unsigned int u_int{};
+    long long ll_signed{};
+    std::optional<double> opt_double;
+    std::optional<int64_t> opt_int64;
+    std::string label;
+    signed char tiny_signed{};
+    unsigned char tiny_unsigned{};
+    char single_char{};
+    Color color{Color::Red};
+    std::chrono::year_month_day date_field{std::chrono::year{2000} / std::chrono::January / std::chrono::day{1}};
+    std::chrono::system_clock::time_point datetime_field{};
+    std::chrono::seconds duration_field{};
+    std::filesystem::path file_path;
+    std::vector<std::byte> raw_data;
+    storm::UUID uuid_field;
+    std::optional<Color> opt_color;
+    std::optional<std::chrono::system_clock::time_point> opt_timestamp;
+    std::optional<std::filesystem::path> opt_path;
+};
+
+// =============================================================================
+// Section 3: FK-dependent structs (must come after section 1)
+// =============================================================================
+
+struct Task {
+    [[= storm::meta::FieldAttr::primary]] int id{};
+    [[= storm::meta::FieldAttr::fk]] Person assignee;
+    [[= storm::meta::FieldAttr::fk]] Person reviewer;
+    std::string description;
+};
+
+// =============================================================================
+// Section 4: Seed datasets
+// =============================================================================
+
+namespace storm::test {
+
+// clang-format off
+inline constexpr std::array<Person, 25> PEOPLE_25 = {
+    Person{.name = "Alice",   .age = 25, .salary = 55000.0, .is_active = true,  .years_experience = 5,  .department = "Engineering", .score = std::optional<int>(85),      .nickname = std::optional<std::string>("Ali")},
+    Person{.name = "Bob",     .age = 30, .salary = 62000.0, .is_active = true,  .years_experience = 10, .department = "Sales",       .score = std::optional<int>(90),      .nickname = std::optional<std::string>("Bobby")},
+    Person{.name = "Charlie", .age = 35, .salary = 78000.0, .is_active = false, .years_experience = 15, .department = "Marketing",   .score = std::nullopt,                .nickname = std::nullopt},
+    Person{.name = "Diana",   .age = 28, .salary = 48000.0, .is_active = true,  .years_experience = 5,  .department = "HR",          .score = std::optional<int>(75),      .nickname = std::optional<std::string>("Di")},
+    Person{.name = "Eve",     .age = 40, .salary = 92000.0, .is_active = false, .years_experience = 10, .department = "Engineering", .score = std::nullopt,                .nickname = std::nullopt},
+    Person{.name = "Frank",   .age = 45, .salary = 88000.0, .is_active = true,  .years_experience = 15, .department = "Sales",       .score = std::optional<int>(60),      .nickname = std::nullopt},
+    Person{.name = "Grace",   .age = 25, .salary = 52000.0, .is_active = true,  .years_experience = 5,  .department = "Marketing",   .score = std::optional<int>(95),      .nickname = std::optional<std::string>("Gracie")},
+    Person{.name = "Henry",   .age = 33, .salary = 70000.0, .is_active = false, .years_experience = 10, .department = "Support",     .score = std::nullopt,                .nickname = std::nullopt},
+    Person{.name = "Ivy",     .age = 30, .salary = 65000.0, .is_active = true,  .years_experience = 5,  .department = "Engineering", .score = std::optional<int>(80),      .nickname = std::optional<std::string>("Iv")},
+    Person{.name = "Jack",    .age = 38, .salary = 85000.0, .is_active = false, .years_experience = 15, .department = "HR",          .score = std::nullopt,                .nickname = std::nullopt},
+    Person{.name = "Karen",   .age = 25, .salary = 50000.0, .is_active = true,  .years_experience = 5,  .department = "Sales",       .score = std::optional<int>(85),      .nickname = std::optional<std::string>("Kiki")},
+    Person{.name = "Leo",     .age = 42, .salary = 95000.0, .is_active = true,  .years_experience = 10, .department = "Engineering", .score = std::optional<int>(70),      .nickname = std::nullopt},
+    Person{.name = "Mia",     .age = 28, .salary = 46000.0, .is_active = true,  .years_experience = 5,  .department = "Marketing",   .score = std::nullopt,                .nickname = std::nullopt},
+    Person{.name = "Nick",    .age = 35, .salary = 72000.0, .is_active = false, .years_experience = 15, .department = "Support",     .score = std::optional<int>(55),      .nickname = std::optional<std::string>("Nicky")},
+    Person{.name = "Olivia",  .age = 48, .salary = 98000.0, .is_active = true,  .years_experience = 10, .department = "Sales",       .score = std::nullopt,                .nickname = std::nullopt},
+    Person{.name = "Paul",    .age = 22, .salary = 32000.0, .is_active = false, .years_experience = 5,  .department = "HR",          .score = std::optional<int>(40),      .nickname = std::nullopt},
+    Person{.name = "Quinn",   .age = 30, .salary = 67000.0, .is_active = true,  .years_experience = 10, .department = "Engineering", .score = std::nullopt,                .nickname = std::nullopt},
+    Person{.name = "Rachel",  .age = 36, .salary = 76000.0, .is_active = false, .years_experience = 5,  .department = "Support",     .score = std::optional<int>(65),      .nickname = std::optional<std::string>("Rach")},
+    Person{.name = "Sam",     .age = 40, .salary = 90000.0, .is_active = true,  .years_experience = 15, .department = "Marketing",   .score = std::nullopt,                .nickname = std::nullopt},
+    Person{.name = "Tina",    .age = 27, .salary = 44000.0, .is_active = true,  .years_experience = 5,  .department = "Sales",       .score = std::optional<int>(88),      .nickname = std::optional<std::string>("T")},
+    Person{.name = "Uma",     .age = 33, .salary = 69000.0, .is_active = false, .years_experience = 10, .department = "HR",          .score = std::optional<int>(50),      .nickname = std::nullopt},
+    Person{.name = "Victor",  .age = 45, .salary = 93000.0, .is_active = true,  .years_experience = 15, .department = "Engineering", .score = std::nullopt,                .nickname = std::nullopt},
+    Person{.name = "Wendy",   .age = 29, .salary = 58000.0, .is_active = true,  .years_experience = 10, .department = "Support",     .score = std::optional<int>(78),      .nickname = std::optional<std::string>("Wen")},
+    Person{.name = "Xander",  .age = 38, .salary = 82000.0, .is_active = false, .years_experience = 15, .department = "Marketing",   .score = std::nullopt,                .nickname = std::nullopt},
+    Person{.name = "Yara",    .age = 22, .salary = 35000.0, .is_active = true,  .years_experience = 5,  .department = "Support",     .score = std::optional<int>(92),      .nickname = std::optional<std::string>("Yari")},
+};
+// clang-format on
+
+// 8 Messages — sender IDs are placeholders (1-4); for PostgreSQL, re-query after insert.
+inline constexpr std::array<Message, 8> MESSAGES_8 = {
+    Message{.content = "Hello", .value = 10, .sender = {.id = 1}},
+    Message{.content = "World", .value = 20, .sender = {.id = 1}},
+    Message{.content = "Hi there", .value = 30, .sender = {.id = 1}},
+    Message{.content = "Goodbye", .value = 40, .sender = {.id = 2}},
+    Message{.content = "Testing", .value = 50, .sender = {.id = 2}},
+    Message{.content = "Greetings", .value = 60, .sender = {.id = 3}},
+    Message{.content = "Reply", .value = 70, .sender = {.id = 3}},
+    Message{.content = "Quick note", .value = 80, .sender = {.id = 4}},
+};
+
+} // namespace storm::test

--- a/tests/test_models.h
+++ b/tests/test_models.h
@@ -2,7 +2,7 @@
 
 /**
  * @file test_models.h
- * @brief Shared test model structs for Storm ORM test suite.
+ * @brief Test-specific helpers + re-export of shared model structs.
  *
  * IMPORTANT: Include this file AFTER `import storm;` in each .cpp that uses it.
  * The [[= storm::meta::FieldAttr::*]] attributes require the storm module to be
@@ -13,99 +13,12 @@
  *   #include "test_models.h"  // AFTER import
  */
 
-#include <array>
-#include <chrono>
-#include <cstddef>
-#include <cstdint>
-#include <filesystem>
+// Shared model structs (Person, SimpleRecord, Message, ExtendedTypes, Task, Color,
+// Indexes<Person>, PEOPLE_25, MESSAGES_8) — also used by benchmarks.
+#include "../shared/models.h"
+
 #include <gtest/gtest.h>
-#include <optional>
 #include <span>
-#include <string>
-#include <vector>
-
-// Shared Person model — covers id/name/age tests, salary/experience aggregates,
-// is_active ordering, optional score/nickname, and avatar BLOB.
-struct Person {
-    [[= storm::meta::FieldAttr::primary]] int id{};
-    [[= storm::meta::FieldAttr::unique]] std::string name;
-    int age{};
-    double salary{};
-    bool is_active{};
-    int years_experience{};
-    [[= storm::meta::FieldAttr::indexed]] std::string department;
-    std::optional<int> score;
-    std::optional<std::string> nickname;
-    std::vector<uint8_t> avatar;
-};
-
-// Composite indexes for Person — specialize the trait after struct definition
-template <> struct storm::Indexes<Person> {
-    using type = std::tuple<storm::Index<^^Person::department, ^^Person::age>,
-                            storm::UniqueIndex<^^Person::name, ^^Person::department>>;
-};
-
-// Shared simple record — covers batch/transaction/update/reset tests needing {id, name, value}.
-struct SimpleRecord {
-    [[= storm::meta::FieldAttr::primary]] int id{};
-    std::string name;
-    int value{};
-};
-
-// Shared Message model — covers FK join tests. Sender is a Person.
-struct Message {
-    [[= storm::meta::FieldAttr::primary]] int id{};
-    std::string content;
-    int value{};
-    [[= storm::meta::FieldAttr::fk]] Person sender;
-};
-
-// =============================================================================
-// Section 1: Type coverage structs (no FK dependencies)
-// =============================================================================
-
-// Enum type for testing enum field support
-enum class Color : int { Red = 0, Green = 1, Blue = 2 };
-
-// Extended types model — covers all supported SQLite column types.
-// Includes: int64, float, double, unsigned, long long, char types, enum,
-// chrono date/datetime/duration, filesystem::path, UUID, vector<byte>,
-// plus optional variants.
-struct ExtendedTypes {
-    [[= storm::meta::FieldAttr::primary]] int id{};
-    int64_t big_num{};
-    double precise{};
-    float approx{};
-    unsigned int u_int{};
-    long long ll_signed{};
-    std::optional<double> opt_double;
-    std::optional<int64_t> opt_int64;
-    std::string label;
-    signed char tiny_signed{};
-    unsigned char tiny_unsigned{};
-    char single_char{};
-    Color color{Color::Red};
-    std::chrono::year_month_day date_field{std::chrono::year{2000} / std::chrono::January / std::chrono::day{1}};
-    std::chrono::system_clock::time_point datetime_field{};
-    std::chrono::seconds duration_field{};
-    std::filesystem::path file_path;
-    std::vector<std::byte> raw_data;
-    storm::UUID uuid_field;
-    std::optional<Color> opt_color;
-    std::optional<std::chrono::system_clock::time_point> opt_timestamp;
-    std::optional<std::filesystem::path> opt_path;
-};
-
-// =============================================================================
-// Section 2: FK-dependent structs (must come after section 1)
-// =============================================================================
-
-struct Task {
-    [[= storm::meta::FieldAttr::primary]] int id{};
-    [[= storm::meta::FieldAttr::fk]] Person assignee;
-    [[= storm::meta::FieldAttr::fk]] Person reviewer;
-    std::string description;
-};
 
 // =============================================================================
 
@@ -190,53 +103,6 @@ template <> inline auto is_original_record<Person>(const Person &p) -> bool { re
 template <> inline auto is_original_record<SimpleRecord>(const SimpleRecord &r) -> bool {
     return r.name.starts_with("R");
 }
-
-// ---------------------------------------------------------------------------
-// Unified seed dataset — ONE shared 25-row Person + 8-row Message dataset.
-// Used by both C++ fixtures and YAML tests.
-// ---------------------------------------------------------------------------
-
-// clang-format off
-inline constexpr std::array<Person, 25> PEOPLE_25 = {
-    Person{.name = "Alice",   .age = 25, .salary = 55000.0, .is_active = true,  .years_experience = 5,  .department = "Engineering", .score = std::optional<int>(85),      .nickname = std::optional<std::string>("Ali")},
-    Person{.name = "Bob",     .age = 30, .salary = 62000.0, .is_active = true,  .years_experience = 10, .department = "Sales",       .score = std::optional<int>(90),      .nickname = std::optional<std::string>("Bobby")},
-    Person{.name = "Charlie", .age = 35, .salary = 78000.0, .is_active = false, .years_experience = 15, .department = "Marketing",   .score = std::nullopt,                .nickname = std::nullopt},
-    Person{.name = "Diana",   .age = 28, .salary = 48000.0, .is_active = true,  .years_experience = 5,  .department = "HR",          .score = std::optional<int>(75),      .nickname = std::optional<std::string>("Di")},
-    Person{.name = "Eve",     .age = 40, .salary = 92000.0, .is_active = false, .years_experience = 10, .department = "Engineering", .score = std::nullopt,                .nickname = std::nullopt},
-    Person{.name = "Frank",   .age = 45, .salary = 88000.0, .is_active = true,  .years_experience = 15, .department = "Sales",       .score = std::optional<int>(60),      .nickname = std::nullopt},
-    Person{.name = "Grace",   .age = 25, .salary = 52000.0, .is_active = true,  .years_experience = 5,  .department = "Marketing",   .score = std::optional<int>(95),      .nickname = std::optional<std::string>("Gracie")},
-    Person{.name = "Henry",   .age = 33, .salary = 70000.0, .is_active = false, .years_experience = 10, .department = "Support",     .score = std::nullopt,                .nickname = std::nullopt},
-    Person{.name = "Ivy",     .age = 30, .salary = 65000.0, .is_active = true,  .years_experience = 5,  .department = "Engineering", .score = std::optional<int>(80),      .nickname = std::optional<std::string>("Iv")},
-    Person{.name = "Jack",    .age = 38, .salary = 85000.0, .is_active = false, .years_experience = 15, .department = "HR",          .score = std::nullopt,                .nickname = std::nullopt},
-    Person{.name = "Karen",   .age = 25, .salary = 50000.0, .is_active = true,  .years_experience = 5,  .department = "Sales",       .score = std::optional<int>(85),      .nickname = std::optional<std::string>("Kiki")},
-    Person{.name = "Leo",     .age = 42, .salary = 95000.0, .is_active = true,  .years_experience = 10, .department = "Engineering", .score = std::optional<int>(70),      .nickname = std::nullopt},
-    Person{.name = "Mia",     .age = 28, .salary = 46000.0, .is_active = true,  .years_experience = 5,  .department = "Marketing",   .score = std::nullopt,                .nickname = std::nullopt},
-    Person{.name = "Nick",    .age = 35, .salary = 72000.0, .is_active = false, .years_experience = 15, .department = "Support",     .score = std::optional<int>(55),      .nickname = std::optional<std::string>("Nicky")},
-    Person{.name = "Olivia",  .age = 48, .salary = 98000.0, .is_active = true,  .years_experience = 10, .department = "Sales",       .score = std::nullopt,                .nickname = std::nullopt},
-    Person{.name = "Paul",    .age = 22, .salary = 32000.0, .is_active = false, .years_experience = 5,  .department = "HR",          .score = std::optional<int>(40),      .nickname = std::nullopt},
-    Person{.name = "Quinn",   .age = 30, .salary = 67000.0, .is_active = true,  .years_experience = 10, .department = "Engineering", .score = std::nullopt,                .nickname = std::nullopt},
-    Person{.name = "Rachel",  .age = 36, .salary = 76000.0, .is_active = false, .years_experience = 5,  .department = "Support",     .score = std::optional<int>(65),      .nickname = std::optional<std::string>("Rach")},
-    Person{.name = "Sam",     .age = 40, .salary = 90000.0, .is_active = true,  .years_experience = 15, .department = "Marketing",   .score = std::nullopt,                .nickname = std::nullopt},
-    Person{.name = "Tina",    .age = 27, .salary = 44000.0, .is_active = true,  .years_experience = 5,  .department = "Sales",       .score = std::optional<int>(88),      .nickname = std::optional<std::string>("T")},
-    Person{.name = "Uma",     .age = 33, .salary = 69000.0, .is_active = false, .years_experience = 10, .department = "HR",          .score = std::optional<int>(50),      .nickname = std::nullopt},
-    Person{.name = "Victor",  .age = 45, .salary = 93000.0, .is_active = true,  .years_experience = 15, .department = "Engineering", .score = std::nullopt,                .nickname = std::nullopt},
-    Person{.name = "Wendy",   .age = 29, .salary = 58000.0, .is_active = true,  .years_experience = 10, .department = "Support",     .score = std::optional<int>(78),      .nickname = std::optional<std::string>("Wen")},
-    Person{.name = "Xander",  .age = 38, .salary = 82000.0, .is_active = false, .years_experience = 15, .department = "Marketing",   .score = std::nullopt,                .nickname = std::nullopt},
-    Person{.name = "Yara",    .age = 22, .salary = 35000.0, .is_active = true,  .years_experience = 5,  .department = "Support",     .score = std::optional<int>(92),      .nickname = std::optional<std::string>("Yari")},
-};
-// clang-format on
-
-// 8 Messages — sender IDs are placeholders (1-4); for PostgreSQL, re-query after insert.
-inline constexpr std::array<Message, 8> MESSAGES_8 = {
-    Message{.content = "Hello", .value = 10, .sender = {.id = 1}},
-    Message{.content = "World", .value = 20, .sender = {.id = 1}},
-    Message{.content = "Hi there", .value = 30, .sender = {.id = 1}},
-    Message{.content = "Goodbye", .value = 40, .sender = {.id = 2}},
-    Message{.content = "Testing", .value = 50, .sender = {.id = 2}},
-    Message{.content = "Greetings", .value = 60, .sender = {.id = 3}},
-    Message{.content = "Reply", .value = 70, .sender = {.id = 3}},
-    Message{.content = "Quick note", .value = 80, .sender = {.id = 4}},
-};
 
 } // namespace storm::test
 


### PR DESCRIPTION
## Summary
- Extract shared model structs (`Person`, `SimpleRecord`, `Message`, `ExtendedTypes`, `Task`) to `shared/models.h` — single source of truth for tests and benchmarks
- Replace hand-written SQL in benchmarks with ORM `.sql()` generation (aggregate, distinct, group by, having, insert, update, delete, select)
- Deduplicate `extract_row`/`bind_fields` helpers using C++26 reflection `consteval` member accessors (avoids heap allocation with large structs)
- Fix raw SQLite benchmark 0-operations bug caused by Person's UNIQUE constraint on `name`

Closes #188

## Follow-up issues
- #189: Chunked batch logic reuses ORM's adaptive chunking
- #191: JOIN alias alignment + COUNT(DISTINCT) ORM support

## Test plan
- [x] All 1887 tests pass (SQLite + PostgreSQL)
- [x] All benchmarks produce non-zero results with 93-110% efficiency vs raw SQLite
- [x] Pre-commit hook passes (clang-format, clang-tidy, tests, 100% coverage)
- [x] `shared/models.h` added to C++26 clang-tidy skip list

🤖 Generated with [Claude Code](https://claude.com/claude-code)