### PR TITLE
refactor(benchmarks): nest benchmark test schema

### DIFF
--- a/benchmarks/parser.hpp
+++ b/benchmarks/parser.hpp
@@ -1,10 +1,36 @@
 #pragma once
 
 /**
- * Compile-Time Flat JSON Parser for Benchmark Tests
+ * Compile-Time Nested JSON Parser for Benchmark Tests
  *
- * Parses flat JSON structure at compile time using C++26 #embed.
- * Converts JSON to nested C++ structs (BenchmarkTest with WhereClause).
+ * Parses nested JSON using C++26 #embed at compile time. Converts JSON to
+ * nested C++ structs defined in schema.hpp (BenchmarkTest + WhereSpec,
+ * OrderBySpec, GroupBySpec with nested HavingSpec, DistinctSpec, LimitSpec,
+ * AggregateSpec, JoinSpec).
+ *
+ * JSON layout example:
+ *   {
+ *     "test_name": "...",
+ *     "model": "Person",
+ *     "operation": "order_by_where",
+ *     "iterations": 1000,
+ *     "dataset_size": 10000,
+ *     "where":    { "field": "age", "op": ">", "value": 30 },
+ *     "order_by": [ { "field": "salary", "direction": "DESC" } ],
+ *     "group_by": { "fields": ["department"],
+ *                   "having": { "field": "age", "op": ">", "value": 30 } },
+ *     "distinct": { "fields": ["name", "age"] },
+ *     "limit":    { "value": 10, "offset": 20 },
+ *     "aggregate": { "func": "sum", "field": "salary" },
+ *     "join":     { "type": "inner", "related": "User", "fk": "sender" }
+ *   }
+ *
+ * `where.value` is sniffed from the JSON token type — int, double, bool,
+ * or string — and stored in a TypedValue tagged union. Two-value operators
+ * (BETWEEN) use `value2`; IN uses `in_values`. A second clause combined
+ * with AND/OR is expressed via `"and": { ... }` or `"or": { ... }` inside
+ * `where`, encoded as flat fields (`field2`, `op2`, `value2_rhs`) plus
+ * a `combine_and`/`combine_or` flag.
  */
 
 #include <array>
@@ -13,14 +39,15 @@
 
 namespace storm::benchmark {
 
-    // Helper: Skip whitespace
+    // ========================================================================
+    // Primitive parsers
+    // ========================================================================
     constexpr auto skip_whitespace(std::string_view json, size_t& pos) -> void {
         while (pos < json.size() && (json[pos] == ' ' || json[pos] == '\n' || json[pos] == '\r' || json[pos] == '\t')) {
             pos++;
         }
     }
 
-    // Helper: Skip specific character with whitespace
     constexpr auto skip_char(std::string_view json, size_t& pos, char c) -> void {
         skip_whitespace(json, pos);
         if (pos < json.size() && json[pos] == c) {
@@ -28,45 +55,33 @@ namespace storm::benchmark {
         }
     }
 
-    // Parse int
     constexpr auto parse_int(std::string_view json, size_t& pos) -> int {
         skip_whitespace(json, pos);
-
         int  result   = 0;
         bool negative = false;
-
         if (pos < json.size() && json[pos] == '-') {
             negative = true;
             pos++;
         }
-
         while (pos < json.size() && json[pos] >= '0' && json[pos] <= '9') {
             result = result * 10 + (json[pos] - '0');
             pos++;
         }
-
         return negative ? -result : result;
     }
 
-    // Parse double
     constexpr auto parse_double(std::string_view json, size_t& pos) -> double {
         skip_whitespace(json, pos);
-
         double result   = 0.0;
         bool   negative = false;
-
         if (pos < json.size() && json[pos] == '-') {
             negative = true;
             pos++;
         }
-
-        // Integer part
         while (pos < json.size() && json[pos] >= '0' && json[pos] <= '9') {
             result = result * 10.0 + (json[pos] - '0');
             pos++;
         }
-
-        // Decimal part
         if (pos < json.size() && json[pos] == '.') {
             pos++;
             double fraction = 0.1;
@@ -76,14 +91,11 @@ namespace storm::benchmark {
                 pos++;
             }
         }
-
         return negative ? -result : result;
     }
 
-    // Parse bool
     constexpr auto parse_bool(std::string_view json, size_t& pos) -> bool {
         skip_whitespace(json, pos);
-
         if (pos + 4 <= json.size() && json.substr(pos, 4) == "true") {
             pos += 4;
             return true;
@@ -92,19 +104,14 @@ namespace storm::benchmark {
             pos += 5;
             return false;
         }
-
         return false;
     }
 
-    // Parse string into ConstexprString
     template <size_t N> constexpr auto parse_string(std::string_view json, size_t& pos) -> ConstexprString<N> {
         skip_whitespace(json, pos);
-
         ConstexprString<N> result;
-
         if (pos < json.size() && json[pos] == '"') {
-            pos++; // Skip opening quote
-
+            pos++; // opening quote
             size_t i = 0;
             while (pos < json.size() && json[pos] != '"' && i < N - 1) {
                 result.data[i] = json[pos];
@@ -113,84 +120,438 @@ namespace storm::benchmark {
             }
             result.len     = i;
             result.data[i] = '\0';
-
             if (pos < json.size() && json[pos] == '"') {
-                pos++; // Skip closing quote
+                pos++; // closing quote
             }
         }
-
         return result;
     }
 
-    // Skip a JSON value (string, number, bool, null)
-    constexpr auto skip_value(std::string_view json, size_t& pos) -> void {
+    constexpr auto parse_key(std::string_view json, size_t& pos) -> ConstexprString<64> {
+        return parse_string<64>(json, pos);
+    }
+
+    // ========================================================================
+    // Value skipping (for unknown keys and recursive object/array skip)
+    // ========================================================================
+    constexpr auto skip_value(std::string_view json, size_t& pos) -> void { // NOSONAR(cpp:S3776)
         skip_whitespace(json, pos);
-
-        if (pos >= json.size())
-            return;
-
-        // String
-        if (json[pos] == '"') {
-            pos++; // Skip opening quote
-            while (pos < json.size() && json[pos] != '"') {
-                if (json[pos] == '\\')
-                    pos++; // Skip escape
-                pos++;
-            }
-            if (pos < json.size())
-                pos++; // Skip closing quote
+        if (pos >= json.size()) {
             return;
         }
 
-        // Number, bool, null
+        if (json[pos] == '"') {
+            pos++;
+            while (pos < json.size() && json[pos] != '"') {
+                if (json[pos] == '\\') {
+                    pos++;
+                }
+                pos++;
+            }
+            if (pos < json.size()) {
+                pos++;
+            }
+            return;
+        }
+
+        if (json[pos] == '{' || json[pos] == '[') {
+            char open  = json[pos];
+            char close = (open == '{') ? '}' : ']';
+            int  depth = 0;
+            while (pos < json.size()) {
+                if (json[pos] == '"') {
+                    pos++;
+                    while (pos < json.size() && json[pos] != '"') {
+                        if (json[pos] == '\\') {
+                            pos++;
+                        }
+                        pos++;
+                    }
+                    if (pos < json.size()) {
+                        pos++;
+                    }
+                    continue;
+                }
+                if (json[pos] == open) {
+                    depth++;
+                } else if (json[pos] == close) {
+                    depth--;
+                    if (depth == 0) {
+                        pos++;
+                        return;
+                    }
+                }
+                pos++;
+            }
+            return;
+        }
+
+        // number, bool, null
         while (pos < json.size() && json[pos] != ',' && json[pos] != '}' && json[pos] != ']' && json[pos] != ' ' &&
                json[pos] != '\n' && json[pos] != '\r' && json[pos] != '\t') {
             pos++;
         }
     }
 
-    // Parse key name from JSON (returns the key string)
-    constexpr auto parse_key(std::string_view json, size_t& pos) -> ConstexprString<64> {
-        return parse_string<64>(json, pos);
+    // ========================================================================
+    // TypedValue — sniff the next JSON token and populate a tagged union.
+    //
+    // Lookahead: " → string, t/f → bool, digit/-  → scan ahead for '.' → double else int.
+    // ========================================================================
+    constexpr auto parse_typed_value(std::string_view json, size_t& pos) -> TypedValue {
+        skip_whitespace(json, pos);
+        TypedValue tv;
+        if (pos >= json.size()) {
+            return tv;
+        }
+
+        char c = json[pos];
+
+        if (c == '"') {
+            tv.kind      = TypedValue::Kind::String;
+            tv.as_string = parse_string<64>(json, pos);
+            return tv;
+        }
+        if (c == 't' || c == 'f') {
+            tv.kind    = TypedValue::Kind::Bool;
+            tv.as_bool = parse_bool(json, pos);
+            return tv;
+        }
+        // Number — peek ahead for '.' to decide int vs double
+        bool has_dot = false;
+        for (size_t q = pos; q < json.size(); q++) {
+            char qc = json[q];
+            if (qc == '.') {
+                has_dot = true;
+                break;
+            }
+            if (qc == ',' || qc == '}' || qc == ']' || qc == ' ' || qc == '\n' || qc == '\r' || qc == '\t') {
+                break;
+            }
+        }
+        if (has_dot) {
+            tv.kind      = TypedValue::Kind::Double;
+            tv.as_double = parse_double(json, pos);
+        } else {
+            tv.kind   = TypedValue::Kind::Int;
+            tv.as_int = parse_int(json, pos);
+        }
+        return tv;
     }
 
-    // Helper: Parse JSON array of integers into WhereClause (reduces nesting in main parser)
-    constexpr auto parse_int_array_into_where(WhereClause& where, std::string_view json, size_t& pos) -> void {
+    // ========================================================================
+    // Array of integers — used by where.in_values
+    // ========================================================================
+    constexpr auto parse_int_array_into_where(WhereSpec& where, std::string_view json, size_t& pos) -> void {
         skip_whitespace(json, pos);
         if (pos >= json.size() || json[pos] != '[') {
             return;
         }
-
-        pos++; // Skip '['
+        pos++; // '['
         size_t count = 0;
-
-        while (pos < json.size() && count < WhereClause::MAX_IN_VALUES) {
+        while (pos < json.size() && count < WhereSpec::MAX_IN_VALUES) {
             skip_whitespace(json, pos);
             if (json[pos] == ']') {
-                pos++; // Skip ']'
+                pos++;
                 break;
             }
-
             where.in_values_int[count] = parse_int(json, pos);
             count++;
             skip_whitespace(json, pos);
-
             if (json[pos] == ',') {
-                pos++; // Skip ','
+                pos++;
             }
         }
-
         where.in_values_count = count;
-        where.value_type      = WhereClause::ValueType::Int;
     }
 
-    // Helper: Parse and assign key-value pair to BenchmarkTest
-    constexpr void parse_and_assign_field( // NOSONAR(cpp:S3776) - consteval JSON parser dispatches on 20+ field names; complexity is inherent
+    // ========================================================================
+    // Array of short strings — used by group_by.fields, distinct.fields, join.fks
+    // ========================================================================
+    template <size_t MaxItems, typename AssignFn>
+    constexpr auto parse_string_array(std::string_view json, size_t& pos, AssignFn assign) -> size_t {
+        skip_whitespace(json, pos);
+        if (pos >= json.size() || json[pos] != '[') {
+            return 0;
+        }
+        pos++; // '['
+        size_t count = 0;
+        while (pos < json.size() && count < MaxItems) {
+            skip_whitespace(json, pos);
+            if (json[pos] == ']') {
+                pos++;
+                break;
+            }
+            auto s = parse_string<32>(json, pos);
+            assign(count, s);
+            count++;
+            skip_whitespace(json, pos);
+            if (json[pos] == ',') {
+                pos++;
+            }
+        }
+        // Handle possible trailing whitespace + ']'
+        skip_whitespace(json, pos);
+        if (pos < json.size() && json[pos] == ']') {
+            pos++;
+        }
+        return count;
+    }
+
+    // ========================================================================
+    // Nested object parsers
+    // ========================================================================
+
+    // Generic object-walker: iterate key/value pairs and dispatch via callback.
+    // Callback receives (key_view, json, pos) and consumes exactly one value.
+    template <typename Dispatch>
+    constexpr auto parse_object_keys(std::string_view json, size_t& pos, Dispatch dispatch) -> void {
+        skip_char(json, pos, '{');
+        while (pos < json.size()) {
+            skip_whitespace(json, pos);
+            if (pos < json.size() && json[pos] == '}') {
+                pos++;
+                return;
+            }
+            auto key = parse_key(json, pos);
+            skip_char(json, pos, ':');
+            dispatch(key.view(), json, pos);
+            skip_whitespace(json, pos);
+            if (pos < json.size() && json[pos] == ',') {
+                pos++;
+            }
+        }
+    }
+
+    // --- where leaf fields (shared by WhereSpec top level and inner and/or) ---
+    constexpr auto parse_where_leaf_field( // NOSONAR(cpp:S3776)
+            std::string_view key, std::string_view json, size_t& pos, ConstexprString<32>& field_out,
+            ConstexprString<16>& op_out, TypedValue& value_out
+    ) -> bool {
+        if (key == "field") {
+            field_out = parse_string<32>(json, pos);
+            return true;
+        }
+        if (key == "op") {
+            op_out = parse_string<16>(json, pos);
+            return true;
+        }
+        if (key == "value") {
+            value_out = parse_typed_value(json, pos);
+            return true;
+        }
+        return false;
+    }
+
+    // --- parse_where_into ---
+    constexpr auto parse_where_into(WhereSpec& w, std::string_view json, size_t& pos) -> void { // NOSONAR(cpp:S3776)
+        w.enabled = true;
+        parse_object_keys(json, pos, [&](std::string_view key, std::string_view j, size_t& p) {
+            if (parse_where_leaf_field(key, j, p, w.field, w.op, w.value)) {
+                return;
+            }
+            if (key == "value2") {
+                w.value2 = parse_typed_value(j, p);
+                return;
+            }
+            if (key == "in_values") {
+                parse_int_array_into_where(w, j, p);
+                return;
+            }
+            if (key == "field2") {
+                w.field2 = parse_string<32>(j, p);
+                return;
+            }
+            if (key == "op2") {
+                w.op2 = parse_string<8>(j, p);
+                return;
+            }
+            if (key == "value2_rhs") {
+                w.value2_rhs = parse_typed_value(j, p);
+                return;
+            }
+            if (key == "combine") {
+                auto s = parse_string<8>(j, p);
+                if (s == std::string_view("and"))
+                    w.combine_and = true;
+                else if (s == std::string_view("or"))
+                    w.combine_or = true;
+                return;
+            }
+            if (key == "and" || key == "or") {
+                if (key == "and") {
+                    w.combine_and = true;
+                }
+                if (key == "or") {
+                    w.combine_or = true;
+                }
+                // Parse nested {field, op, value} into the _rhs fields
+                parse_object_keys(j, p, [&](std::string_view k2, std::string_view j2, size_t& p2) {
+                    if (k2 == "field") {
+                        w.field2 = parse_string<32>(j2, p2);
+                    } else if (k2 == "op") {
+                        w.op2 = parse_string<8>(j2, p2);
+                    } else if (k2 == "value") {
+                        w.value2_rhs = parse_typed_value(j2, p2);
+                    } else {
+                        skip_value(j2, p2);
+                    }
+                });
+                return;
+            }
+            skip_value(j, p);
+        });
+    }
+
+    // --- parse_order_by_entry_into (one OrderBySpec) ---
+    constexpr auto parse_order_by_entry_into(OrderBySpec& o, std::string_view json, size_t& pos) -> void {
+        o.enabled = true;
+        parse_object_keys(json, pos, [&](std::string_view key, std::string_view j, size_t& p) {
+            if (key == "field") {
+                o.field = parse_string<32>(j, p);
+            } else if (key == "direction") {
+                o.direction = parse_string<8>(j, p);
+            } else if (key == "collate") {
+                o.collate = parse_string<16>(j, p);
+            } else {
+                skip_value(j, p);
+            }
+        });
+    }
+
+    // --- parse_order_by_into (array of entries) ---
+    constexpr auto parse_order_by_array_into(BenchmarkTest& test, std::string_view json, size_t& pos) -> void {
+        skip_whitespace(json, pos);
+        if (pos >= json.size() || json[pos] != '[') {
+            return;
+        }
+        pos++; // '['
+        size_t count = 0;
+        while (pos < json.size() && count < BenchmarkTest::MAX_ORDER_BY) {
+            skip_whitespace(json, pos);
+            if (json[pos] == ']') {
+                pos++;
+                break;
+            }
+            parse_order_by_entry_into(test.order_by[count], json, pos);
+            count++;
+            skip_whitespace(json, pos);
+            if (json[pos] == ',') {
+                pos++;
+            }
+        }
+        skip_whitespace(json, pos);
+        if (pos < json.size() && json[pos] == ']') {
+            pos++;
+        }
+        test.order_by_count = count;
+    }
+
+    // --- parse_having_into ---
+    constexpr auto parse_having_into(HavingSpec& h, std::string_view json, size_t& pos) -> void {
+        h.enabled = true;
+        parse_object_keys(json, pos, [&](std::string_view key, std::string_view j, size_t& p) {
+            if (key == "field") {
+                h.field = parse_string<32>(j, p);
+            } else if (key == "op") {
+                h.op = parse_string<16>(j, p);
+            } else if (key == "value") {
+                h.value = parse_typed_value(j, p);
+            } else {
+                skip_value(j, p);
+            }
+        });
+    }
+
+    // --- parse_group_by_into ---
+    constexpr auto parse_group_by_into(GroupBySpec& g, std::string_view json, size_t& pos) -> void {
+        g.enabled = true;
+        parse_object_keys(json, pos, [&](std::string_view key, std::string_view j, size_t& p) {
+            if (key == "fields") {
+                g.field_count =
+                        parse_string_array<GroupBySpec::MAX_FIELDS>(j, p, [&](size_t i, const ConstexprString<32>& s) {
+                            g.fields[i] = s;
+                        });
+            } else if (key == "having") {
+                parse_having_into(g.having, j, p);
+            } else {
+                skip_value(j, p);
+            }
+        });
+    }
+
+    // --- parse_distinct_into ---
+    constexpr auto parse_distinct_into(DistinctSpec& d, std::string_view json, size_t& pos) -> void {
+        d.enabled = true;
+        parse_object_keys(json, pos, [&](std::string_view key, std::string_view j, size_t& p) {
+            if (key == "fields") {
+                d.field_count =
+                        parse_string_array<DistinctSpec::MAX_FIELDS>(j, p, [&](size_t i, const ConstexprString<32>& s) {
+                            d.fields[i] = s;
+                        });
+            } else {
+                skip_value(j, p);
+            }
+        });
+    }
+
+    // --- parse_limit_into ---
+    constexpr auto parse_limit_into(LimitSpec& l, std::string_view json, size_t& pos) -> void {
+        l.enabled = true;
+        parse_object_keys(json, pos, [&](std::string_view key, std::string_view j, size_t& p) {
+            if (key == "value") {
+                l.value = parse_int(j, p);
+            } else if (key == "offset") {
+                l.offset = parse_int(j, p);
+            } else {
+                skip_value(j, p);
+            }
+        });
+    }
+
+    // --- parse_aggregate_into ---
+    constexpr auto parse_aggregate_into(AggregateSpec& a, std::string_view json, size_t& pos) -> void {
+        a.enabled = true;
+        parse_object_keys(json, pos, [&](std::string_view key, std::string_view j, size_t& p) {
+            if (key == "func") {
+                a.func = parse_string<16>(j, p);
+            } else if (key == "field") {
+                a.field = parse_string<32>(j, p);
+            } else {
+                skip_value(j, p);
+            }
+        });
+    }
+
+    // --- parse_join_into ---
+    constexpr auto parse_join_into(JoinSpec& jn, std::string_view json, size_t& pos) -> void {
+        jn.enabled = true;
+        parse_object_keys(json, pos, [&](std::string_view key, std::string_view j, size_t& p) {
+            if (key == "type") {
+                jn.type = parse_string<8>(j, p);
+            } else if (key == "related") {
+                jn.related = parse_string<32>(j, p);
+            } else if (key == "fk") {
+                jn.fk = parse_string<32>(j, p);
+            } else if (key == "fks") {
+                jn.fk_count = parse_string_array<JoinSpec::MAX_FKS>(j, p, [&](size_t i, const ConstexprString<32>& s) {
+                    jn.fks[i] = s;
+                });
+            } else {
+                skip_value(j, p);
+            }
+        });
+    }
+
+    // ========================================================================
+    // Top-level BenchmarkTest field dispatcher
+    // ========================================================================
+    constexpr auto parse_test_field( // NOSONAR(cpp:S3776)
             BenchmarkTest& test, std::string_view key, std::string_view json, size_t& pos
-    ) { // NOSONAR(cpp:S3776)
+    ) -> void {
         if (key == "test_name") {
             test.test_name = parse_string<64>(json, pos);
-        } else if (key == "test_category") {
+        } else if (key == "test_category" || key == "category") {
             test.test_category = parse_string<32>(json, pos);
         } else if (key == "description") {
             test.description = parse_string<128>(json, pos);
@@ -198,112 +559,63 @@ namespace storm::benchmark {
             test.model = parse_string<32>(json, pos);
         } else if (key == "operation") {
             test.operation = parse_string<32>(json, pos);
-        } else if (key == "where_field") {
-            test.where.field = parse_string<32>(json, pos);
-        } else if (key == "where_op") {
-            test.where.op = parse_string<16>(json, pos);
-        } else if (key == "where_value_int") {
-            test.where.value_int  = parse_int(json, pos);
-            test.where.value_type = WhereClause::ValueType::Int;
-        } else if (key == "where_value_double") {
-            test.where.value_double = parse_double(json, pos);
-            test.where.value_type   = WhereClause::ValueType::Double;
-        } else if (key == "where_value_bool") {
-            test.where.value_bool = parse_bool(json, pos);
-            test.where.value_type = WhereClause::ValueType::Bool;
-        } else if (key == "where_value_string") {
-            test.where.value_string = parse_string<64>(json, pos);
-            test.where.value_type   = WhereClause::ValueType::String;
-        } else if (key == "where_value_int2") {
-            test.where.value_int2 = parse_int(json, pos);
-        } else if (key == "where_value_double2") {
-            test.where.value_double2 = parse_double(json, pos);
-        } else if (key == "where_in_values") {
-            // Parse JSON array of integers using helper (reduces nesting depth)
-            parse_int_array_into_where(test.where, json, pos);
-        } else if (key == "where_field2") {
-            test.where.field2 = parse_string<32>(json, pos);
-        } else if (key == "where_op2") {
-            test.where.op2 = parse_string<8>(json, pos);
-        } else if (key == "where_value2_int") {
-            test.where.value2_int = parse_int(json, pos);
         } else if (key == "iterations") {
             test.iterations = parse_int(json, pos);
         } else if (key == "dataset_size") {
             test.dataset_size = parse_int(json, pos);
         } else if (key == "batch_size") {
             test.batch_size = parse_int(json, pos);
-        } else if (key == "aggregate_field") {
-            test.aggregate_field = parse_string<32>(json, pos);
-        } else if (key == "distinct_field") {
-            test.distinct_field = parse_string<32>(json, pos);
-        } else if (key == "distinct_field2") {
-            test.distinct_field2 = parse_string<32>(json, pos);
-        } else if (key == "distinct_field3") {
-            test.distinct_field3 = parse_string<32>(json, pos);
-        } else if (key == "limit_value") {
-            test.limit_value = parse_int(json, pos);
-        } else if (key == "offset_value") {
-            test.offset_value = parse_int(json, pos);
-        } else if (key == "order_by_field") {
-            test.order_by_field = parse_string<32>(json, pos);
-        } else if (key == "order_by_direction") {
-            test.order_by_direction = parse_string<8>(json, pos);
-        } else if (key == "order_by_collate") {
-            test.order_by_collate = parse_string<16>(json, pos);
-        } else if (key == "order_by_field2") {
-            test.order_by_field2 = parse_string<32>(json, pos);
-        } else if (key == "order_by_direction2") {
-            test.order_by_direction2 = parse_string<8>(json, pos);
-        } else if (key == "group_by_field") {
-            test.group_by_field = parse_string<32>(json, pos);
-        } else if (key == "group_by_field2") {
-            test.group_by_field2 = parse_string<32>(json, pos);
-        } else if (key == "having_field") {
-            test.having_field = parse_string<32>(json, pos);
-        } else if (key == "having_value_int") {
-            test.having_value_int = parse_int(json, pos);
         } else if (key == "size_profile") {
             test.size_profile = parse_string<32>(json, pos);
+        } else if (key == "where") {
+            parse_where_into(test.where, json, pos);
+        } else if (key == "order_by") {
+            parse_order_by_array_into(test, json, pos);
+        } else if (key == "group_by") {
+            parse_group_by_into(test.group_by, json, pos);
+        } else if (key == "distinct") {
+            parse_distinct_into(test.distinct, json, pos);
+        } else if (key == "limit") {
+            parse_limit_into(test.limit, json, pos);
+        } else if (key == "aggregate") {
+            parse_aggregate_into(test.aggregate, json, pos);
+        } else if (key == "join") {
+            parse_join_into(test.join, json, pos);
         } else {
-            // Unknown key - skip value
             skip_value(json, pos);
         }
     }
 
-    // Parse single benchmark test object from flat JSON
     constexpr auto parse_test_object(std::string_view json, size_t& pos) -> BenchmarkTest {
         BenchmarkTest test;
-        skip_char(json, pos, '{');
-
-        while (pos < json.size()) {
-            skip_whitespace(json, pos);
-
-            if (json[pos] == '}') {
-                pos++; // Skip closing brace
-                break;
-            }
-
-            // Parse key-value pair and assign to test object
-            auto key = parse_key(json, pos);
-            skip_char(json, pos, ':');
-            parse_and_assign_field(test, key.view(), json, pos);
-
-            skip_whitespace(json, pos);
-            if (pos < json.size() && json[pos] == ',') {
-                pos++; // Skip comma
-            }
-        }
-
+        parse_object_keys(json, pos, [&](std::string_view key, std::string_view j, size_t& p) {
+            parse_test_field(test, key, j, p);
+        });
         return test;
     }
 
-    // Helper: Skip to end of JSON object (reduces nesting depth)
+    // ========================================================================
+    // Test array parsing
+    // ========================================================================
     constexpr auto skip_json_object(std::string_view json, size_t& pos) -> void {
         int brace_depth = 0;
         while (pos < json.size()) {
-            if (json[pos] == '{')
+            if (json[pos] == '"') {
+                pos++;
+                while (pos < json.size() && json[pos] != '"') {
+                    if (json[pos] == '\\') {
+                        pos++;
+                    }
+                    pos++;
+                }
+                if (pos < json.size()) {
+                    pos++;
+                }
+                continue;
+            }
+            if (json[pos] == '{') {
                 brace_depth++;
+            }
             if (json[pos] == '}') {
                 brace_depth--;
                 if (brace_depth == 0) {
@@ -315,78 +627,58 @@ namespace storm::benchmark {
         }
     }
 
-    // Count tests in JSON array (needed for std::array size)
     constexpr auto count_tests(std::string_view json) -> size_t {
         size_t count = 0;
         size_t pos   = 0;
-
         skip_char(json, pos, '[');
-
         while (pos < json.size()) {
             skip_whitespace(json, pos);
-
             if (json[pos] == ']') {
                 break;
             }
-
             if (json[pos] == '{') {
                 count++;
                 skip_json_object(json, pos);
             }
-
             skip_whitespace(json, pos);
             if (pos < json.size() && json[pos] == ',') {
                 pos++;
             }
         }
-
         return count;
     }
 
-    // Parse entire JSON array
     template <size_t N> constexpr auto parse_tests(std::string_view json) -> std::array<BenchmarkTest, N> {
         std::array<BenchmarkTest, N> tests{};
-
-        size_t pos = 0;
+        size_t                       pos = 0;
         skip_char(json, pos, '[');
-
         for (size_t i = 0; i < N; i++) {
             skip_whitespace(json, pos);
-
             if (pos >= json.size() || json[pos] == ']') {
                 break;
             }
-
             tests[i] = parse_test_object(json, pos);
-
             skip_whitespace(json, pos);
             if (pos < json.size() && json[pos] == ',') {
-                pos++; // Skip comma
+                pos++;
             }
         }
-
         return tests;
     }
 
-    // Load and parse JSON from embedded file
+    // ========================================================================
+    // Load embedded JSON at compile time
+    // ========================================================================
     consteval auto load_benchmark_tests() {
-        // Embed JSON file at compile time
         static constexpr const char json_data[] = {
 #embed "tests/benchmark_tests.json"
                 , '\0'
         };
-
         constexpr std::string_view json_str(json_data);
-
-        // Count tests to determine array size
-        constexpr size_t test_count = count_tests(json_str);
-
-        // Parse tests
+        constexpr size_t           test_count = count_tests(json_str);
         return parse_tests<test_count>(json_str);
     }
 
-    // Compile-time constant tests loaded from JSON
-    // Define this AFTER load_benchmark_tests() is defined
     inline constexpr auto BENCHMARK_TESTS = load_benchmark_tests();
 
 } // namespace storm::benchmark

--- a/benchmarks/runner.hpp
+++ b/benchmarks/runner.hpp
@@ -311,7 +311,7 @@ namespace storm::benchmark {
         static auto run_where_operation(BenchmarkRunner& runner, int iterations) -> void {
             constexpr std::string_view field_name   = test.where.field.view();
             constexpr auto             op_str       = test.where.op;
-            constexpr int              value        = test.where.value_int;
+            constexpr int              value        = test.where.value.as_int;
             constexpr auto             field_info   = dispatch_field<Model>(field_name);
             constexpr int              dataset_size = test.dataset_size;
 
@@ -454,7 +454,7 @@ namespace storm::benchmark {
         static auto run_select_where_join_operation(BenchmarkRunner& runner, int iterations) -> void {
             constexpr std::string_view field_name = test.where.field.view();
             constexpr auto             op_str     = test.where.op;
-            constexpr int              value      = test.where.value_int;
+            constexpr int              value      = test.where.value.as_int;
             constexpr auto             field_info = dispatch_field<User>(field_name);
 
             constexpr auto profile_str = test.size_profile.view();
@@ -517,7 +517,7 @@ namespace storm::benchmark {
         static auto run_select_left_join_where_operation(BenchmarkRunner& runner, int iterations) -> void {
             constexpr std::string_view field_name = test.where.field.view();
             constexpr auto             op_str     = test.where.op;
-            constexpr int              value      = test.where.value_int;
+            constexpr int              value      = test.where.value.as_int;
             constexpr auto             field_info = dispatch_field<User>(field_name);
 
             constexpr auto profile_str = test.size_profile.view();
@@ -580,7 +580,7 @@ namespace storm::benchmark {
         static auto run_select_right_join_where_operation(BenchmarkRunner& runner, int iterations) -> void {
             constexpr std::string_view field_name = test.where.field.view();
             constexpr auto             op_str     = test.where.op;
-            constexpr int              value      = test.where.value_int;
+            constexpr int              value      = test.where.value.as_int;
             constexpr auto             field_info = dispatch_field<User>(field_name);
 
             constexpr auto profile_str = test.size_profile.view();
@@ -664,7 +664,7 @@ namespace storm::benchmark {
 
         template <typename Model, auto& test>
         static auto run_aggregate_count_field_operation(BenchmarkRunner& runner, int iterations) -> void {
-            constexpr std::string_view field_name  = test.aggregate_field.view();
+            constexpr std::string_view field_name  = test.aggregate.field.view();
             constexpr auto             field_info  = dispatch_field<Model>(field_name);
             constexpr auto             profile_str = test.size_profile.view();
             constexpr auto             profile     = sizes::profile_from_string(profile_str);
@@ -685,7 +685,7 @@ namespace storm::benchmark {
 
         template <typename Model, auto& test>
         static auto run_aggregate_count_distinct_operation(BenchmarkRunner& runner, int iterations) -> void {
-            constexpr std::string_view field_name  = test.aggregate_field.view();
+            constexpr std::string_view field_name  = test.aggregate.field.view();
             constexpr auto             field_info  = dispatch_field<Model>(field_name);
             constexpr auto             profile_str = test.size_profile.view();
             constexpr auto             profile     = sizes::profile_from_string(profile_str);
@@ -708,7 +708,7 @@ namespace storm::benchmark {
 
         template <typename Model, auto& test>
         static auto run_aggregate_sum_operation(BenchmarkRunner& runner, int iterations) -> void {
-            constexpr std::string_view field_name  = test.aggregate_field.view();
+            constexpr std::string_view field_name  = test.aggregate.field.view();
             constexpr auto             field_info  = dispatch_field<Model>(field_name);
             constexpr auto             profile_str = test.size_profile.view();
             constexpr auto             profile     = sizes::profile_from_string(profile_str);
@@ -727,7 +727,7 @@ namespace storm::benchmark {
 
         template <typename Model, auto& test>
         static auto run_aggregate_avg_operation(BenchmarkRunner& runner, int iterations) -> void {
-            constexpr std::string_view field_name  = test.aggregate_field.view();
+            constexpr std::string_view field_name  = test.aggregate.field.view();
             constexpr auto             field_info  = dispatch_field<Model>(field_name);
             constexpr auto             profile_str = test.size_profile.view();
             constexpr auto             profile     = sizes::profile_from_string(profile_str);
@@ -746,7 +746,7 @@ namespace storm::benchmark {
 
         template <typename Model, auto& test>
         static auto run_aggregate_min_operation(BenchmarkRunner& runner, int iterations) -> void {
-            constexpr std::string_view field_name  = test.aggregate_field.view();
+            constexpr std::string_view field_name  = test.aggregate.field.view();
             constexpr auto             field_info  = dispatch_field<Model>(field_name);
             constexpr auto             profile_str = test.size_profile.view();
             constexpr auto             profile     = sizes::profile_from_string(profile_str);
@@ -765,7 +765,7 @@ namespace storm::benchmark {
 
         template <typename Model, auto& test>
         static auto run_aggregate_max_operation(BenchmarkRunner& runner, int iterations) -> void {
-            constexpr std::string_view field_name  = test.aggregate_field.view();
+            constexpr std::string_view field_name  = test.aggregate.field.view();
             constexpr auto             field_info  = dispatch_field<Model>(field_name);
             constexpr auto             profile_str = test.size_profile.view();
             constexpr auto             profile     = sizes::profile_from_string(profile_str);
@@ -788,7 +788,7 @@ namespace storm::benchmark {
 
         template <typename Model, auto& test>
         static auto run_distinct_operation(BenchmarkRunner& runner, int iterations) -> void {
-            constexpr std::string_view field_name  = test.distinct_field.view();
+            constexpr std::string_view field_name  = test.distinct.fields[0].view();
             constexpr auto             field_info  = dispatch_field<Model>(field_name);
             constexpr auto             profile_str = test.size_profile.view();
             constexpr auto             profile     = sizes::profile_from_string(profile_str);
@@ -811,12 +811,12 @@ namespace storm::benchmark {
 
         template <typename Model, auto& test>
         static auto run_distinct_where_operation(BenchmarkRunner& runner, int iterations) -> void {
-            constexpr std::string_view distinct_field_name = test.distinct_field.view();
+            constexpr std::string_view distinct_field_name = test.distinct.fields[0].view();
             constexpr auto             distinct_field_info = dispatch_field<Model>(distinct_field_name);
             constexpr std::string_view where_field_name    = test.where.field.view();
             constexpr auto             where_field_info    = dispatch_field<Model>(where_field_name);
             constexpr auto             op_str              = test.where.op;
-            constexpr double           value               = test.where.value_double;
+            constexpr double           value               = test.where.value.as_double;
             constexpr auto             profile_str         = test.size_profile.view();
             constexpr auto             profile             = sizes::profile_from_string(profile_str);
 
@@ -846,7 +846,7 @@ namespace storm::benchmark {
 
         template <typename Model, auto& test>
         static auto run_distinct_join_operation(BenchmarkRunner& runner, int iterations) -> void {
-            constexpr std::string_view distinct_field_name = test.distinct_field.view();
+            constexpr std::string_view distinct_field_name = test.distinct.fields[0].view();
             constexpr auto             distinct_field_info = dispatch_field<FKMessage>(distinct_field_name);
             constexpr auto             profile_str         = test.size_profile.view();
             constexpr auto             profile             = sizes::profile_from_string(profile_str);
@@ -873,12 +873,12 @@ namespace storm::benchmark {
 
         template <typename Model, auto& test>
         static auto run_distinct_where_join_operation(BenchmarkRunner& runner, int iterations) -> void {
-            constexpr std::string_view distinct_field_name = test.distinct_field.view();
+            constexpr std::string_view distinct_field_name = test.distinct.fields[0].view();
             constexpr auto             distinct_field_info = dispatch_field<FKMessage>(distinct_field_name);
             constexpr std::string_view where_field_name    = test.where.field.view();
             constexpr auto             where_field_info    = dispatch_field<User>(where_field_name);
             constexpr auto             op_str              = test.where.op;
-            constexpr int              value               = test.where.value_int;
+            constexpr int              value               = test.where.value.as_int;
             constexpr auto             profile_str         = test.size_profile.view();
             constexpr auto             profile             = sizes::profile_from_string(profile_str);
 
@@ -922,8 +922,8 @@ namespace storm::benchmark {
 
         template <typename Model, auto& test>
         static auto run_distinct_multi_2_operation(BenchmarkRunner& runner, int iterations) -> void {
-            constexpr std::string_view field_name1  = test.distinct_field.view();
-            constexpr std::string_view field_name2  = test.distinct_field2.view();
+            constexpr std::string_view field_name1  = test.distinct.fields[0].view();
+            constexpr std::string_view field_name2  = test.distinct.fields[1].view();
             constexpr auto             field_info1  = dispatch_field<Model>(field_name1);
             constexpr auto             field_info2  = dispatch_field<Model>(field_name2);
             constexpr int              dataset_size = test.dataset_size;
@@ -936,9 +936,9 @@ namespace storm::benchmark {
 
         template <typename Model, auto& test>
         static auto run_distinct_multi_3_operation(BenchmarkRunner& runner, int iterations) -> void {
-            constexpr std::string_view field_name1  = test.distinct_field.view();
-            constexpr std::string_view field_name2  = test.distinct_field2.view();
-            constexpr std::string_view field_name3  = test.distinct_field3.view();
+            constexpr std::string_view field_name1  = test.distinct.fields[0].view();
+            constexpr std::string_view field_name2  = test.distinct.fields[1].view();
+            constexpr std::string_view field_name3  = test.distinct.fields[2].view();
             constexpr auto             field_info1  = dispatch_field<Model>(field_name1);
             constexpr auto             field_info2  = dispatch_field<Model>(field_name2);
             constexpr auto             field_info3  = dispatch_field<Model>(field_name3);
@@ -956,8 +956,8 @@ namespace storm::benchmark {
 
         template <typename Model, auto& test>
         static auto run_distinct_order_by_asc_operation(BenchmarkRunner& runner, int iterations) -> void {
-            constexpr std::string_view distinct_field_name = test.distinct_field.view();
-            constexpr std::string_view order_field_name    = test.order_by_field.view();
+            constexpr std::string_view distinct_field_name = test.distinct.fields[0].view();
+            constexpr std::string_view order_field_name    = test.order_by[0].field.view();
             constexpr auto             distinct_field_info = dispatch_field<Model>(distinct_field_name);
             constexpr auto             order_field_info    = dispatch_field<Model>(order_field_name);
             constexpr int              dataset_size        = test.dataset_size;
@@ -970,8 +970,8 @@ namespace storm::benchmark {
 
         template <typename Model, auto& test>
         static auto run_distinct_order_by_desc_operation(BenchmarkRunner& runner, int iterations) -> void {
-            constexpr std::string_view distinct_field_name = test.distinct_field.view();
-            constexpr std::string_view order_field_name    = test.order_by_field.view();
+            constexpr std::string_view distinct_field_name = test.distinct.fields[0].view();
+            constexpr std::string_view order_field_name    = test.order_by[0].field.view();
             constexpr auto             distinct_field_info = dispatch_field<Model>(distinct_field_name);
             constexpr auto             order_field_info    = dispatch_field<Model>(order_field_name);
             constexpr int              dataset_size        = test.dataset_size;
@@ -989,7 +989,7 @@ namespace storm::benchmark {
         template <typename Model, auto& test>
         static auto run_select_limit_operation(BenchmarkRunner& runner, int iterations) -> void {
             constexpr int dataset_size = test.dataset_size;
-            constexpr int limit_value  = test.limit_value;
+            constexpr int limit_value  = test.limit.value;
             runner.run_benchmark(
                     test.test_name.c_str(), SelectLimitBenchmark<Model, limit_value>{dataset_size}, iterations
             );
@@ -998,7 +998,7 @@ namespace storm::benchmark {
         template <typename Model, auto& test>
         static auto run_select_offset_operation(BenchmarkRunner& runner, int iterations) -> void {
             constexpr int dataset_size = test.dataset_size;
-            constexpr int offset_value = test.offset_value;
+            constexpr int offset_value = test.limit.offset;
             runner.run_benchmark(
                     test.test_name.c_str(), SelectOffsetBenchmark<Model, offset_value>{dataset_size}, iterations
             );
@@ -1007,8 +1007,8 @@ namespace storm::benchmark {
         template <typename Model, auto& test>
         static auto run_select_limit_offset_operation(BenchmarkRunner& runner, int iterations) -> void {
             constexpr int dataset_size = test.dataset_size;
-            constexpr int limit_value  = test.limit_value;
-            constexpr int offset_value = test.offset_value;
+            constexpr int limit_value  = test.limit.value;
+            constexpr int offset_value = test.limit.offset;
             runner.run_benchmark(
                     test.test_name.c_str(),
                     SelectLimitOffsetBenchmark<Model, limit_value, offset_value>{dataset_size},
@@ -1020,10 +1020,10 @@ namespace storm::benchmark {
         static auto run_select_where_limit_operation(BenchmarkRunner& runner, int iterations) -> void {
             constexpr std::string_view field_name   = test.where.field.view();
             constexpr auto             op_str       = test.where.op;
-            constexpr int              value        = test.where.value_int;
+            constexpr int              value        = test.where.value.as_int;
             constexpr auto             field_info   = dispatch_field<Model>(field_name);
             constexpr int              dataset_size = test.dataset_size;
-            constexpr int              limit_value  = test.limit_value;
+            constexpr int              limit_value  = test.limit.value;
             runner.run_benchmark(
                     test.test_name.c_str(),
                     SelectWhereLimitBenchmark<Model, field_info, op_str, int, limit_value>{value, dataset_size},
@@ -1034,7 +1034,7 @@ namespace storm::benchmark {
         template <typename Model, auto& test>
         static auto run_select_join_limit_operation(BenchmarkRunner& runner, int iterations) -> void {
             constexpr int dataset_size = test.dataset_size;
-            constexpr int limit_value  = test.limit_value;
+            constexpr int limit_value  = test.limit.value;
             runner.run_benchmark(
                     test.test_name.c_str(),
                     SelectJoinLimitBenchmark<FKMessage, User, &FKMessage::sender, limit_value>{dataset_size},
@@ -1045,8 +1045,8 @@ namespace storm::benchmark {
         template <typename Model, auto& test>
         static auto run_select_join_limit_offset_operation(BenchmarkRunner& runner, int iterations) -> void {
             constexpr int dataset_size = test.dataset_size;
-            constexpr int limit_value  = test.limit_value;
-            constexpr int offset_value = test.offset_value;
+            constexpr int limit_value  = test.limit.value;
+            constexpr int offset_value = test.limit.offset;
             runner.run_benchmark(
                     test.test_name.c_str(),
                     SelectJoinLimitOffsetBenchmark<FKMessage, User, &FKMessage::sender, limit_value, offset_value>{
@@ -1062,7 +1062,7 @@ namespace storm::benchmark {
 
         template <typename Model, auto& test>
         static auto run_select_order_by_asc_operation(BenchmarkRunner& runner, int iterations) -> void {
-            constexpr std::string_view field_name   = test.order_by_field.view();
+            constexpr std::string_view field_name   = test.order_by[0].field.view();
             constexpr auto             field_info   = dispatch_field<Model>(field_name);
             constexpr int              dataset_size = test.dataset_size;
             runner.run_benchmark(
@@ -1072,7 +1072,7 @@ namespace storm::benchmark {
 
         template <typename Model, auto& test>
         static auto run_select_order_by_desc_operation(BenchmarkRunner& runner, int iterations) -> void {
-            constexpr std::string_view field_name   = test.order_by_field.view();
+            constexpr std::string_view field_name   = test.order_by[0].field.view();
             constexpr auto             field_info   = dispatch_field<Model>(field_name);
             constexpr int              dataset_size = test.dataset_size;
             runner.run_benchmark(
@@ -1082,14 +1082,14 @@ namespace storm::benchmark {
 
         template <typename Model, auto& test>
         static auto run_select_order_by_where_operation(BenchmarkRunner& runner, int iterations) -> void {
-            constexpr std::string_view order_field_name = test.order_by_field.view();
+            constexpr std::string_view order_field_name = test.order_by[0].field.view();
             constexpr auto             order_field_info = dispatch_field<Model>(order_field_name);
             constexpr std::string_view where_field_name = test.where.field.view();
             constexpr auto             where_field_info = dispatch_field<Model>(where_field_name);
             constexpr auto             op_str           = test.where.op;
-            constexpr int              value            = test.where.value_int;
+            constexpr int              value            = test.where.value.as_int;
             constexpr int              dataset_size     = test.dataset_size;
-            constexpr std::string_view dir_str          = test.order_by_direction.view();
+            constexpr std::string_view dir_str          = test.order_by[0].direction.view();
             // Default to ASC if direction not specified
             if constexpr (dir_str == "DESC") {
                 runner.run_benchmark(
@@ -1120,11 +1120,11 @@ namespace storm::benchmark {
 
         template <typename Model, auto& test>
         static auto run_select_order_by_limit_operation(BenchmarkRunner& runner, int iterations) -> void {
-            constexpr std::string_view field_name   = test.order_by_field.view();
+            constexpr std::string_view field_name   = test.order_by[0].field.view();
             constexpr auto             field_info   = dispatch_field<Model>(field_name);
             constexpr int              dataset_size = test.dataset_size;
-            constexpr int              limit_value  = test.limit_value;
-            constexpr std::string_view dir_str      = test.order_by_direction.view();
+            constexpr int              limit_value  = test.limit.value;
+            constexpr std::string_view dir_str      = test.order_by[0].direction.view();
             // Default to ASC if direction not specified
             if constexpr (dir_str == "DESC") {
                 runner.run_benchmark(
@@ -1156,11 +1156,11 @@ namespace storm::benchmark {
 
         template <typename Model, auto& test>
         static auto run_select_order_by_collate_operation(BenchmarkRunner& runner, int iterations) -> void {
-            constexpr std::string_view field_name   = test.order_by_field.view();
+            constexpr std::string_view field_name   = test.order_by[0].field.view();
             constexpr auto             field_info   = dispatch_field<Model>(field_name);
             constexpr int              dataset_size = test.dataset_size;
-            constexpr auto             collation    = parse_collate(test.order_by_collate.view());
-            constexpr std::string_view dir_str      = test.order_by_direction.view();
+            constexpr auto             collation    = parse_collate(test.order_by[0].collate.view());
+            constexpr std::string_view dir_str      = test.order_by[0].direction.view();
 
             if constexpr (dir_str == "DESC") {
                 runner.run_benchmark(
@@ -1179,14 +1179,14 @@ namespace storm::benchmark {
 
         template <typename Model, auto& test>
         static auto run_select_order_by_collate_where_operation(BenchmarkRunner& runner, int iterations) -> void {
-            constexpr auto order_field_info = dispatch_field<Model>(test.order_by_field.view());
+            constexpr auto order_field_info = dispatch_field<Model>(test.order_by[0].field.view());
             constexpr auto where_field_info = dispatch_field<Model>(test.where.field.view());
             constexpr auto op_str           = test.where.op;
-            constexpr int  value            = test.where.value_int;
+            constexpr int  value            = test.where.value.as_int;
             constexpr int  dataset_size     = test.dataset_size;
-            constexpr auto collation        = parse_collate(test.order_by_collate.view());
+            constexpr auto collation        = parse_collate(test.order_by[0].collate.view());
             constexpr auto dir =
-                    (test.order_by_direction.view() == "DESC") ? OrderDirection::DESC : OrderDirection::ASC;
+                    (test.order_by[0].direction.view() == "DESC") ? OrderDirection::DESC : OrderDirection::ASC;
 
             runner.run_benchmark(
                     test.test_name.c_str(),
@@ -1208,8 +1208,8 @@ namespace storm::benchmark {
 
         template <typename Model, auto& test>
         static auto run_order_by_multi_2_asc_operation(BenchmarkRunner& runner, int iterations) -> void {
-            constexpr std::string_view field_name1  = test.order_by_field.view();
-            constexpr std::string_view field_name2  = test.order_by_field2.view();
+            constexpr std::string_view field_name1  = test.order_by[0].field.view();
+            constexpr std::string_view field_name2  = test.order_by[1].field.view();
             constexpr auto             field_info1  = dispatch_field<Model>(field_name1);
             constexpr auto             field_info2  = dispatch_field<Model>(field_name2);
             constexpr int              dataset_size = test.dataset_size;
@@ -1222,8 +1222,8 @@ namespace storm::benchmark {
 
         template <typename Model, auto& test>
         static auto run_order_by_multi_2_desc_operation(BenchmarkRunner& runner, int iterations) -> void {
-            constexpr std::string_view field_name1  = test.order_by_field.view();
-            constexpr std::string_view field_name2  = test.order_by_field2.view();
+            constexpr std::string_view field_name1  = test.order_by[0].field.view();
+            constexpr std::string_view field_name2  = test.order_by[1].field.view();
             constexpr auto             field_info1  = dispatch_field<Model>(field_name1);
             constexpr auto             field_info2  = dispatch_field<Model>(field_name2);
             constexpr int              dataset_size = test.dataset_size;
@@ -1236,8 +1236,8 @@ namespace storm::benchmark {
 
         template <typename Model, auto& test>
         static auto run_order_by_multi_2_mixed_operation(BenchmarkRunner& runner, int iterations) -> void {
-            constexpr std::string_view field_name1  = test.order_by_field.view();
-            constexpr std::string_view field_name2  = test.order_by_field2.view();
+            constexpr std::string_view field_name1  = test.order_by[0].field.view();
+            constexpr std::string_view field_name2  = test.order_by[1].field.view();
             constexpr auto             field_info1  = dispatch_field<Model>(field_name1);
             constexpr auto             field_info2  = dispatch_field<Model>(field_name2);
             constexpr int              dataset_size = test.dataset_size;
@@ -1254,7 +1254,7 @@ namespace storm::benchmark {
 
         template <typename Model, auto& test>
         static auto run_group_by_operation(BenchmarkRunner& runner, int iterations) -> void {
-            constexpr std::string_view field_name   = test.group_by_field.view();
+            constexpr std::string_view field_name   = test.group_by.fields[0].view();
             constexpr auto             field_info   = dispatch_field<Model>(field_name);
             constexpr int              dataset_size = test.dataset_size;
             runner.run_benchmark(
@@ -1264,12 +1264,12 @@ namespace storm::benchmark {
 
         template <typename Model, auto& test>
         static auto run_group_by_where_operation(BenchmarkRunner& runner, int iterations) -> void {
-            constexpr std::string_view group_field_name = test.group_by_field.view();
+            constexpr std::string_view group_field_name = test.group_by.fields[0].view();
             constexpr auto             group_field_info = dispatch_field<Model>(group_field_name);
             constexpr std::string_view where_field_name = test.where.field.view();
             constexpr auto             where_field_info = dispatch_field<Model>(where_field_name);
             constexpr auto             op_str           = test.where.op;
-            constexpr int              value            = test.where.value_int;
+            constexpr int              value            = test.where.value.as_int;
             constexpr int              dataset_size     = test.dataset_size;
             runner.run_benchmark(
                     test.test_name.c_str(),
@@ -1282,8 +1282,8 @@ namespace storm::benchmark {
 
         template <typename Model, auto& test>
         static auto run_group_by_multi_2_operation(BenchmarkRunner& runner, int iterations) -> void {
-            constexpr std::string_view field_name1  = test.group_by_field.view();
-            constexpr std::string_view field_name2  = test.group_by_field2.view();
+            constexpr std::string_view field_name1  = test.group_by.fields[0].view();
+            constexpr std::string_view field_name2  = test.group_by.fields[1].view();
             constexpr auto             field_info1  = dispatch_field<Model>(field_name1);
             constexpr auto             field_info2  = dispatch_field<Model>(field_name2);
             constexpr int              dataset_size = test.dataset_size;
@@ -1296,7 +1296,7 @@ namespace storm::benchmark {
 
         template <typename Model, auto& test>
         static auto run_group_by_with_count_operation(BenchmarkRunner& runner, int iterations) -> void {
-            constexpr std::string_view field_name   = test.group_by_field.view();
+            constexpr std::string_view field_name   = test.group_by.fields[0].view();
             constexpr auto             field_info   = dispatch_field<Model>(field_name);
             constexpr int              dataset_size = test.dataset_size;
             runner.run_benchmark(
@@ -1306,8 +1306,8 @@ namespace storm::benchmark {
 
         template <typename Model, auto& test>
         static auto run_group_by_with_sum_operation(BenchmarkRunner& runner, int iterations) -> void {
-            constexpr std::string_view group_field_name = test.group_by_field.view();
-            constexpr std::string_view agg_field_name   = test.aggregate_field.view();
+            constexpr std::string_view group_field_name = test.group_by.fields[0].view();
+            constexpr std::string_view agg_field_name   = test.aggregate.field.view();
             constexpr auto             group_field_info = dispatch_field<Model>(group_field_name);
             constexpr auto             agg_field_info   = dispatch_field<Model>(agg_field_name);
             constexpr int              dataset_size     = test.dataset_size;
@@ -1320,8 +1320,8 @@ namespace storm::benchmark {
 
         template <typename Model, auto& test>
         static auto run_group_by_with_avg_operation(BenchmarkRunner& runner, int iterations) -> void {
-            constexpr std::string_view group_field_name = test.group_by_field.view();
-            constexpr std::string_view agg_field_name   = test.aggregate_field.view();
+            constexpr std::string_view group_field_name = test.group_by.fields[0].view();
+            constexpr std::string_view agg_field_name   = test.aggregate.field.view();
             constexpr auto             group_field_info = dispatch_field<Model>(group_field_name);
             constexpr auto             agg_field_info   = dispatch_field<Model>(agg_field_name);
             constexpr int              dataset_size     = test.dataset_size;
@@ -1334,8 +1334,8 @@ namespace storm::benchmark {
 
         template <typename Model, auto& test>
         static auto run_group_by_with_min_operation(BenchmarkRunner& runner, int iterations) -> void {
-            constexpr std::string_view group_field_name = test.group_by_field.view();
-            constexpr std::string_view agg_field_name   = test.aggregate_field.view();
+            constexpr std::string_view group_field_name = test.group_by.fields[0].view();
+            constexpr std::string_view agg_field_name   = test.aggregate.field.view();
             constexpr auto             group_field_info = dispatch_field<Model>(group_field_name);
             constexpr auto             agg_field_info   = dispatch_field<Model>(agg_field_name);
             constexpr int              dataset_size     = test.dataset_size;
@@ -1348,8 +1348,8 @@ namespace storm::benchmark {
 
         template <typename Model, auto& test>
         static auto run_group_by_with_max_operation(BenchmarkRunner& runner, int iterations) -> void {
-            constexpr std::string_view group_field_name = test.group_by_field.view();
-            constexpr std::string_view agg_field_name   = test.aggregate_field.view();
+            constexpr std::string_view group_field_name = test.group_by.fields[0].view();
+            constexpr std::string_view agg_field_name   = test.aggregate.field.view();
             constexpr auto             group_field_info = dispatch_field<Model>(group_field_name);
             constexpr auto             agg_field_info   = dispatch_field<Model>(agg_field_name);
             constexpr int              dataset_size     = test.dataset_size;
@@ -1366,11 +1366,11 @@ namespace storm::benchmark {
 
         template <typename Model, auto& test>
         static auto run_group_by_having_count_operation(BenchmarkRunner& runner, int iterations) -> void {
-            constexpr std::string_view group_field_name  = test.group_by_field.view();
-            constexpr std::string_view having_field_name = test.having_field.view();
+            constexpr std::string_view group_field_name  = test.group_by.fields[0].view();
+            constexpr std::string_view having_field_name = test.group_by.having.field.view();
             constexpr auto             group_field_info  = dispatch_field<Model>(group_field_name);
             constexpr auto             having_field_info = dispatch_field<Model>(having_field_name);
-            constexpr int              having_value      = test.having_value_int;
+            constexpr int              having_value      = test.group_by.having.value.as_int;
             constexpr int              dataset_size      = test.dataset_size;
             runner.run_benchmark(
                     test.test_name.c_str(),
@@ -1383,13 +1383,13 @@ namespace storm::benchmark {
 
         template <typename Model, auto& test>
         static auto run_group_by_having_sum_operation(BenchmarkRunner& runner, int iterations) -> void {
-            constexpr std::string_view group_field_name  = test.group_by_field.view();
-            constexpr std::string_view agg_field_name    = test.aggregate_field.view();
-            constexpr std::string_view having_field_name = test.having_field.view();
+            constexpr std::string_view group_field_name  = test.group_by.fields[0].view();
+            constexpr std::string_view agg_field_name    = test.aggregate.field.view();
+            constexpr std::string_view having_field_name = test.group_by.having.field.view();
             constexpr auto             group_field_info  = dispatch_field<Model>(group_field_name);
             constexpr auto             agg_field_info    = dispatch_field<Model>(agg_field_name);
             constexpr auto             having_field_info = dispatch_field<Model>(having_field_name);
-            constexpr int              having_value      = test.having_value_int;
+            constexpr int              having_value      = test.group_by.having.value.as_int;
             constexpr int              dataset_size      = test.dataset_size;
             runner.run_benchmark(
                     test.test_name.c_str(),
@@ -1412,7 +1412,7 @@ namespace storm::benchmark {
             constexpr std::string_view field_name   = test.where.field.view();
             constexpr auto             field_info   = dispatch_field<Model>(field_name);
             constexpr int              dataset_size = test.dataset_size;
-            std::string                pattern(test.where.value_string.view());
+            std::string                pattern(test.where.value.as_string.view());
             runner.run_benchmark(
                     test.test_name.c_str(),
                     WhereLikeBenchmark<Model, field_info>{std::move(pattern), dataset_size},
@@ -1425,8 +1425,8 @@ namespace storm::benchmark {
             constexpr std::string_view field_name   = test.where.field.view();
             constexpr auto             field_info   = dispatch_field<Model>(field_name);
             constexpr int              dataset_size = test.dataset_size;
-            constexpr int              min_value    = test.where.value_int;
-            constexpr int              max_value    = test.where.value_int2;
+            constexpr int              min_value    = test.where.value.as_int;
+            constexpr int              max_value    = test.where.value2.as_int;
             runner.run_benchmark(
                     test.test_name.c_str(),
                     WhereBetweenBenchmark<Model, field_info, int>{min_value, max_value, dataset_size},
@@ -1459,11 +1459,11 @@ namespace storm::benchmark {
             constexpr std::string_view field_name1  = test.where.field.view();
             constexpr auto             field_info1  = dispatch_field<Model>(field_name1);
             constexpr auto             op1          = test.where.op;
-            constexpr int              value1       = test.where.value_int;
+            constexpr int              value1       = test.where.value.as_int;
             constexpr std::string_view field_name2  = test.where.field2.view();
             constexpr auto             field_info2  = dispatch_field<Model>(field_name2);
             constexpr auto             op2          = test.where.op2;
-            constexpr int              value2       = test.where.value2_int;
+            constexpr int              value2       = test.where.value2_rhs.as_int;
             constexpr int              dataset_size = test.dataset_size;
             constexpr bool             is_and       = true;
             runner.run_benchmark(
@@ -1480,11 +1480,11 @@ namespace storm::benchmark {
             constexpr std::string_view field_name1  = test.where.field.view();
             constexpr auto             field_info1  = dispatch_field<Model>(field_name1);
             constexpr auto             op1          = test.where.op;
-            constexpr int              value1       = test.where.value_int;
+            constexpr int              value1       = test.where.value.as_int;
             constexpr std::string_view field_name2  = test.where.field2.view();
             constexpr auto             field_info2  = dispatch_field<Model>(field_name2);
             constexpr auto             op2          = test.where.op2;
-            constexpr int              value2       = test.where.value2_int;
+            constexpr int              value2       = test.where.value2_rhs.as_int;
             constexpr int              dataset_size = test.dataset_size;
             constexpr bool             is_and       = false;
             runner.run_benchmark(
@@ -1544,7 +1544,7 @@ namespace storm::benchmark {
             constexpr std::string_view field_name   = test.where.field.view();
             constexpr auto             field_info   = dispatch_field<Model>(field_name);
             constexpr auto             op           = test.where.op;
-            constexpr int              value        = test.where.value_int;
+            constexpr int              value        = test.where.value.as_int;
             constexpr int              dataset_size = test.dataset_size;
             runner.run_benchmark(
                     test.test_name.c_str(),
@@ -1561,7 +1561,7 @@ namespace storm::benchmark {
             constexpr std::string_view field_name   = test.where.field.view();
             constexpr auto             field_info   = dispatch_field<Model>(field_name);
             constexpr auto             op           = test.where.op;
-            constexpr int              value        = test.where.value_int;
+            constexpr int              value        = test.where.value.as_int;
             constexpr int              dataset_size = test.dataset_size;
             runner.run_benchmark(
                     test.test_name.c_str(),
@@ -1584,7 +1584,7 @@ namespace storm::benchmark {
                     int actual_iterations = calculate_iterations(sizes::iterations_for_dataset(size), runner.mode());
                     std::string name      = std::format("{}_{}", test.test_name.view(), size);
                     if constexpr (WithLimit) {
-                        constexpr int limit_value = test.limit_value;
+                        constexpr int limit_value = test.limit.value;
                         runner.run_benchmark(
                                 name.c_str(),
                                 SetOpBenchmark<Model, OpType, WithOrderBy, WithLimit>{size, limit_value},
@@ -1601,7 +1601,7 @@ namespace storm::benchmark {
             } else {
                 constexpr int dataset_size = test.dataset_size;
                 if constexpr (WithLimit) {
-                    constexpr int limit_value = test.limit_value;
+                    constexpr int limit_value = test.limit.value;
                     runner.run_benchmark(
                             test.test_name.c_str(),
                             SetOpBenchmark<Model, OpType, WithOrderBy, WithLimit>{dataset_size, limit_value},

--- a/benchmarks/schema.hpp
+++ b/benchmarks/schema.hpp
@@ -1,16 +1,30 @@
 #pragma once
 
 /**
- * Benchmark Test Schema with Nested Structs
+ * Benchmark Test Schema — Nested Layout
  *
- * JSON is FLAT (for constexpr parsing):
- *   "where_field": "age", "where_op": ">", "where_value_int": 30
+ * JSON source (human-readable, nested):
+ *   {
+ *     "where": { "field": "age", "op": ">", "value": 30 },
+ *     "order_by": [ { "field": "salary", "direction": "DESC" } ],
+ *     "group_by": { "fields": ["department"], "having": { "field": "age", "op": ">", "value": 30 } },
+ *     ...
+ *   }
  *
- * C++ is NESTED (for clean organization):
- *   test.where.field, test.where.op, test.where.value_int
+ * C++ mirrors this layout: test.where.field, test.order_by[0].field,
+ * test.group_by.fields[0], test.group_by.having.field, etc.
+ *
+ * Each sub-spec carries a `bool enabled` flag set by the parser when the
+ * corresponding JSON object is present, so consumers can dispatch at
+ * compile time with `if constexpr (test.where.enabled) { ... }`.
+ *
+ * Values use a tagged TypedValue so the parser sniffs the JSON token type
+ * (int / double / bool / string) — no more where_value_int / _double / _bool / _string
+ * suffix proliferation.
  */
 
 #include <array>
+#include <cstddef>
 #include <string_view>
 
 namespace storm::benchmark {
@@ -40,43 +54,139 @@ namespace storm::benchmark {
             return data.data();
         }
 
+        constexpr auto empty() const -> bool {
+            return len == 0;
+        }
+
         constexpr bool operator==(std::string_view other) const {
             return view() == other;
         }
     };
 
-    // Nested WHERE clause structure
-    struct WhereClause {
+    // ========================================================================
+    // TypedValue — tagged union of supported leaf value types
+    // ========================================================================
+    struct TypedValue {
+        enum class Kind : unsigned char { None, Int, Double, Bool, String };
+
+        Kind                kind      = Kind::None;
+        int                 as_int    = 0;
+        double              as_double = 0.0;
+        bool                as_bool   = false;
+        ConstexprString<64> as_string;
+
+        constexpr auto is_set() const -> bool {
+            return kind != Kind::None;
+        }
+    };
+
+    // ========================================================================
+    // WhereSpec — a WHERE clause, optionally combined with a second clause via AND/OR
+    //
+    // Supports leaf operators (>, >=, <, <=, ==, !=, LIKE, BETWEEN, IN,
+    // IS NULL, IS NOT NULL) plus a single optional AND/OR right-hand side.
+    // Two-value operators (BETWEEN) use value2. IN uses in_values.
+    // ========================================================================
+    struct WhereSpec {
+        bool                enabled = false;
         ConstexprString<32> field;
-        ConstexprString<16> op; // Increased for operators like "BETWEEN", "LIKE", "IN", "AND_OR"
+        ConstexprString<16> op;
+        TypedValue          value;
+        TypedValue          value2; // for BETWEEN
 
-        // Union-like for different value types
-        int                 value_int    = 0;
-        double              value_double = 0.0;
-        bool                value_bool   = false;
-        ConstexprString<64> value_string;
-
-        // Second value for BETWEEN operator
-        int    value_int2    = 0;
-        double value_double2 = 0.0;
-
-        // Array values for IN operator (fixed size for compile-time)
         static constexpr size_t        MAX_IN_VALUES = 10;
         std::array<int, MAX_IN_VALUES> in_values_int{};
         size_t                         in_values_count = 0;
 
-        // Second field for complex AND/OR expressions
+        // Optional second clause combined with and/or
+        // We only ever have depth 1 in practice, so we encode as flat second clause
+        // rather than recursive (which would blow up structural-type complexity).
+        bool                combine_and = false; // true if combined with AND
+        bool                combine_or  = false; // true if combined with OR
         ConstexprString<32> field2;
         ConstexprString<8>  op2;
-        int                 value2_int = 0;
-
-        enum class ValueType { None, Int, Double, Bool, String };
-        ValueType value_type = ValueType::None;
-
-        consteval WhereClause() = default;
+        TypedValue          value2_rhs; // right-hand value of the combined clause
     };
 
-    // Main benchmark test with nested structure
+    // ========================================================================
+    // OrderBySpec — one ORDER BY term. Tests use an array of up to 2 terms.
+    // ========================================================================
+    struct OrderBySpec {
+        bool                enabled = false;
+        ConstexprString<32> field;
+        ConstexprString<8>  direction; // "ASC" / "DESC" (empty = ASC)
+        ConstexprString<16> collate;   // "NOCASE" / "BINARY" / "RTRIM" (empty = none)
+    };
+
+    // ========================================================================
+    // HavingSpec — HAVING clause, only valid nested inside GroupBySpec.
+    // ========================================================================
+    struct HavingSpec {
+        bool                enabled = false;
+        ConstexprString<32> field;
+        ConstexprString<16> op;
+        TypedValue          value;
+    };
+
+    // ========================================================================
+    // GroupBySpec — one or more GROUP BY fields, optional HAVING.
+    // ========================================================================
+    struct GroupBySpec {
+        bool                                        enabled    = false;
+        static constexpr size_t                     MAX_FIELDS = 2;
+        std::array<ConstexprString<32>, MAX_FIELDS> fields{};
+        size_t                                      field_count = 0;
+        HavingSpec                                  having;
+    };
+
+    // ========================================================================
+    // DistinctSpec — SELECT DISTINCT over 1..3 fields.
+    // ========================================================================
+    struct DistinctSpec {
+        bool                                        enabled    = false;
+        static constexpr size_t                     MAX_FIELDS = 3;
+        std::array<ConstexprString<32>, MAX_FIELDS> fields{};
+        size_t                                      field_count = 0;
+    };
+
+    // ========================================================================
+    // LimitSpec — LIMIT and/or OFFSET. `enabled` is true if either is set.
+    // ========================================================================
+    struct LimitSpec {
+        bool enabled = false;
+        int  value   = 0; // 0 = no LIMIT
+        int  offset  = 0; // 0 = no OFFSET
+    };
+
+    // ========================================================================
+    // AggregateSpec — aggregate function (count/sum/avg/min/max/count_distinct)
+    // over an optional field. `count` with empty field means COUNT(*).
+    // ========================================================================
+    struct AggregateSpec {
+        bool                enabled = false;
+        ConstexprString<16> func;  // "count" / "sum" / "avg" / "min" / "max" / "count_distinct"
+        ConstexprString<32> field; // optional — empty means COUNT(*)
+    };
+
+    // ========================================================================
+    // JoinSpec — JOIN configuration. Reserved for PR2 (schema-driven JOINs).
+    // In PR1 this is parsed-but-unused; existing run_*_operation methods
+    // continue to hardcode JOIN types until PR2.
+    // ========================================================================
+    struct JoinSpec {
+        bool                enabled = false;
+        ConstexprString<8>  type;    // "inner" / "left" / "right"
+        ConstexprString<32> related; // related model name ("User")
+        ConstexprString<32> fk;      // FK field name ("sender")
+        // Multi-FK support (up to 2 for now)
+        static constexpr size_t                  MAX_FKS = 2;
+        std::array<ConstexprString<32>, MAX_FKS> fks{};
+        size_t                                   fk_count = 0;
+    };
+
+    // ========================================================================
+    // BenchmarkTest — nested top-level test definition.
+    // ========================================================================
     struct BenchmarkTest { // NOSONAR(cpp:S1820)
         ConstexprString<64>  test_name;
         ConstexprString<32>  test_category;
@@ -84,51 +194,31 @@ namespace storm::benchmark {
         ConstexprString<32>  model;
         ConstexprString<32>  operation;
 
-        // Nested WHERE clause
-        WhereClause where;
+        // Nested specs
+        WhereSpec                             where;
+        static constexpr size_t               MAX_ORDER_BY = 2;
+        std::array<OrderBySpec, MAX_ORDER_BY> order_by{};
+        size_t                                order_by_count = 0;
+        GroupBySpec                           group_by;
+        DistinctSpec                          distinct;
+        LimitSpec                             limit;
+        AggregateSpec                         aggregate;
+        JoinSpec                              join;
 
-        // Aggregate field (for SUM, AVG, MIN, MAX, COUNT(field), COUNT(DISTINCT))
-        ConstexprString<32> aggregate_field;
-
-        // Distinct field (for SELECT DISTINCT operations)
-        ConstexprString<32> distinct_field;
-        ConstexprString<32> distinct_field2; // Second field for multi-field DISTINCT
-        ConstexprString<32> distinct_field3; // Third field for multi-field DISTINCT
-
-        // Test parameters
+        // Scalar test parameters
         int iterations   = 1000;
         int dataset_size = 10000;
-        int batch_size   = 1; // For batch operations (1 = single operation)
-
-        // LIMIT/OFFSET clause parameters
-        int limit_value  = 0; // 0 = no LIMIT, > 0 = LIMIT n
-        int offset_value = 0; // 0 = no OFFSET, > 0 = OFFSET n
-
-        // ORDER BY clause parameters
-        ConstexprString<32> order_by_field;      // Field name to order by (empty = no ORDER BY)
-        ConstexprString<8>  order_by_direction;  // "ASC" or "DESC" (empty = default ASC)
-        ConstexprString<16> order_by_collate;    // "NOCASE", "BINARY", "RTRIM" (empty = no COLLATE)
-        ConstexprString<32> order_by_field2;     // Second field for multi-field ORDER BY
-        ConstexprString<8>  order_by_direction2; // "ASC" or "DESC" for second field
-
-        // GROUP BY clause parameters
-        ConstexprString<32> group_by_field;  // Field name to group by (empty = no GROUP BY)
-        ConstexprString<32> group_by_field2; // Second field for multi-field GROUP BY
-
-        // HAVING clause parameters
-        ConstexprString<32> having_field;         // Field name for HAVING condition
-        int                 having_value_int = 0; // Integer value for HAVING comparison
+        int batch_size   = 1;
 
         // Size profile for automatic iteration over sizes
         // Values: "none", "batch_standard", "batch_insert_edge", "batch_update_edge",
         //         "dataset_standard", "dataset_small"
-        ConstexprString<32> size_profile; // Empty or "none" = non-scaled test (run once)
+        ConstexprString<32> size_profile;
 
         consteval BenchmarkTest() = default;
     };
 
-    // Note: BENCHMARK_TESTS will be defined after including benchmark_json_parser.hpp
-    // Forward declaration only
+    // Forward declaration — defined in parser.hpp
     consteval auto load_benchmark_tests();
 
 } // namespace storm::benchmark

--- a/benchmarks/scripts/yaml_to_json.py
+++ b/benchmarks/scripts/yaml_to_json.py
@@ -2,8 +2,8 @@
 """
 Convert benchmark_tests.yaml to benchmark_tests.json
 
-This script converts the human-friendly YAML benchmark definitions
-to JSON format for compile-time parsing with C++26 #embed.
+Reads the nested-format YAML benchmark definitions and emits JSON that the
+compile-time C++ parser (parser.hpp) consumes via #embed.
 
 Usage:
     python yaml_to_json.py [input.yaml] [output.json]
@@ -12,250 +12,146 @@ If no arguments provided, uses default paths:
     Input:  benchmarks/tests/benchmark_tests.yaml
     Output: benchmarks/tests/benchmark_tests.json
 
-Note: Uses built-in simple YAML parser (no external dependencies required).
-      Supports the subset of YAML used by benchmark definitions.
+Requires PyYAML.
 """
 
 import json
 import sys
 from pathlib import Path
 
-
-def parse_yaml_value(value: str):
-    """Parse a YAML value string into Python type."""
-    value = value.strip()
-
-    if not value:
-        return None
-
-    # Handle quoted strings
-    if (value.startswith('"') and value.endswith('"')) or \
-       (value.startswith("'") and value.endswith("'")):
-        return value[1:-1]
-
-    # Handle booleans
-    if value.lower() == 'true':
-        return True
-    if value.lower() == 'false':
-        return False
-
-    # Handle null
-    if value.lower() in ('null', '~'):
-        return None
-
-    # Handle numbers
-    try:
-        if '.' in value:
-            return float(value)
-        return int(value)
-    except ValueError:
-        pass
-
-    # Handle inline arrays [1, 2, 3]
-    if value.startswith('[') and value.endswith(']'):
-        inner = value[1:-1].strip()
-        if not inner:
-            return []
-        items = [parse_yaml_value(item.strip()) for item in inner.split(',')]
-        return items
-
-    # Return as string
-    return value
+try:
+    import yaml  # type: ignore
+except ImportError:
+    print("Error: PyYAML is required. Install with: pip install pyyaml", file=sys.stderr)
+    sys.exit(1)
 
 
-class _YamlParserState:
-    """Mutable state for the simple YAML parser."""
+# Top-level keys from YAML to JSON (with 'test_' prefix where parser.hpp expects it)
+TOP_LEVEL_RENAME = {
+    "name": "test_name",
+    "category": "test_category",
+}
 
-    def __init__(self):
-        self.result = {}
-        self.in_list = False
-        self.list_key = None
-        self.list_items = []
-        self.current_item = None
-        self.list_item_indent = 0
+# Nested spec keys that are passed through as-is
+NESTED_KEYS = {"where", "order_by", "group_by", "distinct", "limit", "aggregate", "join"}
 
-    def finalize_list(self):
-        """Save the current list into result and reset list state."""
-        if self.current_item is not None:
-            self.list_items.append(self.current_item)
-        self.result[self.list_key] = self.list_items
-        self.in_list = False
-        self.list_key = None
-        self.list_items = []
-        self.current_item = None
-
-
-def _parse_list_item_start(state: _YamlParserState, stripped: str, indent: int):
-    """Handle a '- ' prefixed list item line."""
-    if not state.in_list:
-        return
-
-    # Save previous item if exists
-    if state.current_item is not None:
-        state.list_items.append(state.current_item)
-
-    rest = stripped[2:].strip()
-    state.list_item_indent = indent
-
-    if ':' in rest:
-        key, _, value = rest.partition(':')
-        state.current_item = {}
-        value = value.strip()
-        if value:
-            state.current_item[key.strip()] = parse_yaml_value(value)
-    else:
-        state.current_item = parse_yaml_value(rest)
+# Scalar top-level keys that are passed through as-is
+SCALAR_PASSTHROUGH = {
+    "description",
+    "model",
+    "operation",
+    "iterations",
+    "dataset_size",
+    "batch_size",
+    "size_profile",
+}
 
 
-def _parse_nested_list_kv(state: _YamlParserState, stripped: str):
-    """Handle a nested key-value pair inside a list item."""
-    if not isinstance(state.current_item, dict):
-        return
-    key, _, value = stripped.partition(':')
-    value = value.strip()
-    if value:
-        state.current_item[key.strip()] = parse_yaml_value(value)
+def typed_value(v):
+    """Wrap a scalar in the {kind, value} form that parser.hpp's parse_typed_value expects."""
+    if isinstance(v, bool):
+        return {"kind": "bool", "value": v}
+    if isinstance(v, int):
+        return {"kind": "int", "value": v}
+    if isinstance(v, float):
+        return {"kind": "double", "value": v}
+    if isinstance(v, str):
+        return {"kind": "string", "value": v}
+    raise TypeError(f"Unsupported scalar type for typed_value: {type(v).__name__}")
 
 
-def _parse_top_level_kv(state: _YamlParserState, stripped: str):
-    """Handle a top-level key-value pair (outside any list)."""
-    key, _, value = stripped.partition(':')
-    key = key.strip()
-    value = value.strip()
-
-    if value:
-        state.result[key] = parse_yaml_value(value)
-    else:
-        # Assume it starts a list
-        state.in_list = True
-        state.list_key = key
-        state.list_items = []
-        state.current_item = None
+def transform_where(w: dict) -> dict:
+    """Wrap raw YAML scalar values in the TypedValue envelope."""
+    out = {}
+    for k, v in w.items():
+        if k in ("value", "value2", "value2_rhs"):
+            out[k] = typed_value(v)
+        elif k == "in_values":
+            out[k] = list(v)  # array of ints, stays flat
+        else:
+            out[k] = v
+    return out
 
 
-def parse_simple_yaml(yaml_content: str) -> dict:
-    """
-    Parse a simple subset of YAML used by benchmark definitions.
+def transform_having(h: dict) -> dict:
+    out = {}
+    for k, v in h.items():
+        if k == "value":
+            out[k] = typed_value(v)
+        else:
+            out[k] = v
+    return out
 
-    Supports:
-    - Comments (#)
-    - Key-value pairs
-    - Lists (with - prefix)
-    - Nested objects (via indentation)
-    - Inline arrays [1, 2, 3]
-    - Strings, integers, floats, booleans
-    """
-    state = _YamlParserState()
 
-    for line in yaml_content.split('\n'):
-        stripped = line.strip()
-        if not stripped or stripped.startswith('#'):
-            continue
+def transform_group_by(g: dict) -> dict:
+    out = {}
+    for k, v in g.items():
+        if k == "having":
+            out[k] = transform_having(v)
+        else:
+            out[k] = v
+    return out
 
-        indent = len(line) - len(line.lstrip())
 
-        # Check if we're ending a list (dedent)
-        if state.in_list and indent == 0 and not stripped.startswith('-'):
-            state.finalize_list()
+def transform_test(test: dict) -> dict:
+    """Transform one YAML test entry into the JSON shape parser.hpp expects."""
+    out: dict = {}
 
-        # Dispatch to appropriate handler
-        if stripped.startswith('- '):
-            _parse_list_item_start(state, stripped, indent)
-        elif state.in_list and indent > state.list_item_indent and ':' in stripped:
-            _parse_nested_list_kv(state, stripped)
-        elif ':' in stripped and not state.in_list:
-            _parse_top_level_kv(state, stripped)
+    for yaml_key, json_key in TOP_LEVEL_RENAME.items():
+        if yaml_key in test and test[yaml_key] is not None:
+            out[json_key] = test[yaml_key]
 
-    # Don't forget the last item/list
-    if state.in_list:
-        state.finalize_list()
+    for key in SCALAR_PASSTHROUGH:
+        if key in test and test[key] is not None:
+            out[key] = test[key]
 
-    return state.result
+    if "where" in test and test["where"]:
+        out["where"] = transform_where(test["where"])
+
+    if "order_by" in test and test["order_by"]:
+        out["order_by"] = list(test["order_by"])  # array of OrderBySpec dicts
+
+    if "group_by" in test and test["group_by"]:
+        out["group_by"] = transform_group_by(test["group_by"])
+
+    if "distinct" in test and test["distinct"]:
+        out["distinct"] = test["distinct"]
+
+    if "limit" in test and test["limit"]:
+        out["limit"] = test["limit"]
+
+    if "aggregate" in test and test["aggregate"]:
+        out["aggregate"] = test["aggregate"]
+
+    if "join" in test and test["join"]:
+        out["join"] = test["join"]
+
+    return out
 
 
 def convert_yaml_to_json(yaml_path: Path, json_path: Path) -> None:
-    """Convert YAML benchmark definitions to JSON format."""
+    with open(yaml_path) as f:
+        data = yaml.safe_load(f)
 
-    # Read YAML
-    with open(yaml_path, 'r') as f:
-        yaml_content = f.read()
-
-    data = parse_simple_yaml(yaml_content)
-
-    if 'tests' not in data:
-        print("Error: YAML file must have a 'tests' key", file=sys.stderr)
-        print(f"Parsed keys: {list(data.keys())}", file=sys.stderr)
+    if not isinstance(data, dict) or "tests" not in data:
+        print("Error: YAML file must have a top-level 'tests' key", file=sys.stderr)
         sys.exit(1)
 
-    tests = data['tests']
-
+    tests = data["tests"]
     if tests is None:
-        print("Error: 'tests' is None - parsing failed", file=sys.stderr)
+        print("Error: 'tests' is None — parsing failed", file=sys.stderr)
         sys.exit(1)
 
-    # Transform YAML format to JSON format expected by C++ parser
-    json_tests = []
-    for test in tests:
-        if not isinstance(test, dict):
-            continue
+    json_tests = [transform_test(t) for t in tests if isinstance(t, dict)]
 
-        json_test = {}
-
-        # Map YAML keys to JSON keys (with test_ prefix where needed)
-        key_mapping = {
-            'name': 'test_name',
-            'category': 'test_category',
-            'description': 'description',
-            'model': 'model',
-            'operation': 'operation',
-            'size_profile': 'size_profile',
-            'iterations': 'iterations',
-            'dataset_size': 'dataset_size',
-            'batch_size': 'batch_size',
-            'where_field': 'where_field',
-            'where_op': 'where_op',
-            'where_value_int': 'where_value_int',
-            'where_value_int2': 'where_value_int2',
-            'where_value_double': 'where_value_double',
-            'where_value_bool': 'where_value_bool',
-            'where_value_string': 'where_value_string',
-            'where_field2': 'where_field2',
-            'where_op2': 'where_op2',
-            'where_value2_int': 'where_value2_int',
-            'where_in_values': 'where_in_values',
-            'distinct_field': 'distinct_field',
-            'distinct_field2': 'distinct_field2',
-            'distinct_field3': 'distinct_field3',
-            'aggregate_field': 'aggregate_field',
-            'limit_value': 'limit_value',
-            'offset_value': 'offset_value',
-            'order_by_field': 'order_by_field',
-            'order_by_direction': 'order_by_direction',
-            'order_by_field2': 'order_by_field2',
-            'order_by_direction2': 'order_by_direction2',
-            'group_by_field': 'group_by_field',
-            'group_by_field2': 'group_by_field2',
-            'having_field': 'having_field',
-            'having_value_int': 'having_value_int',
-        }
-
-        for yaml_key, json_key in key_mapping.items():
-            if yaml_key in test and test[yaml_key] is not None:
-                json_test[json_key] = test[yaml_key]
-
-        if json_test:  # Only add non-empty tests
-            json_tests.append(json_test)
-
-    # Write JSON with nice formatting
-    with open(json_path, 'w') as f:
+    with open(json_path, "w") as f:
         json.dump(json_tests, f, indent=2)
-        f.write('\n')  # Trailing newline
+        f.write("\n")
 
     print(f"Converted {len(json_tests)} tests: {yaml_path} -> {json_path}")
 
 
 def main():
-    # Determine paths
     script_dir = Path(__file__).parent
     benchmarks_dir = script_dir.parent
 
@@ -264,10 +160,10 @@ def main():
         json_path = Path(sys.argv[2])
     elif len(sys.argv) == 2:
         yaml_path = Path(sys.argv[1])
-        json_path = yaml_path.with_suffix('.json')
+        json_path = yaml_path.with_suffix(".json")
     else:
-        yaml_path = benchmarks_dir / 'tests' / 'benchmark_tests.yaml'
-        json_path = benchmarks_dir / 'tests' / 'benchmark_tests.json'
+        yaml_path = benchmarks_dir / "tests" / "benchmark_tests.yaml"
+        json_path = benchmarks_dir / "tests" / "benchmark_tests.json"
 
     if not yaml_path.exists():
         print(f"Error: YAML file not found: {yaml_path}", file=sys.stderr)
@@ -276,5 +172,5 @@ def main():
     convert_yaml_to_json(yaml_path, json_path)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/benchmarks/tests/benchmark_tests.yaml
+++ b/benchmarks/tests/benchmark_tests.yaml
@@ -17,65 +17,69 @@ tests:
     description: "WHERE with integer > comparison (age > 30)"
     model: Person
     operation: where
-    where_field: age
-    where_op: ">"
-    where_value_int: 30
     iterations: 1000
     dataset_size: 10000
+    where:
+        field: age
+        op: ">"
+        value: 30
 
   - name: where_bool_equality
     category: WHERE
-    description: "WHERE with boolean equality (is_active == true)"
+    description: WHERE with boolean equality (is_active == true)
     model: Person
     operation: where
-    where_field: is_active
-    where_op: "=="
-    where_value_bool: true
     iterations: 1000
     dataset_size: 10000
+    where:
+        field: is_active
+        op: ==
+        value: true
 
   - name: where_double_comparison
     category: WHERE
     description: "WHERE with double >= comparison (salary >= 50000.0)"
     model: Person
     operation: where
-    where_field: salary
-    where_op: ">="
-    where_value_double: 50000.0
     iterations: 1000
     dataset_size: 10000
+    where:
+        field: salary
+        op: ">="
+        value: 50000.0
 
   - name: where_int_less_than
     category: WHERE
-    description: "WHERE with integer < comparison (age < 25)"
+    description: WHERE with integer < comparison (age < 25)
     model: Person
     operation: where
-    where_field: age
-    where_op: "<"
-    where_value_int: 25
     iterations: 1000
     dataset_size: 10000
+    where:
+        field: age
+        op: <
+        value: 25
 
   # ============================================================================
   # INSERT Operations (with size profiles)
   # ============================================================================
   - name: insert
     category: INSERT
-    description: "INSERT operations with various batch sizes"
+    description: INSERT operations with various batch sizes
     model: Person
     operation: insert
     size_profile: batch_standard
 
   - name: insert_no_return
     category: INSERT
-    description: "INSERT without RETURNING clause (no ID retrieval)"
+    description: INSERT without RETURNING clause (no ID retrieval)
     model: Person
     operation: insert_no_return
     size_profile: batch_standard
 
   - name: insert_edge
     category: INSERT_EDGE
-    description: "INSERT at SQLite chunk boundary (999/4 fields = 249)"
+    description: INSERT at SQLite chunk boundary (999/4 fields = 249)
     model: Person
     operation: insert
     size_profile: batch_insert_edge
@@ -85,14 +89,14 @@ tests:
   # ============================================================================
   - name: update_pk
     category: UPDATE_PK
-    description: "UPDATE by primary key with various batch sizes"
+    description: UPDATE by primary key with various batch sizes
     model: Person
     operation: update_pk
     size_profile: batch_standard
 
   - name: update_pk_edge
     category: UPDATE_PK_EDGE
-    description: "UPDATE at SQLite chunk boundary (999/5 fields = 199)"
+    description: UPDATE at SQLite chunk boundary (999/5 fields = 199)
     model: Person
     operation: update_pk
     size_profile: batch_update_edge
@@ -102,7 +106,7 @@ tests:
   # ============================================================================
   - name: delete_pk
     category: DELETE_PK
-    description: "DELETE by primary key with various batch sizes"
+    description: DELETE by primary key with various batch sizes
     model: Person
     operation: delete_pk
     size_profile: batch_standard
@@ -112,7 +116,7 @@ tests:
   # ============================================================================
   - name: select
     category: SELECT
-    description: "Simple SELECT all rows"
+    description: Simple SELECT all rows
     model: Person
     operation: select
     size_profile: dataset_standard
@@ -122,7 +126,7 @@ tests:
   # ============================================================================
   - name: select_join
     category: SELECT_JOIN
-    description: "SELECT with INNER JOIN on FK field"
+    description: SELECT with INNER JOIN on FK field
     model: FKMessage
     operation: select_join
     size_profile: dataset_standard
@@ -132,14 +136,15 @@ tests:
     description: "SELECT with WHERE + JOIN (User.age > 30)"
     model: FKMessage
     operation: select_where_join
-    where_field: age
-    where_op: ">"
-    where_value_int: 30
     size_profile: dataset_standard
+    where:
+        field: age
+        op: ">"
+        value: 30
 
   - name: select_left_join
     category: SELECT_LEFT_JOIN
-    description: "SELECT with LEFT JOIN on FK field"
+    description: SELECT with LEFT JOIN on FK field
     model: FKMessage
     operation: select_left_join
     size_profile: dataset_standard
@@ -149,14 +154,15 @@ tests:
     description: "SELECT with LEFT JOIN + WHERE (User.age > 30)"
     model: FKMessage
     operation: select_left_join_where
-    where_field: age
-    where_op: ">"
-    where_value_int: 30
     size_profile: dataset_standard
+    where:
+        field: age
+        op: ">"
+        value: 30
 
   - name: select_right_join
     category: SELECT_RIGHT_JOIN
-    description: "SELECT with RIGHT JOIN on FK field"
+    description: SELECT with RIGHT JOIN on FK field
     model: FKMessage
     operation: select_right_join
     size_profile: dataset_standard
@@ -166,14 +172,15 @@ tests:
     description: "SELECT with RIGHT JOIN + WHERE (User.age > 30)"
     model: FKMessage
     operation: select_right_join_where
-    where_field: age
-    where_op: ">"
-    where_value_int: 30
     size_profile: dataset_standard
+    where:
+        field: age
+        op: ">"
+        value: 30
 
   - name: select_multi_fk_join
     category: SELECT_MULTI_FK_JOIN
-    description: "SELECT with multiple FK JOINs (sender + receiver)"
+    description: SELECT with multiple FK JOINs (sender + receiver)
     model: FKMessage
     operation: select_multi_fk_join
     size_profile: dataset_standard
@@ -190,372 +197,417 @@ tests:
 
   - name: aggregate_count_field
     category: AGGREGATE
-    description: "COUNT(age) aggregate"
+    description: COUNT(age) aggregate
     model: Person
     operation: aggregate_count_field
-    aggregate_field: age
     size_profile: dataset_small
+    aggregate:
+        field: age
 
   - name: aggregate_count_distinct
     category: AGGREGATE
-    description: "COUNT(DISTINCT age) aggregate"
+    description: COUNT(DISTINCT age) aggregate
     model: Person
     operation: aggregate_count_distinct
-    aggregate_field: age
     size_profile: dataset_small
+    aggregate:
+        field: age
 
   - name: aggregate_sum
     category: AGGREGATE
-    description: "SUM(age) aggregate"
+    description: SUM(age) aggregate
     model: Person
     operation: aggregate_sum
-    aggregate_field: age
     size_profile: dataset_small
+    aggregate:
+        field: age
 
   - name: aggregate_avg
     category: AGGREGATE
-    description: "AVG(salary) aggregate"
+    description: AVG(salary) aggregate
     model: Person
     operation: aggregate_avg
-    aggregate_field: salary
     size_profile: dataset_small
+    aggregate:
+        field: salary
 
   - name: aggregate_min
     category: AGGREGATE
-    description: "MIN(age) aggregate"
+    description: MIN(age) aggregate
     model: Person
     operation: aggregate_min
-    aggregate_field: age
     size_profile: dataset_small
+    aggregate:
+        field: age
 
   - name: aggregate_max
     category: AGGREGATE
-    description: "MAX(salary) aggregate"
+    description: MAX(salary) aggregate
     model: Person
     operation: aggregate_max
-    aggregate_field: salary
     size_profile: dataset_small
+    aggregate:
+        field: salary
 
   # ============================================================================
   # DISTINCT Operations (with size profiles)
   # ============================================================================
   - name: distinct_simple
     category: DISTINCT
-    description: "SELECT DISTINCT age"
+    description: SELECT DISTINCT age
     model: Person
     operation: distinct
-    distinct_field: age
     size_profile: dataset_standard
+    distinct:
+        fields: [age]
 
   - name: distinct_where
     category: DISTINCT_WHERE
     description: "SELECT DISTINCT age WHERE salary >= 50000.0"
     model: Person
     operation: distinct_where
-    distinct_field: age
-    where_field: salary
-    where_op: ">="
-    where_value_double: 50000.0
     size_profile: dataset_standard
+    where:
+        field: salary
+        op: ">="
+        value: 50000.0
+    distinct:
+        fields: [age]
 
   - name: distinct_join
     category: DISTINCT_JOIN
-    description: "SELECT DISTINCT text with INNER JOIN"
+    description: SELECT DISTINCT text with INNER JOIN
     model: FKMessage
     operation: distinct_join
-    distinct_field: text
     size_profile: dataset_standard
+    distinct:
+        fields: [text]
 
   - name: distinct_where_join
     category: DISTINCT_WHERE_JOIN
     description: "SELECT DISTINCT text WHERE age > 30 with JOIN"
     model: FKMessage
     operation: distinct_where_join
-    distinct_field: text
-    where_field: age
-    where_op: ">"
-    where_value_int: 30
     size_profile: dataset_standard
+    where:
+        field: age
+        op: ">"
+        value: 30
+    distinct:
+        fields: [text]
 
   # ============================================================================
   # LIMIT/OFFSET Operations (fixed size)
   # ============================================================================
   - name: select_limit_10
     category: SELECT_LIMIT
-    description: "SELECT with LIMIT 10 (from 10000 rows)"
+    description: SELECT with LIMIT 10 (from 10000 rows)
     model: Person
     operation: select_limit
-    limit_value: 10
     iterations: 10000
     dataset_size: 10000
+    limit:
+        value: 10
 
   - name: select_limit_100
     category: SELECT_LIMIT
-    description: "SELECT with LIMIT 100 (from 10000 rows)"
+    description: SELECT with LIMIT 100 (from 10000 rows)
     model: Person
     operation: select_limit
-    limit_value: 100
     iterations: 2000
     dataset_size: 10000
+    limit:
+        value: 100
 
   - name: select_limit_1000
     category: SELECT_LIMIT
-    description: "SELECT with LIMIT 1000 (from 10000 rows)"
+    description: SELECT with LIMIT 1000 (from 10000 rows)
     model: Person
     operation: select_limit
-    limit_value: 1000
     iterations: 200
     dataset_size: 10000
+    limit:
+        value: 1000
 
   - name: select_offset_100
     category: SELECT_OFFSET
     description: "SELECT with OFFSET 100 (from 1000 rows, returns 900)"
     model: Person
     operation: select_offset
-    offset_value: 100
     iterations: 1000
     dataset_size: 1000
+    limit:
+        offset: 100
 
   - name: select_limit_offset_page1
     category: SELECT_LIMIT_OFFSET
     description: "Pagination: LIMIT 100 OFFSET 0 (page 1)"
     model: Person
     operation: select_limit_offset
-    limit_value: 100
-    offset_value: 0
     iterations: 2000
     dataset_size: 10000
+    limit:
+        value: 100
+        offset: 0
 
   - name: select_limit_offset_deep
     category: SELECT_LIMIT_OFFSET
     description: "Deep pagination: LIMIT 100 OFFSET 9000"
     model: Person
     operation: select_limit_offset
-    limit_value: 100
-    offset_value: 9000
     iterations: 2000
     dataset_size: 10000
+    limit:
+        value: 100
+        offset: 9000
 
   - name: select_where_limit_100
     category: SELECT_WHERE_LIMIT
     description: "SELECT WHERE age > 30 LIMIT 100"
     model: Person
     operation: select_where_limit
-    where_field: age
-    where_op: ">"
-    where_value_int: 30
-    limit_value: 100
     iterations: 2000
     dataset_size: 10000
+    where:
+        field: age
+        op: ">"
+        value: 30
+    limit:
+        value: 100
 
   - name: select_join_limit_100
     category: SELECT_JOIN_LIMIT
-    description: "SELECT with JOIN and LIMIT 100"
+    description: SELECT with JOIN and LIMIT 100
     model: FKMessage
     operation: select_join_limit
-    limit_value: 100
     iterations: 2000
     dataset_size: 10000
+    limit:
+        value: 100
 
   - name: select_join_limit_offset_page1
     category: SELECT_JOIN_LIMIT_OFFSET
     description: "JOIN pagination: LIMIT 100 OFFSET 0"
     model: FKMessage
     operation: select_join_limit_offset
-    limit_value: 100
-    offset_value: 0
     iterations: 2000
     dataset_size: 10000
+    limit:
+        value: 100
+        offset: 0
 
   # ============================================================================
   # ORDER BY Operations (fixed size)
   # ============================================================================
   - name: order_by_single_asc
     category: ORDER_BY
-    description: "SELECT ORDER BY age ASC (10000 rows)"
+    description: SELECT ORDER BY age ASC (10000 rows)
     model: Person
     operation: order_by_asc
-    order_by_field: age
-    order_by_direction: ASC
     iterations: 1000
     dataset_size: 10000
+    order_by:
+        - field: age
+          direction: ASC
 
   - name: order_by_single_desc
     category: ORDER_BY
-    description: "SELECT ORDER BY salary DESC (10000 rows)"
+    description: SELECT ORDER BY salary DESC (10000 rows)
     model: Person
     operation: order_by_desc
-    order_by_field: salary
-    order_by_direction: DESC
     iterations: 1000
     dataset_size: 10000
+    order_by:
+        - field: salary
+          direction: DESC
 
   - name: order_by_with_where
     category: ORDER_BY_WHERE
     description: "SELECT WHERE age > 30 ORDER BY salary DESC"
     model: Person
     operation: order_by_where
-    order_by_field: salary
-    order_by_direction: DESC
-    where_field: age
-    where_op: ">"
-    where_value_int: 30
     iterations: 1000
     dataset_size: 10000
+    where:
+        field: age
+        op: ">"
+        value: 30
+    order_by:
+        - field: salary
+          direction: DESC
 
   - name: order_by_with_limit_10
     category: ORDER_BY_LIMIT
     description: "Top-N: SELECT ORDER BY salary DESC LIMIT 10"
     model: Person
     operation: order_by_limit
-    order_by_field: salary
-    order_by_direction: DESC
-    limit_value: 10
     iterations: 5000
     dataset_size: 10000
+    order_by:
+        - field: salary
+          direction: DESC
+    limit:
+        value: 10
 
   # ============================================================================
   # ORDER BY + COLLATE Operations
   # ============================================================================
-
   - name: order_by_collate_nocase_asc
     category: ORDER_BY_COLLATE
-    description: "SELECT ORDER BY name COLLATE NOCASE ASC (10000 rows)"
+    description: SELECT ORDER BY name COLLATE NOCASE ASC (10000 rows)
     model: Person
     operation: order_by_collate
-    order_by_field: name
-    order_by_direction: ASC
-    order_by_collate: NOCASE
     iterations: 1000
     dataset_size: 10000
+    order_by:
+        - field: name
+          direction: ASC
+          collate: NOCASE
 
   - name: order_by_collate_nocase_desc
     category: ORDER_BY_COLLATE
-    description: "SELECT ORDER BY name COLLATE NOCASE DESC (10000 rows)"
+    description: SELECT ORDER BY name COLLATE NOCASE DESC (10000 rows)
     model: Person
     operation: order_by_collate
-    order_by_field: name
-    order_by_direction: DESC
-    order_by_collate: NOCASE
     iterations: 1000
     dataset_size: 10000
+    order_by:
+        - field: name
+          direction: DESC
+          collate: NOCASE
 
   - name: order_by_collate_binary
     category: ORDER_BY_COLLATE
-    description: "SELECT ORDER BY name COLLATE BINARY ASC (10000 rows)"
+    description: SELECT ORDER BY name COLLATE BINARY ASC (10000 rows)
     model: Person
     operation: order_by_collate
-    order_by_field: name
-    order_by_direction: ASC
-    order_by_collate: BINARY
     iterations: 1000
     dataset_size: 10000
+    order_by:
+        - field: name
+          direction: ASC
+          collate: BINARY
 
   - name: order_by_collate_where
     category: ORDER_BY_COLLATE_WHERE
     description: "SELECT WHERE age > 30 ORDER BY name COLLATE NOCASE DESC"
     model: Person
     operation: order_by_collate_where
-    order_by_field: name
-    order_by_direction: DESC
-    order_by_collate: NOCASE
-    where_field: age
-    where_op: ">"
-    where_value_int: 30
     iterations: 1000
     dataset_size: 10000
+    where:
+        field: age
+        op: ">"
+        value: 30
+    order_by:
+        - field: name
+          direction: DESC
+          collate: NOCASE
 
   # ============================================================================
   # GROUP BY Operations (fixed size)
   # ============================================================================
   - name: group_by_single_age
     category: GROUP_BY
-    description: "SELECT GROUP BY age (10000 rows)"
+    description: SELECT GROUP BY age (10000 rows)
     model: Person
     operation: group_by
-    group_by_field: age
     iterations: 1000
     dataset_size: 10000
+    group_by:
+        fields: [age]
 
   - name: group_by_single_is_active
     category: GROUP_BY
-    description: "SELECT GROUP BY is_active (10000 rows)"
+    description: SELECT GROUP BY is_active (10000 rows)
     model: Person
     operation: group_by
-    group_by_field: is_active
     iterations: 1000
     dataset_size: 10000
+    group_by:
+        fields: [is_active]
 
   - name: group_by_with_where_gt
     category: GROUP_BY_WHERE
     description: "SELECT GROUP BY age WHERE salary > 50000"
     model: Person
     operation: group_by_where
-    group_by_field: age
-    where_field: salary
-    where_op: ">"
-    where_value_int: 50000
     iterations: 1000
     dataset_size: 10000
+    where:
+        field: salary
+        op: ">"
+        value: 50000
+    group_by:
+        fields: [age]
 
   - name: group_by_multi_2
     category: GROUP_BY_MULTI
     description: "SELECT GROUP BY age, is_active (10000 rows)"
     model: Person
     operation: group_by_multi_2
-    group_by_field: age
-    group_by_field2: is_active
     iterations: 500
     dataset_size: 10000
+    group_by:
+        fields: [age, is_active]
 
   - name: group_by_with_count
     category: GROUP_BY_COUNT
     description: "SELECT age, COUNT(*) GROUP BY age"
     model: Person
     operation: group_by_with_count
-    group_by_field: age
     iterations: 1000
     dataset_size: 10000
+    group_by:
+        fields: [age]
 
   - name: group_by_with_sum
     category: GROUP_BY_SUM
     description: "SELECT age, SUM(salary) GROUP BY age"
     model: Person
     operation: group_by_with_sum
-    group_by_field: age
-    aggregate_field: salary
     iterations: 1000
     dataset_size: 10000
+    group_by:
+        fields: [age]
+    aggregate:
+        field: salary
 
   - name: group_by_with_avg
     category: GROUP_BY_AVG
     description: "SELECT age, AVG(salary) GROUP BY age"
     model: Person
     operation: group_by_with_avg
-    group_by_field: age
-    aggregate_field: salary
     iterations: 1000
     dataset_size: 10000
+    group_by:
+        fields: [age]
+    aggregate:
+        field: salary
 
   - name: group_by_with_min
     category: GROUP_BY_MIN
     description: "SELECT age, MIN(salary) GROUP BY age"
     model: Person
     operation: group_by_with_min
-    group_by_field: age
-    aggregate_field: salary
     iterations: 1000
     dataset_size: 10000
+    group_by:
+        fields: [age]
+    aggregate:
+        field: salary
 
   - name: group_by_with_max
     category: GROUP_BY_MAX
     description: "SELECT age, MAX(salary) GROUP BY age"
     model: Person
     operation: group_by_with_max
-    group_by_field: age
-    aggregate_field: salary
     iterations: 1000
     dataset_size: 10000
+    group_by:
+        fields: [age]
+    aggregate:
+        field: salary
 
   # ============================================================================
   # GROUP BY + HAVING (fixed size)
@@ -565,23 +617,30 @@ tests:
     description: "SELECT age, COUNT(*) GROUP BY age HAVING age > 30"
     model: Person
     operation: group_by_having_count
-    group_by_field: age
-    having_field: age
-    having_value_int: 30
     iterations: 1000
     dataset_size: 10000
+    group_by:
+        fields: [age]
+        having:
+          field: age
+          op: ">"
+          value: 30
 
   - name: group_by_having_sum
     category: GROUP_BY_HAVING
     description: "SELECT age, SUM(salary) GROUP BY age HAVING age > 30"
     model: Person
     operation: group_by_having_sum
-    group_by_field: age
-    aggregate_field: salary
-    having_field: age
-    having_value_int: 30
     iterations: 1000
     dataset_size: 10000
+    group_by:
+        fields: [age]
+        having:
+          field: age
+          op: ">"
+          value: 30
+    aggregate:
+        field: salary
 
   # ============================================================================
   # Advanced WHERE Operations (fixed size)
@@ -591,90 +650,100 @@ tests:
     description: "WHERE name LIKE 'Person1%'"
     model: Person
     operation: where_like
-    where_field: name
-    where_value_string: "Person1%"
     iterations: 1000
     dataset_size: 10000
+    where:
+        field: name
+        value: "Person1%"
 
   - name: where_like_contains
     category: WHERE_LIKE
     description: "WHERE name LIKE '%son%'"
     model: Person
     operation: where_like
-    where_field: name
-    where_value_string: "%son%"
     iterations: 1000
     dataset_size: 10000
+    where:
+        field: name
+        value: "%son%"
 
   - name: where_between_int
     category: WHERE_BETWEEN
-    description: "WHERE age BETWEEN 25 AND 45"
+    description: WHERE age BETWEEN 25 AND 45
     model: Person
     operation: where_between
-    where_field: age
-    where_value_int: 25
-    where_value_int2: 45
     iterations: 1000
     dataset_size: 10000
+    where:
+        field: age
+        value: 25
+        value2: 45
 
   - name: where_in_small
     category: WHERE_IN
     description: "WHERE age IN (25, 30, 35)"
     model: Person
     operation: where_in
-    where_field: age
-    where_in_values: [25, 30, 35]
     iterations: 1000
     dataset_size: 10000
+    where:
+        field: age
+        in_values: [25, 30, 35]
 
   - name: where_and_simple
     category: WHERE_AND
     description: "WHERE age > 30 AND salary > 50000"
     model: Person
     operation: where_and
-    where_field: age
-    where_op: ">"
-    where_value_int: 30
-    where_field2: salary
-    where_op2: ">"
-    where_value2_int: 50000
     iterations: 1000
     dataset_size: 10000
+    where:
+        field: age
+        op: ">"
+        value: 30
+        field2: salary
+        op2: ">"
+        combine: and
+        value2_rhs: 50000
 
   - name: where_or_simple
     category: WHERE_OR
     description: "WHERE age < 25 OR age > 60"
     model: Person
     operation: where_or
-    where_field: age
-    where_op: "<"
-    where_value_int: 25
-    where_field2: age
-    where_op2: ">"
-    where_value2_int: 60
     iterations: 1000
     dataset_size: 10000
+    where:
+        field: age
+        op: <
+        value: 25
+        field2: age
+        op2: ">"
+        combine: or
+        value2_rhs: 60
 
   # ============================================================================
   # IS NULL / IS NOT NULL (fixed size)
   # ============================================================================
   - name: where_is_null
     category: WHERE_IS_NULL
-    description: "WHERE score IS NULL"
+    description: WHERE score IS NULL
     model: Person
     operation: where_is_null
-    where_field: score
     iterations: 1000
     dataset_size: 10000
+    where:
+        field: score
 
   - name: where_is_not_null
     category: WHERE_IS_NULL
-    description: "WHERE score IS NOT NULL"
+    description: WHERE score IS NOT NULL
     model: Person
     operation: where_is_not_null
-    where_field: score
     iterations: 1000
     dataset_size: 10000
+    where:
+        field: score
 
   # ============================================================================
   # Multi-Field DISTINCT (fixed size)
@@ -684,43 +753,46 @@ tests:
     description: "SELECT DISTINCT name, age (10000 rows)"
     model: Person
     operation: distinct_multi_2
-    distinct_field: name
-    distinct_field2: age
     iterations: 1000
     dataset_size: 10000
+    distinct:
+        fields: [name, age]
 
   - name: distinct_multi_field_3
     category: DISTINCT_MULTI
     description: "SELECT DISTINCT name, age, is_active (10000 rows)"
     model: Person
     operation: distinct_multi_3
-    distinct_field: name
-    distinct_field2: age
-    distinct_field3: is_active
     iterations: 1000
     dataset_size: 10000
+    distinct:
+        fields: [name, age, is_active]
 
   - name: distinct_order_by_asc
     category: DISTINCT_ORDER
-    description: "SELECT DISTINCT age ORDER BY age ASC"
+    description: SELECT DISTINCT age ORDER BY age ASC
     model: Person
     operation: distinct_order_by_asc
-    distinct_field: age
-    order_by_field: age
-    order_by_direction: ASC
     iterations: 1000
     dataset_size: 10000
+    order_by:
+        - field: age
+          direction: ASC
+    distinct:
+        fields: [age]
 
   - name: distinct_order_by_desc
     category: DISTINCT_ORDER
-    description: "SELECT DISTINCT age ORDER BY age DESC"
+    description: SELECT DISTINCT age ORDER BY age DESC
     model: Person
     operation: distinct_order_by_desc
-    distinct_field: age
-    order_by_field: age
-    order_by_direction: DESC
     iterations: 1000
     dataset_size: 10000
+    order_by:
+        - field: age
+          direction: DESC
+    distinct:
+        fields: [age]
 
   # ============================================================================
   # Multi-Field ORDER BY (fixed size)
@@ -730,43 +802,46 @@ tests:
     description: "SELECT ORDER BY age ASC, salary ASC (10000 rows)"
     model: Person
     operation: order_by_multi_2_asc
-    order_by_field: age
-    order_by_direction: ASC
-    order_by_field2: salary
-    order_by_direction2: ASC
     iterations: 1000
     dataset_size: 10000
+    order_by:
+        - field: age
+          direction: ASC
+        - field: salary
+          direction: ASC
 
   - name: order_by_multi_2_desc
     category: ORDER_BY_MULTI
     description: "SELECT ORDER BY age DESC, salary DESC (10000 rows)"
     model: Person
     operation: order_by_multi_2_desc
-    order_by_field: age
-    order_by_direction: DESC
-    order_by_field2: salary
-    order_by_direction2: DESC
     iterations: 1000
     dataset_size: 10000
+    order_by:
+        - field: age
+          direction: DESC
+        - field: salary
+          direction: DESC
 
   - name: order_by_multi_2_mixed
     category: ORDER_BY_MULTI
     description: "SELECT ORDER BY age ASC, salary DESC (10000 rows)"
     model: Person
     operation: order_by_multi_2_mixed
-    order_by_field: age
-    order_by_direction: ASC
-    order_by_field2: salary
-    order_by_direction2: DESC
     iterations: 1000
     dataset_size: 10000
+    order_by:
+        - field: age
+          direction: ASC
+        - field: salary
+          direction: DESC
 
   # ============================================================================
   # FIRST Operations (retrieve first matching row with LIMIT 1)
   # ============================================================================
   - name: first
     category: FIRST
-    description: "FIRST (retrieves first row with LIMIT 1)"
+    description: FIRST (retrieves first row with LIMIT 1)
     model: Person
     operation: first
     size_profile: dataset_standard
@@ -776,68 +851,72 @@ tests:
     description: "FIRST WHERE age > 30"
     model: Person
     operation: first_where
-    where_field: age
-    where_op: ">"
-    where_value_int: 30
     iterations: 10000
     dataset_size: 10000
+    where:
+        field: age
+        op: ">"
+        value: 30
 
   # ============================================================================
   # GET Operations (retrieve exactly one row, error on 0 or >1)
   # ============================================================================
   - name: get_where_eq
     category: GET
-    description: "GET WHERE id == N (single row by PK)"
+    description: GET WHERE id == N (single row by PK)
     model: Person
     operation: get_where
-    where_field: id
-    where_op: "=="
-    where_value_int: 1
     iterations: 10000
     dataset_size: 10000
+    where:
+        field: id
+        op: ==
+        value: 1
 
   # ============================================================================
   # SET OPERATIONS (UNION, UNION ALL, EXCEPT, INTERSECT)
   # ============================================================================
   - name: setop_union
     category: SETOP
-    description: "UNION with WHERE on both sides"
+    description: UNION with WHERE on both sides
     model: Person
     operation: setop_union
     size_profile: dataset_standard
 
   - name: setop_union_all
     category: SETOP
-    description: "UNION ALL with WHERE on both sides"
+    description: UNION ALL with WHERE on both sides
     model: Person
     operation: setop_union_all
     size_profile: dataset_standard
 
   - name: setop_except
     category: SETOP
-    description: "EXCEPT with WHERE on both sides"
+    description: EXCEPT with WHERE on both sides
     model: Person
     operation: setop_except
     size_profile: dataset_standard
 
   - name: setop_intersect
     category: SETOP
-    description: "INTERSECT with WHERE on both sides"
+    description: INTERSECT with WHERE on both sides
     model: Person
     operation: setop_intersect
     size_profile: dataset_standard
 
   - name: setop_union_order_by
     category: SETOP_ORDER
-    description: "UNION + ORDER BY age ASC"
+    description: UNION + ORDER BY age ASC
     model: Person
     operation: setop_union_order_by
     size_profile: dataset_standard
 
   - name: setop_union_limit
     category: SETOP_LIMIT
-    description: "UNION + LIMIT 100"
+    description: UNION + LIMIT 100
     model: Person
     operation: setop_union_limit
-    limit_value: 100
     size_profile: dataset_standard
+    limit:
+        value: 100
+


### PR DESCRIPTION
## Summary

Migrates `BenchmarkTest` (schema.hpp), `benchmark_tests.yaml`/`.json`, and `runner.hpp` from a flat layout to a nested one. Preparatory work for #190 (the big dispatch-collapse refactor).

- **Schema** — flat `where_field` / `where_value_int` / `order_by_field2` / `group_by_field` / `having_value_int` / `limit_value` / `aggregate_field` / … replaced with nested specs: `WhereSpec where`, `OrderBySpec order_by[2]`, `GroupBySpec group_by` (with nested `HavingSpec`), `DistinctSpec distinct`, `LimitSpec limit`, `AggregateSpec aggregate`, `JoinSpec join`.
- **TypedValue** — `where.value` / `having.value` wrap scalars in a tagged union so we stop needing `_int` / `_double` / `_bool` / `_string` suffix proliferation. Type is sniffed from the JSON token.
- **YAML pipeline** — `benchmark_tests.yaml` rewritten in nested form (human-edited source). `yaml_to_json.py` rewritten to use PyYAML and emit nested JSON with `TypedValue`-wrapped scalars; the old hand-rolled flat YAML parser is gone.
- **Parser** — `parser.hpp` gets nested object parsers (`parse_where_into`, `parse_order_by_entry_into`, `parse_group_by_into`, `parse_having_into`, `parse_distinct_into`, `parse_limit_into`, `parse_aggregate_into`, `parse_join_into`) plus `parse_typed_value` for type sniffing.
- **Runner** — ~70 consumer sites in `runner.hpp` mechanically migrated (`test.where.value_int` → `test.where.value.as_int`, `test.aggregate_field` → `test.aggregate.field`, `test.limit_value` → `test.limit.value`, etc.).

## Non-goals

Zero behavioral change. The ~60 `run_*_operation` methods and the 69-branch `else if constexpr` dispatch in `BenchmarkRunner` are **untouched**. Collapsing them into a single `QueryBenchmark<Model, test>` NTTP class lands in follow-up #194 (under parent #190).

## Test plan

- [x] `cmake --build --preset ninja-release` clean (benchmarks + tests + mocks all link)
- [x] `./build/release/benchmarks/storm_bench -c WHERE_AND` — two-clause AND path works end-to-end (YAML → PyYAML → nested JSON → TypedValue parser → runner)
- [x] `./build/release/benchmarks/storm_bench --quick` runs to completion, efficiency numbers within normal noise
- [ ] Full baseline diff (`--thorough` run vs pre-refactor) — deferred until CI green
- [ ] SonarCloud gate green
- [ ] `ninja-asan-ubsan` + `ninja-tsan` clean

Closes #193
Refs #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)