### PR TITLE
refactor(orm): unify aggregate/.../values terminals on .execute() (#195)

### DIFF
--- a/.claude/agents/git.md
+++ b/.claude/agents/git.md
@@ -43,6 +43,36 @@ SKIP_SONAR=1 git commit -m "docs: update README"
 
 The hook automatically: runs clang-format, clang-tidy --fix, re-stages modified files, runs full test suite, runs sonar check, runs benchmark sanity check.
 
+## After Push: Always Create the PR
+
+After a successful `git push` on a `feature/<N>-<description>` branch, **always** create the PR immediately — do not wait to be asked. Exceptions: only skip if the caller explicitly said "push only, do not open PR" or the branch is not issue-linked.
+
+```bash
+# Check if a PR already exists for this branch
+gh pr view --json number,url 2>/dev/null && echo "PR exists" || gh pr create \
+  --base develop \
+  --title "<same subject as the commit>" \
+  --body "$(cat <<'EOF'
+## Summary
+<1-3 bullets describing what changed and why>
+
+## Test plan
+- [ ] `ctest --preset ninja-debug` (SQLite + PG): all pass
+- [ ] `ctest --preset ninja-asan-ubsan`: all pass
+- [ ] `ctest --preset ninja-tsan`: all pass
+- [ ] SonarCloud quality gate clean
+
+Closes #<N>
+EOF
+)"
+```
+
+Rules:
+1. The PR title should match the commit subject (conventional commit form). Keep it ≤70 chars.
+2. The body **must** include `Closes #<N>` so the issue auto-closes on merge.
+3. Populate the `## Test plan` checklist based on verifications the caller already reported — do not invent claims.
+4. After creating the PR, report back the PR URL and number to the caller. Do NOT merge — the caller runs the SonarCloud gate check separately and decides when to merge.
+
 ## Branching & PR Workflow
 
 Per CLAUDE.md rules:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -370,23 +370,23 @@ auto young = base.where(age < 30);    // base unchanged
 auto old   = base.where(age > 50);    // base still unchanged
 
 // Scalar aggregates (no GROUP BY) → .get()
-qs.count().get();                          // int64_t
-qs.sum<^^Person::age>().get();             // int64_t
-qs.avg<^^Person::salary>().get();          // double
+qs.count().execute();                          // int64_t
+qs.sum<^^Person::age>().execute();             // int64_t
+qs.avg<^^Person::salary>().execute();          // double
 
 // GROUP BY with aggregates → .select()
-qs.group_by<^^Person::department>().count().select();
+qs.group_by<^^Person::department>().count().execute();
 
 // HAVING (only with GROUP BY) — filters groups after aggregation
-qs.group_by<^^Person::age>().having(field<^^Person::age>() > 30).count().select();
-qs.group_by<^^Person::dept>().count().having(field<^^Person::dept>() == "Eng").select();
+qs.group_by<^^Person::age>().having(field<^^Person::age>() > 30).count().execute();
+qs.group_by<^^Person::dept>().count().having(field<^^Person::dept>() == "Eng").execute();
 
 // DISTINCT
-qs.distinct<^^Person::name>().select();
+qs.distinct<^^Person::name>().execute();
 
 // Column projection (SELECT specific columns, duplicates preserved)
-qs.values<^^Person::name>().select();                      // plf::hive<std::string>
-qs.values<^^Person::name, ^^Person::age>().select();       // plf::hive<std::tuple<std::string, int>>
+qs.values<^^Person::name>().execute();                      // plf::hive<std::string>
+qs.values<^^Person::name, ^^Person::age>().execute();       // plf::hive<std::tuple<std::string, int>>
 
 // JOIN
 qs.join<Message>().where(...).select();

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -819,7 +819,7 @@ COMMIT;
 - `distinct_where_join_1000` / `distinct_where_join_10000` - DISTINCT with WHERE + JOIN
 
 **What's tested:**
-- **Storm ORM**: Uses `QuerySet::distinct<Field>().select()` with automatic SQL generation
+- **Storm ORM**: Uses `QuerySet::distinct<Field>().execute()` with automatic SQL generation
 - **Raw SQLite**: Manual `SELECT DISTINCT field FROM table` with prepared statements
 - **Fair comparison**: Both versions use prepared statement caching and identical query patterns
 
@@ -904,7 +904,7 @@ class QueryBenchmark : public DataBenchmarkBase<QueryBenchmark<Model, test>, Mod
 - `distinct_order_by_desc_1000` / `distinct_order_by_desc_10000` - DISTINCT + ORDER BY DESC
 
 **What's tested:**
-- **Storm ORM**: Uses `QuerySet::distinct<Field1, Field2>().select()` for multi-field
+- **Storm ORM**: Uses `QuerySet::distinct<Field1, Field2>().execute()` for multi-field
 - **Raw SQLite**: Manual `SELECT DISTINCT field1, field2 FROM table` with prepared statements
 - **Fair comparison**: Both versions use statement caching and identical query patterns
 
@@ -1197,7 +1197,7 @@ class QueryBenchmark : public DataBenchmarkBase<QueryBenchmark<Model, test>, Mod
 - `group_by_multi_2_is_active_age_10000` - 2-field GROUP BY reversed order (10K rows)
 
 **What's tested:**
-- **Storm ORM**: Uses `QuerySet::group_by<Field>().select()` with automatic SQL generation
+- **Storm ORM**: Uses `QuerySet::group_by<Field>().execute()` with automatic SQL generation
 - **Raw SQLite**: Manual `SELECT ... GROUP BY field` with prepared statements
 - **Fair comparison**: Both versions use prepared statement caching
 
@@ -1270,7 +1270,7 @@ class QueryBenchmark : public DataBenchmarkBase<QueryBenchmark<Model, test>, Mod
 - `group_by_with_count_age_100000` - COUNT per age group (100K rows)
 
 **What's tested:**
-- **Storm ORM**: Uses `qs.group_by<field>().count().select()` returning `plf::hive<std::tuple<GroupKeyType, int64_t>>`
+- **Storm ORM**: Uses `qs.group_by<field>().count().execute()` returning `plf::hive<std::tuple<GroupKeyType, int64_t>>`
 - **Raw SQLite**: Manual `SELECT field, COUNT(*) FROM table GROUP BY field`
 - **Fair comparison**: Both count actual groups returned
 
@@ -1286,7 +1286,7 @@ class QueryBenchmark : public DataBenchmarkBase<QueryBenchmark<Model, test>, Mod
 **Key Findings:**
 
 1. **GROUP BY + COUNT achieves near-parity (98.9-100.1%)**
-   - Proper chaining: `group_by<field>().count().select()`
+   - Proper chaining: `group_by<field>().count().execute()`
    - Both Storm and raw SQLite return same group count
 
 2. **Low throughput is expected:**
@@ -1313,7 +1313,7 @@ class QueryBenchmark : public DataBenchmarkBase<QueryBenchmark<Model, test>, Mod
 - `group_by_with_sum_age_salary_100000` - SUM(salary) per age group (100K rows)
 
 **What's tested:**
-- **Storm ORM**: Uses `qs.group_by<field>().sum<agg_field>().select()` returning `plf::hive<std::tuple<GroupKeyType, double>>`
+- **Storm ORM**: Uses `qs.group_by<field>().sum<agg_field>().execute()` returning `plf::hive<std::tuple<GroupKeyType, double>>`
 - **Raw SQLite**: Manual `SELECT field, SUM(agg_field) FROM table GROUP BY field`
 - **Fair comparison**: Both count actual groups returned
 
@@ -1329,7 +1329,7 @@ class QueryBenchmark : public DataBenchmarkBase<QueryBenchmark<Model, test>, Mod
 **Key Findings:**
 
 1. **GROUP BY + SUM achieves near-parity (98.4-99.6%)**
-   - Proper chaining: `group_by<field>().sum<agg_field>().select()`
+   - Proper chaining: `group_by<field>().sum<agg_field>().execute()`
    - Both Storm and raw SQLite return same group count
 
 2. **Low throughput is expected:**

--- a/benchmarks/operations/query_benchmark.hpp
+++ b/benchmarks/operations/query_benchmark.hpp
@@ -675,14 +675,10 @@ namespace storm::benchmark {
         }
 
         // ====================================================================
-        // run_terminal — executes the terminal statement (.execute() vs .select())
+        // run_terminal — executes the terminal statement
         // ====================================================================
         static auto run_terminal(auto& stmt) -> void {
-            if constexpr (is_group_by_op() || is_distinct_op()) {
-                (void)stmt.select();
-            } else {
-                (void)stmt.execute();
-            }
+            (void)stmt.execute();
         }
 
         // Derive QuerySet type from build_qs — it may be finalized (<..., true>)

--- a/docs/COOKBOOK.md
+++ b/docs/COOKBOOK.md
@@ -112,48 +112,48 @@ qs.remove_all();
 
 ```cpp
 // Scalar aggregates (no GROUP BY) — use .get()
-auto count = qs.count().get();                           // int64_t
-auto total = qs.sum<^^Person::salary>().get();           // int64_t
-auto avg   = qs.avg<^^Person::salary>().get();           // double
-auto lo    = qs.min<^^Person::age>().get();              // int64_t
-auto hi    = qs.max<^^Person::age>().get();              // int64_t
+auto count = qs.count().execute();                           // int64_t
+auto total = qs.sum<^^Person::salary>().execute();           // int64_t
+auto avg   = qs.avg<^^Person::salary>().execute();           // double
+auto lo    = qs.min<^^Person::age>().execute();              // int64_t
+auto hi    = qs.max<^^Person::age>().execute();              // int64_t
 
 // With WHERE
-auto active_count = qs.where(field<^^Person::is_active>() == true).count().get();
+auto active_count = qs.where(field<^^Person::is_active>() == true).count().execute();
 ```
 
 ## GROUP BY + HAVING
 
 ```cpp
 // Group and count
-auto groups = qs.group_by<^^Person::is_active>().count().select();
+auto groups = qs.group_by<^^Person::is_active>().count().execute();
 
 // GROUP BY with HAVING
 auto large_groups = qs
     .group_by<^^Person::age>()
     .having(field<^^Person::age>() > 30)
     .count()
-    .select();
+    .execute();
 ```
 
 ## DISTINCT
 
 ```cpp
 // Single field
-auto names = qs.distinct<^^Person::name>().select();
+auto names = qs.distinct<^^Person::name>().execute();
 
 // Multi-field
-auto combos = qs.distinct<^^Person::name, ^^Person::age>().select();
+auto combos = qs.distinct<^^Person::name, ^^Person::age>().execute();
 ```
 
 ## Column Projection (VALUES)
 
 ```cpp
 // Single column → hive<T>
-auto names = qs.values<^^Person::name>().select();  // plf::hive<std::string>
+auto names = qs.values<^^Person::name>().execute();  // plf::hive<std::string>
 
 // Multiple columns → hive<tuple<...>>
-auto pairs = qs.values<^^Person::name, ^^Person::age>().select();
+auto pairs = qs.values<^^Person::name, ^^Person::age>().execute();
 // plf::hive<std::tuple<std::string, int>>
 ```
 

--- a/docs/benchmarks/DISTINCT_ANALYSIS.md
+++ b/docs/benchmarks/DISTINCT_ANALYSIS.md
@@ -46,15 +46,15 @@ class DistinctStatement : private BaseStatement<T> {
 QuerySet<Person> qs;
 
 // Single field DISTINCT (backward compatible)
-auto names = qs.distinct<&Person::name>().select();
+auto names = qs.distinct<&Person::name>().execute();
 // Returns: std::vector<std::string>
 
 // Multiple field DISTINCT
-auto pairs = qs.distinct<&Person::name, &Person::age>().select();
+auto pairs = qs.distinct<&Person::name, &Person::age>().execute();
 // Returns: std::vector<std::tuple<std::string, int>>
 
 // Default to primary key
-auto ids = qs.distinct().select();
+auto ids = qs.distinct().execute();
 // Returns: std::vector<int>
 ```
 

--- a/docs/development/COMMON_TASKS.md
+++ b/docs/development/COMMON_TASKS.md
@@ -223,7 +223,7 @@ void worker_thread() {
     QuerySet<Person> qs{conn};
 
     for (int i = 0; i < 1000; i++) {
-        qs.where(age > 30).distinct<^^Person::name>().select();
+        qs.where(age > 30).distinct<^^Person::name>().execute();
     }
 }
 
@@ -251,30 +251,30 @@ auto results = qs.select();  // Returns plf::hive<Person>
 
 ```cpp
 // Single field - returns plf::hive<std::string>
-auto names = qs.distinct<^^Person::name>().select();
+auto names = qs.distinct<^^Person::name>().execute();
 
 // Multiple fields - returns plf::hive<std::tuple<std::string, int>>
-auto pairs = qs.distinct<^^Person::name, ^^Person::age>().select();
+auto pairs = qs.distinct<^^Person::name, ^^Person::age>().execute();
 
 // values() for specific columns
-auto values = qs.values<^^Person::name, ^^Person::age>().select();
+auto values = qs.values<^^Person::name, ^^Person::age>().execute();
 ```
 
 ### Aggregate Mode (via aggregates)
 
 ```cpp
 // Standalone aggregates - return scalar values via .get()
-auto min_age = qs.min<^^Person::age>().get();
-auto max_age = qs.max<^^Person::age>().get();
-auto count = qs.count().get();
+auto min_age = qs.min<^^Person::age>().execute();
+auto max_age = qs.max<^^Person::age>().execute();
+auto count = qs.count().execute();
 
 // GROUP BY + aggregate - returns tuples
-auto by_dept = qs.group_by<^^Person::department>().count().select();
+auto by_dept = qs.group_by<^^Person::department>().count().execute();
 // Returns: plf::hive<std::tuple<DeptType, int64_t>>
 
 // Multiple GROUP BY fields
 auto by_age_dept = qs.group_by<^^Person::age, ^^Person::department>()
-                     .sum<^^Person::salary>().select();
+                     .sum<^^Person::salary>().execute();
 ```
 
 ### Available Methods

--- a/src/orm/queryset.cppm
+++ b/src/orm/queryset.cppm
@@ -199,10 +199,10 @@ export namespace storm {
 
         // Field-specific DISTINCT support using reflection
         // Usage:
-        //   auto names = queryset.distinct<^^Person::name>().select();  // plf::hive<std::string>
-        //   auto pairs = queryset.distinct<^^Person::name, ^^Person::age>().select();
+        //   auto names = queryset.distinct<^^Person::name>().execute();  // plf::hive<std::string>
+        //   auto pairs = queryset.distinct<^^Person::name, ^^Person::age>().execute();
         //   // Returns plf::hive<std::tuple<std::string, int>>
-        //   auto ids = queryset.distinct().select();  // plf::hive<int> (defaults to PK)
+        //   auto ids = queryset.distinct().execute();  // plf::hive<int> (defaults to PK)
         //
         // OPTIMIZATION: Returns cached DistinctStatement for optimal performance
         // Returns DistinctStatement by value - connection-level prepare_cached() handles SQL caching
@@ -220,8 +220,8 @@ export namespace storm {
 
         // Column projection support using reflection (SELECT specific columns)
         // Usage:
-        //   auto names = queryset.values<^^Person::name>().select();  // plf::hive<std::string>
-        //   auto pairs = queryset.values<^^Person::name, ^^Person::age>().select();
+        //   auto names = queryset.values<^^Person::name>().execute();  // plf::hive<std::string>
+        //   auto pairs = queryset.values<^^Person::name, ^^Person::age>().execute();
         //   // Returns plf::hive<std::tuple<std::string, int>>
         //
         // Unlike distinct(), values() does NOT apply DISTINCT — all rows are returned
@@ -310,9 +310,9 @@ export namespace storm {
 
         // GROUP BY - returns GroupByBuilder for fluent aggregate chaining
         // Usage:
-        //   qs.group_by<^^Person::department>().count().select()    // grouped → .select()
-        //   qs.group_by<^^Person::dept, ^^Person::role>().sum<^^Person::salary>().select()
-        //   qs.where(age > 25).group_by<^^Person::years_exp>().count().select()
+        //   qs.group_by<^^Person::department>().count().execute()    // grouped → .execute()
+        //   qs.group_by<^^Person::dept, ^^Person::role>().sum<^^Person::salary>().execute()
+        //   qs.where(age > 25).group_by<^^Person::years_exp>().count().execute()
         template <std::meta::info... GroupFieldInfos>
             requires(sizeof...(GroupFieldInfos) > 0)
         auto group_by() {
@@ -367,9 +367,9 @@ export namespace storm {
 
         // SUM aggregate (multi-field: SUM(f1 + f2 + ...))
         // Supports WHERE and JOIN clauses
-        // Usage: queryset.sum<^^Person::age>().get()
-        //        queryset.where(age > 30).sum<^^Person::age>().get()
-        //        queryset.join<FK>().sum<^^Person::salary>().get()
+        // Usage: queryset.sum<^^Person::age>().execute()
+        //        queryset.where(age > 30).sum<^^Person::age>().execute()
+        //        queryset.join<FK>().sum<^^Person::salary>().execute()
         // Returns statement by value - connection-level prepare_cached() handles SQL caching
         template <std::meta::info... FieldInfos> auto sum() {
             using StmtType = orm::statements::AggregateStatement<
@@ -382,9 +382,9 @@ export namespace storm {
 
         // COUNT aggregate (defaults to COUNT(*) if no fields)
         // Supports WHERE and JOIN clauses
-        // Usage: queryset.count().get()  // COUNT(*)
-        //        queryset.where(age > 30).count().get()
-        //        queryset.join<FK>().count().get()
+        // Usage: queryset.count().execute()  // COUNT(*)
+        //        queryset.where(age > 30).count().execute()
+        //        queryset.join<FK>().count().execute()
         // Returns statement by value - connection-level prepare_cached() handles SQL caching
         template <std::meta::info... FieldInfos> auto count() {
             using StmtType = orm::statements::AggregateStatement<
@@ -397,8 +397,8 @@ export namespace storm {
 
         // AVG aggregate (multi-field: AVG(f1 + f2 + ...))
         // Supports WHERE and JOIN clauses
-        // Usage: queryset.avg<^^Person::salary>().get()
-        //        queryset.where(department == "Engineering").avg<^^Person::salary>().get()
+        // Usage: queryset.avg<^^Person::salary>().execute()
+        //        queryset.where(department == "Engineering").avg<^^Person::salary>().execute()
         // Returns statement by value - connection-level prepare_cached() handles SQL caching
         template <std::meta::info... FieldInfos> auto avg() {
             using StmtType = orm::statements::AggregateStatement<
@@ -411,8 +411,8 @@ export namespace storm {
 
         // MIN aggregate (multi-field: MIN(f1 + f2 + ...))
         // Supports WHERE and JOIN clauses
-        // Usage: queryset.min<^^Person::age>().get()
-        //        queryset.where(active == true).min<^^Person::age>().get()
+        // Usage: queryset.min<^^Person::age>().execute()
+        //        queryset.where(active == true).min<^^Person::age>().execute()
         // Returns statement by value - connection-level prepare_cached() handles SQL caching
         template <std::meta::info... FieldInfos> auto min() {
             using StmtType = orm::statements::AggregateStatement<
@@ -425,8 +425,8 @@ export namespace storm {
 
         // MAX aggregate (multi-field: MAX(f1 + f2 + ...))
         // Supports WHERE and JOIN clauses
-        // Usage: queryset.max<^^Person::age>().get()
-        //        queryset.where(department == "Sales").max<^^Person::salary>().get()
+        // Usage: queryset.max<^^Person::age>().execute()
+        //        queryset.where(department == "Sales").max<^^Person::salary>().execute()
         // Returns statement by value - connection-level prepare_cached() handles SQL caching
         template <std::meta::info... FieldInfos> auto max() {
             using StmtType = orm::statements::AggregateStatement<
@@ -439,8 +439,8 @@ export namespace storm {
 
         // COUNT(DISTINCT field) aggregate
         // Supports WHERE and JOIN clauses
-        // Usage: queryset.count_distinct<^^Person::age>().get()
-        //        queryset.where(active == true).count_distinct<^^Person::department>().get()
+        // Usage: queryset.count_distinct<^^Person::age>().execute()
+        //        queryset.where(active == true).count_distinct<^^Person::department>().execute()
         // Returns statement by value - connection-level prepare_cached() handles SQL caching
         template <std::meta::info FieldInfo> auto count_distinct() {
             using StmtType = orm::statements::AggregateStatement<

--- a/src/orm/statements/aggregate.cppm
+++ b/src/orm/statements/aggregate.cppm
@@ -277,20 +277,6 @@ export namespace storm::orm::statements {
             return result;
         }
 
-        // Scalar aggregate: no GROUP BY → returns single value via .get()
-        [[nodiscard]] __attribute__((always_inline)) auto get() -> std::expected<ResultType, Error>
-            requires(NumOps > 0 && !HasGroupBy)
-        {
-            return execute();
-        }
-
-        // Grouped aggregate: GROUP BY → returns collection via .select()
-        [[nodiscard]] __attribute__((always_inline)) auto select() -> std::expected<ResultType, Error>
-            requires(NumOps > 0 && HasGroupBy)
-        {
-            return execute();
-        }
-
         [[nodiscard]] __attribute__((flatten)) auto execute() -> std::expected<ResultType, Error>
             requires(NumOps > 0)
         {

--- a/src/orm/statements/distinct.cppm
+++ b/src/orm/statements/distinct.cppm
@@ -41,8 +41,8 @@ export namespace storm::orm::statements {
     // - Instance-level caching eliminates per-call TLS access and object construction
     //
     // API: Use ^^ operator to pass reflected field information directly
-    // Example: qs.distinct<^^Person::name>().select()
-    //          qs.values<^^Person::name, ^^Person::age>().select()
+    // Example: qs.distinct<^^Person::name>().execute()
+    //          qs.values<^^Person::name, ^^Person::age>().execute()
     template <typename T, storm::db::DatabaseConnection ConnType, ProjectionMode Mode, std::meta::info... FieldInfos>
         requires(sizeof...(FieldInfos) > 0)
     class ProjectionStatement : private BaseStatement<T> {
@@ -201,11 +201,6 @@ export namespace storm::orm::statements {
             , limit_(limit)
             , offset_(offset)
             , order_by_wrapper_(order_by_wrapper) {}
-
-        // Alias for execute() - provides familiar QuerySet-like API
-        [[nodiscard]] auto select() -> std::expected<ResultType, Error> {
-            return execute();
-        }
 
         // Return the SQL that would be executed (for testing/debugging)
         [[nodiscard]] auto sql() -> std::string {

--- a/tests/crud/test_crud.cpp
+++ b/tests/crud/test_crud.cpp
@@ -34,7 +34,7 @@ template <typename ConnType> class PersonCrudTestBase : public StormTestFixture<
 
     static auto countPersons() -> int {
         storm::QuerySet<Person, ConnType> qs;
-        auto                              result = qs.count().get();
+        auto                              result = qs.count().execute();
         if (!result.has_value()) {
             return -1;
         }
@@ -454,43 +454,43 @@ TYPED_TEST(QueryResetTest, ReuseSameQuerySetMultipleTimes) {
 }
 
 TYPED_TEST(QueryResetTest, ResetBetweenDifferentOperations) {
-    auto count1 = this->qs->count().get();
+    auto count1 = this->qs->count().execute();
     ASSERT_TRUE(count1.has_value());
     EXPECT_EQ(count1.value(), 25);
 
     this->qs->reset();
 
-    auto sum1 = this->qs->template sum<^^Person::age>().get();
+    auto sum1 = this->qs->template sum<^^Person::age>().execute();
     ASSERT_TRUE(sum1.has_value());
     EXPECT_EQ(sum1.value(), 829);
 
     this->qs->reset();
 
-    auto avg1 = this->qs->template avg<^^Person::age>().get();
+    auto avg1 = this->qs->template avg<^^Person::age>().execute();
     ASSERT_TRUE(avg1.has_value());
     EXPECT_NEAR(avg1.value(), 33.16, 0.01);
 
     this->qs->reset();
 
-    auto min1 = this->qs->template min<^^Person::age>().get();
+    auto min1 = this->qs->template min<^^Person::age>().execute();
     ASSERT_TRUE(min1.has_value());
     EXPECT_EQ(min1.value(), 22);
 
     this->qs->reset();
 
-    auto max1 = this->qs->template max<^^Person::age>().get();
+    auto max1 = this->qs->template max<^^Person::age>().execute();
     ASSERT_TRUE(max1.has_value());
     EXPECT_EQ(max1.value(), 48);
 }
 
 TYPED_TEST(QueryResetTest, AggregatesWithWhere) {
-    auto count = this->qs->where(storm::orm::where::field<^^Person::age>() >= 35).count().get();
+    auto count = this->qs->where(storm::orm::where::field<^^Person::age>() >= 35).count().execute();
     ASSERT_TRUE(count.has_value());
     EXPECT_EQ(count.value(), 11);
 
     this->qs->reset();
 
-    auto sum = this->qs->where(storm::orm::where::field<^^Person::age>() >= 35).template sum<^^Person::age>().get();
+    auto sum = this->qs->where(storm::orm::where::field<^^Person::age>() >= 35).template sum<^^Person::age>().execute();
     ASSERT_TRUE(sum.has_value());
     EXPECT_EQ(sum.value(), 442);
 }
@@ -511,7 +511,7 @@ TYPED_TEST(InsertNoReturnTest, SingleInsertNoReturnSucceeds) {
 
     ASSERT_TRUE(result.has_value()) << "insert<ReturnId::No> should succeed";
 
-    auto count = qs.count().get();
+    auto count = qs.count().execute();
     ASSERT_TRUE(count.has_value());
     EXPECT_EQ(count.value(), 1) << "Should have 1 row after insert";
 }
@@ -591,7 +591,7 @@ TYPED_TEST(InsertNoReturnTest, MultipleInsertNoReturn) {
     ASSERT_TRUE(qs.template insert<ReturnId::No>(bob).execute().has_value());
     ASSERT_TRUE(qs.template insert<ReturnId::No>(charlie).execute().has_value());
 
-    auto count = qs.count().get();
+    auto count = qs.count().execute();
     ASSERT_TRUE(count.has_value());
     EXPECT_EQ(count.value(), 3);
 }
@@ -632,7 +632,7 @@ TYPED_TEST(InsertNoReturnTest, MixedInsertModes) {
     auto         void_result = qs.template insert<ReturnId::No>(bob).execute();
     ASSERT_TRUE(void_result.has_value());
 
-    auto count = qs.count().get();
+    auto count = qs.count().execute();
     ASSERT_TRUE(count.has_value());
     EXPECT_EQ(count.value(), 2);
 }

--- a/tests/crud/test_insert_returning.cpp
+++ b/tests/crud/test_insert_returning.cpp
@@ -101,7 +101,7 @@ TYPED_TEST(BatchInsertReturningTest, SingleElementBatch) {
     EXPECT_GT(result.value()[0], 0) << "Returned ID should be positive";
 
     // Verify count
-    auto count = qs.count().get();
+    auto count = qs.count().execute();
     ASSERT_TRUE(count.has_value());
     EXPECT_EQ(count.value(), 1);
 }
@@ -268,7 +268,7 @@ TYPED_TEST(ChunkedBatchInsertReturningTest, ChunkedBatchReturnsAllIds) {
     }
 
     // Verify total count
-    auto count = qs.count().get();
+    auto count = qs.count().execute();
     ASSERT_TRUE(count.has_value());
     EXPECT_EQ(count.value(), num_records);
 }
@@ -337,7 +337,7 @@ TYPED_TEST(ChunkedBatchInsertReturningTest, MultipleChunksWithRemainder) {
     ASSERT_EQ(result.value().size(), static_cast<size_t>(num_records));
 
     // Verify count
-    auto count = qs.count().get();
+    auto count = qs.count().execute();
     ASSERT_TRUE(count.has_value());
     EXPECT_EQ(count.value(), num_records);
 }
@@ -408,7 +408,7 @@ TYPED_TEST(BatchInsertReturningTest, ExplicitReturnIdNoBatchReturnsVoid) {
     );
     ASSERT_TRUE(result.has_value()) << "Explicit ReturnId::No batch insert should succeed";
 
-    auto count = qs.count().get();
+    auto count = qs.count().execute();
     ASSERT_TRUE(count.has_value());
     EXPECT_EQ(count.value(), 3);
 }

--- a/tests/errors/test_sqlite_errors.cpp
+++ b/tests/errors/test_sqlite_errors.cpp
@@ -967,17 +967,17 @@ TEST_F(ORMErrorTest, AggregateOnEmptyTable) {
     storm::QuerySet<Person> qs;
 
     // COUNT on empty table should return 0
-    auto count_result = qs.count().get();
+    auto count_result = qs.count().execute();
     ASSERT_TRUE(count_result.has_value()) << "COUNT on empty table should succeed";
     EXPECT_EQ(count_result.value(), 0);
 
     // SUM on empty table should return 0 (NULL coerced to 0)
-    auto sum_result = qs.sum<^^Person::age>().get();
+    auto sum_result = qs.sum<^^Person::age>().execute();
     ASSERT_TRUE(sum_result.has_value()) << "SUM on empty table should succeed";
     EXPECT_EQ(sum_result.value(), 0);
 
     // AVG on empty table should return 0.0
-    auto avg_result = qs.avg<^^Person::age>().get();
+    auto avg_result = qs.avg<^^Person::age>().execute();
     ASSERT_TRUE(avg_result.has_value()) << "AVG on empty table should succeed";
     EXPECT_DOUBLE_EQ(avg_result.value(), 0.0);
 }
@@ -991,7 +991,7 @@ TEST_F(ORMErrorTest, AggregateWithWhereNoMatch) {
     ASSERT_TRUE(insert_result.has_value());
 
     // COUNT with WHERE that matches nothing
-    auto count_result = qs.where(storm::orm::where::field<^^Person::age>() > 100).count().get();
+    auto count_result = qs.where(storm::orm::where::field<^^Person::age>() > 100).count().execute();
     ASSERT_TRUE(count_result.has_value()) << "COUNT with no matches should succeed";
     EXPECT_EQ(count_result.value(), 0);
 }
@@ -1000,7 +1000,7 @@ TEST_F(ORMErrorTest, DistinctOnEmptyTable) {
     storm::QuerySet<Person> qs;
 
     // DISTINCT on empty table
-    auto result = qs.distinct<^^Person::name>().select();
+    auto result = qs.distinct<^^Person::name>().execute();
     ASSERT_TRUE(result.has_value()) << "DISTINCT on empty table should succeed";
     EXPECT_TRUE(result.value().empty());
 }
@@ -1009,7 +1009,7 @@ TEST_F(ORMErrorTest, GroupByOnEmptyTable) {
     storm::QuerySet<Person> qs;
 
     // GROUP BY on empty table
-    auto result = qs.group_by<^^Person::age>().count().select();
+    auto result = qs.group_by<^^Person::age>().count().execute();
     ASSERT_TRUE(result.has_value()) << "GROUP BY on empty table should succeed";
     EXPECT_TRUE(result.value().empty());
 }
@@ -1074,7 +1074,7 @@ TEST_F(ORMErrorTest, LargeBatchInsertThenRemove) {
     ASSERT_TRUE(insert_result.has_value()) << "Large batch insert should succeed";
 
     // Verify count
-    auto count_result = qs.count().get();
+    auto count_result = qs.count().execute();
     ASSERT_TRUE(count_result.has_value());
     EXPECT_EQ(count_result.value(), 100);
 
@@ -1093,7 +1093,7 @@ TEST_F(ORMErrorTest, LargeBatchInsertThenRemove) {
     ASSERT_TRUE(remove_result.has_value()) << "Large batch remove should succeed";
 
     // Verify all removed
-    auto final_count = qs.count().get();
+    auto final_count = qs.count().execute();
     ASSERT_TRUE(final_count.has_value());
     EXPECT_EQ(final_count.value(), 0);
 }
@@ -1173,7 +1173,7 @@ TEST_F(ORMErrorTest, ChunkedInsertRollsBackOnConstraintViolation) {
     EXPECT_TRUE((result.error().code() & 0xFF) == SQLITE_CONSTRAINT);
 
     // Verify rollback: only the seed row exists, the first chunk was rolled back too
-    auto count = qs.count().get();
+    auto count = qs.count().execute();
     ASSERT_TRUE(count.has_value());
     EXPECT_EQ(count.value(), 1) << "Transaction rollback should leave only the seeded row";
 }

--- a/tests/mock_sqlite/test_orm_mock_errors.cpp
+++ b/tests/mock_sqlite/test_orm_mock_errors.cpp
@@ -250,7 +250,7 @@ namespace {
         MockSqlite3Config::prepare_returns(SQLITE_ERROR);
 
         QuerySet<MockPerson> qs;
-        auto                 result = qs.count().get();
+        auto                 result = qs.count().execute();
 
         ASSERT_FALSE(result.has_value());
         EXPECT_EQ(result.error().code(), SQLITE_ERROR);
@@ -260,7 +260,7 @@ namespace {
         MockSqlite3Config::step_returns(SQLITE_MISUSE);
 
         QuerySet<MockPerson> qs;
-        auto                 result = qs.sum<^^MockPerson::age>().get();
+        auto                 result = qs.sum<^^MockPerson::age>().execute();
 
         ASSERT_FALSE(result.has_value());
         EXPECT_EQ(result.error().code(), SQLITE_MISUSE);
@@ -270,7 +270,7 @@ namespace {
         MockSqlite3Config::step_returns(SQLITE_NOMEM);
 
         QuerySet<MockPerson> qs;
-        auto                 result = qs.avg<^^MockPerson::age>().get();
+        auto                 result = qs.avg<^^MockPerson::age>().execute();
 
         ASSERT_FALSE(result.has_value());
         EXPECT_EQ(result.error().code(), SQLITE_NOMEM);
@@ -323,7 +323,7 @@ namespace {
         MockSqlite3Config::prepare_returns(SQLITE_ERROR);
 
         QuerySet<MockPerson> qs;
-        auto                 result = qs.distinct<^^MockPerson::name>().select();
+        auto                 result = qs.distinct<^^MockPerson::name>().execute();
 
         ASSERT_FALSE(result.has_value());
         EXPECT_EQ(result.error().code(), SQLITE_ERROR);
@@ -333,7 +333,7 @@ namespace {
         MockSqlite3Config::step_returns(SQLITE_CORRUPT);
 
         QuerySet<MockPerson> qs;
-        auto                 result = qs.distinct<^^MockPerson::name>().select();
+        auto                 result = qs.distinct<^^MockPerson::name>().execute();
 
         ASSERT_FALSE(result.has_value());
         EXPECT_EQ(result.error().code(), SQLITE_CORRUPT);
@@ -347,7 +347,7 @@ namespace {
         MockSqlite3Config::prepare_returns(SQLITE_ERROR);
 
         QuerySet<MockPerson> qs;
-        auto                 result = qs.group_by<^^MockPerson::age>().count().select();
+        auto                 result = qs.group_by<^^MockPerson::age>().count().execute();
 
         ASSERT_FALSE(result.has_value());
         EXPECT_EQ(result.error().code(), SQLITE_ERROR);
@@ -357,7 +357,7 @@ namespace {
         MockSqlite3Config::step_returns(SQLITE_IOERR);
 
         QuerySet<MockPerson> qs;
-        auto                 result = qs.group_by<^^MockPerson::name>().sum<^^MockPerson::age>().select();
+        auto                 result = qs.group_by<^^MockPerson::name>().sum<^^MockPerson::age>().execute();
 
         ASSERT_FALSE(result.has_value());
         EXPECT_EQ(result.error().code(), SQLITE_IOERR);
@@ -543,7 +543,7 @@ namespace {
         MockSqlite3Config::prepare_returns(SQLITE_ERROR);
 
         QuerySet<MockPerson> qs;
-        auto                 result = qs.min<^^MockPerson::age>().get();
+        auto                 result = qs.min<^^MockPerson::age>().execute();
 
         ASSERT_FALSE(result.has_value());
         EXPECT_EQ(result.error().code(), SQLITE_ERROR);
@@ -553,7 +553,7 @@ namespace {
         MockSqlite3Config::step_returns(SQLITE_IOERR);
 
         QuerySet<MockPerson> qs;
-        auto                 result = qs.min<^^MockPerson::age>().get();
+        auto                 result = qs.min<^^MockPerson::age>().execute();
 
         ASSERT_FALSE(result.has_value());
         EXPECT_EQ(result.error().code(), SQLITE_IOERR);
@@ -563,7 +563,7 @@ namespace {
         MockSqlite3Config::prepare_returns(SQLITE_ERROR);
 
         QuerySet<MockPerson> qs;
-        auto                 result = qs.max<^^MockPerson::age>().get();
+        auto                 result = qs.max<^^MockPerson::age>().execute();
 
         ASSERT_FALSE(result.has_value());
         EXPECT_EQ(result.error().code(), SQLITE_ERROR);
@@ -573,7 +573,7 @@ namespace {
         MockSqlite3Config::step_returns(SQLITE_CORRUPT);
 
         QuerySet<MockPerson> qs;
-        auto                 result = qs.max<^^MockPerson::age>().get();
+        auto                 result = qs.max<^^MockPerson::age>().execute();
 
         ASSERT_FALSE(result.has_value());
         EXPECT_EQ(result.error().code(), SQLITE_CORRUPT);
@@ -692,7 +692,7 @@ namespace {
 
         QuerySet<MockPerson> qs;
         auto                 age    = storm::orm::where::Field<^^MockPerson::age>{};
-        auto                 result = qs.where(age > 25).distinct<^^MockPerson::name>().select();
+        auto                 result = qs.where(age > 25).distinct<^^MockPerson::name>().execute();
 
         if (!result.has_value()) {
             EXPECT_EQ(result.error().code(), SQLITE_NOMEM);
@@ -703,7 +703,7 @@ namespace {
         MockSqlite3Config::step_returns(SQLITE_IOERR);
 
         QuerySet<MockPerson> qs;
-        auto                 result = qs.distinct<^^MockPerson::name, ^^MockPerson::age>().select();
+        auto                 result = qs.distinct<^^MockPerson::name, ^^MockPerson::age>().execute();
 
         ASSERT_FALSE(result.has_value());
         EXPECT_EQ(result.error().code(), SQLITE_IOERR);
@@ -718,7 +718,7 @@ namespace {
 
         QuerySet<MockPerson> qs;
         auto                 age    = storm::orm::where::Field<^^MockPerson::age>{};
-        auto                 result = qs.where(age > 25).group_by<^^MockPerson::name>().count().select();
+        auto                 result = qs.where(age > 25).group_by<^^MockPerson::name>().count().execute();
 
         if (!result.has_value()) {
             EXPECT_EQ(result.error().code(), SQLITE_NOMEM);
@@ -729,7 +729,7 @@ namespace {
         MockSqlite3Config::step_returns(SQLITE_CORRUPT);
 
         QuerySet<MockPerson> qs;
-        auto                 result = qs.group_by<^^MockPerson::name>().avg<^^MockPerson::age>().select();
+        auto                 result = qs.group_by<^^MockPerson::name>().avg<^^MockPerson::age>().execute();
 
         ASSERT_FALSE(result.has_value());
         EXPECT_EQ(result.error().code(), SQLITE_CORRUPT);
@@ -739,7 +739,7 @@ namespace {
         MockSqlite3Config::step_returns(SQLITE_NOMEM);
 
         QuerySet<MockPerson> qs;
-        auto                 result = qs.group_by<^^MockPerson::name>().min<^^MockPerson::age>().select();
+        auto                 result = qs.group_by<^^MockPerson::name>().min<^^MockPerson::age>().execute();
 
         ASSERT_FALSE(result.has_value());
         EXPECT_EQ(result.error().code(), SQLITE_NOMEM);
@@ -749,7 +749,7 @@ namespace {
         MockSqlite3Config::step_returns(SQLITE_BUSY);
 
         QuerySet<MockPerson> qs;
-        auto                 result = qs.group_by<^^MockPerson::name>().max<^^MockPerson::age>().select();
+        auto                 result = qs.group_by<^^MockPerson::name>().max<^^MockPerson::age>().execute();
 
         ASSERT_FALSE(result.has_value());
         EXPECT_EQ(result.error().code(), SQLITE_BUSY);
@@ -870,7 +870,7 @@ namespace {
         MockSqlite3Config::step_returns_sequence({SQLITE_ROW, SQLITE_IOERR});
 
         QuerySet<MockPerson> qs;
-        auto                 result = qs.distinct<^^MockPerson::name>().select();
+        auto                 result = qs.distinct<^^MockPerson::name>().execute();
 
         ASSERT_FALSE(result.has_value());
         EXPECT_EQ(result.error().code(), SQLITE_IOERR);
@@ -932,7 +932,7 @@ namespace {
 
         QuerySet<MockPerson> qs;
         auto                 age    = storm::orm::where::Field<^^MockPerson::age>{};
-        auto                 result = qs.where(age > 25).count().get();
+        auto                 result = qs.where(age > 25).count().execute();
 
         if (!result.has_value()) {
             EXPECT_EQ(result.error().code(), SQLITE_NOMEM);
@@ -944,7 +944,7 @@ namespace {
 
         QuerySet<MockPerson> qs;
         auto                 age    = storm::orm::where::Field<^^MockPerson::age>{};
-        auto                 result = qs.where(age > 25).sum<^^MockPerson::age>().get();
+        auto                 result = qs.where(age > 25).sum<^^MockPerson::age>().execute();
 
         if (!result.has_value()) {
             EXPECT_EQ(result.error().code(), SQLITE_NOMEM);
@@ -1049,7 +1049,7 @@ namespace {
         MockSqlite3Config::prepare_returns(SQLITE_ERROR);
 
         QuerySet<MockPerson> qs;
-        auto                 result = qs.order_by<^^MockPerson::age>().limit(5).distinct<^^MockPerson::name>().select();
+        auto result = qs.order_by<^^MockPerson::age>().limit(5).distinct<^^MockPerson::name>().execute();
 
         ASSERT_FALSE(result.has_value());
         EXPECT_EQ(result.error().code(), SQLITE_ERROR);
@@ -1155,7 +1155,7 @@ namespace {
         MockSqlite3Config::step_returns_sequence({SQLITE_ROW, SQLITE_ROW, SQLITE_CORRUPT});
 
         QuerySet<MockPerson> qs;
-        auto                 result = qs.group_by<^^MockPerson::age>().count().select();
+        auto                 result = qs.group_by<^^MockPerson::age>().count().execute();
 
         ASSERT_FALSE(result.has_value());
         EXPECT_EQ(result.error().code(), SQLITE_CORRUPT);
@@ -1165,7 +1165,7 @@ namespace {
         MockSqlite3Config::step_returns(SQLITE_IOERR);
 
         QuerySet<MockPerson> qs;
-        auto                 result = qs.order_by<^^MockPerson::age>().count().get();
+        auto                 result = qs.order_by<^^MockPerson::age>().count().execute();
 
         ASSERT_FALSE(result.has_value());
         EXPECT_EQ(result.error().code(), SQLITE_IOERR);
@@ -1218,7 +1218,7 @@ namespace {
         MockSqlite3Config::step_returns(SQLITE_NOMEM);
 
         QuerySet<MockPerson> qs;
-        auto                 result = qs.count().get();
+        auto                 result = qs.count().execute();
 
         ASSERT_FALSE(result.has_value());
         EXPECT_EQ(result.error().code(), SQLITE_NOMEM);
@@ -1452,7 +1452,7 @@ namespace {
         MockSqlite3Config::prepare_returns(SQLITE_ERROR);
 
         QuerySet<MockPerson> qs;
-        auto                 result = qs.sum<^^MockPerson::age>().get();
+        auto                 result = qs.sum<^^MockPerson::age>().execute();
 
         ASSERT_FALSE(result.has_value()) << "Aggregate SUM should fail on prepare error";
         EXPECT_EQ(result.error().code(), SQLITE_ERROR);
@@ -1462,7 +1462,7 @@ namespace {
         MockSqlite3Config::prepare_returns(SQLITE_CANTOPEN);
 
         QuerySet<MockPerson> qs;
-        auto                 result = qs.avg<^^MockPerson::age>().get();
+        auto                 result = qs.avg<^^MockPerson::age>().execute();
 
         ASSERT_FALSE(result.has_value()) << "Aggregate AVG should fail on prepare error";
         EXPECT_EQ(result.error().code(), SQLITE_CANTOPEN);
@@ -1472,7 +1472,7 @@ namespace {
         MockSqlite3Config::prepare_returns(SQLITE_CORRUPT);
 
         QuerySet<MockPerson> qs;
-        auto                 result = qs.min<^^MockPerson::age>().get();
+        auto                 result = qs.min<^^MockPerson::age>().execute();
 
         ASSERT_FALSE(result.has_value()) << "Aggregate MIN should fail on prepare error";
         EXPECT_EQ(result.error().code(), SQLITE_CORRUPT);
@@ -1482,7 +1482,7 @@ namespace {
         MockSqlite3Config::prepare_returns(SQLITE_FULL);
 
         QuerySet<MockPerson> qs;
-        auto                 result = qs.max<^^MockPerson::age>().get();
+        auto                 result = qs.max<^^MockPerson::age>().execute();
 
         ASSERT_FALSE(result.has_value()) << "Aggregate MAX should fail on prepare error";
         EXPECT_EQ(result.error().code(), SQLITE_FULL);
@@ -1497,7 +1497,7 @@ namespace {
         MockSqlite3Config::step_returns(SQLITE_CORRUPT);
 
         QuerySet<MockPerson> qs;
-        auto                 result = qs.sum<^^MockPerson::age>().get();
+        auto                 result = qs.sum<^^MockPerson::age>().execute();
 
         ASSERT_FALSE(result.has_value()) << "Aggregate SUM should fail on step error";
         EXPECT_EQ(result.error().code(), SQLITE_CORRUPT);
@@ -1507,7 +1507,7 @@ namespace {
         MockSqlite3Config::step_returns(SQLITE_IOERR);
 
         QuerySet<MockPerson> qs;
-        auto                 result = qs.min<^^MockPerson::age>().get();
+        auto                 result = qs.min<^^MockPerson::age>().execute();
 
         ASSERT_FALSE(result.has_value()) << "Aggregate MIN should fail on step error";
         EXPECT_EQ(result.error().code(), SQLITE_IOERR);
@@ -1517,7 +1517,7 @@ namespace {
         MockSqlite3Config::step_returns(SQLITE_NOTADB);
 
         QuerySet<MockPerson> qs;
-        auto                 result = qs.max<^^MockPerson::age>().get();
+        auto                 result = qs.max<^^MockPerson::age>().execute();
 
         ASSERT_FALSE(result.has_value()) << "Aggregate MAX should fail on step error";
         EXPECT_EQ(result.error().code(), SQLITE_NOTADB);
@@ -1533,7 +1533,7 @@ namespace {
 
         QuerySet<MockPerson> qs;
         auto                 age    = storm::orm::where::Field<^^MockPerson::age>{};
-        auto                 result = qs.where(age > 25).sum<^^MockPerson::age>().get();
+        auto                 result = qs.where(age > 25).sum<^^MockPerson::age>().execute();
 
         ASSERT_FALSE(result.has_value()) << "Aggregate with WHERE should fail on prepare error";
         EXPECT_EQ(result.error().code(), SQLITE_ERROR);
@@ -1545,7 +1545,7 @@ namespace {
 
         QuerySet<MockPerson> qs;
         auto                 age    = storm::orm::where::Field<^^MockPerson::age>{};
-        auto                 result = qs.where(age > 25).sum<^^MockPerson::age>().get();
+        auto                 result = qs.where(age > 25).sum<^^MockPerson::age>().execute();
 
         if (!result.has_value()) {
             EXPECT_EQ(result.error().code(), SQLITE_NOMEM);
@@ -1557,7 +1557,7 @@ namespace {
 
         QuerySet<MockPerson> qs;
         auto                 age    = storm::orm::where::Field<^^MockPerson::age>{};
-        auto                 result = qs.where(age > 30).count().get();
+        auto                 result = qs.where(age > 30).count().execute();
 
         if (!result.has_value()) {
             EXPECT_EQ(result.error().code(), SQLITE_TOOBIG);
@@ -1573,7 +1573,7 @@ namespace {
         MockSqlite3Config::prepare_returns(SQLITE_ERROR);
 
         QuerySet<MockPerson> qs;
-        auto                 result = qs.group_by<^^MockPerson::age>().count().select();
+        auto                 result = qs.group_by<^^MockPerson::age>().count().execute();
 
         ASSERT_FALSE(result.has_value()) << "GROUP BY aggregate should fail on prepare error";
         EXPECT_EQ(result.error().code(), SQLITE_ERROR);
@@ -1584,7 +1584,7 @@ namespace {
         MockSqlite3Config::step_returns(SQLITE_CORRUPT);
 
         QuerySet<MockPerson> qs;
-        auto                 result = qs.group_by<^^MockPerson::age>().count().select();
+        auto                 result = qs.group_by<^^MockPerson::age>().count().execute();
 
         ASSERT_FALSE(result.has_value()) << "GROUP BY aggregate should fail on step error";
         EXPECT_EQ(result.error().code(), SQLITE_CORRUPT);
@@ -1594,7 +1594,7 @@ namespace {
         MockSqlite3Config::prepare_returns(SQLITE_CANTOPEN);
 
         QuerySet<MockPerson> qs;
-        auto                 result = qs.group_by<^^MockPerson::name>().sum<^^MockPerson::age>().select();
+        auto                 result = qs.group_by<^^MockPerson::name>().sum<^^MockPerson::age>().execute();
 
         ASSERT_FALSE(result.has_value()) << "GROUP BY SUM should fail on prepare error";
         EXPECT_EQ(result.error().code(), SQLITE_CANTOPEN);
@@ -1765,7 +1765,7 @@ namespace {
         MockSqlite3Config::prepare_returns(SQLITE_ERROR);
 
         QuerySet<MockMessage> qs;
-        auto                  result = qs.join<&MockMessage::sender>().sum<^^MockMessage::id>().get();
+        auto                  result = qs.join<&MockMessage::sender>().sum<^^MockMessage::id>().execute();
 
         ASSERT_FALSE(result.has_value()) << "Aggregate with JOIN should fail on prepare error";
         EXPECT_EQ(result.error().code(), SQLITE_ERROR);
@@ -1775,7 +1775,7 @@ namespace {
         MockSqlite3Config::step_returns(SQLITE_CORRUPT);
 
         QuerySet<MockMessage> qs;
-        auto                  result = qs.join<&MockMessage::sender>().count().get();
+        auto                  result = qs.join<&MockMessage::sender>().count().execute();
 
         ASSERT_FALSE(result.has_value()) << "Aggregate with JOIN should fail on step error";
         EXPECT_EQ(result.error().code(), SQLITE_CORRUPT);
@@ -1787,7 +1787,7 @@ namespace {
 
         QuerySet<MockMessage> qs;
         auto                  id     = storm::orm::where::Field<^^MockMessage::id>{};
-        auto                  result = qs.where(id > 5).join<&MockMessage::sender>().count().get();
+        auto                  result = qs.where(id > 5).join<&MockMessage::sender>().count().execute();
 
         ASSERT_FALSE(result.has_value()) << "Aggregate with WHERE+JOIN should fail on prepare error";
         EXPECT_EQ(result.error().code(), SQLITE_ERROR);
@@ -1799,7 +1799,7 @@ namespace {
 
         QuerySet<MockMessage> qs;
         auto                  id     = storm::orm::where::Field<^^MockMessage::id>{};
-        auto                  result = qs.where(id > 5).join<&MockMessage::sender>().sum<^^MockMessage::id>().get();
+        auto                  result = qs.where(id > 5).join<&MockMessage::sender>().sum<^^MockMessage::id>().execute();
 
         if (!result.has_value()) {
             EXPECT_EQ(result.error().code(), SQLITE_NOMEM);
@@ -2747,7 +2747,7 @@ namespace {
 
         QuerySet<MockPerson> qs;
         auto                 age = storm::orm::where::Field<^^MockPerson::age>{};
-        auto result              = qs.where(age > 30).group_by<^^MockPerson::age>().having(age > 25).count().select();
+        auto result              = qs.where(age > 30).group_by<^^MockPerson::age>().having(age > 25).count().execute();
 
         ASSERT_FALSE(result.has_value());
         EXPECT_EQ(result.error().code(), SQLITE_NOMEM);
@@ -2760,7 +2760,7 @@ namespace {
 
         QuerySet<MockPerson> qs;
         auto                 age    = storm::orm::where::Field<^^MockPerson::age>{};
-        auto                 result = qs.group_by<^^MockPerson::age>().having(age > 25).count().select();
+        auto                 result = qs.group_by<^^MockPerson::age>().having(age > 25).count().execute();
 
         ASSERT_FALSE(result.has_value());
         EXPECT_EQ(result.error().code(), SQLITE_ERROR);
@@ -2774,7 +2774,7 @@ namespace {
 
         QuerySet<MockPerson> qs;
         auto                 age    = storm::orm::where::Field<^^MockPerson::age>{};
-        auto                 result = qs.group_by<^^MockPerson::age>().having(age > 25).count().select();
+        auto                 result = qs.group_by<^^MockPerson::age>().having(age > 25).count().execute();
 
         ASSERT_FALSE(result.has_value());
         EXPECT_EQ(result.error().code(), SQLITE_NOMEM);
@@ -2787,7 +2787,7 @@ namespace {
 
         QuerySet<MockPerson> qs;
         auto                 age    = storm::orm::where::Field<^^MockPerson::age>{};
-        auto                 result = qs.group_by<^^MockPerson::age>().having(age > 30).count().select();
+        auto                 result = qs.group_by<^^MockPerson::age>().having(age > 30).count().execute();
 
         ASSERT_FALSE(result.has_value());
         EXPECT_EQ(result.error().code(), SQLITE_CORRUPT);
@@ -2799,7 +2799,7 @@ namespace {
         MockSqlite3Config::step_returns(SQLITE_CORRUPT);
 
         QuerySet<MockPerson> qs;
-        auto                 result = qs.count().get();
+        auto                 result = qs.count().execute();
 
         ASSERT_FALSE(result.has_value());
         EXPECT_EQ(result.error().code(), SQLITE_CORRUPT);
@@ -2811,7 +2811,7 @@ namespace {
         MockSqlite3Config::step_returns(SQLITE_DONE);
 
         QuerySet<MockPerson> qs;
-        auto                 result = qs.count().get();
+        auto                 result = qs.count().execute();
 
         ASSERT_TRUE(result.has_value());
         EXPECT_EQ(result.value(), 0);
@@ -2824,7 +2824,7 @@ namespace {
 
         QuerySet<MockPerson> qs;
         auto                 age    = storm::orm::where::Field<^^MockPerson::age>{};
-        auto                 result = qs.where(age > 25).sum<^^MockPerson::age>().get();
+        auto                 result = qs.where(age > 25).sum<^^MockPerson::age>().execute();
 
         ASSERT_FALSE(result.has_value());
         EXPECT_EQ(result.error().code(), SQLITE_CORRUPT);
@@ -2836,7 +2836,7 @@ namespace {
 
         QuerySet<MockPerson> qs;
         auto                 age    = storm::orm::where::Field<^^MockPerson::age>{};
-        auto                 result = qs.where(age > 25).count().get();
+        auto                 result = qs.where(age > 25).count().execute();
 
         ASSERT_TRUE(result.has_value());
         EXPECT_EQ(result.value(), 0);

--- a/tests/query/test_aggregate.cpp
+++ b/tests/query/test_aggregate.cpp
@@ -88,7 +88,7 @@ TYPED_TEST(AggregateTest, SumMultipleFields) {
     this->insert_test_data();
 
     // SUM(age + years_experience) = 829 + 235 = 1064
-    auto result = this->qs->template sum<^^Person::age, ^^Person::years_experience>().get();
+    auto result = this->qs->template sum<^^Person::age, ^^Person::years_experience>().execute();
     ASSERT_TRUE(result.has_value()) << "SUM multi-field failed: " << result.error().message();
     EXPECT_EQ(result.value(), 1064);
 }
@@ -97,7 +97,7 @@ TYPED_TEST(AggregateTest, AvgMultipleFields) {
     this->insert_test_data();
 
     // AVG(age + years_experience) = 1064 / 25 = 42.56
-    auto result = this->qs->template avg<^^Person::age, ^^Person::years_experience>().get();
+    auto result = this->qs->template avg<^^Person::age, ^^Person::years_experience>().execute();
     ASSERT_TRUE(result.has_value()) << "AVG multi-field failed: " << result.error().message();
     EXPECT_NEAR(result.value(), 42.56, 0.01);
 }
@@ -106,7 +106,7 @@ TYPED_TEST(AggregateTest, MinMultipleFields) {
     this->insert_test_data();
 
     // MIN(age + years_experience) = MIN(30,40,50,33,...) = 27 (Paul: 22+5, Yara: 22+5)
-    auto result = this->qs->template min<^^Person::age, ^^Person::years_experience>().get();
+    auto result = this->qs->template min<^^Person::age, ^^Person::years_experience>().execute();
     ASSERT_TRUE(result.has_value()) << "MIN multi-field failed: " << result.error().message();
     EXPECT_DOUBLE_EQ(result.value(), 27.0);
 }
@@ -115,7 +115,7 @@ TYPED_TEST(AggregateTest, MaxMultipleFields) {
     this->insert_test_data();
 
     // MAX(age + years_experience) = MAX(..., 45+15, 40+15, ...) = 60 (Frank or Victor: 45+15)
-    auto result = this->qs->template max<^^Person::age, ^^Person::years_experience>().get();
+    auto result = this->qs->template max<^^Person::age, ^^Person::years_experience>().execute();
     ASSERT_TRUE(result.has_value()) << "MAX multi-field failed: " << result.error().message();
     EXPECT_DOUBLE_EQ(result.value(), 60.0);
 }
@@ -131,7 +131,7 @@ TYPED_TEST(AggregateTest, MaxMultipleFields) {
 TYPED_TEST(AggregateTest, DirectChain_TypeSafety) {
     this->insert_test_data();
 
-    auto result = this->qs->template sum<^^Person::age>().count().get();
+    auto result = this->qs->template sum<^^Person::age>().count().execute();
     ASSERT_TRUE(result.has_value());
     static_assert(
             std::is_same_v<std::remove_reference_t<decltype(result.value())>, std::tuple<int64_t, int64_t>>,
@@ -153,7 +153,7 @@ TYPED_TEST(AggregateTest, SingleAggregates_WithWhereAndJoin) {
     auto sum_result = this->msg_qs->where(storm::orm::where::field<^^Message::value>() > 25)
                               .template join<&Message::sender>()
                               .template sum<^^Message::value>()
-                              .get();
+                              .execute();
     ASSERT_TRUE(sum_result.has_value()) << "SUM with WHERE+JOIN failed: " << sum_result.error().message();
     EXPECT_EQ(sum_result.value(), 180); // 30+40+50+60
 
@@ -162,7 +162,7 @@ TYPED_TEST(AggregateTest, SingleAggregates_WithWhereAndJoin) {
     auto count_result = this->msg_qs->where(storm::orm::where::field<^^Message::value>() > 25)
                                 .template join<&Message::sender>()
                                 .count()
-                                .get();
+                                .execute();
     ASSERT_TRUE(count_result.has_value()) << "COUNT with WHERE+JOIN failed: " << count_result.error().message();
     EXPECT_EQ(count_result.value(), 4); // 4 messages
 
@@ -171,7 +171,7 @@ TYPED_TEST(AggregateTest, SingleAggregates_WithWhereAndJoin) {
     auto min_result = this->msg_qs->where(storm::orm::where::field<^^Message::value>() > 25)
                               .template join<&Message::sender>()
                               .template min<^^Message::value>()
-                              .get();
+                              .execute();
     ASSERT_TRUE(min_result.has_value()) << "MIN with WHERE+JOIN failed: " << min_result.error().message();
     EXPECT_DOUBLE_EQ(min_result.value(), 30.0); // min is 30
 }
@@ -184,23 +184,23 @@ TYPED_TEST(AggregateTest, SingleRow_AllAggregates) {
     ASSERT_TRUE(insert_result.has_value());
 
     // Test all aggregate types
-    auto sum = this->qs->template sum<^^Person::age>().get();
+    auto sum = this->qs->template sum<^^Person::age>().execute();
     ASSERT_TRUE(sum.has_value());
     EXPECT_EQ(sum.value(), 25);
 
-    auto count = this->qs->count().get();
+    auto count = this->qs->count().execute();
     ASSERT_TRUE(count.has_value());
     EXPECT_EQ(count.value(), 1);
 
-    auto avg = this->qs->template avg<^^Person::age>().get();
+    auto avg = this->qs->template avg<^^Person::age>().execute();
     ASSERT_TRUE(avg.has_value());
     EXPECT_DOUBLE_EQ(avg.value(), 25.0);
 
-    auto min_val = this->qs->template min<^^Person::age>().get();
+    auto min_val = this->qs->template min<^^Person::age>().execute();
     ASSERT_TRUE(min_val.has_value());
     EXPECT_DOUBLE_EQ(min_val.value(), 25.0);
 
-    auto max_val = this->qs->template max<^^Person::age>().get();
+    auto max_val = this->qs->template max<^^Person::age>().execute();
     ASSERT_TRUE(max_val.has_value());
     EXPECT_DOUBLE_EQ(max_val.value(), 25.0);
 }
@@ -221,7 +221,7 @@ TYPED_TEST(AggregateTest, LargeDataset_Sum) {
     auto batch_result = this->qs->insert(std::span<const Person>(people)).execute();
     ASSERT_TRUE(batch_result.has_value()) << "Batch insert failed: " << batch_result.error().message();
 
-    auto result = this->qs->template sum<^^Person::age>().get();
+    auto result = this->qs->template sum<^^Person::age>().execute();
     ASSERT_TRUE(result.has_value()) << "SUM large dataset failed: " << result.error().message();
     EXPECT_EQ(result.value(), 500500);
 }
@@ -238,7 +238,7 @@ TYPED_TEST(AggregateTest, LargeDataset_Count) {
     auto insert_result = this->qs->insert(std::span<const Person>(people)).execute();
     ASSERT_TRUE(insert_result.has_value()) << "Batch insert failed: " << insert_result.error().message();
 
-    auto result = this->qs->count().get();
+    auto result = this->qs->count().execute();
     ASSERT_TRUE(result.has_value()) << "COUNT large dataset failed: " << result.error().message();
     EXPECT_EQ(result.value(), 10000);
 }
@@ -251,7 +251,7 @@ TYPED_TEST(AggregateTest, TypeSafety_IntegerResult) {
     this->insert_test_data();
 
     // Verify SUM returns int64_t
-    auto result = this->qs->template sum<^^Person::age>().get();
+    auto result = this->qs->template sum<^^Person::age>().execute();
     ASSERT_TRUE(result.has_value());
     static_assert(
             std::is_same_v<std::remove_reference_t<decltype(result.value())>, int64_t>, "SUM should return int64_t"
@@ -262,7 +262,7 @@ TYPED_TEST(AggregateTest, TypeSafety_DoubleResult) {
     this->insert_test_data();
 
     // Verify AVG returns double
-    auto result = this->qs->template avg<^^Person::age>().get();
+    auto result = this->qs->template avg<^^Person::age>().execute();
     ASSERT_TRUE(result.has_value());
     static_assert(
             std::is_same_v<std::remove_reference_t<decltype(result.value())>, double>, "AVG should return double"
@@ -284,7 +284,7 @@ TYPED_TEST(AggregateTest, StatementCaching_RepeatedQueries) {
 
     // Run same query 100 times - should use cached statement
     for (int i = 0; i < 100; ++i) {
-        auto result = this->qs->count().get();
+        auto result = this->qs->count().execute();
         ASSERT_TRUE(result.has_value()) << "Iteration " << i << " failed";
         EXPECT_EQ(result.value(), 25);
     }
@@ -296,15 +296,15 @@ TYPED_TEST(AggregateTest, StatementCaching_DifferentAggregates) {
 
     // Run different aggregates multiple times
     for (int i = 0; i < 10; ++i) {
-        auto sum = this->qs->template sum<^^Person::age>().get();
+        auto sum = this->qs->template sum<^^Person::age>().execute();
         ASSERT_TRUE(sum.has_value());
         EXPECT_EQ(sum.value(), 829);
 
-        auto count = this->qs->count().get();
+        auto count = this->qs->count().execute();
         ASSERT_TRUE(count.has_value());
         EXPECT_EQ(count.value(), 25);
 
-        auto avg = this->qs->template avg<^^Person::salary>().get();
+        auto avg = this->qs->template avg<^^Person::salary>().execute();
         ASSERT_TRUE(avg.has_value());
         EXPECT_NEAR(avg.value(), 68080.0, 0.01);
     }
@@ -328,13 +328,13 @@ TYPED_TEST(AggregateTest, Integration_AfterInsert) {
                                      .execute();
         ASSERT_TRUE(insert_result.has_value());
 
-        auto count = this->qs->count().get();
+        auto count = this->qs->count().execute();
         ASSERT_TRUE(count.has_value());
         EXPECT_EQ(count.value(), i);
     }
 
     // Final aggregate
-    auto sum = this->qs->template sum<^^Person::age>().get();
+    auto sum = this->qs->template sum<^^Person::age>().execute();
     ASSERT_TRUE(sum.has_value());
     EXPECT_EQ(sum.value(), 10 + 20 + 30 + 40 + 50); // 150
 }
@@ -353,7 +353,7 @@ TYPED_TEST(AggregateTest, Integration_AfterUpdate) {
     }
 
     // SUM(age) should now be 30 * 25 = 750
-    auto sum = this->qs->template sum<^^Person::age>().get();
+    auto sum = this->qs->template sum<^^Person::age>().execute();
     ASSERT_TRUE(sum.has_value());
     EXPECT_EQ(sum.value(), 750);
 }
@@ -373,7 +373,7 @@ TYPED_TEST(AggregateTest, Integration_AfterDelete) {
     ASSERT_TRUE(delete_result.has_value());
 
     // COUNT should now be 23
-    auto count = this->qs->count().get();
+    auto count = this->qs->count().execute();
     ASSERT_TRUE(count.has_value());
     EXPECT_EQ(count.value(), 23);
 }
@@ -389,7 +389,7 @@ TYPED_TEST(AggregateTest, WhereWithMultiFieldSum) {
     // sum_age=442, sum_ye=140 → total=582
     auto result = this->qs->where(storm::orm::where::field<^^Person::age>() >= 35)
                           .template sum<^^Person::age, ^^Person::years_experience>()
-                          .get();
+                          .execute();
     ASSERT_TRUE(result.has_value()) << "WHERE + SUM(multi-field) failed: " << result.error().message();
     EXPECT_EQ(result.value(), 582);
 }
@@ -400,7 +400,7 @@ TYPED_TEST(AggregateTest, WhereRepeatedQueries) {
     // Run same WHERE + aggregate query multiple times (tests caching)
     // No reset() needed — where() returns a new QuerySet each time
     for (int i = 0; i < 100; ++i) {
-        auto result = this->qs->where(storm::orm::where::field<^^Person::age>() > 30).count().get();
+        auto result = this->qs->where(storm::orm::where::field<^^Person::age>() > 30).count().execute();
         ASSERT_TRUE(result.has_value()) << "Iteration " << i << " failed: " << result.error().message();
         EXPECT_EQ(result.value(), 13);
     }
@@ -410,19 +410,19 @@ TYPED_TEST(AggregateTest, WhereDifferentConditions) {
     this->insert_test_data();
 
     // Run queries with different WHERE conditions
-    auto result1 = this->qs->where(storm::orm::where::field<^^Person::age>() > 30).count().get();
+    auto result1 = this->qs->where(storm::orm::where::field<^^Person::age>() > 30).count().execute();
     ASSERT_TRUE(result1.has_value());
     EXPECT_EQ(result1.value(), 13);
 
     (*this->qs).reset(); // Clear WHERE clause
 
-    auto result2 = this->qs->where(storm::orm::where::field<^^Person::age>() < 30).count().get();
+    auto result2 = this->qs->where(storm::orm::where::field<^^Person::age>() < 30).count().execute();
     ASSERT_TRUE(result2.has_value());
     EXPECT_EQ(result2.value(), 9);
 
     (*this->qs).reset();
 
-    auto result3 = this->qs->where(storm::orm::where::field<^^Person::age>() == 30).count().get();
+    auto result3 = this->qs->where(storm::orm::where::field<^^Person::age>() == 30).count().execute();
     ASSERT_TRUE(result3.has_value());
     EXPECT_EQ(result3.value(), 3); // Bob, Ivy, Quinn
 }
@@ -440,7 +440,7 @@ TYPED_TEST(AggregateTest, WhereJoinRepeatedQueries) {
         auto result = this->msg_qs->where(storm::orm::where::field<^^Message::value>() > 20)
                               .template join<&Message::sender>()
                               .count()
-                              .get();
+                              .execute();
         ASSERT_TRUE(result.has_value()) << "Iteration " << i << " failed: " << result.error().message();
         EXPECT_EQ(result.value(), 4); // 30, 40, 50, 60
     }
@@ -457,7 +457,7 @@ TYPED_TEST(AggregateTest, GroupByWithCount) {
 
     // Group by years_experience and count
     // years_experience groups: 5(10), 10(8), 15(7)
-    auto result = this->qs->template group_by<^^Person::years_experience>().count().select();
+    auto result = this->qs->template group_by<^^Person::years_experience>().count().execute();
     ASSERT_TRUE(result.has_value()) << "GROUP BY + COUNT failed: " << result.error().message();
 
     auto& results = result.value();
@@ -475,7 +475,7 @@ TYPED_TEST(AggregateTest, GroupByWithSum) {
     this->insert_test_data();
 
     // Group by years_experience and sum age
-    auto result = this->qs->template group_by<^^Person::years_experience>().template sum<^^Person::age>().select();
+    auto result = this->qs->template group_by<^^Person::years_experience>().template sum<^^Person::age>().execute();
     ASSERT_TRUE(result.has_value()) << "GROUP BY + SUM failed: " << result.error().message();
 
     EXPECT_EQ(result.value().size(), 3); // 3 unique years_experience values
@@ -492,7 +492,7 @@ TYPED_TEST(AggregateTest, GroupByWithAvg) {
     this->insert_test_data();
 
     // Group by years_experience and average salary
-    auto result = this->qs->template group_by<^^Person::years_experience>().template avg<^^Person::salary>().select();
+    auto result = this->qs->template group_by<^^Person::years_experience>().template avg<^^Person::salary>().execute();
     ASSERT_TRUE(result.has_value()) << "GROUP BY + AVG failed: " << result.error().message();
 
     EXPECT_EQ(result.value().size(), 3);
@@ -512,7 +512,7 @@ TYPED_TEST(AggregateTest, GroupByWithMin) {
     this->insert_test_data();
 
     // Group by years_experience and min salary
-    auto result = this->qs->template group_by<^^Person::years_experience>().template min<^^Person::salary>().select();
+    auto result = this->qs->template group_by<^^Person::years_experience>().template min<^^Person::salary>().execute();
     ASSERT_TRUE(result.has_value()) << "GROUP BY + MIN failed: " << result.error().message();
 
     EXPECT_EQ(result.value().size(), 3);
@@ -532,7 +532,7 @@ TYPED_TEST(AggregateTest, GroupByWithMax) {
     this->insert_test_data();
 
     // Group by years_experience and max age
-    auto result = this->qs->template group_by<^^Person::years_experience>().template max<^^Person::age>().select();
+    auto result = this->qs->template group_by<^^Person::years_experience>().template max<^^Person::age>().execute();
     ASSERT_TRUE(result.has_value()) << "GROUP BY + MAX failed: " << result.error().message();
 
     EXPECT_EQ(result.value().size(), 3);
@@ -558,7 +558,7 @@ TYPED_TEST(AggregateTest, GroupByWithJoinAndSum) {
     auto result = this->msg_qs->template join<&Message::sender>()
                           .template group_by<^^Message::content>()
                           .template sum<^^Message::value>()
-                          .select();
+                          .execute();
     ASSERT_TRUE(result.has_value()) << "JOIN + GROUP BY + SUM failed: " << result.error().message();
 
     EXPECT_EQ(result.value().size(), 6);
@@ -575,7 +575,7 @@ TYPED_TEST(AggregateTest, GroupByRepeatedQueries) {
 
     // Run same GROUP BY query multiple times (tests caching)
     for (int i = 0; i < 50; ++i) {
-        auto result = this->qs->template group_by<^^Person::years_experience>().count().select();
+        auto result = this->qs->template group_by<^^Person::years_experience>().count().execute();
         ASSERT_TRUE(result.has_value()) << "Iteration " << i << " failed";
         EXPECT_EQ(result.value().size(), 3);
     }
@@ -583,7 +583,7 @@ TYPED_TEST(AggregateTest, GroupByRepeatedQueries) {
 
 TYPED_TEST(AggregateTest, GroupByEmptyTable) {
     // Don't insert any data
-    auto result = this->qs->template group_by<^^Person::years_experience>().count().select();
+    auto result = this->qs->template group_by<^^Person::years_experience>().count().execute();
     ASSERT_TRUE(result.has_value()) << "GROUP BY on empty table failed: " << result.error().message();
     EXPECT_EQ(result.value().size(), 0);
 }
@@ -625,7 +625,7 @@ TYPED_TEST(AggregateTest, GroupByFullChain_WhereJoinGroupByAggregate) {
                                 .template join<&Message::sender>()
                                 .template group_by<^^Message::value>()
                                 .count()
-                                .select();
+                                .execute();
     ASSERT_TRUE(count_result.has_value()) << "Full chain COUNT failed: " << count_result.error().message();
     // Values >= 20: 20, 25, 30, 35, 50, 70, 100 (7 unique values, each appears once)
     EXPECT_EQ(count_result.value().size(), 7) << "Expected 7 groups (7 unique values >= 20)";
@@ -645,7 +645,7 @@ TYPED_TEST(AggregateTest, GroupByFullChain_WhereJoinGroupByAggregate) {
                               .template join<&Message::sender>()
                               .template group_by<^^Message::content>()
                               .template sum<^^Message::value>()
-                              .select();
+                              .execute();
     ASSERT_TRUE(sum_result.has_value()) << "Full chain SUM failed: " << sum_result.error().message();
     EXPECT_EQ(sum_result.value().size(), 7) << "Expected 7 groups (7 messages with value < 50)";
 
@@ -660,7 +660,7 @@ TYPED_TEST(AggregateTest, GroupByFullChain_WhereJoinGroupByAggregate) {
                               .template join<&Message::sender>()
                               .template group_by<^^Message::value>()
                               .template avg<^^Message::value>()
-                              .select();
+                              .execute();
     ASSERT_TRUE(avg_result.has_value()) << "Full chain AVG failed: " << avg_result.error().message();
 
     // Values between 10-70: 10, 15, 20, 25, 30, 35, 50, 70 (8 unique values)
@@ -687,7 +687,7 @@ TYPED_TEST(AggregateTest, CountDistinctWithDuplicates) {
             {.id = 0, .name = "Eve", .age = 35, .salary = 90000.0, .years_experience = 15},  // Same age as Charlie
     })));
 
-    auto result = this->qs->template count_distinct<^^Person::age>().get();
+    auto result = this->qs->template count_distinct<^^Person::age>().execute();
     ASSERT_TRUE(result.has_value()) << "COUNT(DISTINCT) with duplicates failed";
     EXPECT_EQ(result.value(), 2); // Only 2 unique ages (30, 35)
 }
@@ -696,7 +696,7 @@ TYPED_TEST(AggregateTest, CountDistinctWithJoin) {
     this->insert_join_test_data();
 
     // Count distinct message values
-    auto result = this->msg_qs->template join<&Message::sender>().template count_distinct<^^Message::value>().get();
+    auto result = this->msg_qs->template join<&Message::sender>().template count_distinct<^^Message::value>().execute();
     ASSERT_TRUE(result.has_value()) << "COUNT(DISTINCT) with JOIN failed";
     EXPECT_EQ(result.value(), 6); // 10, 20, 30, 40, 50, 60 - all unique
 }
@@ -706,7 +706,7 @@ TYPED_TEST(AggregateTest, CountDistinctRepeatedQueries) {
 
     // Run same COUNT(DISTINCT) query multiple times (tests caching)
     for (int i = 0; i < 50; ++i) {
-        auto result = this->qs->template count_distinct<^^Person::years_experience>().get();
+        auto result = this->qs->template count_distinct<^^Person::years_experience>().execute();
         ASSERT_TRUE(result.has_value()) << "Iteration " << i << " failed";
         EXPECT_EQ(result.value(), 3);
     }
@@ -742,12 +742,12 @@ TYPED_TEST(OptionalAggregateTest, CountWithNullValues) {
     })));
 
     // COUNT(*) includes all rows
-    auto count_all = this->qs->count().get();
+    auto count_all = this->qs->count().execute();
     ASSERT_TRUE(count_all.has_value());
     EXPECT_EQ(count_all.value(), 4);
 
     // COUNT(age) excludes NULL values
-    auto count_age = this->qs->template count<^^Person::score>().get();
+    auto count_age = this->qs->template count<^^Person::score>().execute();
     ASSERT_TRUE(count_age.has_value());
     EXPECT_EQ(count_age.value(), 2); // Only Alice (25) and Charlie (35)
 }
@@ -759,7 +759,7 @@ TYPED_TEST(OptionalAggregateTest, SumWithNullValues) {
             {.name = "Charlie", .salary = 70000.0, .score = 35},
     })));
 
-    auto sum = this->qs->template sum<^^Person::score>().get();
+    auto sum = this->qs->template sum<^^Person::score>().execute();
     ASSERT_TRUE(sum.has_value());
     EXPECT_EQ(sum.value(), 60); // 25 + 35, NULL ignored
 }
@@ -771,7 +771,7 @@ TYPED_TEST(OptionalAggregateTest, AvgWithNullValues) {
             {.name = "Charlie", .salary = 70000.0, .score = 40},
     })));
 
-    auto avg = this->qs->template avg<^^Person::score>().get();
+    auto avg = this->qs->template avg<^^Person::score>().execute();
     ASSERT_TRUE(avg.has_value());
     EXPECT_NEAR(avg.value(), 30.0, 0.01); // (20 + 40) / 2 = 30, NULL ignored
 }
@@ -784,11 +784,11 @@ TYPED_TEST(OptionalAggregateTest, MinMaxWithNullValues) {
             {.name = "Dave", .salary = 80000.0, .score = std::nullopt},
     })));
 
-    auto min_val = this->qs->template min<^^Person::score>().get();
+    auto min_val = this->qs->template min<^^Person::score>().execute();
     ASSERT_TRUE(min_val.has_value());
     EXPECT_NEAR(min_val.value(), 25.0, 0.01);
 
-    auto max_val = this->qs->template max<^^Person::score>().get();
+    auto max_val = this->qs->template max<^^Person::score>().execute();
     ASSERT_TRUE(max_val.has_value());
     EXPECT_NEAR(max_val.value(), 45.0, 0.01);
 }
@@ -803,7 +803,7 @@ TYPED_TEST(OptionalAggregateTest, CountDistinctWithNullValues) {
     })));
 
     // COUNT(DISTINCT age) - NULL excluded, should count 2 (30, 40)
-    auto result = this->qs->template count_distinct<^^Person::score>().get();
+    auto result = this->qs->template count_distinct<^^Person::score>().execute();
     ASSERT_TRUE(result.has_value());
     EXPECT_EQ(result.value(), 2);
 }
@@ -818,7 +818,7 @@ TYPED_TEST(OptionalAggregateTest, GroupByWithAllNullValuesInGroupColumn) {
 
     // GROUP BY on age (all NULL) - should produce one group with NULL key
     // SQLite treats NULL as a distinct group key in GROUP BY
-    auto result = this->qs->template group_by<^^Person::score>().count().select();
+    auto result = this->qs->template group_by<^^Person::score>().count().execute();
     ASSERT_TRUE(result.has_value()) << "GROUP BY with all NULL values failed";
 
     // Should have exactly one group (the NULL group) with count 3
@@ -844,7 +844,7 @@ TYPED_TEST(OptionalAggregateTest, GroupByWithMixedNullAndNonNullValues) {
     })));
 
     // GROUP BY on age - should produce 3 groups: NULL (2 rows), 25 (2 rows), 30 (1 row)
-    auto result = this->qs->template group_by<^^Person::score>().count().select();
+    auto result = this->qs->template group_by<^^Person::score>().count().execute();
     ASSERT_TRUE(result.has_value()) << "GROUP BY with mixed NULL values failed";
 
     EXPECT_EQ(result.value().size(), 3) << "Expected 3 groups (NULL, 25, 30)";
@@ -877,7 +877,7 @@ TYPED_TEST(AggregateTest, NegativeNumbersInSum) {
             {.name = "Charlie", .age = -3, .salary = 70000.0, .years_experience = 7},
     })));
 
-    auto sum = this->qs->template sum<^^Person::age>().get();
+    auto sum = this->qs->template sum<^^Person::age>().execute();
     ASSERT_TRUE(sum.has_value());
     EXPECT_EQ(sum.value(), -8); // -10 + 5 + (-3) = -8
 }
@@ -889,7 +889,7 @@ TYPED_TEST(AggregateTest, NegativeNumbersInAvg) {
             {.name = "Charlie", .age = 0, .salary = 70000.0, .years_experience = 7},
     })));
 
-    auto avg = this->qs->template avg<^^Person::age>().get();
+    auto avg = this->qs->template avg<^^Person::age>().execute();
     ASSERT_TRUE(avg.has_value());
     EXPECT_NEAR(avg.value(), -2.0, 0.01); // (-12 + 6 + 0) / 3 = -2
 }
@@ -902,11 +902,11 @@ TYPED_TEST(AggregateTest, NegativeNumbersInMinMax) {
             {.name = "Dave", .age = 15, .salary = 80000.0, .years_experience = 10},
     })));
 
-    auto min_val = this->qs->template min<^^Person::age>().get();
+    auto min_val = this->qs->template min<^^Person::age>().execute();
     ASSERT_TRUE(min_val.has_value());
     EXPECT_NEAR(min_val.value(), -20.0, 0.01);
 
-    auto max_val = this->qs->template max<^^Person::age>().get();
+    auto max_val = this->qs->template max<^^Person::age>().execute();
     ASSERT_TRUE(max_val.has_value());
     EXPECT_NEAR(max_val.value(), 15.0, 0.01);
 }
@@ -919,12 +919,12 @@ TYPED_TEST(AggregateTest, NegativeNumbersInCount) {
     })));
 
     // Count should still count all rows regardless of negative values
-    auto count = this->qs->count().get();
+    auto count = this->qs->count().execute();
     ASSERT_TRUE(count.has_value());
     EXPECT_EQ(count.value(), 3);
 
     // Count with field also counts negative values
-    auto count_age = this->qs->template count<^^Person::age>().get();
+    auto count_age = this->qs->template count<^^Person::age>().execute();
     ASSERT_TRUE(count_age.has_value());
     EXPECT_EQ(count_age.value(), 3);
 }
@@ -939,12 +939,13 @@ TYPED_TEST(AggregateTest, NegativeNumbersInWhere) {
     })));
 
     // Count where age < 0
-    auto result = this->qs->where(storm::orm::where::field<^^Person::age>() < 0).count().get();
+    auto result = this->qs->where(storm::orm::where::field<^^Person::age>() < 0).count().execute();
     ASSERT_TRUE(result.has_value());
     EXPECT_EQ(result.value(), 2); // Alice (-10) and Bob (-5)
 
     // Sum of negative ages
-    auto sum_neg = this->qs->where(storm::orm::where::field<^^Person::age>() < 0).template sum<^^Person::age>().get();
+    auto sum_neg =
+            this->qs->where(storm::orm::where::field<^^Person::age>() < 0).template sum<^^Person::age>().execute();
     ASSERT_TRUE(sum_neg.has_value());
     EXPECT_EQ(sum_neg.value(), -15); // -10 + (-5) = -15
 }
@@ -1072,7 +1073,7 @@ TYPED_TEST(AggregateTest, GroupByWithAllAggregateTypes) {
     //   ye=15 (7 people): sum_age=276, avg≈39.43, min=35, max=45
 
     // Test 1: GROUP BY with COUNT
-    auto count_result = this->qs->template group_by<^^Person::years_experience>().count().select();
+    auto count_result = this->qs->template group_by<^^Person::years_experience>().count().execute();
     ASSERT_TRUE(count_result.has_value()) << "GROUP BY + COUNT failed: " << count_result.error().message();
     EXPECT_EQ(count_result.value().size(), 3) << "Expected 3 groups";
     for (const auto& [years_exp, count_val] : count_result.value()) {
@@ -1089,7 +1090,7 @@ TYPED_TEST(AggregateTest, GroupByWithAllAggregateTypes) {
 
     // Test 2: GROUP BY with SUM
     this->qs->reset();
-    auto sum_result = this->qs->template group_by<^^Person::years_experience>().template sum<^^Person::age>().select();
+    auto sum_result = this->qs->template group_by<^^Person::years_experience>().template sum<^^Person::age>().execute();
     ASSERT_TRUE(sum_result.has_value()) << "GROUP BY + SUM failed: " << sum_result.error().message();
     for (const auto& [years_exp, sum_age] : sum_result.value()) {
         if (years_exp == 5) {
@@ -1103,7 +1104,7 @@ TYPED_TEST(AggregateTest, GroupByWithAllAggregateTypes) {
 
     // Test 3: GROUP BY with AVG
     this->qs->reset();
-    auto avg_result = this->qs->template group_by<^^Person::years_experience>().template avg<^^Person::age>().select();
+    auto avg_result = this->qs->template group_by<^^Person::years_experience>().template avg<^^Person::age>().execute();
     ASSERT_TRUE(avg_result.has_value()) << "GROUP BY + AVG failed: " << avg_result.error().message();
     for (const auto& [years_exp, avg_age] : avg_result.value()) {
         if (years_exp == 5) {
@@ -1117,7 +1118,7 @@ TYPED_TEST(AggregateTest, GroupByWithAllAggregateTypes) {
 
     // Test 4: GROUP BY with MIN
     this->qs->reset();
-    auto min_result = this->qs->template group_by<^^Person::years_experience>().template min<^^Person::age>().select();
+    auto min_result = this->qs->template group_by<^^Person::years_experience>().template min<^^Person::age>().execute();
     ASSERT_TRUE(min_result.has_value()) << "GROUP BY + MIN failed: " << min_result.error().message();
     for (const auto& [years_exp, min_age] : min_result.value()) {
         if (years_exp == 5) {
@@ -1131,7 +1132,7 @@ TYPED_TEST(AggregateTest, GroupByWithAllAggregateTypes) {
 
     // Test 5: GROUP BY with MAX
     this->qs->reset();
-    auto max_result = this->qs->template group_by<^^Person::years_experience>().template max<^^Person::age>().select();
+    auto max_result = this->qs->template group_by<^^Person::years_experience>().template max<^^Person::age>().execute();
     ASSERT_TRUE(max_result.has_value()) << "GROUP BY + MAX failed: " << max_result.error().message();
     for (const auto& [years_exp, max_age] : max_result.value()) {
         if (years_exp == 5) {
@@ -1148,7 +1149,7 @@ TYPED_TEST(AggregateTest, GroupByWithAllAggregateTypes) {
     auto filtered_sum = this->qs->where(storm::orm::where::field<^^Person::years_experience>() == 5)
                                 .template group_by<^^Person::years_experience>()
                                 .template sum<^^Person::age>()
-                                .select();
+                                .execute();
     ASSERT_TRUE(filtered_sum.has_value()) << "WHERE + GROUP BY + SUM failed";
     EXPECT_EQ(filtered_sum.value().size(), 1) << "Expected 1 group after WHERE filter";
     const auto& [years_exp, sum_age] = *filtered_sum.value().begin();
@@ -1168,7 +1169,7 @@ TYPED_TEST(AggregateTest, GroupByWithOrderBy) {
     auto result = this->qs->template order_by<^^Person::years_experience>()
                           .template group_by<^^Person::years_experience>()
                           .count()
-                          .select();
+                          .execute();
     ASSERT_TRUE(result.has_value()) << "GROUP BY + ORDER BY failed: " << result.error().message();
     EXPECT_EQ(result.value().size(), 3);
 
@@ -1190,7 +1191,7 @@ TYPED_TEST(AggregateTest, GroupByWithOrderByDesc) {
     auto result = this->qs->template order_by<^^Person::years_experience, false>()
                           .template group_by<^^Person::years_experience>()
                           .count()
-                          .select();
+                          .execute();
     ASSERT_TRUE(result.has_value()) << "GROUP BY + ORDER BY DESC failed: " << result.error().message();
     EXPECT_EQ(result.value().size(), 3);
 
@@ -1213,7 +1214,7 @@ TYPED_TEST(AggregateTest, GroupByWithLimitOffset) {
                           .offset(1)
                           .template group_by<^^Person::years_experience>()
                           .count()
-                          .select();
+                          .execute();
     ASSERT_TRUE(result.has_value()) << "GROUP BY + LIMIT + OFFSET failed: " << result.error().message();
     EXPECT_EQ(result.value().size(), 2);
 
@@ -1231,7 +1232,7 @@ TYPED_TEST(AggregateTest, GroupByMultipleFields) {
 
     // Group by TWO fields: age AND years_experience using PEOPLE_25
     // Many (age, ye) combos — verify total counts match
-    auto result = this->qs->template group_by<^^Person::age, ^^Person::years_experience>().count().select();
+    auto result = this->qs->template group_by<^^Person::age, ^^Person::years_experience>().count().execute();
     ASSERT_TRUE(result.has_value()) << "Multi-field GROUP BY failed: " << result.error().message();
 
     // Verify total count across all groups = 25
@@ -1263,7 +1264,7 @@ TYPED_TEST(AggregateTest, GroupByMultipleFieldsWithOrderByLimit) {
                           .limit(2)
                           .template group_by<^^Person::age, ^^Person::years_experience>()
                           .count()
-                          .select();
+                          .execute();
     ASSERT_TRUE(result.has_value()) << "Multi-field GROUP BY + ORDER BY + LIMIT failed";
     EXPECT_EQ(result.value().size(), 2) << "Should return only 2 groups due to LIMIT";
 }
@@ -1286,7 +1287,7 @@ TYPED_TEST(AggregateTest, HavingOnGroupByBuilder) {
     auto result = this->qs->template group_by<^^Person::years_experience>()
                           .having(storm::orm::where::field<^^Person::years_experience>() > 5)
                           .count()
-                          .select();
+                          .execute();
     ASSERT_TRUE(result.has_value()) << "HAVING on GroupByBuilder failed: " << result.error().message();
     EXPECT_EQ(result.value().size(), 1) << "Expected 1 group (years_experience=10)";
 
@@ -1308,7 +1309,7 @@ TYPED_TEST(AggregateTest, HavingOnAggregateStatement) {
     auto result = this->qs->template group_by<^^Person::years_experience>()
                           .count()
                           .having(storm::orm::where::field<^^Person::years_experience>() > 5)
-                          .select();
+                          .execute();
     ASSERT_TRUE(result.has_value()) << "HAVING on AggregateStatement failed: " << result.error().message();
     EXPECT_EQ(result.value().size(), 1) << "Expected 1 group (years_experience=10)";
 
@@ -1326,7 +1327,7 @@ TYPED_TEST(AggregateTest, HavingWithJoin) {
                           .template group_by<^^Message::value>()
                           .having(storm::orm::where::field<^^Message::value>() > 30)
                           .count()
-                          .select();
+                          .execute();
     ASSERT_TRUE(result.has_value()) << "HAVING + JOIN failed: " << result.error().message();
     EXPECT_EQ(result.value().size(), 3) << "Expected 3 groups (values 40, 50, 60)";
 }
@@ -1339,7 +1340,7 @@ TYPED_TEST(AggregateTest, HavingRepeatedQueries) {
         auto result = this->qs->template group_by<^^Person::age>()
                               .having(storm::orm::where::field<^^Person::age>() > 30)
                               .count()
-                              .select();
+                              .execute();
         ASSERT_TRUE(result.has_value()) << "Iteration " << i << " failed";
         EXPECT_EQ(result.value().size(), 8); // 8 unique ages > 30
     }
@@ -1352,7 +1353,7 @@ TYPED_TEST(AggregateTest, HavingWithSum) {
     auto result = this->qs->template group_by<^^Person::years_experience>()
                           .having(storm::orm::where::field<^^Person::years_experience>() == 5)
                           .template sum<^^Person::age>()
-                          .select();
+                          .execute();
     ASSERT_TRUE(result.has_value()) << "HAVING + SUM failed: " << result.error().message();
     EXPECT_EQ(result.value().size(), 1);
 
@@ -1382,7 +1383,7 @@ TYPED_TEST(AggregateTest, HavingWithWhereAndJoin) {
                           .template group_by<^^Message::value>()
                           .having(storm::orm::where::field<^^Message::value>() > 25)
                           .count()
-                          .select();
+                          .execute();
     ASSERT_TRUE(result.has_value()) << "HAVING + WHERE + JOIN failed: " << result.error().message();
     EXPECT_EQ(result.value().size(), 3) << "Expected 3 groups after WHERE + HAVING + JOIN";
 }
@@ -1394,7 +1395,7 @@ TYPED_TEST(AggregateTest, HavingWithNotEqual) {
     auto result = this->qs->template group_by<^^Person::age>()
                           .having(storm::orm::where::field<^^Person::age>() != 30)
                           .count()
-                          .select();
+                          .execute();
     ASSERT_TRUE(result.has_value()) << "HAVING != failed: " << result.error().message();
     // All groups except age=30
     for (const auto& [age, count] : result.value()) {
@@ -1407,7 +1408,7 @@ TYPED_TEST(AggregateTest, HavingWithLessThan) {
     auto result = this->qs->template group_by<^^Person::age>()
                           .having(storm::orm::where::field<^^Person::age>() < 30)
                           .count()
-                          .select();
+                          .execute();
     ASSERT_TRUE(result.has_value()) << "HAVING < failed: " << result.error().message();
     for (const auto& [age, count] : result.value()) {
         EXPECT_LT(age, 30) << "HAVING < should only include age < 30";
@@ -1419,7 +1420,7 @@ TYPED_TEST(AggregateTest, HavingWithLessEqual) {
     auto result = this->qs->template group_by<^^Person::age>()
                           .having(storm::orm::where::field<^^Person::age>() <= 30)
                           .count()
-                          .select();
+                          .execute();
     ASSERT_TRUE(result.has_value()) << "HAVING <= failed: " << result.error().message();
     for (const auto& [age, count] : result.value()) {
         EXPECT_LE(age, 30) << "HAVING <= should only include age <= 30";
@@ -1431,7 +1432,7 @@ TYPED_TEST(AggregateTest, HavingWithGreaterEqual) {
     auto result = this->qs->template group_by<^^Person::age>()
                           .having(storm::orm::where::field<^^Person::age>() >= 30)
                           .count()
-                          .select();
+                          .execute();
     ASSERT_TRUE(result.has_value()) << "HAVING >= failed: " << result.error().message();
     for (const auto& [age, count] : result.value()) {
         EXPECT_GE(age, 30) << "HAVING >= should only include age >= 30";
@@ -1443,7 +1444,7 @@ TYPED_TEST(AggregateTest, HavingWithIn) {
     auto result = this->qs->template group_by<^^Person::age>()
                           .having(storm::orm::where::field<^^Person::age>().in(25, 30, 35))
                           .count()
-                          .select();
+                          .execute();
     ASSERT_TRUE(result.has_value()) << "HAVING IN failed: " << result.error().message();
     for (const auto& [age, count] : result.value()) {
         EXPECT_TRUE(age == 25 || age == 30 || age == 35)
@@ -1456,7 +1457,7 @@ TYPED_TEST(AggregateTest, HavingWithBetween) {
     auto result = this->qs->template group_by<^^Person::age>()
                           .having(storm::orm::where::field<^^Person::age>().between(25, 35))
                           .count()
-                          .select();
+                          .execute();
     ASSERT_TRUE(result.has_value()) << "HAVING BETWEEN failed: " << result.error().message();
     for (const auto& [age, count] : result.value()) {
         EXPECT_GE(age, 25) << "HAVING BETWEEN lower bound failed";
@@ -1469,7 +1470,7 @@ TYPED_TEST(AggregateTest, HavingWithLike) {
     auto result = this->qs->template group_by<^^Person::name>()
                           .having(storm::orm::where::field<^^Person::name>().like("A%"))
                           .count()
-                          .select();
+                          .execute();
     ASSERT_TRUE(result.has_value()) << "HAVING LIKE failed: " << result.error().message();
     for (const auto& [name, count] : result.value()) {
         EXPECT_TRUE(name.find("A") == 0) << "HAVING LIKE 'A%' should only match names starting with A, got: " << name;
@@ -1482,7 +1483,7 @@ TYPED_TEST(AggregateTest, HavingWithLogicalAnd) {
                           .having(storm::orm::where::field<^^Person::age>() > 20 &&
                                   storm::orm::where::field<^^Person::age>() < 40)
                           .count()
-                          .select();
+                          .execute();
     ASSERT_TRUE(result.has_value()) << "HAVING AND failed: " << result.error().message();
     for (const auto& [age, count] : result.value()) {
         EXPECT_GT(age, 20) << "HAVING AND: age should be > 20";
@@ -1496,7 +1497,7 @@ TYPED_TEST(AggregateTest, HavingWithLogicalOr) {
                           .having(storm::orm::where::field<^^Person::age>() < 25 ||
                                   storm::orm::where::field<^^Person::age>() > 35)
                           .count()
-                          .select();
+                          .execute();
     ASSERT_TRUE(result.has_value()) << "HAVING OR failed: " << result.error().message();
     for (const auto& [age, count] : result.value()) {
         EXPECT_TRUE(age < 25 || age > 35) << "HAVING OR: age should be < 25 or > 35, got: " << age;
@@ -1510,7 +1511,7 @@ TYPED_TEST(AggregateTest, HavingWithComplexLogical) {
                                    storm::orm::where::field<^^Person::age>() <= 35) ||
                                   storm::orm::where::field<^^Person::age>() == 50)
                           .count()
-                          .select();
+                          .execute();
     ASSERT_TRUE(result.has_value()) << "HAVING complex logical failed: " << result.error().message();
     for (const auto& [age, count] : result.value()) {
         EXPECT_TRUE((age >= 25 && age <= 35) || age == 50) << "HAVING complex: age should be 25-35 or 50, got: " << age;
@@ -1523,7 +1524,7 @@ TYPED_TEST(AggregateTest, HavingWithWhereAndIn) {
                           .template group_by<^^Person::age>()
                           .having(storm::orm::where::field<^^Person::age>().in(25, 30, 35))
                           .count()
-                          .select();
+                          .execute();
     ASSERT_TRUE(result.has_value()) << "WHERE + HAVING IN failed: " << result.error().message();
     for (const auto& [age, count] : result.value()) {
         EXPECT_TRUE(age == 25 || age == 30 || age == 35) << "WHERE + HAVING IN: unexpected age " << age;
@@ -1536,7 +1537,7 @@ TYPED_TEST(AggregateTest, HavingWithWhereAndBetween) {
                           .template group_by<^^Person::years_experience>()
                           .having(storm::orm::where::field<^^Person::years_experience>().between(3, 8))
                           .count()
-                          .select();
+                          .execute();
     ASSERT_TRUE(result.has_value()) << "WHERE + HAVING BETWEEN failed: " << result.error().message();
     for (const auto& [years, count] : result.value()) {
         EXPECT_GE(years, 3) << "WHERE + HAVING BETWEEN lower bound failed";
@@ -1551,7 +1552,7 @@ TYPED_TEST(AggregateTest, HavingWithWhereAndLogicalAnd) {
                           .having(storm::orm::where::field<^^Person::age>() > 20 &&
                                   storm::orm::where::field<^^Person::age>() < 40)
                           .count()
-                          .select();
+                          .execute();
     ASSERT_TRUE(result.has_value()) << "WHERE + HAVING AND failed: " << result.error().message();
     for (const auto& [age, count] : result.value()) {
         EXPECT_GT(age, 20) << "WHERE + HAVING AND: age should be > 20";
@@ -1564,7 +1565,7 @@ TYPED_TEST(AggregateTest, HavingInOnAggregateStatement) {
     auto result = this->qs->template group_by<^^Person::age>()
                           .count()
                           .having(storm::orm::where::field<^^Person::age>().in(25, 30))
-                          .select();
+                          .execute();
     ASSERT_TRUE(result.has_value()) << "HAVING IN on AggregateStatement failed: " << result.error().message();
     for (const auto& [age, count] : result.value()) {
         EXPECT_TRUE(age == 25 || age == 30) << "HAVING IN on AggregateStatement: unexpected age " << age;
@@ -1576,7 +1577,7 @@ TYPED_TEST(AggregateTest, HavingBetweenOnAggregateStatement) {
     auto result = this->qs->template group_by<^^Person::age>()
                           .template sum<^^Person::salary>()
                           .having(storm::orm::where::field<^^Person::age>().between(25, 35))
-                          .select();
+                          .execute();
     ASSERT_TRUE(result.has_value()) << "HAVING BETWEEN on AggregateStatement failed: " << result.error().message();
     for (const auto& [age, sum_salary] : result.value()) {
         EXPECT_GE(age, 25) << "HAVING BETWEEN on AggregateStatement: lower bound";
@@ -1590,7 +1591,7 @@ TYPED_TEST(AggregateTest, HavingLogicalOnAggregateStatement) {
                           .template avg<^^Person::salary>()
                           .having(storm::orm::where::field<^^Person::age>() >= 25 &&
                                   storm::orm::where::field<^^Person::age>() <= 40)
-                          .select();
+                          .execute();
     ASSERT_TRUE(result.has_value()) << "HAVING AND on AggregateStatement failed: " << result.error().message();
     for (const auto& [age, avg_salary] : result.value()) {
         EXPECT_GE(age, 25) << "HAVING AND on AggregateStatement: lower bound";
@@ -1610,7 +1611,7 @@ TYPED_TEST(GroupByOrderByTest, GroupByWithOrderByAscending) {
     auto result = this->qs->template order_by<^^Person::department>()
                           .template group_by<^^Person::department>()
                           .count()
-                          .select();
+                          .execute();
 
     ASSERT_TRUE(result.has_value()) << "GROUP BY + ORDER BY should succeed";
     ASSERT_FALSE(result.value().empty());
@@ -1629,7 +1630,7 @@ TYPED_TEST(GroupByOrderByTest, GroupByWithOrderByDescending) {
     auto result = this->qs->template order_by<^^Person::department, false>()
                           .template group_by<^^Person::department>()
                           .count()
-                          .select();
+                          .execute();
 
     ASSERT_TRUE(result.has_value()) << "GROUP BY + ORDER BY DESC should succeed";
     ASSERT_FALSE(result.value().empty());
@@ -1649,7 +1650,7 @@ TYPED_TEST(GroupByOrderByTest, GroupByRepeatedExecution) {
         auto result = this->qs->template order_by<^^Person::department>()
                               .template group_by<^^Person::department>()
                               .count()
-                              .select();
+                              .execute();
 
         ASSERT_TRUE(result.has_value()) << "Repeated GROUP BY should succeed on iteration " << i;
         EXPECT_EQ(result.value().size(), 5) << "Should have 5 departments";
@@ -1657,13 +1658,13 @@ TYPED_TEST(GroupByOrderByTest, GroupByRepeatedExecution) {
 }
 
 TYPED_TEST(GroupByOrderByTest, GroupByWithDifferentAggregatesSequentially) {
-    auto count_result = this->qs->template group_by<^^Person::department>().count().select();
+    auto count_result = this->qs->template group_by<^^Person::department>().count().execute();
     ASSERT_TRUE(count_result.has_value());
 
-    auto sum_result = this->qs->template group_by<^^Person::department>().template sum<^^Person::salary>().select();
+    auto sum_result = this->qs->template group_by<^^Person::department>().template sum<^^Person::salary>().execute();
     ASSERT_TRUE(sum_result.has_value());
 
-    auto avg_result = this->qs->template group_by<^^Person::department>().template avg<^^Person::age>().select();
+    auto avg_result = this->qs->template group_by<^^Person::department>().template avg<^^Person::age>().execute();
     ASSERT_TRUE(avg_result.has_value());
 
     EXPECT_EQ(count_result.value().size(), sum_result.value().size());
@@ -1683,7 +1684,7 @@ TYPED_TEST(AggregateTest, HavingWithOrderByAndLimit) {
                           .template group_by<^^Person::age>()
                           .having(storm::orm::where::field<^^Person::age>() > 25)
                           .count()
-                          .select();
+                          .execute();
     ASSERT_TRUE(result.has_value()) << "HAVING + ORDER BY + LIMIT failed: " << result.error().message();
 
     const auto& groups = result.value();
@@ -1704,7 +1705,7 @@ TYPED_TEST(AggregateTest, HavingWithOrderByOnly) {
                           .template group_by<^^Person::age>()
                           .having(storm::orm::where::field<^^Person::age>() > 30)
                           .count()
-                          .select();
+                          .execute();
     ASSERT_TRUE(result.has_value()) << "HAVING + ORDER BY failed: " << result.error().message();
 
     const auto& groups   = result.value();
@@ -1722,7 +1723,7 @@ TYPED_TEST(AggregateTest, HavingWithLimitOnly) {
                           .template group_by<^^Person::age>()
                           .having(storm::orm::where::field<^^Person::age>() > 25)
                           .count()
-                          .select();
+                          .execute();
     ASSERT_TRUE(result.has_value()) << "HAVING + LIMIT failed: " << result.error().message();
 
     EXPECT_LE(result.value().size(), 2) << "LIMIT 2 should return at most 2 groups";
@@ -1734,7 +1735,7 @@ TYPED_TEST(AggregateTest, HavingWithOffsetOnly) {
                           .template group_by<^^Person::age>()
                           .having(storm::orm::where::field<^^Person::age>() > 25)
                           .count()
-                          .select();
+                          .execute();
     ASSERT_TRUE(result.has_value()) << "HAVING + OFFSET failed: " << result.error().message();
 }
 

--- a/tests/query/test_distinct.cpp
+++ b/tests/query/test_distinct.cpp
@@ -36,7 +36,7 @@ TYPED_TEST(DistinctTest, DistinctNameFieldWithDuplicates) {
     ASSERT_TRUE(insert_result.has_value()) << "INSERT failed: " << insert_result.error().message();
 
     // SELECT DISTINCT age
-    auto result = queryset.template distinct<^^Person::age>().select();
+    auto result = queryset.template distinct<^^Person::age>().execute();
     ASSERT_TRUE(result.has_value()) << "SELECT DISTINCT failed: " << result.error().message();
 
     const auto& ages = result.value();
@@ -61,7 +61,7 @@ TYPED_TEST(DistinctTest, DistinctAgeFieldWithDuplicates) {
     ASSERT_TRUE(insert_result.has_value());
 
     // SELECT DISTINCT age
-    auto result = queryset.template distinct<^^Person::age>().select();
+    auto result = queryset.template distinct<^^Person::age>().execute();
     ASSERT_TRUE(result.has_value());
 
     const auto& ages = result.value();
@@ -85,7 +85,7 @@ TYPED_TEST(DistinctTest, DistinctDefaultsToPrimaryKey) {
     ASSERT_TRUE(insert_result.has_value());
 
     // SELECT DISTINCT (defaults to PK)
-    auto result = queryset.distinct().select();
+    auto result = queryset.distinct().execute();
     ASSERT_TRUE(result.has_value());
 
     const auto& ids = result.value();
@@ -109,7 +109,7 @@ TYPED_TEST(DistinctTest, DistinctNameFieldAllUnique) {
     ASSERT_TRUE(insert_result.has_value());
 
     // SELECT DISTINCT name
-    auto result = queryset.template distinct<^^Person::name>().select();
+    auto result = queryset.template distinct<^^Person::name>().execute();
     ASSERT_TRUE(result.has_value());
 
     const auto& names = result.value();
@@ -128,7 +128,7 @@ TYPED_TEST(DistinctTest, DistinctWithSingleRow) {
     ASSERT_TRUE(insert_result.has_value());
 
     // SELECT DISTINCT name
-    auto result = queryset.template distinct<^^Person::name>().select();
+    auto result = queryset.template distinct<^^Person::name>().execute();
     ASSERT_TRUE(result.has_value());
 
     const auto& names = result.value();
@@ -151,7 +151,7 @@ TYPED_TEST(DistinctTest, DistinctWithLargeDataset) {
     ASSERT_TRUE(insert_result.has_value());
 
     // SELECT DISTINCT age
-    auto result = queryset.template distinct<^^Person::age>().select();
+    auto result = queryset.template distinct<^^Person::age>().execute();
     ASSERT_TRUE(result.has_value());
 
     const auto& ages = result.value();
@@ -169,7 +169,7 @@ TYPED_TEST(DistinctTest, DistinctWithEmptyStrings) {
     ASSERT_TRUE(insert_result.has_value());
 
     // SELECT DISTINCT age
-    auto result = queryset.template distinct<^^Person::age>().select();
+    auto result = queryset.template distinct<^^Person::age>().execute();
     ASSERT_TRUE(result.has_value());
 
     const auto& ages = result.value();
@@ -188,15 +188,15 @@ TYPED_TEST(DistinctTest, VerifyReturnTypes) {
     std::ignore = queryset.insert(Person{.id = 0, .name = "Alice", .age = 30}).execute();
 
     // Verify return type for distinct on name field is hive of strings
-    auto names_result = queryset.template distinct<^^Person::name>().select();
+    auto names_result = queryset.template distinct<^^Person::name>().execute();
     static_assert(std::is_same_v<decltype(names_result.value()), plf::hive<std::string>&>);
 
     // Verify return type for distinct on age field is hive of integers
-    auto ages_result = queryset.template distinct<^^Person::age>().select();
+    auto ages_result = queryset.template distinct<^^Person::age>().execute();
     static_assert(std::is_same_v<decltype(ages_result.value()), plf::hive<int>&>);
 
     // Verify return type for distinct on primary key is hive of integers
-    auto ids_result = queryset.distinct().select();
+    auto ids_result = queryset.distinct().execute();
     static_assert(std::is_same_v<decltype(ids_result.value()), plf::hive<int>&>);
 }
 
@@ -220,7 +220,7 @@ TYPED_TEST(DistinctTest, DistinctTwoFieldsNameAndAge) {
     ASSERT_TRUE(insert_result.has_value());
 
     // SELECT DISTINCT name, age — all (name, age) pairs are unique since names are unique
-    auto result = queryset.template distinct<^^Person::name, ^^Person::age>().select();
+    auto result = queryset.template distinct<^^Person::name, ^^Person::age>().execute();
     ASSERT_TRUE(result.has_value()) << "SELECT DISTINCT failed: " << result.error().message();
 
     const auto& pairs = result.value();
@@ -253,7 +253,7 @@ TYPED_TEST(DistinctTest, DistinctThreeFieldsAllFields) {
     auto insert_result = queryset.insert(std::span<const Person>(people_to_insert)).execute();
     ASSERT_TRUE(insert_result.has_value());
 
-    auto result = queryset.template distinct<^^Person::name, ^^Person::age>().select();
+    auto result = queryset.template distinct<^^Person::name, ^^Person::age>().execute();
     ASSERT_TRUE(result.has_value());
 
     const auto& pairs = result.value();
@@ -282,7 +282,7 @@ TYPED_TEST(DistinctTest, DistinctTwoFieldsAllDuplicates) {
     ASSERT_TRUE(insert_result.has_value());
 
     // SELECT DISTINCT age — all have the same age, so only 1 result
-    auto result = queryset.template distinct<^^Person::age>().select();
+    auto result = queryset.template distinct<^^Person::age>().execute();
     ASSERT_TRUE(result.has_value());
 
     const auto& ages = result.value();
@@ -308,7 +308,7 @@ TYPED_TEST(DistinctTest, DistinctTwoFieldsLargeDataset) {
     ASSERT_TRUE(insert_result.has_value());
 
     // SELECT DISTINCT age — should deduplicate to 10 unique ages
-    auto result = queryset.template distinct<^^Person::age>().select();
+    auto result = queryset.template distinct<^^Person::age>().execute();
     ASSERT_TRUE(result.has_value());
 
     const auto& ages = result.value();
@@ -327,7 +327,7 @@ TYPED_TEST(DistinctTest, DistinctTwoFieldsDifferentOrder) {
     ASSERT_TRUE(insert_result.has_value());
 
     // SELECT DISTINCT age, name (reversed order)
-    auto result = queryset.template distinct<^^Person::age, ^^Person::name>().select();
+    auto result = queryset.template distinct<^^Person::age, ^^Person::name>().execute();
     ASSERT_TRUE(result.has_value());
 
     const auto& pairs = result.value();
@@ -349,11 +349,11 @@ TYPED_TEST(DistinctTest, VerifyMultiFieldReturnTypes) {
     std::ignore = queryset.insert(Person{.id = 0, .name = "Alice", .age = 30}).execute();
 
     // Verify return type for distinct on name and age is hive of tuples containing string and int
-    auto pairs_result = queryset.template distinct<^^Person::name, ^^Person::age>().select();
+    auto pairs_result = queryset.template distinct<^^Person::name, ^^Person::age>().execute();
     static_assert(std::is_same_v<decltype(pairs_result.value()), plf::hive<std::tuple<std::string, int>>&>);
 
     // Verify return type for distinct on age and name (reversed order) is hive of tuples containing int and string
-    auto reversed_result = queryset.template distinct<^^Person::age, ^^Person::name>().select();
+    auto reversed_result = queryset.template distinct<^^Person::age, ^^Person::name>().execute();
     static_assert(std::is_same_v<decltype(reversed_result.value()), plf::hive<std::tuple<int, std::string>>&>);
 }
 
@@ -365,7 +365,7 @@ TYPED_TEST(DistinctTest, DistinctTwoFieldsWithSingleRow) {
     auto         insert_result = queryset.insert(alice).execute();
     ASSERT_TRUE(insert_result.has_value());
 
-    auto result = queryset.template distinct<^^Person::name, ^^Person::age>().select();
+    auto result = queryset.template distinct<^^Person::name, ^^Person::age>().execute();
     ASSERT_TRUE(result.has_value());
 
     const auto& pairs = result.value();
@@ -388,7 +388,7 @@ TYPED_TEST(DistinctTest, DuplicateFieldSpecification) {
     ASSERT_TRUE(insert_result.has_value());
 
     // SELECT DISTINCT age, age (redundant but valid SQL)
-    auto result = queryset.template distinct<^^Person::age, ^^Person::age>().select();
+    auto result = queryset.template distinct<^^Person::age, ^^Person::age>().execute();
     ASSERT_TRUE(result.has_value());
 
     const auto& pairs = result.value();
@@ -418,7 +418,7 @@ TYPED_TEST(DistinctTest, TriplicateFieldSpecification) {
     std::ignore                = queryset.insert(std::span<const Person>(people)).execute();
 
     // SELECT DISTINCT age, age, age (extreme redundancy)
-    auto result = queryset.template distinct<^^Person::age, ^^Person::age, ^^Person::age>().select();
+    auto result = queryset.template distinct<^^Person::age, ^^Person::age, ^^Person::age>().execute();
     ASSERT_TRUE(result.has_value());
 
     const auto& triples = result.value();
@@ -450,7 +450,7 @@ TYPED_TEST(DistinctTest, CrossStructFieldAccessPrevented) {
      *
      * Example that WON'T compile:
      *   QuerySet<Person> person_qs;
-     *   person_qs.template distinct<&Message::sender_id>().select(); // COMPILE ERROR!
+     *   person_qs.template distinct<&Message::sender_id>().execute(); // COMPILE ERROR!
      *
      * Error: "left hand operand to .* must be a class compatible with the right hand operand"
      *
@@ -468,11 +468,11 @@ TYPED_TEST(DistinctTest, VerifyDuplicateFieldReturnTypes) {
     std::ignore = queryset.insert(Person{.id = 0, .name = "Alice", .age = 30}).execute();
 
     // Duplicate field returns tuple with same type repeated
-    auto dup_result = queryset.template distinct<^^Person::name, ^^Person::name>().select();
+    auto dup_result = queryset.template distinct<^^Person::name, ^^Person::name>().execute();
     static_assert(std::is_same_v<decltype(dup_result.value()), plf::hive<std::tuple<std::string, std::string>>&>);
 
     // Triple duplicate
-    auto trip_result = queryset.template distinct<^^Person::age, ^^Person::age, ^^Person::age>().select();
+    auto trip_result = queryset.template distinct<^^Person::age, ^^Person::age, ^^Person::age>().execute();
     static_assert(std::is_same_v<decltype(trip_result.value()), plf::hive<std::tuple<int, int, int>>&>);
 }
 
@@ -486,7 +486,7 @@ TYPED_TEST(DistinctTest, MixedDuplicateFields) {
     std::ignore = queryset.insert(std::span<const Person>(people)).execute();
 
     // SELECT DISTINCT age, name, age (age appears twice)
-    auto result = queryset.template distinct<^^Person::age, ^^Person::name, ^^Person::age>().select();
+    auto result = queryset.template distinct<^^Person::age, ^^Person::name, ^^Person::age>().execute();
     ASSERT_TRUE(result.has_value());
 
     const auto& triples = result.value();
@@ -551,7 +551,7 @@ TYPED_TEST(DistinctTest, DistinctOnBaseTableWithoutJoin) {
     QuerySet<Message, TypeParam> msg_qs;
 
     // DISTINCT on Message.content (no JOIN involved)
-    auto result = msg_qs.template distinct<^^Message::content>().select();
+    auto result = msg_qs.template distinct<^^Message::content>().execute();
     ASSERT_TRUE(result.has_value());
 
     const auto& contents = result.value();
@@ -622,12 +622,12 @@ TYPED_TEST(DistinctTest, DesiredSQLForDistinctWithJoin) {
      * Option A: Chaining
      *   msg_qs.template join<&Message::sender>()
      *         .template distinct<&Person::name>()  // PROBLEM: &Person::name won't match Message fields
-     *         .select()
+     *         .execute()
      *
      * Option B: Separate DISTINCT type for JOINs
      *   msg_qs.template join<&Message::sender>()
      *         .distinct_joined<&Message::sender, &Person::name>()
-     *         .select()
+     *         .execute()
      *
      * Option C: SQL-style field selection
      *   msg_qs.template join<&Message::sender>()
@@ -773,7 +773,7 @@ TYPED_TEST(DistinctTest, DistinctWithWhereSingleField) {
     ASSERT_TRUE(insert_result.has_value());
 
     // SELECT DISTINCT age WHERE age > 22
-    auto result = queryset.where(field<^^Person::age>() > 22).template distinct<^^Person::age>().select();
+    auto result = queryset.where(field<^^Person::age>() > 22).template distinct<^^Person::age>().execute();
     ASSERT_TRUE(result.has_value()) << "DISTINCT with WHERE failed: " << result.error().message();
 
     const auto& ages = result.value();
@@ -807,7 +807,7 @@ TYPED_TEST(DistinctTest, DistinctWithWhereMultipleFields) {
 
     // SELECT DISTINCT name, age WHERE age > 22
     auto result =
-            queryset.where(field<^^Person::age>() > 22).template distinct<^^Person::name, ^^Person::age>().select();
+            queryset.where(field<^^Person::age>() > 22).template distinct<^^Person::name, ^^Person::age>().execute();
     ASSERT_TRUE(result.has_value()) << "DISTINCT with WHERE failed: " << result.error().message();
 
     const auto& pairs = result.value();
@@ -835,7 +835,7 @@ TYPED_TEST(DistinctTest, DistinctWithWhereNoResults) {
     ASSERT_TRUE(insert_result.has_value());
 
     // SELECT DISTINCT name WHERE age > 100 (no matches)
-    auto result = queryset.where(field<^^Person::age>() > 100).template distinct<^^Person::name>().select();
+    auto result = queryset.where(field<^^Person::age>() > 100).template distinct<^^Person::name>().execute();
     ASSERT_TRUE(result.has_value());
 
     const auto& names = result.value();
@@ -860,7 +860,7 @@ TYPED_TEST(DistinctTest, DistinctWithComplexWhere) {
     ASSERT_TRUE(insert_result.has_value());
 
     // SELECT DISTINCT age WHERE age >= 25 AND age <= 35
-    auto result = queryset.where(field<^^Person::age>().between(25, 35)).template distinct<^^Person::age>().select();
+    auto result = queryset.where(field<^^Person::age>().between(25, 35)).template distinct<^^Person::age>().execute();
     ASSERT_TRUE(result.has_value());
 
     const auto& ages = result.value();
@@ -882,7 +882,7 @@ TYPED_TEST(DistinctTest, DistinctWithJoinSingleField) {
     // SELECT DISTINCT sender.name (via JOIN)
     // Note: We need to select from Message and distinct on Message fields
     // The JOIN should expand the result set
-    auto result = msg_qs.template join<&Message::sender>().template distinct<^^Message::content>().select();
+    auto result = msg_qs.template join<&Message::sender>().template distinct<^^Message::content>().execute();
     ASSERT_TRUE(result.has_value()) << "DISTINCT with JOIN failed: " << result.error().message();
 
     const auto& contents = result.value();
@@ -905,7 +905,7 @@ TYPED_TEST(DistinctTest, ChainingOrderWhereJoinDistinct) {
     auto result = msg_qs.where(field<^^Message::content>().like("%e%"))
                           .template join<&Message::sender>()
                           .template distinct<^^Message::content>()
-                          .select();
+                          .execute();
     ASSERT_TRUE(result.has_value()) << "WHERE -> JOIN -> DISTINCT failed: " << result.error().message();
 }
 
@@ -920,7 +920,7 @@ TYPED_TEST(DistinctTest, ChainingOrderJoinWhereDistinct) {
     auto result = msg_qs.template join<&Message::sender>()
                           .where(field<^^Message::content>().like("%e%"))
                           .template distinct<^^Message::content>()
-                          .select();
+                          .execute();
     ASSERT_TRUE(result.has_value()) << "JOIN -> WHERE -> DISTINCT failed: " << result.error().message();
 }
 
@@ -938,7 +938,7 @@ TYPED_TEST(DistinctTest, DistinctDefaultPKWithWhere) {
     ASSERT_TRUE(insert_result.has_value());
 
     // SELECT DISTINCT id (default PK) WHERE age > 22
-    auto result = queryset.where(field<^^Person::age>() > 22).distinct().select();
+    auto result = queryset.where(field<^^Person::age>() > 22).distinct().execute();
     ASSERT_TRUE(result.has_value());
 
     const auto& ids = result.value();
@@ -963,7 +963,7 @@ TYPED_TEST(DistinctTest, MultipleWhereClausesWithDistinct) {
     auto result = queryset.where(field<^^Person::age>() > 22)
                           .where(field<^^Person::age>() < 32)
                           .template distinct<^^Person::name>()
-                          .select();
+                          .execute();
     ASSERT_TRUE(result.has_value());
 
     const auto&                              names = result.value();
@@ -999,7 +999,7 @@ TYPED_TEST(DistinctTest, DistinctKeywordInjectionInJoinQueries) {
     QuerySet<Message, TypeParam> msg_qs;
 
     // Test 1: Verify JOIN + DISTINCT works (implicit validation of SELECT clause injection)
-    auto result = msg_qs.template join<&Message::sender>().template distinct<^^Message::content>().select();
+    auto result = msg_qs.template join<&Message::sender>().template distinct<^^Message::content>().execute();
     ASSERT_TRUE(result.has_value()) << "JOIN + DISTINCT failed: " << result.error().message();
 
     const auto& contents = result.value();
@@ -1031,7 +1031,7 @@ TYPED_TEST(DistinctTest, DistinctWithOrderByAsc) {
     ASSERT_TRUE(insert_result.has_value());
 
     // SELECT DISTINCT age ORDER BY age ASC
-    auto result = queryset.template order_by<^^Person::age>().template distinct<^^Person::age>().select();
+    auto result = queryset.template order_by<^^Person::age>().template distinct<^^Person::age>().execute();
     ASSERT_TRUE(result.has_value()) << "DISTINCT with ORDER BY failed: " << result.error().message();
 
     const auto& ages = result.value();
@@ -1058,7 +1058,7 @@ TYPED_TEST(DistinctTest, DistinctWithOrderByDesc) {
     ASSERT_TRUE(insert_result.has_value());
 
     // SELECT DISTINCT name ORDER BY name DESC
-    auto result = queryset.template order_by<^^Person::name, false>().template distinct<^^Person::name>().select();
+    auto result = queryset.template order_by<^^Person::name, false>().template distinct<^^Person::name>().execute();
     ASSERT_TRUE(result.has_value()) << "DISTINCT with ORDER BY DESC failed: " << result.error().message();
 
     const auto& names = result.value();
@@ -1086,7 +1086,7 @@ TYPED_TEST(DistinctTest, DistinctWithOrderByIntegerField) {
     ASSERT_TRUE(insert_result.has_value());
 
     // SELECT DISTINCT age ORDER BY age ASC
-    auto result = queryset.template order_by<^^Person::age>().template distinct<^^Person::age>().select();
+    auto result = queryset.template order_by<^^Person::age>().template distinct<^^Person::age>().execute();
     ASSERT_TRUE(result.has_value());
 
     const auto& ages = result.value();
@@ -1115,7 +1115,7 @@ TYPED_TEST(DistinctTest, DistinctMultiFieldWithOrderBy) {
 
     // SELECT DISTINCT name, age ORDER BY name ASC
     auto result =
-            queryset.template order_by<^^Person::name>().template distinct<^^Person::name, ^^Person::age>().select();
+            queryset.template order_by<^^Person::name>().template distinct<^^Person::name, ^^Person::age>().execute();
     ASSERT_TRUE(result.has_value());
 
     const auto& pairs = result.value();
@@ -1146,7 +1146,7 @@ TYPED_TEST(DistinctTest, DistinctWithOrderByAndLimit) {
     ASSERT_TRUE(insert_result.has_value());
 
     // SELECT DISTINCT name ORDER BY name ASC LIMIT 3
-    auto result = queryset.template order_by<^^Person::name>().limit(3).template distinct<^^Person::name>().select();
+    auto result = queryset.template order_by<^^Person::name>().limit(3).template distinct<^^Person::name>().execute();
     ASSERT_TRUE(result.has_value()) << "DISTINCT with ORDER BY and LIMIT failed: " << result.error().message();
 
     const auto& names = result.value();
@@ -1176,7 +1176,7 @@ TYPED_TEST(DistinctTest, DistinctWithOrderByDescAndLimit) {
 
     // SELECT DISTINCT name ORDER BY name DESC LIMIT 2
     auto result =
-            queryset.template order_by<^^Person::name, false>().limit(2).template distinct<^^Person::name>().select();
+            queryset.template order_by<^^Person::name, false>().limit(2).template distinct<^^Person::name>().execute();
     ASSERT_TRUE(result.has_value());
 
     const auto& names = result.value();
@@ -1209,7 +1209,7 @@ TYPED_TEST(DistinctTest, DistinctWithOrderByLimitOffset) {
                           .limit(2)
                           .offset(2)
                           .template distinct<^^Person::name>()
-                          .select();
+                          .execute();
     ASSERT_TRUE(result.has_value());
 
     const auto& names = result.value();
@@ -1241,7 +1241,7 @@ TYPED_TEST(DistinctTest, DistinctWithWhereOrderByLimit) {
                           .template order_by<^^Person::name>()
                           .limit(2)
                           .template distinct<^^Person::name>()
-                          .select();
+                          .execute();
     ASSERT_TRUE(result.has_value());
 
     const auto& names = result.value();
@@ -1274,7 +1274,7 @@ TYPED_TEST(DistinctTest, DistinctOptionalIntFieldWithNulls) {
     ASSERT_TRUE(insert_result.has_value()) << "Insert failed: " << insert_result.error().message();
 
     // SELECT DISTINCT age (should include NULL as a distinct value)
-    auto result = queryset.template distinct<^^Person::score>().select();
+    auto result = queryset.template distinct<^^Person::score>().execute();
     ASSERT_TRUE(result.has_value()) << "DISTINCT on optional field failed: " << result.error().message();
 
     const auto& ages = result.value();
@@ -1315,7 +1315,7 @@ TYPED_TEST(DistinctTest, DistinctOptionalStringFieldWithNulls) {
     ASSERT_TRUE(insert_result.has_value()) << "Insert failed: " << insert_result.error().message();
 
     // SELECT DISTINCT nickname (should include NULL as a distinct value)
-    auto result = queryset.template distinct<^^Person::nickname>().select();
+    auto result = queryset.template distinct<^^Person::nickname>().execute();
     ASSERT_TRUE(result.has_value()) << "DISTINCT on optional string field failed: " << result.error().message();
 
     const auto& nicknames = result.value();
@@ -1359,7 +1359,7 @@ TYPED_TEST(DistinctTest, DistinctOptionalFieldAllNulls) {
     ASSERT_TRUE(insert_result.has_value());
 
     // SELECT DISTINCT age (all NULLs)
-    auto result = queryset.template distinct<^^Person::score>().select();
+    auto result = queryset.template distinct<^^Person::score>().execute();
     ASSERT_TRUE(result.has_value());
 
     const auto& ages = result.value();
@@ -1383,7 +1383,7 @@ TYPED_TEST(DistinctTest, DistinctOptionalFieldNoNulls) {
     ASSERT_TRUE(insert_result.has_value());
 
     // SELECT DISTINCT age (no NULLs)
-    auto result = queryset.template distinct<^^Person::score>().select();
+    auto result = queryset.template distinct<^^Person::score>().execute();
     ASSERT_TRUE(result.has_value());
 
     const auto& ages = result.value();
@@ -1412,7 +1412,7 @@ TYPED_TEST(DistinctTest, DistinctMultiFieldWithOptional) {
     ASSERT_TRUE(insert_result.has_value());
 
     // SELECT DISTINCT name, score
-    auto result = queryset.template distinct<^^Person::name, ^^Person::score>().select();
+    auto result = queryset.template distinct<^^Person::name, ^^Person::score>().execute();
     ASSERT_TRUE(result.has_value());
 
     const auto& pairs = result.value();
@@ -1435,7 +1435,7 @@ TYPED_TEST(DistinctTest, DistinctOptionalWithWhereOnOptional) {
     ASSERT_TRUE(insert_result.has_value());
 
     // SELECT DISTINCT name WHERE age > 20 (filters out NULLs)
-    auto result = queryset.where(field<^^Person::score>() > 20).template distinct<^^Person::name>().select();
+    auto result = queryset.where(field<^^Person::score>() > 20).template distinct<^^Person::name>().execute();
     ASSERT_TRUE(result.has_value());
 
     const auto& names = result.value();
@@ -1466,7 +1466,7 @@ TYPED_TEST(DistinctTest, DistinctOptionalWithOrderBy) {
 
     // SELECT DISTINCT age ORDER BY age ASC
     // NULL values typically sort first or last depending on DB
-    auto result = queryset.template order_by<^^Person::score>().template distinct<^^Person::score>().select();
+    auto result = queryset.template order_by<^^Person::score>().template distinct<^^Person::score>().execute();
     ASSERT_TRUE(result.has_value());
 
     const auto& ages = result.value();
@@ -1487,7 +1487,7 @@ TYPED_TEST(DistinctTest, DistinctReturnsExpectedType) {
     std::ignore = queryset.insert(Person{.id = 0, .name = "Alice", .age = 30}).execute();
 
     // Verify return type is std::expected
-    auto result = queryset.template distinct<^^Person::name>().select();
+    auto result = queryset.template distinct<^^Person::name>().execute();
 
     // Verify result is a std::expected type by checking has_value()
     // The exact type includes the connection's Error type, which is internal
@@ -1526,7 +1526,7 @@ TYPED_TEST(DistinctTest, ErrorHandlingDocumentation) {
      *
      * 5. **Example Error Handling**:
      *    ```cpp
-     *    auto result = queryset.template distinct<^^Person::name>().select();
+     *    auto result = queryset.template distinct<^^Person::name>().execute();
      *    if (!result.has_value()) {
      *        // Handle error
      *        std::cerr << "Error: " << result.error().message() << std::endl;
@@ -1561,7 +1561,7 @@ TYPED_TEST(DistinctTest, StatementReuseStability) {
     // Execute the same DISTINCT query multiple times
     // This tests that statement caching works correctly
     for (int i = 0; i < 5; ++i) {
-        auto result = queryset.template distinct<^^Person::name>().select();
+        auto result = queryset.template distinct<^^Person::name>().execute();
         ASSERT_TRUE(result.has_value()) << "Iteration " << i << " failed: " << result.error().message();
         EXPECT_EQ(result.value().size(), 3) << "Iteration " << i << " returned wrong count";
     }
@@ -1581,7 +1581,7 @@ TYPED_TEST(DistinctTest, DifferentWhereExpressionsWithCaching) {
     std::ignore = queryset.insert(people).execute();
 
     // Query 1: age > 25
-    auto result1 = queryset.where(field<^^Person::age>() > 25).template distinct<^^Person::name>().select();
+    auto result1 = queryset.where(field<^^Person::age>() > 25).template distinct<^^Person::name>().execute();
     ASSERT_TRUE(result1.has_value());
     EXPECT_EQ(result1.value().size(), 3); // Bob, Charlie, Dave
 
@@ -1589,14 +1589,14 @@ TYPED_TEST(DistinctTest, DifferentWhereExpressionsWithCaching) {
     queryset.reset();
 
     // Query 2: age > 35
-    auto result2 = queryset.where(field<^^Person::age>() > 35).template distinct<^^Person::name>().select();
+    auto result2 = queryset.where(field<^^Person::age>() > 35).template distinct<^^Person::name>().execute();
     ASSERT_TRUE(result2.has_value());
     EXPECT_EQ(result2.value().size(), 1); // Dave only
 
     // Reset and Query 3: different condition
     queryset.reset();
 
-    auto result3 = queryset.where(field<^^Person::age>() < 30).template distinct<^^Person::name>().select();
+    auto result3 = queryset.where(field<^^Person::age>() < 30).template distinct<^^Person::name>().execute();
     ASSERT_TRUE(result3.has_value());
     EXPECT_EQ(result3.value().size(), 1); // Alice only
 }

--- a/tests/query/test_limit_offset.cpp
+++ b/tests/query/test_limit_offset.cpp
@@ -144,7 +144,7 @@ TYPED_TEST(LimitOffsetTest, WhereWithOffsetNoLimit) {
 TYPED_TEST(LimitOffsetTest, DistinctWithLimit) {
     QuerySet<Person, TypeParam> qs;
 
-    auto result = qs.limit(5).template distinct<^^Person::name>().select();
+    auto result = qs.limit(5).template distinct<^^Person::name>().execute();
     ASSERT_TRUE(result.has_value()) << "DISTINCT with LIMIT failed: " << result.error().message();
 
     const auto& names = result.value();

--- a/tests/query/test_values.cpp
+++ b/tests/query/test_values.cpp
@@ -39,7 +39,7 @@ TYPED_TEST(ValuesTest, SingleFieldNameWithDuplicates) {
     ASSERT_TRUE(insert_result.has_value()) << "INSERT failed: " << insert_result.error().message();
 
     // SELECT age (no DISTINCT — should return ALL rows including duplicates)
-    auto result = queryset.template values<^^Person::age>().select();
+    auto result = queryset.template values<^^Person::age>().execute();
     ASSERT_TRUE(result.has_value()) << "SELECT values failed: " << result.error().message();
 
     const auto& ages = result.value();
@@ -57,7 +57,7 @@ TYPED_TEST(ValuesTest, SingleFieldAgeWithDuplicates) {
     ASSERT_TRUE(insert_result.has_value());
 
     // SELECT age — should return 4 rows (duplicates preserved)
-    auto result = queryset.template values<^^Person::age>().select();
+    auto result = queryset.template values<^^Person::age>().execute();
     ASSERT_TRUE(result.has_value());
 
     const auto& ages = result.value();
@@ -82,7 +82,7 @@ TYPED_TEST(ValuesTest, SingleFieldAgeWithDuplicates) {
 TYPED_TEST(ValuesTest, SingleFieldFromEmptyTable) {
     QuerySet<Person, TypeParam> queryset;
 
-    auto result = queryset.template values<^^Person::name>().select();
+    auto result = queryset.template values<^^Person::name>().execute();
     ASSERT_TRUE(result.has_value());
 
     const auto& names = result.value();
@@ -97,7 +97,7 @@ TYPED_TEST(ValuesTest, SingleFieldWithSingleRow) {
     auto         insert_result = queryset.insert(alice).execute();
     ASSERT_TRUE(insert_result.has_value());
 
-    auto result = queryset.template values<^^Person::name>().select();
+    auto result = queryset.template values<^^Person::name>().execute();
     ASSERT_TRUE(result.has_value());
 
     const auto& names = result.value();
@@ -123,7 +123,7 @@ TYPED_TEST(ValuesTest, TwoFieldsNameAndAge) {
     auto insert_result = queryset.insert(std::span<const Person>(people)).execute();
     ASSERT_TRUE(insert_result.has_value());
 
-    auto result = queryset.template values<^^Person::name, ^^Person::age>().select();
+    auto result = queryset.template values<^^Person::name, ^^Person::age>().execute();
     ASSERT_TRUE(result.has_value()) << "SELECT values failed: " << result.error().message();
 
     const auto& pairs = result.value();
@@ -138,19 +138,19 @@ TYPED_TEST(ValuesTest, VerifyReturnTypes) {
     std::ignore = queryset.insert(Person{.id = 0, .name = "Alice", .age = 30}).execute();
 
     // Verify return type for values on name field is hive of strings
-    auto names_result = queryset.template values<^^Person::name>().select();
+    auto names_result = queryset.template values<^^Person::name>().execute();
     static_assert(std::is_same_v<decltype(names_result.value()), plf::hive<std::string>&>);
 
     // Verify return type for values on age field is hive of integers
-    auto ages_result = queryset.template values<^^Person::age>().select();
+    auto ages_result = queryset.template values<^^Person::age>().execute();
     static_assert(std::is_same_v<decltype(ages_result.value()), plf::hive<int>&>);
 
     // Verify return type for multi-field values is hive of tuples
-    auto pairs_result = queryset.template values<^^Person::name, ^^Person::age>().select();
+    auto pairs_result = queryset.template values<^^Person::name, ^^Person::age>().execute();
     static_assert(std::is_same_v<decltype(pairs_result.value()), plf::hive<std::tuple<std::string, int>>&>);
 
     // Reversed order
-    auto reversed_result = queryset.template values<^^Person::age, ^^Person::name>().select();
+    auto reversed_result = queryset.template values<^^Person::age, ^^Person::name>().execute();
     static_assert(std::is_same_v<decltype(reversed_result.value()), plf::hive<std::tuple<int, std::string>>&>);
 }
 
@@ -172,7 +172,7 @@ TYPED_TEST(ValuesTest, DuplicatesPreserved) {
     ASSERT_TRUE(insert_result.has_value());
 
     // values() should return ALL 10 rows (duplicate ages preserved)
-    auto values_result = queryset.template values<^^Person::age>().select();
+    auto values_result = queryset.template values<^^Person::age>().execute();
     ASSERT_TRUE(values_result.has_value());
     EXPECT_EQ(values_result.value().size(), 10) << "values() should preserve all duplicates";
 
@@ -202,7 +202,7 @@ TYPED_TEST(ValuesTest, WithWhereSingleField) {
     ASSERT_TRUE(insert_result.has_value());
 
     // SELECT name WHERE age > 22
-    auto result = queryset.where(field<^^Person::age>() > 22).template values<^^Person::name>().select();
+    auto result = queryset.where(field<^^Person::age>() > 22).template values<^^Person::name>().execute();
     ASSERT_TRUE(result.has_value()) << "values with WHERE failed: " << result.error().message();
 
     const auto& names = result.value();
@@ -228,7 +228,7 @@ TYPED_TEST(ValuesTest, WithMultipleWhereClauses) {
     auto result = queryset.where(field<^^Person::age>() > 22)
                           .where(field<^^Person::age>() < 32)
                           .template values<^^Person::name>()
-                          .select();
+                          .execute();
     ASSERT_TRUE(result.has_value());
 
     const auto& names = result.value();
@@ -251,7 +251,7 @@ TYPED_TEST(ValuesTest, WithComplexWhere) {
     ASSERT_TRUE(insert_result.has_value());
 
     // SELECT name WHERE age BETWEEN 25 AND 35
-    auto result = queryset.where(field<^^Person::age>().between(25, 35)).template values<^^Person::name>().select();
+    auto result = queryset.where(field<^^Person::age>().between(25, 35)).template values<^^Person::name>().execute();
     ASSERT_TRUE(result.has_value());
 
     const auto& names = result.value();
@@ -266,7 +266,7 @@ TYPED_TEST(ValuesTest, WithWhereNoResults) {
     auto                insert_result = queryset.insert(people).execute();
     ASSERT_TRUE(insert_result.has_value());
 
-    auto result = queryset.where(field<^^Person::age>() > 100).template values<^^Person::name>().select();
+    auto result = queryset.where(field<^^Person::age>() > 100).template values<^^Person::name>().execute();
     ASSERT_TRUE(result.has_value());
     EXPECT_EQ(result.value().size(), 0);
 }
@@ -282,7 +282,7 @@ TYPED_TEST(ValuesTest, WithJoinSingleField) {
     QuerySet<Message, TypeParam> msg_qs;
 
     // SELECT content FROM Message JOIN Person (values replaces field list)
-    auto result = msg_qs.template join<&Message::sender>().template values<^^Message::content>().select();
+    auto result = msg_qs.template join<&Message::sender>().template values<^^Message::content>().execute();
     ASSERT_TRUE(result.has_value()) << "values with JOIN failed: " << result.error().message();
 
     const auto& contents = result.value();
@@ -299,7 +299,7 @@ TYPED_TEST(ValuesTest, WithJoinAndWhere) {
     auto result = msg_qs.template join<&Message::sender>()
                           .where(field<^^Message::content>().like("%o%")) // Hello, World, Goodbye
                           .template values<^^Message::content>()
-                          .select();
+                          .execute();
     ASSERT_TRUE(result.has_value()) << "values with JOIN and WHERE failed: " << result.error().message();
 
     const auto& contents = result.value();
@@ -330,7 +330,7 @@ TYPED_TEST(ValuesTest, WithOrderByAsc) {
     auto insert_result = queryset.insert(people).execute();
     ASSERT_TRUE(insert_result.has_value());
 
-    auto result = queryset.template order_by<^^Person::name>().template values<^^Person::name>().select();
+    auto result = queryset.template order_by<^^Person::name>().template values<^^Person::name>().execute();
     ASSERT_TRUE(result.has_value());
 
     const auto& names = result.value();
@@ -355,7 +355,7 @@ TYPED_TEST(ValuesTest, WithOrderByDesc) {
     auto insert_result = queryset.insert(people).execute();
     ASSERT_TRUE(insert_result.has_value());
 
-    auto result = queryset.template order_by<^^Person::name, false>().template values<^^Person::name>().select();
+    auto result = queryset.template order_by<^^Person::name, false>().template values<^^Person::name>().execute();
     ASSERT_TRUE(result.has_value());
 
     const auto& names = result.value();
@@ -386,7 +386,7 @@ TYPED_TEST(ValuesTest, WithLimit) {
     auto insert_result = queryset.insert(people).execute();
     ASSERT_TRUE(insert_result.has_value());
 
-    auto result = queryset.template order_by<^^Person::name>().limit(3).template values<^^Person::name>().select();
+    auto result = queryset.template order_by<^^Person::name>().limit(3).template values<^^Person::name>().execute();
     ASSERT_TRUE(result.has_value());
 
     const auto& names = result.value();
@@ -415,7 +415,7 @@ TYPED_TEST(ValuesTest, WithLimitAndOffset) {
 
     // Skip Alice, Bob and return Charlie, Dave
     auto result =
-            queryset.template order_by<^^Person::name>().limit(2).offset(2).template values<^^Person::name>().select();
+            queryset.template order_by<^^Person::name>().limit(2).offset(2).template values<^^Person::name>().execute();
     ASSERT_TRUE(result.has_value());
 
     const auto& names = result.value();
@@ -445,7 +445,7 @@ TYPED_TEST(ValuesTest, WithWhereOrderByLimit) {
                           .template order_by<^^Person::name>()
                           .limit(2)
                           .template values<^^Person::name>()
-                          .select();
+                          .execute();
     ASSERT_TRUE(result.has_value());
 
     const auto& names = result.value();
@@ -476,7 +476,7 @@ TYPED_TEST(ValuesTest, OptionalIntFieldWithNulls) {
     auto insert_result = queryset.insert(people).execute();
     ASSERT_TRUE(insert_result.has_value()) << "Insert failed: " << insert_result.error().message();
 
-    auto result = queryset.template values<^^Person::score>().select();
+    auto result = queryset.template values<^^Person::score>().execute();
     ASSERT_TRUE(result.has_value()) << "values on optional field failed: " << result.error().message();
 
     const auto& ages = result.value();
@@ -507,7 +507,7 @@ TYPED_TEST(ValuesTest, OptionalStringFieldWithNulls) {
     auto insert_result = queryset.insert(people).execute();
     ASSERT_TRUE(insert_result.has_value());
 
-    auto result = queryset.template values<^^Person::nickname>().select();
+    auto result = queryset.template values<^^Person::nickname>().execute();
     ASSERT_TRUE(result.has_value());
 
     const auto& nicknames = result.value();
@@ -543,7 +543,7 @@ TYPED_TEST(ValuesTest, StatementReuseStability) {
     std::ignore = queryset.insert(people).execute();
 
     for (int i = 0; i < 5; ++i) {
-        auto result = queryset.template values<^^Person::name>().select();
+        auto result = queryset.template values<^^Person::name>().execute();
         ASSERT_TRUE(result.has_value()) << "Iteration " << i << " failed: " << result.error().message();
         EXPECT_EQ(result.value().size(), 3) << "Iteration " << i << " returned wrong count";
     }
@@ -562,14 +562,14 @@ TYPED_TEST(ValuesTest, DifferentWhereExpressionsWithCaching) {
     std::ignore = queryset.insert(people).execute();
 
     // Query 1: age > 25
-    auto result1 = queryset.where(field<^^Person::age>() > 25).template values<^^Person::name>().select();
+    auto result1 = queryset.where(field<^^Person::age>() > 25).template values<^^Person::name>().execute();
     ASSERT_TRUE(result1.has_value());
     EXPECT_EQ(result1.value().size(), 3); // Bob, Charlie, Dave
 
     queryset.reset();
 
     // Query 2: age > 35
-    auto result2 = queryset.where(field<^^Person::age>() > 35).template values<^^Person::name>().select();
+    auto result2 = queryset.where(field<^^Person::age>() > 35).template values<^^Person::name>().execute();
     ASSERT_TRUE(result2.has_value());
     EXPECT_EQ(result2.value().size(), 1); // Dave only
 }

--- a/tests/query/test_where.cpp
+++ b/tests/query/test_where.cpp
@@ -378,7 +378,7 @@ TYPED_TEST(WhereTest, WhereInLoopWithoutReset) {
     QuerySet<Person, TypeParam> queryset;
 
     for (int i = 0; i < 10; ++i) {
-        auto result = queryset.where(field<^^Person::age>() > 30).count().get();
+        auto result = queryset.where(field<^^Person::age>() > 30).count().execute();
         ASSERT_TRUE(result.has_value()) << "Iteration " << i << " failed: " << result.error().message();
         EXPECT_EQ(result.value(), 13) << "Each iteration should return 13 (no accumulation)";
     }

--- a/tests/test_select_runner.h
+++ b/tests/test_select_runner.h
@@ -82,49 +82,49 @@ template <typename Model, typename ConnType> class AggregateRunner : public Sele
         this->template apply_where_and_join<Tc>();
 
         if constexpr (Tc.query_type == "count") {
-            auto r = this->qs_.count().get();
+            auto r = this->qs_.count().execute();
             ASSERT_TRUE(r.has_value()) << r.error().message();
             EXPECT_EQ(r.value(), Tc.expected.int_val);
 
         } else if constexpr (Tc.query_type == "count_distinct") {
             constexpr auto fi = dispatch_field<Model>(Tc.agg_field.view());
-            auto r = this->qs_.template count_distinct<fi>().get();
+            auto r = this->qs_.template count_distinct<fi>().execute();
             ASSERT_TRUE(r.has_value()) << r.error().message();
             EXPECT_EQ(r.value(), Tc.expected.int_val);
 
         } else if constexpr (Tc.query_type == "sum") {
             constexpr auto fi = dispatch_field<Model>(Tc.agg_field.view());
             if constexpr (Tc.expected.int_val != -1) {
-                auto r = this->qs_.template sum<fi>().get();
+                auto r = this->qs_.template sum<fi>().execute();
                 ASSERT_TRUE(r.has_value()) << r.error().message();
                 EXPECT_EQ(r.value(), Tc.expected.int_val);
             } else {
-                auto r = this->qs_.template sum<fi>().get();
+                auto r = this->qs_.template sum<fi>().execute();
                 ASSERT_TRUE(r.has_value()) << r.error().message();
                 EXPECT_NEAR(r.value(), Tc.expected.dbl_val, 0.01);
             }
 
         } else if constexpr (Tc.query_type == "avg") {
             constexpr auto fi = dispatch_field<Model>(Tc.agg_field.view());
-            auto r = this->qs_.template avg<fi>().get();
+            auto r = this->qs_.template avg<fi>().execute();
             ASSERT_TRUE(r.has_value()) << r.error().message();
             EXPECT_NEAR(r.value(), Tc.expected.dbl_val, 0.01);
 
         } else if constexpr (Tc.query_type == "min") {
             constexpr auto fi = dispatch_field<Model>(Tc.agg_field.view());
-            auto r = this->qs_.template min<fi>().get();
+            auto r = this->qs_.template min<fi>().execute();
             ASSERT_TRUE(r.has_value()) << r.error().message();
             EXPECT_NEAR(r.value(), Tc.expected.dbl_val, 0.01);
 
         } else if constexpr (Tc.query_type == "max") {
             constexpr auto fi = dispatch_field<Model>(Tc.agg_field.view());
-            auto r = this->qs_.template max<fi>().get();
+            auto r = this->qs_.template max<fi>().execute();
             ASSERT_TRUE(r.has_value()) << r.error().message();
             EXPECT_NEAR(r.value(), Tc.expected.dbl_val, 0.01);
 
         } else if constexpr (Tc.query_type == "count_field") {
             constexpr auto fi = dispatch_field<Model>(Tc.agg_field.view());
-            auto r = this->qs_.template count<fi>().get();
+            auto r = this->qs_.template count<fi>().execute();
             ASSERT_TRUE(r.has_value()) << r.error().message();
             EXPECT_EQ(r.value(), Tc.expected.int_val);
         }
@@ -144,21 +144,21 @@ template <typename Model, typename ConnType> class ChainAggRunner : public Selec
         if constexpr (Tc.chain_len == 2) {
             if constexpr (Tc.aggregations[0].func == "sum" && Tc.aggregations[1].func == "count") {
                 constexpr auto fi0 = dispatch_field<Model>(Tc.aggregations[0].field.view());
-                auto r = this->qs_.template sum<fi0>().count().get();
+                auto r = this->qs_.template sum<fi0>().count().execute();
                 ASSERT_TRUE(r.has_value()) << r.error().message();
                 auto [v0, v1] = r.value();
                 EXPECT_EQ(v0, static_cast<int64_t>(Tc.aggregations[0].res_value));
                 EXPECT_EQ(v1, static_cast<int64_t>(Tc.aggregations[1].res_value));
             } else if constexpr (Tc.aggregations[0].func == "count") {
                 constexpr auto fi1 = dispatch_field<Model>(Tc.aggregations[1].field.view());
-                auto r = this->qs_.count().template sum<fi1>().get();
+                auto r = this->qs_.count().template sum<fi1>().execute();
                 ASSERT_TRUE(r.has_value()) << r.error().message();
                 auto [v0, v1] = r.value();
                 EXPECT_EQ(v0, static_cast<int64_t>(Tc.aggregations[0].res_value));
                 EXPECT_EQ(v1, static_cast<int64_t>(Tc.aggregations[1].res_value));
             } else if constexpr (Tc.aggregations[0].func == "avg" && Tc.aggregations[1].func == "count") {
                 constexpr auto fi0 = dispatch_field<Model>(Tc.aggregations[0].field.view());
-                auto r = this->qs_.template avg<fi0>().count().get();
+                auto r = this->qs_.template avg<fi0>().count().execute();
                 ASSERT_TRUE(r.has_value()) << r.error().message();
                 auto [v0, v1] = r.value();
                 EXPECT_NEAR(v0, Tc.aggregations[0].res_value, 0.01);
@@ -166,7 +166,7 @@ template <typename Model, typename ConnType> class ChainAggRunner : public Selec
             } else if constexpr (Tc.aggregations[0].func == "avg" && Tc.aggregations[1].func == "min") {
                 constexpr auto fi0 = dispatch_field<Model>(Tc.aggregations[0].field.view());
                 constexpr auto fi1 = dispatch_field<Model>(Tc.aggregations[1].field.view());
-                auto r = this->qs_.template avg<fi0>().template min<fi1>().get();
+                auto r = this->qs_.template avg<fi0>().template min<fi1>().execute();
                 ASSERT_TRUE(r.has_value()) << r.error().message();
                 auto [v0, v1] = r.value();
                 EXPECT_NEAR(v0, Tc.aggregations[0].res_value, 0.01);
@@ -174,7 +174,7 @@ template <typename Model, typename ConnType> class ChainAggRunner : public Selec
             } else if constexpr (Tc.aggregations[0].func == "avg" && Tc.aggregations[1].func == "max") {
                 constexpr auto fi0 = dispatch_field<Model>(Tc.aggregations[0].field.view());
                 constexpr auto fi1 = dispatch_field<Model>(Tc.aggregations[1].field.view());
-                auto r = this->qs_.template avg<fi0>().template max<fi1>().get();
+                auto r = this->qs_.template avg<fi0>().template max<fi1>().execute();
                 ASSERT_TRUE(r.has_value()) << r.error().message();
                 auto [v0, v1] = r.value();
                 EXPECT_NEAR(v0, Tc.aggregations[0].res_value, 0.01);
@@ -182,7 +182,7 @@ template <typename Model, typename ConnType> class ChainAggRunner : public Selec
             } else if constexpr (Tc.aggregations[0].func == "sum" && Tc.aggregations[1].func == "avg") {
                 constexpr auto fi0 = dispatch_field<Model>(Tc.aggregations[0].field.view());
                 constexpr auto fi1 = dispatch_field<Model>(Tc.aggregations[1].field.view());
-                auto r = this->qs_.template sum<fi0>().template avg<fi1>().get();
+                auto r = this->qs_.template sum<fi0>().template avg<fi1>().execute();
                 ASSERT_TRUE(r.has_value()) << r.error().message();
                 auto [v0, v1] = r.value();
                 EXPECT_EQ(v0, static_cast<int64_t>(Tc.aggregations[0].res_value));
@@ -190,7 +190,7 @@ template <typename Model, typename ConnType> class ChainAggRunner : public Selec
             } else if constexpr (Tc.aggregations[0].func == "min" && Tc.aggregations[1].func == "max") {
                 constexpr auto fi0 = dispatch_field<Model>(Tc.aggregations[0].field.view());
                 constexpr auto fi1 = dispatch_field<Model>(Tc.aggregations[1].field.view());
-                auto r = this->qs_.template min<fi0>().template max<fi1>().get();
+                auto r = this->qs_.template min<fi0>().template max<fi1>().execute();
                 ASSERT_TRUE(r.has_value()) << r.error().message();
                 auto [v0, v1] = r.value();
                 EXPECT_NEAR(v0, Tc.aggregations[0].res_value, 0.01);
@@ -198,7 +198,7 @@ template <typename Model, typename ConnType> class ChainAggRunner : public Selec
             } else if constexpr (Tc.aggregations[0].func == "min" && Tc.aggregations[1].func == "sum") {
                 constexpr auto fi0 = dispatch_field<Model>(Tc.aggregations[0].field.view());
                 constexpr auto fi1 = dispatch_field<Model>(Tc.aggregations[1].field.view());
-                auto r = this->qs_.template min<fi0>().template sum<fi1>().get();
+                auto r = this->qs_.template min<fi0>().template sum<fi1>().execute();
                 ASSERT_TRUE(r.has_value()) << r.error().message();
                 auto [v0, v1] = r.value();
                 EXPECT_NEAR(v0, Tc.aggregations[0].res_value, 0.01);
@@ -206,7 +206,7 @@ template <typename Model, typename ConnType> class ChainAggRunner : public Selec
             } else if constexpr (Tc.aggregations[0].func == "max" && Tc.aggregations[1].func == "avg") {
                 constexpr auto fi0 = dispatch_field<Model>(Tc.aggregations[0].field.view());
                 constexpr auto fi1 = dispatch_field<Model>(Tc.aggregations[1].field.view());
-                auto r = this->qs_.template max<fi0>().template avg<fi1>().get();
+                auto r = this->qs_.template max<fi0>().template avg<fi1>().execute();
                 ASSERT_TRUE(r.has_value()) << r.error().message();
                 auto [v0, v1] = r.value();
                 EXPECT_NEAR(v0, Tc.aggregations[0].res_value, 0.01);
@@ -214,7 +214,7 @@ template <typename Model, typename ConnType> class ChainAggRunner : public Selec
             } else if constexpr (Tc.aggregations[0].func == "max" && Tc.aggregations[1].func == "min") {
                 constexpr auto fi0 = dispatch_field<Model>(Tc.aggregations[0].field.view());
                 constexpr auto fi1 = dispatch_field<Model>(Tc.aggregations[1].field.view());
-                auto r = this->qs_.template max<fi0>().template min<fi1>().get();
+                auto r = this->qs_.template max<fi0>().template min<fi1>().execute();
                 ASSERT_TRUE(r.has_value()) << r.error().message();
                 auto [v0, v1] = r.value();
                 EXPECT_NEAR(v0, Tc.aggregations[0].res_value, 0.01);
@@ -224,7 +224,7 @@ template <typename Model, typename ConnType> class ChainAggRunner : public Selec
             if constexpr (Tc.aggregations[0].func == "sum") {
                 constexpr auto fi0 = dispatch_field<Model>(Tc.aggregations[0].field.view());
                 constexpr auto fi2 = dispatch_field<Model>(Tc.aggregations[2].field.view());
-                auto r = this->qs_.template sum<fi0>().count().template avg<fi2>().get();
+                auto r = this->qs_.template sum<fi0>().count().template avg<fi2>().execute();
                 ASSERT_TRUE(r.has_value()) << r.error().message();
                 auto [v0, v1, v2] = r.value();
                 EXPECT_EQ(v0, static_cast<int64_t>(Tc.aggregations[0].res_value));
@@ -233,7 +233,7 @@ template <typename Model, typename ConnType> class ChainAggRunner : public Selec
             } else if constexpr (Tc.aggregations[0].func == "count") {
                 constexpr auto fi1 = dispatch_field<Model>(Tc.aggregations[1].field.view());
                 constexpr auto fi2 = dispatch_field<Model>(Tc.aggregations[2].field.view());
-                auto r = this->qs_.count().template sum<fi1>().template avg<fi2>().get();
+                auto r = this->qs_.count().template sum<fi1>().template avg<fi2>().execute();
                 ASSERT_TRUE(r.has_value()) << r.error().message();
                 auto [v0, v1, v2] = r.value();
                 EXPECT_EQ(v0, static_cast<int64_t>(Tc.aggregations[0].res_value));
@@ -244,7 +244,7 @@ template <typename Model, typename ConnType> class ChainAggRunner : public Selec
             constexpr auto fi1 = dispatch_field<Model>(Tc.aggregations[1].field.view());
             constexpr auto fi2 = dispatch_field<Model>(Tc.aggregations[2].field.view());
             constexpr auto fi3 = dispatch_field<Model>(Tc.aggregations[3].field.view());
-            auto r = this->qs_.count().template sum<fi1>().template min<fi2>().template max<fi3>().get();
+            auto r = this->qs_.count().template sum<fi1>().template min<fi2>().template max<fi3>().execute();
             ASSERT_TRUE(r.has_value()) << r.error().message();
             auto [v0, v1, v2, v3] = r.value();
             EXPECT_EQ(v0, static_cast<int64_t>(Tc.aggregations[0].res_value));
@@ -262,7 +262,7 @@ template <typename Model, typename ConnType> class ChainAggRunner : public Selec
                              .template avg<fi2>()
                              .template min<fi3>()
                              .template max<fi4>()
-                             .get();
+                             .execute();
                 ASSERT_TRUE(r.has_value()) << r.error().message();
                 auto [v0, v1, v2, v3, v4] = r.value();
                 EXPECT_EQ(v0, static_cast<int64_t>(Tc.aggregations[0].res_value));
@@ -280,7 +280,7 @@ template <typename Model, typename ConnType> class ChainAggRunner : public Selec
                              .template avg<fi2>()
                              .template min<fi3>()
                              .template max<fi4>()
-                             .get();
+                             .execute();
                 ASSERT_TRUE(r.has_value()) << r.error().message();
                 auto [v0, v1, v2, v3, v4] = r.value();
                 EXPECT_EQ(v0, static_cast<int64_t>(Tc.aggregations[0].res_value));
@@ -303,12 +303,12 @@ template <typename Model, typename ConnType> class DistinctRunner : public Selec
         if constexpr (!Tc.distinct_field2.empty()) {
             constexpr auto fi1 = dispatch_field<Model>(Tc.distinct_field.view());
             constexpr auto fi2 = dispatch_field<Model>(Tc.distinct_field2.view());
-            auto r = this->template qs_with_modifiers<Tc>().template distinct<fi1, fi2>().select();
+            auto r = this->template qs_with_modifiers<Tc>().template distinct<fi1, fi2>().execute();
             ASSERT_TRUE(r.has_value()) << r.error().message();
             EXPECT_EQ(static_cast<int>(r.value().size()), Tc.expected.count);
         } else {
             constexpr auto fi = dispatch_field<Model>(Tc.distinct_field.view());
-            auto r = this->template qs_with_modifiers<Tc>().template distinct<fi>().select();
+            auto r = this->template qs_with_modifiers<Tc>().template distinct<fi>().execute();
             ASSERT_TRUE(r.has_value()) << r.error().message();
             EXPECT_EQ(static_cast<int>(r.value().size()), Tc.expected.count);
         }
@@ -329,7 +329,7 @@ template <typename Model, typename ConnType> class GroupByRunner : public Select
         if constexpr (Tc.query_type == "group_count") {
             if constexpr (!Tc.group_by_field2.empty()) {
                 constexpr auto gb_fi2 = dispatch_field<Model>(Tc.group_by_field2.view());
-                auto r = qs.template group_by<gb_fi, gb_fi2>().count().select();
+                auto r = qs.template group_by<gb_fi, gb_fi2>().count().execute();
                 ASSERT_TRUE(r.has_value()) << r.error().message();
                 EXPECT_EQ(static_cast<int>(r.value().size()), Tc.expected.count);
             } else {
@@ -338,11 +338,11 @@ template <typename Model, typename ConnType> class GroupByRunner : public Select
                     auto r = qs.template group_by<gb_fi>()
                                  .having(build_where_expr<hv_fi>(Tc.having_op.view(), Tc.having_value_int))
                                  .count()
-                                 .select();
+                                 .execute();
                     ASSERT_TRUE(r.has_value()) << r.error().message();
                     EXPECT_EQ(static_cast<int>(r.value().size()), Tc.expected.count);
                 } else {
-                    auto r = qs.template group_by<gb_fi>().count().select();
+                    auto r = qs.template group_by<gb_fi>().count().execute();
                     ASSERT_TRUE(r.has_value()) << r.error().message();
                     EXPECT_EQ(static_cast<int>(r.value().size()), Tc.expected.count);
                     if constexpr (Tc.expected.groups_count > 0) { // NOSONAR(S134) -- constexpr nesting
@@ -363,7 +363,7 @@ template <typename Model, typename ConnType> class GroupByRunner : public Select
 
         } else if constexpr (Tc.query_type == "group_sum") {
             constexpr auto agg_fi = dispatch_field<Model>(Tc.agg_field.view());
-            auto r = qs.template group_by<gb_fi>().template sum<agg_fi>().select();
+            auto r = qs.template group_by<gb_fi>().template sum<agg_fi>().execute();
             ASSERT_TRUE(r.has_value()) << r.error().message();
             EXPECT_EQ(static_cast<int>(r.value().size()), Tc.expected.count);
             if constexpr (Tc.expected.groups_count > 0) {
@@ -380,7 +380,7 @@ template <typename Model, typename ConnType> class GroupByRunner : public Select
 
         } else if constexpr (Tc.query_type == "group_avg") {
             constexpr auto agg_fi = dispatch_field<Model>(Tc.agg_field.view());
-            auto r = qs.template group_by<gb_fi>().template avg<agg_fi>().select();
+            auto r = qs.template group_by<gb_fi>().template avg<agg_fi>().execute();
             ASSERT_TRUE(r.has_value()) << r.error().message();
             EXPECT_EQ(static_cast<int>(r.value().size()), Tc.expected.count);
             if constexpr (Tc.expected.groups_count > 0) {
@@ -398,7 +398,7 @@ template <typename Model, typename ConnType> class GroupByRunner : public Select
 
         } else if constexpr (Tc.query_type == "group_min") {
             constexpr auto agg_fi = dispatch_field<Model>(Tc.agg_field.view());
-            auto r = qs.template group_by<gb_fi>().template min<agg_fi>().select();
+            auto r = qs.template group_by<gb_fi>().template min<agg_fi>().execute();
             ASSERT_TRUE(r.has_value()) << r.error().message();
             EXPECT_EQ(static_cast<int>(r.value().size()), Tc.expected.count);
             if constexpr (Tc.expected.groups_count > 0) {
@@ -416,7 +416,7 @@ template <typename Model, typename ConnType> class GroupByRunner : public Select
 
         } else if constexpr (Tc.query_type == "group_max") {
             constexpr auto agg_fi = dispatch_field<Model>(Tc.agg_field.view());
-            auto r = qs.template group_by<gb_fi>().template max<agg_fi>().select();
+            auto r = qs.template group_by<gb_fi>().template max<agg_fi>().execute();
             ASSERT_TRUE(r.has_value()) << r.error().message();
             EXPECT_EQ(static_cast<int>(r.value().size()), Tc.expected.count);
             if constexpr (Tc.expected.groups_count > 0) {

--- a/tests/test_write_runner.h
+++ b/tests/test_write_runner.h
@@ -22,7 +22,7 @@ template <typename Model, typename ConnType> class InsertRunner : public QueryRu
         if constexpr (Tc.query_type == "insert_one") {
             auto r = this->qs_.insert(make_record<Model>(0)).execute();
             ASSERT_TRUE(r.has_value()) << r.error().message();
-            auto cnt = this->qs_.count().get();
+            auto cnt = this->qs_.count().execute();
             ASSERT_TRUE(cnt.has_value()) << cnt.error().message();
             EXPECT_EQ(static_cast<int>(cnt.value()), Tc.expected.count);
 
@@ -33,7 +33,7 @@ template <typename Model, typename ConnType> class InsertRunner : public QueryRu
                 batch.push_back(make_record<Model>(i));
             auto r = this->qs_.insert(std::span<const Model>(batch)).execute();
             ASSERT_TRUE(r.has_value()) << r.error().message();
-            auto cnt = this->qs_.count().get();
+            auto cnt = this->qs_.count().execute();
             ASSERT_TRUE(cnt.has_value()) << cnt.error().message();
             EXPECT_EQ(static_cast<int>(cnt.value()), Tc.expected.count);
         }
@@ -101,7 +101,7 @@ template <typename Model, typename ConnType> class RemoveRunner : public QueryRu
             auto rem = this->qs_.remove_all().execute();
             ASSERT_TRUE(rem.has_value()) << rem.error().message();
 
-            auto cnt = this->qs_.count().get();
+            auto cnt = this->qs_.count().execute();
             ASSERT_TRUE(cnt.has_value()) << cnt.error().message();
             EXPECT_EQ(static_cast<int>(cnt.value()), Tc.expected.remaining);
 
@@ -130,7 +130,7 @@ template <typename Model, typename ConnType> class RemoveRunner : public QueryRu
             auto rem = this->qs_.remove(std::span<const Model>(to_remove)).execute();
             ASSERT_TRUE(rem.has_value()) << rem.error().message();
 
-            auto cnt = this->qs_.count().get();
+            auto cnt = this->qs_.count().execute();
             ASSERT_TRUE(cnt.has_value()) << cnt.error().message();
             EXPECT_EQ(static_cast<int>(cnt.value()), Tc.expected.remaining);
         }


### PR DESCRIPTION
## Summary

- Unifies aggregate (`.count/.sum/...`), grouped-aggregate (`group_by(...).count/...`), DISTINCT, and VALUES terminals on `.execute()` — removes `.get()` / `.select()` alias methods.
- Collapses `if constexpr (is_group_by_op() || is_distinct_op())` dispatch in `benchmarks/operations/query_benchmark.hpp` to a single `stmt.execute()` call.
- Also updates storm-version-control agent definition to auto-create PRs after push (`.claude/agents/git.md`).

## Test plan

- [x] `ctest --preset ninja-debug` (SQLite + PostgreSQL): 1877/1877 pass
- [x] `ctest --preset ninja-release`: 1877/1877 pass
- [x] `ctest --preset ninja-asan-ubsan` (SQLite + PG): 1877/1877 pass
- [x] `ctest --preset ninja-tsan` (SQLite + PG): 1877/1877 pass
- [x] Pre-commit hook: format, clang-tidy, tests, coverage 100% — all passed on commit 52bd368
- [ ] SonarCloud quality gate clean

Closes #195