### PR TITLE
docs(orm): explain ConstexprString duplication between benchmarks and utilities

### DIFF
--- a/benchmarks/schema.hpp
+++ b/benchmarks/schema.hpp
@@ -29,7 +29,14 @@
 
 namespace storm::benchmark {
 
-    // Fixed-size constexpr string
+    // Fixed-size constexpr string for compile-time JSON parsing.
+    //
+    // Intentionally duplicated from storm::orm::utilities::ConstexprString (see
+    // src/orm/utilities.cppm). This header is #included by traditional headers
+    // (parser.hpp, runner.hpp, ...) that cannot `import storm_orm_utilities`.
+    // The ORM version is feature-rich for runtime SQL building; this one is a
+    // minimal consteval variant tailored to benchmark JSON parsing. See issue
+    // #204 — Option 1 (keep separate) was chosen over a module refactor.
     template <size_t N> struct ConstexprString {
         std::array<char, N> data{};
         size_t              len = 0;

--- a/src/orm/utilities.cppm
+++ b/src/orm/utilities.cppm
@@ -358,6 +358,11 @@ export namespace storm::orm::utilities {
         std::array<char, N> data{};
         size_t              len = 0;
 
+        // NOTE: A stripped-down consteval copy of this template also lives in
+        // benchmarks/schema.hpp. The benchmark code is built as traditional
+        // headers (#pragma once) and cannot import this module, so the
+        // duplicate is kept on purpose. See issue #204 — Option 1 was chosen
+        // over refactoring benchmarks into modules.
         constexpr ConstexprString() = default;
 
         explicit constexpr ConstexprString(const char* str) {


### PR DESCRIPTION
## Summary
- Add cross-reference comments on both `ConstexprString` definitions (`benchmarks/schema.hpp` and `src/orm/utilities.cppm`) documenting why the duplication is intentional.
- Issue #204 Option 1 (keep separate) was chosen: benchmarks are built from traditional `#pragma once` headers that cannot `import storm_orm_utilities`, so a minimal `consteval` copy stays in benchmarks while the feature-rich `constexpr` version remains in the ORM module.
- No code changes; doc-only.

Closes #204.

## Test plan
- [x] Pre-commit hook clean: clang-format, clang-tidy, 1877/1877 tests (SQLite + PostgreSQL), 100% coverage
- [x] `cmake --build --preset ninja-release --target storm_bench` succeeds (benchmark TU still compiles with the edited header)
- [ ] SonarCloud gate passes on the PR
- [ ] CI jobs green (ninja-debug, ninja-asan-ubsan, ninja-tsan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)