### PR TITLE
build(cmake): isolate Clang module cache per preset (#223)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,16 @@ execute_process(
 add_compile_options(-ferror-limit=1
                     $<$<CONFIG:Debug>:-ftemplate-backtrace-limit=0>)
 
+# Pin Clang's module cache to the build dir. Clang hashes compile flags into the
+# module cache path, so two presets with different flags (coverage vs no
+# coverage, sanitizer vs none, etc.) write _Builtin_stddef etc. under different
+# hash subdirs of the shared global cache (~/.cache/clang/ModuleCache/). When a
+# later TU imports a module, Clang sees the same builtin module in both dirs and
+# emits a fatal "module defined in both" error. Keeping the cache local to
+# ${CMAKE_BINARY_DIR} guarantees preset isolation, since every preset already
+# has its own binaryDir.
+add_compile_options("-fmodules-cache-path=${CMAKE_BINARY_DIR}/module-cache")
+
 include(cmake/libcxx.cmake)
 
 # ── Core library ──────────────────────────────────────────────────────────────

--- a/cmake/fuzz.cmake
+++ b/cmake/fuzz.cmake
@@ -3,26 +3,14 @@ option(ENABLE_FUZZING
        OFF)
 
 if(ENABLE_FUZZING)
-  # Compile the storm library with the same instrumentation flags as the fuzz
-  # harnesses (-fsanitize=address,fuzzer-no-link). This is required because:
-  #
-  # 1. clang's module cache hash is derived from compilation flags.  If the storm
-  #   library and fuzz harnesses have DIFFERENT flags, _Builtin_stddef (and
-  #   similar built-in modules) are cached under different hash sub-
-  #   directories.  When loading the storm BMI in a fuzz harness compilation,
-  #   clang finds built-in modules in BOTH directories and emits a fatal
-  #   "defined in both" error.
-  #
-  # 1. Using fuzzer-no-link here (rather than plain fuzzer) means the fuzzer
-  #   runtime is NOT linked into libstorm.a — it is linked only into each fuzz
-  #   harness binary (via target_link_options in fuzz/CMakeLists.txt).
-  #
-  # 1. A shared, build-local module cache (module-cache) keeps all fuzz-build
-  #   module I/O out of the global ~/.cache/clang/ModuleCache/ to avoid
-  #   cross-preset contamination.
-  set(FUZZ_INSTRUMENT_FLAGS
-      -fsanitize=address,fuzzer-no-link -g -fno-omit-frame-pointer
-      "-fmodules-cache-path=${CMAKE_BINARY_DIR}/module-cache")
+  # Compile libstorm with the same instrumentation as the fuzz harnesses
+  # (-fsanitize=address,fuzzer-no-link) so the BMI hashes match across the
+  # library and harnesses. fuzzer-no-link keeps the fuzzer runtime out of
+  # libstorm.a — it is linked only into each harness binary (via
+  # target_link_options in fuzz/CMakeLists.txt). (Module-cache isolation is
+  # handled globally in the root CMakeLists.txt.)
+  set(FUZZ_INSTRUMENT_FLAGS -fsanitize=address,fuzzer-no-link -g
+                            -fno-omit-frame-pointer)
   target_compile_options(storm PRIVATE ${FUZZ_INSTRUMENT_FLAGS})
   target_link_options(storm PRIVATE -fsanitize=address -g
                       -fno-omit-frame-pointer)

--- a/scripts/build-with-retry.sh
+++ b/scripts/build-with-retry.sh
@@ -14,7 +14,14 @@ for attempt in 1 2 3; do
         exit 0
     fi
     echo "Build failed on attempt $attempt, clearing caches..."
-    find build/ -name "*.pcm" -delete 2>/dev/null || true
+    # Clear .ddi scan-deps outputs so ninja re-scans. Leave *.pcm files in
+    # build/*/module-cache/ intact — those are the authoritative per-preset
+    # module cache (pinned via -fmodules-cache-path in root CMakeLists.txt)
+    # and deleting them forces builtin modules to be rebuilt on every retry,
+    # which aggravates the very scan-deps flakiness this retry is working
+    # around. Only prune stray PCMs outside module-cache (there shouldn't be
+    # any in a healthy build, but clean them up defensively).
+    find build/ -name "*.pcm" -not -path "*/module-cache/*" -delete 2>/dev/null || true
     find build/ -name "*.ddi" -delete 2>/dev/null || true
 done
 echo "Build failed after 3 attempts"


### PR DESCRIPTION
## Summary
- Pin Clang's module cache to `${CMAKE_BINARY_DIR}/module-cache` in the root `CMakeLists.txt`, so every preset uses its own build-local cache instead of the shared global `~/.cache/clang/ModuleCache/`.
- Remove the now-redundant local `-fmodules-cache-path` override in `cmake/fuzz.cmake` and trim the obsolete portion of its comment.

### Why
Clang hashes compile flags into the module cache path. Presets with different flags (coverage on/off, sanitizers, fuzzer, …) wrote `_Builtin_stddef.pcm` (and other builtins) under different hash subdirs of the shared global cache. A later TU that imported a module would see the same builtin in both dirs and fail fatally with `module '_Builtin_stddef' is defined in both …`. This manifested as intermittent `storm_schema` build failures on `ninja-debug`, triggered by stale `USE_SANITIZER` entries left over in `build/debug/CMakeCache.txt` from earlier manual configures.

Every preset already has its own `binaryDir`, so a build-local cache guarantees full isolation regardless of which flags a preset carries — no more global-cache contamination, now or with future flags.

## Test plan
- [x] `rm -rf build/debug ~/.cache/clang/ModuleCache && cmake --preset ninja-debug && cmake --build --preset ninja-debug` — clean build succeeds, `storm_schema` and `storm_tests` binaries produced
- [x] Verified `~/.cache/clang/ModuleCache/` is never created; all module artifacts land in `build/debug/module-cache/`
- [x] Pre-commit hook: 1877 tests pass, 100% coverage maintained, cmake-format clean
- [ ] CI: ninja-debug, ninja-asan-ubsan, ninja-tsan all green
- [ ] SonarCloud gate: zero new issues, zero new duplications

Closes #223

🤖 Generated with [Claude Code](https://claude.com/claude-code)