### PR TITLE
build(bench): remove stale -fconstexpr-steps=20000000 override

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -50,8 +50,4 @@ add_storm_benchmark(storm_bench "main.cpp")
 # Ensure JSON is generated before building storm_bench
 add_dependencies(storm_bench generate_benchmark_json)
 
-# Increase constexpr steps limit for compile-time JSON parsing Required due to
-# large number of benchmark tests parsed at compile time
-target_compile_options(storm_bench PRIVATE -fconstexpr-steps=20000000)
-
 message(STATUS "Benchmark executable: storm_bench")


### PR DESCRIPTION
## Summary

- Remove the `target_compile_options(storm_bench PRIVATE -fconstexpr-steps=20000000)` block from `benchmarks/CMakeLists.txt`
- The flag was added to fit the compile-time JSON parser within Clang's constexpr budget but is no longer needed — the default budget is sufficient
- Removing it also eliminates a PCM-cache hash divergence between `storm_bench` and the `storm` library that blocks benchmark-side module conversion (#221)

## Test plan

- [x] `cmake --preset ninja-release && cmake --build --preset ninja-release --target storm_bench` succeeds (clean cache + build)
- [x] `./build/release/benchmarks/storm_bench --list` reports all 81 tests
- [x] Pre-commit hook green: 1887 tests pass (SQLite + PostgreSQL), 100% line coverage
- [ ] CI: `ninja-debug`, `ninja-asan-ubsan`, `ninja-tsan` green
- [ ] SonarCloud gate clean (no new issues, no new duplication)

Closes #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)