### PR TITLE
infra(ci): add Bencher walltime regression gate (#238)

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -18,7 +18,7 @@ jobs:
       # Pin to the same storm-ci digest as ci.yml — Bencher's walltime gate
       # only makes sense against a fixed toolchain. Bump this in lockstep
       # with ci.yml when publishing a new image.
-      image: ghcr.io/spiritecosse/storm-ci@sha256:4718aa1ec4f195aba77de4b17a9190c8223a5c215d01aa34ed230950010e304c
+      image: ghcr.io/spiritecosse/storm-ci@sha256:90e958ac1f10ebe3721906fa67dac3a67285740974b52473fe6409404ebdd431
 
     steps:
       - name: Checkout

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -42,21 +42,39 @@ jobs:
       - name: Build
         run: ./scripts/build-with-retry.sh ninja-release
 
-      - name: Setup Bencher
-        uses: bencherdev/bencher@main
+      - name: Run storm_bench
+        run: |
+          ./build/release/benchmarks/storm_bench \
+              --benchmark_format=json \
+              --benchmark_repetitions=10 \
+              --benchmark_out=storm_bench.json
 
-      - name: Run storm_bench via Bencher
+      - name: Strip BigO/RMS aggregate rows for Bencher
+        # Google Benchmark emits *_BigO and *_RMS rows for benchmarks declared
+        # with ->Complexity(). Those rows omit `real_time`, which Bencher's
+        # `cpp_google` adapter requires — its strict serde parser rejects the
+        # entire batch on one missing field, so the report lands with empty
+        # `results` and the gate fails. Drop those two aggregate types here.
+        run: |
+          jq '.benchmarks |= map(select(.aggregate_name != "BigO" and .aggregate_name != "RMS"))' \
+              storm_bench.json > storm_bench.bencher.json
+
+      - name: Setup Bencher
+        uses: bencherdev/bencher@46d007c103827da37db1a25b705dc73d3aaff7e6 # v0.6.3
+
+      - name: Upload to Bencher
         env:
           BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           bencher run \
             --project storm-orm \
             --branch "${{ github.head_ref || github.ref_name }}" \
             --testbed gha-ubuntu-24-04-storm-ci \
             --adapter cpp_google \
+            --file storm_bench.bencher.json \
             --threshold-measure latency \
             --threshold-test percentage \
             --threshold-upper-boundary 0.05 \
             --err \
-            --github-actions "${{ secrets.GITHUB_TOKEN }}" \
-            "./build/release/benchmarks/storm_bench --benchmark_format=json --benchmark_repetitions=10"
+            --github-actions "$GITHUB_TOKEN"

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,62 @@
+name: Bench
+
+on:
+  push:
+    branches: [develop]
+  pull_request:
+    branches: [develop]
+
+permissions:
+  checks: write
+  pull-requests: write
+
+jobs:
+  bench:
+    name: storm_bench (Bencher)
+    runs-on: ubuntu-24.04
+    container:
+      # Pin to the same storm-ci digest as ci.yml — Bencher's walltime gate
+      # only makes sense against a fixed toolchain. Bump this in lockstep
+      # with ci.yml when publishing a new image.
+      image: ghcr.io/spiritecosse/storm-ci@sha256:4718aa1ec4f195aba77de4b17a9190c8223a5c215d01aa34ed230950010e304c
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Link clang-p2996 next to source dir
+        run: ln -sfn /opt/clang-p2996 "$(dirname "$GITHUB_WORKSPACE")/clang-p2996"
+
+      - name: Cache CPM packages
+        uses: actions/cache@v4
+        with:
+          path: .cache/CPM
+          key: cpm-ninja-release-${{ hashFiles('cmake/cpm.cmake', 'cmake/tests.cmake', 'cmake/bench.cmake') }}
+          restore-keys: |
+            cpm-ninja-release-
+            cpm-
+
+      - name: Configure
+        run: cmake --preset ninja-release
+
+      - name: Build
+        run: ./scripts/build-with-retry.sh ninja-release
+
+      - name: Setup Bencher
+        uses: bencherdev/bencher@main
+
+      - name: Run storm_bench via Bencher
+        env:
+          BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}
+        run: |
+          bencher run \
+            --project storm-orm \
+            --branch "${{ github.head_ref || github.ref_name }}" \
+            --testbed gha-ubuntu-24-04-storm-ci \
+            --adapter cpp_google \
+            --threshold-measure latency \
+            --threshold-test percentage \
+            --threshold-upper-boundary 0.05 \
+            --err \
+            --github-actions "${{ secrets.GITHUB_TOKEN }}" \
+            "./build/release/benchmarks/storm_bench --benchmark_format=json --benchmark_repetitions=10"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     container:
       # Pinned to a specific digest so develop is unaffected by storm-ci image
       # rebuilds. Bump this when publishing a new image (see docker-ci-image.yml).
-      image: ghcr.io/spiritecosse/storm-ci@sha256:4718aa1ec4f195aba77de4b17a9190c8223a5c215d01aa34ed230950010e304c
+      image: ghcr.io/spiritecosse/storm-ci@sha256:90e958ac1f10ebe3721906fa67dac3a67285740974b52473fe6409404ebdd431
 
     services:
       postgres:

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -39,9 +39,13 @@ See [GitHub Issues (benchmarks)](https://github.com/spiritEcosse/storm/issues?q=
 
 ## 📉 Regression detection
 
-The per-PR benchmark gate is **Bencher**, configured in [#235 Phase 6](https://github.com/spiritEcosse/storm/issues/235). Phase 6 depends on [#236 Step 1](https://github.com/spiritEcosse/storm/issues/236) (Dockerized CI toolchain) for runner-class stability — until both land, there is no automatic CI gate on benchmark regressions.
+The per-PR benchmark gate is **Bencher** (`.github/workflows/bench.yml`, issue [#238](https://github.com/spiritEcosse/storm/issues/238)). Every PR targeting `develop` runs `storm_bench` inside the pinned `storm-ci` container, ships JSON to Bencher's server-side store, and posts a PR comment with per-benchmark deltas. The gate fails the workflow on a `>5%` slowdown with statistical significance. Pushes to `develop` archive new reference points for the trend line.
 
-For local-dev investigation, `benchmarks/scripts/compare_against_baseline.sh` runs `storm_bench` and (optionally) diffs against a previously-saved JSON via Google Benchmark's [`compare.py`](https://github.com/google/benchmark/blob/main/tools/compare.py) + Mann-Whitney U-test. There is no committed baseline file in the repo: a baseline is only meaningful on the same hardware class as the comparison run, and Bencher will own that responsibility once Phase 6 lands.
+There is no committed baseline JSON: Bencher's server-side store is authoritative, and a checked-in baseline would only be meaningful on a single hardware class.
+
+For local-dev investigation, `benchmarks/scripts/compare_against_baseline.sh` runs `storm_bench` and (optionally) diffs against a previously-saved JSON via Google Benchmark's [`compare.py`](https://github.com/google/benchmark/blob/main/tools/compare.py) + Mann-Whitney U-test. Pass it any saved JSON snapshot (e.g. one downloaded from Bencher) to diff offline.
+
+**Interpreting Bencher PR comments:** the comment lists each benchmark whose latency moved past the threshold, with the percentage delta and a link to the run on bencher.dev. A green ✅ comment (or no comment on a no-op change) means the gate passed. A red ❌ comment names the regressed benchmarks and blocks merge until the regression is resolved or the upper boundary is intentionally relaxed in `bench.yml`.
 
 **Workflow**
 

--- a/benchmarks/scripts/compare_against_baseline.sh
+++ b/benchmarks/scripts/compare_against_baseline.sh
@@ -1,14 +1,13 @@
 #!/usr/bin/env bash
 # Run storm_bench and (optionally) diff the result against a baseline JSON.
 #
-# This is the local-dev counterpart to the Bencher gate (Phase 6 of #235).
-# Phase 4b deliberately ships *without* a committed baseline because:
-#   - A baseline is only meaningful when generated on the same hardware class
-#     as the comparison run (laptop vs. CI VMs differ by 30%+).
-#   - Bencher (Phase 6) owns the per-PR gate once the Dockerized runner from
-#     #236 lands, so a committed JSON would just be maintenance overhead.
+# This is the local-dev counterpart to the Bencher CI gate
+# (.github/workflows/bench.yml, issue #238). Bencher's server-side store is
+# the authoritative baseline for `develop`; this script is for offline
+# investigation against any saved JSON snapshot (e.g. one downloaded from
+# Bencher, or a /tmp/before.json captured before a local edit).
 #
-# Until then, this script is useful in two ways:
+# Two modes:
 #   1. No-arg / no baseline: just run the benchmarks, write current.json,
 #      print Google Benchmark's own console summary. Exits 0.
 #   2. With a baseline path (or BASELINE= env): diff against it via

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -16,6 +16,7 @@ RUN pacman -Syu --noconfirm \
     && pacman -S --noconfirm --needed \
         cmake ninja gcc sqlite postgresql-libs \
         python python-yaml git valgrind lcov \
+        jq \
     && pacman -Scc --noconfirm
 
 # Prebuilt clang-p2996 from the sibling data-only image.


### PR DESCRIPTION
## Summary
- New `.github/workflows/bench.yml` runs `storm_bench` inside the pinned `storm-ci` container on every PR + push to `develop`, ships JSON to Bencher (project `storm-orm`, testbed `gha-ubuntu-24-04-storm-ci`), posts a PR comment with per-benchmark deltas, and fails the workflow on a `>5%` latency slowdown with statistical significance.
- `benchmarks/README.md` regression-detection section repointed from "Phase 6 future work" to "live PR gate" + an "interpreting PR comments" paragraph.
- `benchmarks/scripts/compare_against_baseline.sh` header reworded to position it as the local-dev counterpart to the now-live CI gate.

## Deviation from issue body
The issue specifies `container: ghcr.io/spiritecosse/storm-ci:latest`. I used the same `@sha256:...` digest pin as `ci.yml` because:
- SonarCloud S6596 forbids `:latest` (project memory).
- Bencher's walltime gate is meaningless if the toolchain shifts under it.

The bench-image digest will need to be bumped in lockstep with `ci.yml` after each storm-ci rebuild.

## Outstanding (manual / post-merge)
- `BENCHER_API_TOKEN` repo secret — **added**.
- Bencher project `storm-orm` must be created on bencher.dev before the first PR run will succeed.
- Post-merge runtime acceptance criteria: dashboard trend line, synthetic regression PR test, no-op PR silence, false-positive-rate measurement.

## Test plan
- [ ] CI: `gh pr checks` shows ninja-debug / asan-ubsan / tsan / msan green (existing jobs unaffected by this change).
- [ ] Bench job runs on this PR, produces a Bencher PR comment.
- [ ] SonarCloud gate clean on new code.
- [ ] After merge: a no-op follow-up PR on `develop` HEAD passes silently with no comment.
- [ ] After merge: a synthetic-regression PR (e.g. `std::this_thread::sleep_for(1us)` in a hot path) gets a PR comment naming the regressed benchmarks; merge is blocked.

Closes #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)