### PR TITLE
infra(ci): add bench-gate deps to storm-ci image (#241)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     container:
       # Pinned to a specific digest so develop is unaffected by storm-ci image
       # rebuilds. Bump this when publishing a new image (see docker-ci-image.yml).
-      image: ghcr.io/spiritecosse/storm-ci@sha256:4718aa1ec4f195aba77de4b17a9190c8223a5c215d01aa34ed230950010e304c
+      image: ghcr.io/spiritecosse/storm-ci@sha256:33791aa51df55044e941edb2cebe5b12e2f9d4008df2cf08f07da33072baa9aa
 
     services:
       postgres:

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -12,10 +12,15 @@ FROM manjarolinux/base:20260315
 
 # System dependencies. valgrind is included for future CodSpeed Macro /
 # cachegrind work; lcov so the same image works for coverage builds.
+# github-cli + jq + python-numpy/scipy are for the bench.yml regression gate
+# (#241): gh fetches the develop-baseline-latest artifact and posts the PR
+# comment, jq renders the comparison table, numpy/scipy back compare.py's
+# Mann-Whitney U-test in benchmarks/scripts/compare_against_baseline.sh.
 RUN pacman -Syu --noconfirm \
     && pacman -S --noconfirm --needed \
         cmake ninja gcc sqlite postgresql-libs \
-        python python-yaml git valgrind lcov \
+        python python-yaml python-numpy python-scipy git valgrind lcov \
+        github-cli jq \
     && pacman -Scc --noconfirm
 
 # Prebuilt clang-p2996 from the sibling data-only image.


### PR DESCRIPTION
## Summary

Prep for the bench.yml regression gate (#241). Adds `github-cli`, `jq`, `python-numpy`, and `python-scipy` to the storm-ci image and bumps the `ci.yml` digest pin to the rebuilt image.

- `gh` — bench.yml will use it to fetch `develop-baseline-latest` artifact and post the per-PR comparison comment
- `jq` — renders the comparison table from `compare.py`'s diff JSON
- `python-numpy` / `python-scipy` — back `compare.py`'s Mann-Whitney U-test (used by `benchmarks/scripts/compare_against_baseline.sh`)

The bench.yml workflow itself, `render_comparison.py`, and the docs sweep land in a follow-up PR once this lands and CI proves the new image is healthy.

New image digest: `sha256:33791aa51df55044e941edb2cebe5b12e2f9d4008df2cf08f07da33072baa9aa` (built by run 25206020452).

## Test plan
- [x] storm-ci image builds successfully (run 25206020452)
- [ ] All `ci.yml` matrix jobs pass on the new image (ninja-debug, ninja-asan-ubsan, ninja-tsan)
- [ ] SonarCloud quality gate passes
- [ ] No regressions vs. previous digest

Refs #241

🤖 Generated with [Claude Code](https://claude.com/claude-code)