### PR TITLE
infra(ci): self-hosted bench regression gate via GHA artifacts (#241)

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -33,6 +33,17 @@ jobs:
     container:
       # Same digest as ci.yml; bump in lockstep when storm-ci is rebuilt.
       image: ghcr.io/spiritecosse/storm-ci@sha256:33791aa51df55044e941edb2cebe5b12e2f9d4008df2cf08f07da33072baa9aa
+    # The storm-ci image's default shell is /bin/sh; force bash for `[[`,
+    # `set +e`, and $GITHUB_OUTPUT redirects the steps below rely on.
+    defaults:
+      run:
+        shell: bash
+    env:
+      # gh otherwise calls `git` to discover the repo, which fails inside the
+      # container because the workspace UID differs from the container user
+      # ("dubious ownership"). Setting GH_REPO bypasses git autodetection
+      # entirely so we never need a `safe.directory` shim.
+      GH_REPO: ${{ github.repository }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,198 @@
+name: Bench
+
+# Self-hosted regression gate (#241). On push to develop the job runs
+# storm_bench and uploads the JSON as the `develop-baseline-latest`
+# artifact (overwriting prior). On a PR the job runs storm_bench, downloads
+# the latest develop baseline, diffs via compare.py + Mann-Whitney U-test,
+# posts a marker-edited PR comment with the regression / improvement table,
+# and fails the gate on any benchmark slower than +5% with p<0.05.
+#
+# All numbers come from benchmarks/scripts/compare_against_baseline.sh —
+# the same engine we use locally — so CI and local-dev produce identical
+# verdicts.
+
+on:
+  push:
+    branches: [develop]
+  pull_request:
+    branches: [develop]
+
+permissions:
+  contents: read
+  actions: read         # download-artifact across runs needs this
+  pull-requests: write  # gh pr comment
+
+concurrency:
+  group: bench-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  bench:
+    name: storm_bench
+    runs-on: ubuntu-24.04
+    container:
+      # Same digest as ci.yml; bump in lockstep when storm-ci is rebuilt.
+      image: ghcr.io/spiritecosse/storm-ci@sha256:33791aa51df55044e941edb2cebe5b12e2f9d4008df2cf08f07da33072baa9aa
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Link clang-p2996 next to source dir
+        run: ln -sfn /opt/clang-p2996 "$(dirname "$GITHUB_WORKSPACE")/clang-p2996"
+
+      - name: Cache CPM packages
+        uses: actions/cache@v4
+        with:
+          path: .cache/CPM
+          key: cpm-ninja-release-${{ hashFiles('cmake/cpm.cmake', 'cmake/tests.cmake', 'cmake/bench.cmake') }}
+          restore-keys: |
+            cpm-ninja-release-
+            cpm-
+
+      - name: Configure
+        run: cmake --preset ninja-release
+
+      - name: Build
+        run: ./scripts/build-with-retry.sh ninja-release
+
+      # ──────────────────────────────────────────────────────────────────
+      # Push-to-develop: run bench, upload as the canonical baseline.
+      # ──────────────────────────────────────────────────────────────────
+      - name: Run storm_bench (baseline)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
+        run: |
+          ./build/release/benchmarks/storm_bench \
+              --benchmark_format=json \
+              --benchmark_repetitions=10 \
+              --benchmark_out=storm_bench.json
+
+      - name: Upload develop baseline
+        if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
+        uses: actions/upload-artifact@v4
+        with:
+          name: develop-baseline-latest
+          path: storm_bench.json
+          overwrite: true
+          retention-days: 90
+
+      # ──────────────────────────────────────────────────────────────────
+      # Pull request: run bench, download latest develop baseline, diff,
+      # post / edit the PR comment, fail gate on regressions.
+      # ──────────────────────────────────────────────────────────────────
+      - name: Find latest develop baseline run
+        if: github.event_name == 'pull_request'
+        id: baseline
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          run_id=$(gh run list \
+              --workflow=bench.yml \
+              --branch=develop \
+              --status=success \
+              --limit=1 \
+              --json databaseId \
+              --jq '.[0].databaseId // empty')
+          if [[ -z "$run_id" ]]; then
+              echo "No successful develop bench run yet — first-run path."
+              echo "have_baseline=false" >> "$GITHUB_OUTPUT"
+          else
+              echo "Baseline run id: $run_id"
+              echo "have_baseline=true" >> "$GITHUB_OUTPUT"
+              echo "run_id=$run_id" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Download develop baseline
+        if: github.event_name == 'pull_request' && steps.baseline.outputs.have_baseline == 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: develop-baseline-latest
+          path: baseline
+          run-id: ${{ steps.baseline.outputs.run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Run storm_bench + compare
+        if: github.event_name == 'pull_request' && steps.baseline.outputs.have_baseline == 'true'
+        id: compare
+        env:
+          BASELINE: baseline/storm_bench.json
+          CURRENT_JSON: current.json
+          BENCH_REPETITIONS: '10'
+        # compare_against_baseline.sh exits non-zero on regression. We capture
+        # that exit, render the PR comment regardless, then propagate the
+        # status at the end of the step list.
+        run: |
+          set +e
+          ./benchmarks/scripts/compare_against_baseline.sh
+          rc=$?
+          set -e
+          echo "exit_code=$rc" >> "$GITHUB_OUTPUT"
+
+      - name: Re-run compare.py with diff JSON dump
+        if: github.event_name == 'pull_request' && steps.baseline.outputs.have_baseline == 'true'
+        # compare_against_baseline.sh wraps compare.py and discards the diff
+        # JSON; we re-invoke it directly here to capture the JSON the renderer
+        # consumes. This is cheap (no benchmark re-run, just JSON math).
+        run: |
+          compare_py="$(awk -F= '/^benchmark_SOURCE_DIR:STATIC=/ { print $2 }' build/release/CMakeCache.txt)/tools/compare.py"
+          python3 "$compare_py" --display_aggregates_only \
+              --dump_to_json diff.json \
+              --no-color \
+              benchmarks baseline/storm_bench.json current.json > /dev/null
+
+      - name: Render PR comment
+        if: github.event_name == 'pull_request' && steps.baseline.outputs.have_baseline == 'true'
+        run: |
+          python3 benchmarks/scripts/render_pr_comment.py diff.json \
+              --threshold 0.05 \
+              --alpha 0.05 \
+              --baseline-run-id "${{ steps.baseline.outputs.run_id }}" \
+              --current-sha "${{ github.event.pull_request.head.sha }}" \
+              > comment.md
+          cat comment.md
+
+      - name: Post / edit PR comment
+        if: github.event_name == 'pull_request' && steps.baseline.outputs.have_baseline == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        # Idempotent upsert by marker. `gh pr comment --edit-last` edits the
+        # most recent comment authored by the GITHUB_TOKEN bot, which is
+        # exactly what we want — we are the only writer using that identity.
+        run: |
+          existing=$(gh api "repos/${{ github.repository }}/issues/$PR_NUMBER/comments" \
+              --jq '.[] | select(.body | startswith("<!-- storm-bench-comment -->")) | .id' \
+              | head -n1)
+          if [[ -n "$existing" ]]; then
+              gh pr comment "$PR_NUMBER" --edit-last --body-file comment.md
+          else
+              gh pr comment "$PR_NUMBER" --body-file comment.md
+          fi
+
+      - name: First-run notice (no baseline yet)
+        if: github.event_name == 'pull_request' && steps.baseline.outputs.have_baseline == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          cat > comment.md <<'EOF'
+          <!-- storm-bench-comment -->
+          ## storm_bench regression gate
+
+          :information_source: **No baseline yet.** The first push to `develop` after this PR lands will seed `develop-baseline-latest`; subsequent PRs will see the regression diff here.
+          EOF
+          existing=$(gh api "repos/${{ github.repository }}/issues/$PR_NUMBER/comments" \
+              --jq '.[] | select(.body | startswith("<!-- storm-bench-comment -->")) | .id' \
+              | head -n1)
+          if [[ -n "$existing" ]]; then
+              gh pr comment "$PR_NUMBER" --edit-last --body-file comment.md
+          else
+              gh pr comment "$PR_NUMBER" --body-file comment.md
+          fi
+
+      - name: Propagate gate status
+        if: github.event_name == 'pull_request' && steps.baseline.outputs.have_baseline == 'true'
+        run: |
+          rc='${{ steps.compare.outputs.exit_code }}'
+          echo "compare_against_baseline.sh exit code: $rc"
+          exit "$rc"

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -64,6 +64,15 @@ jobs:
       - name: Configure
         run: cmake --preset ninja-release
 
+      # bench.yml is the only workflow that builds ninja-release in CI, so it
+      # owns first-run population of the release module-cache. Parallel
+      # clang-scan-deps races against the empty cache and produces duplicate
+      # builtin PCMs ("module '_Builtin_stdint' is defined in both X and X").
+      # Building the storm library alone with -j 1 seeds the cache cleanly;
+      # the parallel build below then fans out without the race.
+      - name: Warm release module-cache (storm lib, -j 1)
+        run: cmake --build --preset ninja-release --target storm -j 1
+
       - name: Build
         run: ./scripts/build-with-retry.sh ninja-release
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -39,11 +39,15 @@ See [GitHub Issues (benchmarks)](https://github.com/spiritEcosse/storm/issues?q=
 
 ## 📉 Regression detection
 
-The per-PR benchmark gate is **Bencher**, configured in [#235 Phase 6](https://github.com/spiritEcosse/storm/issues/235). Phase 6 depends on [#236 Step 1](https://github.com/spiritEcosse/storm/issues/236) (Dockerized CI toolchain) for runner-class stability — until both land, there is no automatic CI gate on benchmark regressions.
+The per-PR benchmark gate (#241) is self-hosted on GitHub Actions and uses **GitHub Actions artifacts** for the baseline store — no external service.
 
-For local-dev investigation, `benchmarks/scripts/compare_against_baseline.sh` runs `storm_bench` and (optionally) diffs against a previously-saved JSON via Google Benchmark's [`compare.py`](https://github.com/google/benchmark/blob/main/tools/compare.py) + Mann-Whitney U-test. There is no committed baseline file in the repo: a baseline is only meaningful on the same hardware class as the comparison run, and Bencher will own that responsibility once Phase 6 lands.
+- **Push to `develop`** runs `storm_bench` and uploads the JSON as the `develop-baseline-latest` artifact (overwriting prior, 90-day retention).
+- **Pull requests** run `storm_bench`, download `develop-baseline-latest` from the most recent successful develop run, diff via Google Benchmark's [`compare.py`](https://github.com/google/benchmark/blob/main/tools/compare.py) + Mann-Whitney U-test, post a marker-edited PR comment with the regression / improvement table, and **fail the gate on any benchmark slower than +5% with p<0.05**.
+- **First-run case** (no `develop-baseline-latest` artifact yet): the PR comment notes the missing baseline and the gate marks green. The first push to `develop` after this lands seeds the baseline.
 
-**Workflow**
+CI runs `benchmarks/scripts/compare_against_baseline.sh` — the same engine you can run locally against a saved JSON to get the same verdict before pushing. No committed baseline lives in the repo: a baseline is only meaningful on the same hardware class as the comparison run.
+
+**Local workflow**
 
 ```bash
 cmake --preset ninja-release && cmake --build --preset ninja-release
@@ -99,7 +103,8 @@ benchmarks/
 ├── anchors_raw.cpp             # `storm_anchors` binary — release-time raw SQLite spot checks
 ├── scripts/
 │   ├── yaml_to_json.py             # YAML → JSON converter (runs at build time)
-│   └── compare_against_baseline.sh # Local-dev regression diff (Mann-Whitney U-test)
+│   ├── compare_against_baseline.sh # Regression diff (Mann-Whitney U-test) — engine for both local-dev and bench.yml
+│   └── render_pr_comment.py        # Markdown renderer for the bench.yml PR comment
 └── tests/
     ├── benchmark_tests.yaml   # Test definitions (human-friendly source of truth)
     └── benchmark_tests.json   # Auto-generated from YAML (loaded at compile time via #embed)

--- a/benchmarks/scripts/compare_against_baseline.sh
+++ b/benchmarks/scripts/compare_against_baseline.sh
@@ -1,19 +1,22 @@
 #!/usr/bin/env bash
 # Run storm_bench and (optionally) diff the result against a baseline JSON.
 #
-# This is the local-dev counterpart to the Bencher gate (Phase 6 of #235).
-# Phase 4b deliberately ships *without* a committed baseline because:
-#   - A baseline is only meaningful when generated on the same hardware class
-#     as the comparison run (laptop vs. CI VMs differ by 30%+).
-#   - Bencher (Phase 6) owns the per-PR gate once the Dockerized runner from
-#     #236 lands, so a committed JSON would just be maintenance overhead.
+# This script is the engine .github/workflows/bench.yml uses for the per-PR
+# regression gate (#241), and it is the same engine you can run locally to
+# get the same verdict before pushing — CI and local-dev produce identical
+# numbers because they call the same script with the same defaults.
 #
-# Until then, this script is useful in two ways:
+# Two modes:
 #   1. No-arg / no baseline: just run the benchmarks, write current.json,
 #      print Google Benchmark's own console summary. Exits 0.
 #   2. With a baseline path (or BASELINE= env): diff against it via
 #      compare.py + Mann-Whitney U-test. Exits 1 on any benchmark slower
 #      than the threshold with statistical significance.
+#
+# No baseline is committed to the repo — a baseline is only meaningful on the
+# same hardware class as the comparison run (laptop vs. CI VMs differ by
+# 30%+). CI uploads its own baseline as the `develop-baseline-latest` GHA
+# artifact (90d retention, overwritten on each push to develop).
 #
 # Usage:
 #   benchmarks/scripts/compare_against_baseline.sh                      # run-only

--- a/benchmarks/scripts/render_pr_comment.py
+++ b/benchmarks/scripts/render_pr_comment.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Render a Markdown PR comment from compare.py's --dump_to_json output.
+
+Companion to benchmarks/scripts/compare_against_baseline.sh and the bench.yml
+regression gate (#241). Reads the diff JSON produced by Google Benchmark's
+compare.py and emits a PR-comment-ready Markdown body on stdout.
+
+The first line is always the marker comment `<!-- storm-bench-comment -->`,
+which bench.yml greps for to decide between creating a new comment and
+editing the existing one.
+
+Usage:
+    render_pr_comment.py <diff.json> [--threshold 0.05] [--alpha 0.05]
+                                     [--baseline-run-id N] [--current-sha SHA]
+
+Exit code: 0 on success (regardless of regression count). The gate decision
+is owned by compare_against_baseline.sh; this script only renders.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+
+
+MARKER = "<!-- storm-bench-comment -->"
+
+
+@dataclass
+class Row:
+    name: str
+    delta: float
+    pvalue: float | None
+    baseline: float
+    current: float
+    time_unit: str
+
+
+def collect_rows(diff: list[dict]) -> list[Row]:
+    rows: list[Row] = []
+    for entry in diff:
+        name = entry.get("name", "")
+        if name == "OVERALL_GEOMEAN":
+            continue
+        if entry.get("aggregate_name", "") not in ("mean", "median"):
+            continue
+        measurements = entry.get("measurements", [])
+        if not measurements:
+            continue
+        m = measurements[0]
+        utest = entry.get("utest") or {}
+        rows.append(
+            Row(
+                name=name,
+                delta=float(m.get("time", 0.0)),
+                pvalue=utest.get("time_pvalue"),
+                baseline=float(m.get("real_time_other", 0.0)),
+                current=float(m.get("real_time", 0.0)),
+                time_unit=entry.get("time_unit", "ns"),
+            )
+        )
+    return rows
+
+
+def is_significant(pvalue: float | None, alpha: float) -> bool:
+    if alpha <= 0 or pvalue is None:
+        return True
+    return pvalue < alpha
+
+
+def fmt_delta(d: float) -> str:
+    sign = "+" if d >= 0 else ""
+    return f"{sign}{d * 100:.2f}%"
+
+
+def fmt_p(p: float | None) -> str:
+    return f"{p:.4f}" if p is not None else "—"
+
+
+def render_table(rows: list[Row]) -> str:
+    if not rows:
+        return "_(none)_\n"
+    lines = [
+        "| Benchmark | Baseline | Current | Δ | p-value |",
+        "|---|---:|---:|---:|---:|",
+    ]
+    for r in rows:
+        lines.append(
+            f"| `{r.name}` | {r.baseline:.1f} {r.time_unit} | "
+            f"{r.current:.1f} {r.time_unit} | **{fmt_delta(r.delta)}** | {fmt_p(r.pvalue)} |"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("diff_json")
+    ap.add_argument("--threshold", type=float, default=0.05)
+    ap.add_argument("--alpha", type=float, default=0.05)
+    ap.add_argument("--baseline-run-id", default="")
+    ap.add_argument("--current-sha", default="")
+    args = ap.parse_args()
+
+    with open(args.diff_json) as f:
+        diff = json.load(f)
+
+    rows = collect_rows(diff)
+    regressions = [r for r in rows if r.delta >= args.threshold and is_significant(r.pvalue, args.alpha)]
+    improvements = [r for r in rows if r.delta <= -args.threshold and is_significant(r.pvalue, args.alpha)]
+    unchanged = [r for r in rows if r not in regressions and r not in improvements]
+
+    regressions.sort(key=lambda r: -r.delta)
+    improvements.sort(key=lambda r: r.delta)
+
+    threshold_pct = args.threshold * 100.0
+    alpha = args.alpha
+    n_total = len(rows)
+    n_reg = len(regressions)
+    n_imp = len(improvements)
+    n_eq = len(unchanged)
+
+    def plur(n: int, word: str) -> str:
+        return f"{n} {word}{'' if n == 1 else 's'}"
+
+    if n_reg:
+        verdict = f":x: **{plur(n_reg, 'regression')} past +{threshold_pct:.1f}% (p<{alpha})**"
+    elif n_imp:
+        verdict = f":white_check_mark: No regressions. {plur(n_imp, 'improvement')} past −{threshold_pct:.1f}%."
+    else:
+        verdict = ":white_check_mark: No significant change."
+
+    out = [MARKER, "## storm_bench regression gate", "", verdict, ""]
+
+    out.append(
+        f"_{n_total} benchmark(s) compared (mean+median aggregates) — "
+        f"{n_reg} regressed, {n_imp} improved, {n_eq} within ±{threshold_pct:.1f}%."
+        f" Threshold +{threshold_pct:.1f}%, Mann-Whitney U-test α={alpha}._"
+    )
+    out.append("")
+
+    if regressions:
+        out += ["### Regressions", "", render_table(regressions)]
+
+    if improvements:
+        out += ["### Improvements", "", render_table(improvements)]
+
+    if args.baseline_run_id or args.current_sha:
+        out.append("---")
+        if args.baseline_run_id:
+            out.append(
+                f"_Baseline: develop run [{args.baseline_run_id}]"
+                f"(https://github.com/spiritEcosse/storm/actions/runs/{args.baseline_run_id})_"
+            )
+        if args.current_sha:
+            out.append(f"_Current: `{args.current_sha[:12]}`_")
+
+    print("\n".join(out))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Replaces the never-merged Bencher integration from PR #240 with a self-hosted gate that uses GitHub Actions artifacts as the baseline store. Same `compare.py` engine in CI as in `benchmarks/scripts/compare_against_baseline.sh` locally, so verdicts are identical.

- **Push to `develop`** runs `storm_bench`, uploads JSON as `develop-baseline-latest` (overwriting prior, 90d retention).
- **Pull requests** run `storm_bench`, download `develop-baseline-latest` from the most recent successful develop run, diff via `compare.py` + Mann-Whitney U-test, post a marker-edited PR comment with regression / improvement tables, and fail the gate on +5% slowdown with p<0.05.
- **First-run case** (no baseline yet): PR comment notes the missing baseline and the gate marks green. The first push to develop seeds the baseline.

## Files

- **New** `.github/workflows/bench.yml` — the gate workflow
- **New** `benchmarks/scripts/render_pr_comment.py` — Markdown table renderer (regressions / improvements / no-change summary)
- **Modified** `benchmarks/scripts/compare_against_baseline.sh` — header reposition; this is the CI engine, not just local-dev
- **Modified** `benchmarks/README.md` — regression-detection section rewritten

Depends on the storm-ci dep additions from PR #242 (gh, jq, numpy, scipy) — already merged in `75d91c7`.

## What this PR will exercise

This PR is itself the first run, so it lands in the **first-run path**: no `develop-baseline-latest` artifact exists yet → PR gets a "no baseline yet" comment and the gate marks green. After merge, the develop run will upload the seed baseline, and the next PR sees the real diff.

## Test plan
- [ ] `bench.yml` runs successfully on this PR (first-run path)
- [ ] PR comment is posted with `<!-- storm-bench-comment -->` marker
- [ ] `bench.yml` job is marked green
- [ ] `ci.yml` matrix jobs all pass (no regression from the new workflow file's mere presence)
- [ ] SonarCloud quality gate passes
- [ ] After merge: develop run uploads `develop-baseline-latest` artifact (verify in Actions UI)
- [ ] After merge: a follow-up no-op PR gets the real comparison comment with "no significant change"

Closes #241

🤖 Generated with [Claude Code](https://claude.com/claude-code)