### PR TITLE
refactor(bench): remove dead chunked-batch constants from DataBenchmarkBase

### DIFF
--- a/benchmarks/base.cppm
+++ b/benchmarks/base.cppm
@@ -31,18 +31,6 @@ import <vector>;
 
 export namespace storm::benchmark {
 
-    // Count of non-PK fields for a model — used as default FieldsPerRow
-    // template argument below. Inlined here (was storm_benchmark_raw) since
-    // it was the only remaining consumer after Phase 5 dropped the raw helpers.
-    template <typename T> consteval auto non_pk_field_count() -> size_t {
-        size_t count = 0;
-        for (auto m : std::meta::nonstatic_data_members_of(^^T, std::meta::access_context::unchecked())) {
-            if (!storm::meta::has_primary_attr(m))
-                ++count;
-        }
-        return count;
-    }
-
     // ========================================================================
     // get_db: Helper to get raw sqlite3* from default connection
     // ========================================================================
@@ -100,8 +88,7 @@ export namespace storm::benchmark {
 
     // CRTP base class for data-driven benchmarks (Insert, UpdateByPK)
     // BatchSize is now a runtime parameter for fair comparison with Storm ORM
-    template <typename Derived, typename Model, size_t FieldsPerRow = non_pk_field_count<Model>()>
-    class DataBenchmarkBase {
+    template <typename Derived, typename Model> class DataBenchmarkBase {
       private:
         QuerySet<Model>    qs_;
         std::vector<Model> data_;
@@ -127,14 +114,6 @@ export namespace storm::benchmark {
         auto set_batch_size(int size) -> void {
             batch_size_ = size;
         }
-
-        // SQLite binding limit constants
-        // 999 is SQLite's default SQLITE_MAX_VARIABLE_NUMBER
-        // FieldsPerRow: 4 for INSERT (name, age, is_active, salary - id is auto-increment)
-        //               5 for UPDATE (name, age, is_active, salary, id - need id for WHERE clause)
-        static constexpr size_t fields_per_row = FieldsPerRow;
-        static constexpr size_t max_bulk       = 999 / fields_per_row; // ~249 for INSERT, ~199 for UPDATE
-        static constexpr size_t bulk_threshold = (max_bulk > 100) ? (max_bulk / 2) : 50;
 
         // Default model creation - derived classes can override via static method hiding
         // index parameter allows generating varied data (useful for SELECT WHERE benchmarks)

--- a/benchmarks/crud_benchmark.cppm
+++ b/benchmarks/crud_benchmark.cppm
@@ -47,8 +47,8 @@ import <meta>;
 export namespace storm::benchmark {
 
     template <typename Model, auto const& test>
-    class CrudBenchmark : public DataBenchmarkBase<CrudBenchmark<Model, test>, Model, 1> {
-        using Base = DataBenchmarkBase<CrudBenchmark<Model, test>, Model, 1>;
+    class CrudBenchmark : public DataBenchmarkBase<CrudBenchmark<Model, test>, Model> {
+        using Base = DataBenchmarkBase<CrudBenchmark<Model, test>, Model>;
 
         static consteval auto is_insert_op() -> bool {
             constexpr auto op = test.operation.view();

--- a/benchmarks/query_benchmark.cppm
+++ b/benchmarks/query_benchmark.cppm
@@ -99,8 +99,8 @@ export namespace storm::benchmark {
     // QueryBenchmark — SELECT-family operations driven by a BenchmarkTest NTTP
     // ========================================================================
     template <typename Model, auto const& test>
-    class QueryBenchmark : public DataBenchmarkBase<QueryBenchmark<Model, test>, Model, 1> {
-        using Base = DataBenchmarkBase<QueryBenchmark<Model, test>, Model, 1>;
+    class QueryBenchmark : public DataBenchmarkBase<QueryBenchmark<Model, test>, Model> {
+        using Base = DataBenchmarkBase<QueryBenchmark<Model, test>, Model>;
 
         static consteval auto is_setop() -> bool {
             return test.setop.enabled;


### PR DESCRIPTION
## Summary

- Removes `non_pk_field_count`, `FieldsPerRow` template param, `fields_per_row`, `max_bulk`, and `bulk_threshold` from `DataBenchmarkBase` — all were defined but never used after the benchmark refactor into modules
- The ORM already owns adaptive chunking via `calculate_adaptive_threshold`; `CrudBenchmark` and `QueryBenchmark` delegate to `qs().insert/update/erase()` directly
- `anchors_raw.cpp` (Phase 4) has no dependency on these constants either

Closes #189

## Test plan

- [ ] Pre-commit hooks passed (clang-format + clang-tidy)
- [ ] Release build + bench run to confirm no regression (`benchmarks/` only change — sanitizer presets not required per project feedback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)