### PR TITLE
feat(migrations): add validate-schema CMake target

### DIFF
--- a/cmake/storm_migrations.cmake
+++ b/cmake/storm_migrations.cmake
@@ -143,4 +143,18 @@ function(storm_enable_migrations)
     COMMENT "Recalculating atlas.sum checksums in ${ARG_MIGRATION_DIR}"
     VERBATIM)
 
+  # validate-schema target
+  add_custom_target(
+    validate-schema
+    COMMAND "${_schema_bin}" --dialect "${ARG_DIALECT}" --output
+            "${CMAKE_CURRENT_BINARY_DIR}/_storm_schema.sql"
+    COMMAND atlas schema diff --from "$ENV{STORM_DB_URL}" --to
+            "file://${CMAKE_CURRENT_BINARY_DIR}/_storm_schema.sql" --dev-url
+            "sqlite://dev?mode=memory"
+    DEPENDS ${ARG_TARGET_NAME}
+    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+    COMMENT
+      "Validating schema matches database (set STORM_DB_URL env var)"
+    VERBATIM)
+
 endfunction()

--- a/cmake/storm_migrations.cmake
+++ b/cmake/storm_migrations.cmake
@@ -148,13 +148,13 @@ function(storm_enable_migrations)
     validate-schema
     COMMAND "${_schema_bin}" --dialect "${ARG_DIALECT}" --output
             "${CMAKE_CURRENT_BINARY_DIR}/_storm_schema.sql"
-    COMMAND atlas schema diff --from "$ENV{STORM_DB_URL}" --to
-            "file://${CMAKE_CURRENT_BINARY_DIR}/_storm_schema.sql" --dev-url
-            "sqlite://dev?mode=memory"
+    COMMAND
+      atlas schema diff --from "$ENV{STORM_DB_URL}" --to
+      "file://${CMAKE_CURRENT_BINARY_DIR}/_storm_schema.sql" --dev-url
+      "sqlite://dev?mode=memory"
     DEPENDS ${ARG_TARGET_NAME}
     WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
-    COMMENT
-      "Validating schema matches database (set STORM_DB_URL env var)"
+    COMMENT "Validating schema matches database (set STORM_DB_URL env var)"
     VERBATIM)
 
 endfunction()

--- a/docs/development/MIGRATIONS.md
+++ b/docs/development/MIGRATIONS.md
@@ -67,7 +67,7 @@ storm_enable_migrations(NAMESPACE "schema")
 That's it. Storm:
 - Auto-detects the header containing `namespace schema {`
 - Generates a schema binary using compile-time reflection
-- Creates `makemigrations`, `migrate`, `migrate-validate`, `migrate-status`, and `migrate-hash` targets
+- Creates `makemigrations`, `migrate`, `migrate-validate`, `migrate-status`, `migrate-hash`, and `validate-schema` targets
 
 ### 3. Generate and Apply Migrations
 
@@ -86,6 +86,9 @@ STORM_DB_URL="sqlite://myapp.db" cmake --build . --target migrate-status
 
 # Recalculate atlas.sum after manual edits to migration files
 cmake --build . --target migrate-hash
+
+# Validate entity definitions match the live database (no changes made)
+STORM_DB_URL="sqlite://myapp.db" cmake --build . --target validate-schema
 ```
 
 ## How Auto-Discovery Works


### PR DESCRIPTION
## Summary

- Adds `validate-schema` target to `storm_enable_migrations()` in `cmake/storm_migrations.cmake`
- Uses `storm_schema` binary to export current C++ entity definitions as SQL, then runs `atlas schema diff` to report drift between live DB and code
- Updates `docs/development/MIGRATIONS.md` with usage example

## Test plan

- [x] Manually verified against matching DB — exits 0
- [x] Manually verified against drifted DB (missing table, extra column) — correctly reports diff SQL
- [x] Pre-commit: cmake-format, all tests, 100% coverage passed

Closes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)