### PR TITLE
test(crud): add full CRUD lifecycle integration tests

### DIFF
--- a/tests/crud/test_crud.cpp
+++ b/tests/crud/test_crud.cpp
@@ -32,6 +32,16 @@ template <typename ConnType> class PersonCrudTestBase : public StormTestFixture<
         ASSERT_TRUE((storm::test::batch_insert<Person, ConnType>(initial)));
     }
 
+    static auto insert_persons_range(storm::QuerySet<Person, ConnType>& qs, int from, int to) -> void {
+        std::vector<Person> batch;
+        batch.reserve(static_cast<std::size_t>(to - from + 1));
+        for (int i = from; i <= to; i++) {
+            batch.push_back(Person{.id = i, .name = std::format("Person{}", i), .age = 20 + (i % 60)});
+        }
+        auto result = qs.insert(std::span<const Person>(batch)).execute();
+        ASSERT_TRUE(result.has_value()) << "Failed to insert test data";
+    }
+
     static auto countPersons() -> int {
         storm::QuerySet<Person, ConnType> qs;
         auto                              result = qs.count().execute();
@@ -92,15 +102,8 @@ TYPED_TEST(QuerySetEraseTest, EraseMultiplePersonsSequentially) {
 TYPED_TEST(QuerySetEraseTest, EraseBatchPerformance) {
     storm::QuerySet<Person, TypeParam> queryset;
 
-    // Add test data for performance comparison (batch insert to avoid per-row round-trips)
-    const int           num_records = 1000;
-    std::vector<Person> setup_batch;
-    setup_batch.reserve(num_records - 3);
-    for (int i = 4; i <= num_records; i++) {
-        setup_batch.push_back(Person{.id = i, .name = std::format("Person{}", i), .age = 20 + (i % 60)});
-    }
-    auto insert_result = queryset.insert(std::span<const Person>(setup_batch)).execute();
-    ASSERT_TRUE(insert_result.has_value()) << "Failed to insert test data";
+    const int num_records = 1000;
+    this->insert_persons_range(queryset, 4, num_records);
 
     // Measure individual removes
     auto start_individual = std::chrono::steady_clock::now();
@@ -142,16 +145,8 @@ TYPED_TEST(QuerySetEraseTest, EraseBatchPerformance) {
 TYPED_TEST(QuerySetEraseTest, EraseBatchChunked) {
     storm::QuerySet<Person, TypeParam> queryset;
 
-    // Add many test records (1000+) to test chunked deletion (batch insert to avoid per-row round-trips)
     // MAX_CHUNK_SIZE is 799, so >799 triggers chunked path
-    const int           num_records = 1000;
-    std::vector<Person> setup_batch;
-    setup_batch.reserve(num_records - 3);
-    for (int i = 4; i <= num_records; i++) {
-        setup_batch.push_back(Person{.id = i, .name = std::format("Person{}", i), .age = 20 + (i % 60)});
-    }
-    auto insert_result = queryset.insert(std::span<const Person>(setup_batch)).execute();
-    ASSERT_TRUE(insert_result.has_value()) << "Failed to insert test data";
+    this->insert_persons_range(queryset, 4, 1000);
 
     // Verify initial state
     EXPECT_EQ(this->countPersons(), 1000) << "Should have 1000 persons initially";
@@ -188,16 +183,8 @@ TYPED_TEST(QuerySetEraseTest, EraseBatchChunked) {
 TYPED_TEST(QuerySetEraseTest, EraseBatchChunkedWithRemainder) {
     storm::QuerySet<Person, TypeParam> queryset;
 
-    // Add many test records to test chunked deletion with remainder (batch insert to avoid per-row round-trips)
     // MAX_CHUNK_SIZE is 799, so 1650 rows = 2 full chunks (1598) + 52 remainder
-    const int           num_records = 1800;
-    std::vector<Person> setup_batch;
-    setup_batch.reserve(num_records - 3);
-    for (int i = 4; i <= num_records; i++) {
-        setup_batch.push_back(Person{.id = i, .name = std::format("Person{}", i), .age = 20 + (i % 60)});
-    }
-    auto insert_result = queryset.insert(std::span<const Person>(setup_batch)).execute();
-    ASSERT_TRUE(insert_result.has_value()) << "Failed to insert test data";
+    this->insert_persons_range(queryset, 4, 1800);
 
     // Verify initial state
     EXPECT_EQ(this->countPersons(), 1800) << "Should have 1800 persons initially";
@@ -493,148 +480,6 @@ TYPED_TEST(QueryResetTest, AggregatesWithWhere) {
     auto sum = this->qs->where(storm::orm::where::field<^^Person::age>() >= 35).template sum<^^Person::age>().execute();
     ASSERT_TRUE(sum.has_value());
     EXPECT_EQ(sum.value(), 442);
-}
-
-// =====================================================
-// InsertNoReturn tests — insert<ReturnId::No>
-// =====================================================
-template <typename ConnType> class InsertNoReturnTest : public StormTestFixture<Person, ConnType> {};
-
-TYPED_TEST_SUITE(InsertNoReturnTest, DatabaseTypes);
-
-TYPED_TEST(InsertNoReturnTest, SingleInsertNoReturnSucceeds) {
-    using ReturnId = storm::orm::statements::ReturnId;
-    storm::QuerySet<Person, TypeParam> qs;
-
-    Person const alice{.name = "Alice", .age = 30};
-    auto         result = qs.template insert<ReturnId::No>(alice).execute();
-
-    ASSERT_TRUE(result.has_value()) << "insert<ReturnId::No> should succeed";
-
-    auto count = qs.count().execute();
-    ASSERT_TRUE(count.has_value());
-    EXPECT_EQ(count.value(), 1) << "Should have 1 row after insert";
-}
-
-TYPED_TEST(InsertNoReturnTest, SingleInsertNoReturnReturnsVoid) {
-    using ReturnId = storm::orm::statements::ReturnId;
-    storm::QuerySet<Person, TypeParam> qs;
-
-    Person const alice{.name = "Alice", .age = 30};
-    auto         result = qs.template insert<ReturnId::No>(alice).execute();
-
-    static_assert(
-            std::is_same_v<decltype(result), std::expected<void, typename TypeParam::Error>>,
-            "ReturnId::No should return std::expected<void, Error>"
-    );
-    ASSERT_TRUE(result.has_value());
-}
-
-TYPED_TEST(InsertNoReturnTest, SingleInsertYesReturnsId) {
-    using ReturnId = storm::orm::statements::ReturnId;
-    storm::QuerySet<Person, TypeParam> qs;
-
-    Person const alice{.name = "Alice", .age = 30};
-    auto         result = qs.template insert<ReturnId::Yes>(alice).execute();
-
-    static_assert(
-            std::is_same_v<decltype(result), std::expected<int64_t, typename TypeParam::Error>>,
-            "ReturnId::Yes should return std::expected<int64_t, Error>"
-    );
-    ASSERT_TRUE(result.has_value());
-    EXPECT_GT(result.value(), 0) << "Should return a valid ID";
-}
-
-TYPED_TEST(InsertNoReturnTest, DefaultInsertReturnsId) {
-    storm::QuerySet<Person, TypeParam> qs;
-
-    Person const alice{.name = "Alice", .age = 30};
-    auto         result = qs.insert(alice).execute();
-
-    static_assert(
-            std::is_same_v<decltype(result), std::expected<int64_t, typename TypeParam::Error>>,
-            "Default insert should return std::expected<int64_t, Error>"
-    );
-    ASSERT_TRUE(result.has_value());
-    EXPECT_GT(result.value(), 0);
-}
-
-TYPED_TEST(InsertNoReturnTest, InsertNoReturnDataIntegrity) {
-    using ReturnId = storm::orm::statements::ReturnId;
-    storm::QuerySet<Person, TypeParam> qs;
-
-    Person const alice{.name = "Alice", .age = 30, .salary = 75000.0, .is_active = true, .department = "Engineering"};
-    auto         result = qs.template insert<ReturnId::No>(alice).execute();
-    ASSERT_TRUE(result.has_value());
-
-    auto rows = qs.select().execute();
-    ASSERT_TRUE(rows.has_value());
-    ASSERT_EQ(rows.value().size(), 1);
-
-    const auto& row = *rows.value().begin();
-    EXPECT_EQ(row.name, "Alice");
-    EXPECT_EQ(row.age, 30);
-    EXPECT_DOUBLE_EQ(row.salary, 75000.0);
-    EXPECT_TRUE(row.is_active);
-    EXPECT_EQ(row.department, "Engineering");
-}
-
-TYPED_TEST(InsertNoReturnTest, MultipleInsertNoReturn) {
-    using ReturnId = storm::orm::statements::ReturnId;
-    storm::QuerySet<Person, TypeParam> qs;
-
-    Person const alice{.name = "Alice", .age = 30};
-    Person const bob{.name = "Bob", .age = 25};
-    Person const charlie{.name = "Charlie", .age = 35};
-
-    ASSERT_TRUE(qs.template insert<ReturnId::No>(alice).execute().has_value());
-    ASSERT_TRUE(qs.template insert<ReturnId::No>(bob).execute().has_value());
-    ASSERT_TRUE(qs.template insert<ReturnId::No>(charlie).execute().has_value());
-
-    auto count = qs.count().execute();
-    ASSERT_TRUE(count.has_value());
-    EXPECT_EQ(count.value(), 3);
-}
-
-TYPED_TEST(InsertNoReturnTest, InsertNoReturnToSql) {
-    using ReturnId = storm::orm::statements::ReturnId;
-    storm::QuerySet<Person, TypeParam> qs;
-
-    Person const alice{.name = "Alice", .age = 30};
-    auto         sql = qs.template insert<ReturnId::No>(alice).to_sql();
-    ASSERT_TRUE(sql.has_value());
-
-    EXPECT_TRUE(sql.value().contains("INSERT INTO")) << "SQL should contain INSERT INTO";
-    EXPECT_FALSE(sql.value().contains("RETURNING")) << "SQL should NOT contain RETURNING";
-}
-
-TYPED_TEST(InsertNoReturnTest, InsertYesToSqlHasReturning) {
-    using ReturnId = storm::orm::statements::ReturnId;
-    storm::QuerySet<Person, TypeParam> qs;
-
-    Person const alice{.name = "Alice", .age = 30};
-    auto         sql = qs.template insert<ReturnId::Yes>(alice).to_sql();
-    ASSERT_TRUE(sql.has_value());
-
-    EXPECT_TRUE(sql.value().contains("RETURNING")) << "SQL should contain RETURNING";
-}
-
-TYPED_TEST(InsertNoReturnTest, MixedInsertModes) {
-    using ReturnId = storm::orm::statements::ReturnId;
-    storm::QuerySet<Person, TypeParam> qs;
-
-    Person const alice{.name = "Alice", .age = 30};
-    auto         id_result = qs.template insert<ReturnId::Yes>(alice).execute();
-    ASSERT_TRUE(id_result.has_value());
-    EXPECT_GT(id_result.value(), 0);
-
-    Person const bob{.name = "Bob", .age = 25};
-    auto         void_result = qs.template insert<ReturnId::No>(bob).execute();
-    ASSERT_TRUE(void_result.has_value());
-
-    auto count = qs.count().execute();
-    ASSERT_TRUE(count.has_value());
-    EXPECT_EQ(count.value(), 2);
 }
 
 // NOLINTEND(misc-use-internal-linkage,modernize-use-trailing-return-type,readability-named-parameter,readability-convert-member-functions-to-static)

--- a/tests/crud/test_crud_lifecycle.cpp
+++ b/tests/crud/test_crud_lifecycle.cpp
@@ -1,0 +1,277 @@
+#include <gtest/gtest.h>
+#include "test_db_helpers.h"
+#include <sqlite3.h>
+
+// NOLINTBEGIN(misc-use-internal-linkage,modernize-use-trailing-return-type,readability-named-parameter,readability-convert-member-functions-to-static)
+
+import storm;
+import <expected>;
+import <string>;
+import <optional>;
+import <span>;
+import <vector>;
+import <format>;
+
+#include "test_models.h" // NOSONAR cpp:S954
+#include "test_seed_helpers.h"
+#include "test_yaml_register.h"
+#include "test_parser.hpp"
+
+template <typename ConnType> class QuerySetCrudLifecycleTest : public StormTestFixture<Person, ConnType> {
+  public:
+    static auto countPersons() -> int {
+        storm::QuerySet<Person, ConnType> qs;
+        auto                              result = qs.count().execute();
+        return result.has_value() ? static_cast<int>(result.value()) : -1;
+    }
+
+    static auto selectAll() {
+        storm::QuerySet<Person, ConnType> qs;
+        return qs.select().execute();
+    }
+
+    static auto verifyFullPersonInserted(const Person& row) -> void {
+        EXPECT_EQ(row.name, "FullPerson");
+        EXPECT_EQ(row.age, 42);
+        EXPECT_DOUBLE_EQ(row.salary, 99999.99);
+        EXPECT_TRUE(row.is_active);
+        EXPECT_EQ(row.department, "Engineering");
+        ASSERT_TRUE(row.score.has_value());
+        EXPECT_EQ(row.score.value(), 95);
+        ASSERT_TRUE(row.nickname.has_value());
+        EXPECT_EQ(row.nickname.value(), "fp");
+        EXPECT_EQ(row.avatar, (std::vector<uint8_t>{0x01, 0x02, 0x03}));
+    }
+
+    static auto verifyFullPersonUpdated(const Person& row) -> void {
+        EXPECT_EQ(row.age, 43);
+        EXPECT_DOUBLE_EQ(row.salary, 12345.67);
+        EXPECT_FALSE(row.is_active);
+        EXPECT_EQ(row.department, "Marketing");
+        EXPECT_FALSE(row.score.has_value());
+        EXPECT_FALSE(row.nickname.has_value());
+        EXPECT_EQ(row.avatar, (std::vector<uint8_t>{0xFF}));
+    }
+};
+
+TYPED_TEST_SUITE(QuerySetCrudLifecycleTest, DatabaseTypes);
+
+TYPED_TEST(QuerySetCrudLifecycleTest, FullLifecycle) {
+    using namespace storm::orm::where;
+    storm::QuerySet<Person, TypeParam> qs;
+
+    // 1. Verify empty state
+    EXPECT_EQ(this->countPersons(), 0) << "Should start empty";
+    auto empty = this->selectAll();
+    ASSERT_TRUE(empty.has_value());
+    EXPECT_TRUE(empty.value().empty()) << "Select should return empty result";
+
+    // 2. Insert data
+    Person const alice{.name = "Alice", .age = 30};
+    Person const bob{.name = "Bob", .age = 25};
+    Person const charlie{.name = "Charlie", .age = 35};
+
+    auto id_alice = qs.insert(alice).execute();
+    ASSERT_TRUE(id_alice.has_value()) << "Insert Alice should succeed";
+    EXPECT_GT(id_alice.value(), 0);
+
+    auto id_bob = qs.insert(bob).execute();
+    ASSERT_TRUE(id_bob.has_value()) << "Insert Bob should succeed";
+
+    auto id_charlie = qs.insert(charlie).execute();
+    ASSERT_TRUE(id_charlie.has_value()) << "Insert Charlie should succeed";
+
+    // 3. Verify data exists
+    EXPECT_EQ(this->countPersons(), 3) << "Should have 3 persons after insert";
+    auto all = this->selectAll();
+    ASSERT_TRUE(all.has_value());
+    EXPECT_EQ(static_cast<int>(all.value().size()), 3) << "Select should return 3 rows";
+
+    // 4. Update data
+    Person updated_alice{.id = static_cast<int>(id_alice.value()), .name = "Alice Updated", .age = 31};
+    auto   update_result = qs.update(updated_alice).execute();
+    ASSERT_TRUE(update_result.has_value()) << "Update should succeed";
+
+    auto alice_result = qs.where(field<^^Person::id>() == static_cast<int>(id_alice.value())).select().execute();
+    ASSERT_TRUE(alice_result.has_value());
+    ASSERT_FALSE(alice_result.value().empty());
+    EXPECT_EQ(alice_result.value().begin()->name, "Alice Updated") << "Name should be updated";
+    EXPECT_EQ(alice_result.value().begin()->age, 31) << "Age should be updated";
+
+    // 5. Delete all data
+    auto del_alice = qs.erase(Person{.id = static_cast<int>(id_alice.value())}).execute();
+    ASSERT_TRUE(del_alice.has_value()) << "Erase Alice should succeed";
+
+    auto del_bob = qs.erase(Person{.id = static_cast<int>(id_bob.value())}).execute();
+    ASSERT_TRUE(del_bob.has_value()) << "Erase Bob should succeed";
+
+    auto del_charlie = qs.erase(Person{.id = static_cast<int>(id_charlie.value())}).execute();
+    ASSERT_TRUE(del_charlie.has_value()) << "Erase Charlie should succeed";
+
+    // 6. Verify empty state again
+    EXPECT_EQ(this->countPersons(), 0) << "Should be empty after all erases";
+    auto final_select = this->selectAll();
+    ASSERT_TRUE(final_select.has_value());
+    EXPECT_TRUE(final_select.value().empty()) << "Select should return empty result after all erases";
+}
+
+TYPED_TEST(QuerySetCrudLifecycleTest, BatchLifecycle) {
+    storm::QuerySet<Person, TypeParam> qs;
+
+    // 1. Verify empty state
+    EXPECT_EQ(this->countPersons(), 0) << "Should start empty";
+
+    // 2. Batch insert
+    std::vector<Person> persons;
+    for (int i = 1; i <= 10; i++) {
+        persons.push_back(Person{.name = std::format("Person{}", i), .age = 20 + i});
+    }
+    auto insert_result = qs.insert(std::span<const Person>(persons)).execute();
+    ASSERT_TRUE(insert_result.has_value()) << "Batch insert should succeed";
+
+    // 3. Verify data exists
+    EXPECT_EQ(this->countPersons(), 10) << "Should have 10 persons after batch insert";
+
+    // 4. Batch update
+    auto all = this->selectAll();
+    ASSERT_TRUE(all.has_value());
+    std::vector<Person> updated;
+    for (auto person : all.value()) {
+        person.age += 1;
+        updated.push_back(person);
+    }
+    auto update_result = qs.update(std::span<const Person>(updated)).execute();
+    ASSERT_TRUE(update_result.has_value()) << "Batch update should succeed";
+
+    // 5. Batch erase
+    auto erase_result = qs.erase(std::span<const Person>(updated)).execute();
+    ASSERT_TRUE(erase_result.has_value()) << "Batch erase should succeed";
+
+    // 6. Verify empty state again
+    EXPECT_EQ(this->countPersons(), 0) << "Should be empty after batch erase";
+}
+
+// All supported field types: int, string, double, bool, optional<int>, optional<string>, blob
+TYPED_TEST(QuerySetCrudLifecycleTest, AllFieldTypesLifecycle) {
+    using namespace storm::orm::where;
+    storm::QuerySet<Person, TypeParam> qs;
+
+    // 1. Insert with all fields populated
+    Person const full{
+            .name       = "FullPerson",
+            .age        = 42,
+            .salary     = 99999.99,
+            .is_active  = true,
+            .department = "Engineering",
+            .score      = 95,
+            .nickname   = "fp",
+            .avatar     = {0x01, 0x02, 0x03},
+    };
+    auto id = qs.insert(full).execute();
+    ASSERT_TRUE(id.has_value()) << "Insert with all fields should succeed";
+
+    // 2. Verify all fields round-trip correctly
+    auto rows = qs.where(field<^^Person::id>() == static_cast<int>(id.value())).select().execute();
+    ASSERT_TRUE(rows.has_value());
+    ASSERT_EQ(rows.value().size(), 1u);
+    this->verifyFullPersonInserted(*rows.value().begin());
+
+    // 3. Update all fields
+    Person updated{
+            .id         = static_cast<int>(id.value()),
+            .name       = "FullPerson",
+            .age        = 43,
+            .salary     = 12345.67,
+            .is_active  = false,
+            .department = "Marketing",
+            .score      = std::nullopt,
+            .nickname   = std::nullopt,
+            .avatar     = {0xFF},
+    };
+    ASSERT_TRUE(qs.update(updated).execute().has_value()) << "Update with all fields should succeed";
+
+    auto updated_rows = qs.where(field<^^Person::id>() == static_cast<int>(id.value())).select().execute();
+    ASSERT_TRUE(updated_rows.has_value());
+    ASSERT_EQ(updated_rows.value().size(), 1u);
+    this->verifyFullPersonUpdated(*updated_rows.value().begin());
+
+    // 4. Erase and verify gone
+    ASSERT_TRUE(qs.erase(Person{.id = static_cast<int>(id.value())}).execute().has_value());
+    EXPECT_EQ(this->countPersons(), 0);
+}
+
+// Batch at the 999-param SQLite boundary: Person has 9 fields → floor(999/9) = 111 rows per chunk
+TYPED_TEST(QuerySetCrudLifecycleTest, BoundaryBatchLifecycle) {
+    storm::QuerySet<Person, TypeParam> qs;
+
+    // 1. Insert exactly 111 rows (fills one 999-param chunk exactly)
+    std::vector<Person> persons;
+    persons.reserve(111);
+    for (int i = 1; i <= 111; i++) {
+        persons.push_back(Person{.name = std::format("Person{}", i), .age = 20 + (i % 60)});
+    }
+    auto insert_result = qs.insert(std::span<const Person>(persons)).execute();
+    ASSERT_TRUE(insert_result.has_value()) << "Insert at boundary should succeed";
+    EXPECT_EQ(this->countPersons(), 111);
+
+    // 2. Insert 112 rows (one past boundary — triggers two chunks)
+    std::vector<Person> over;
+    over.reserve(112);
+    for (int i = 112; i <= 223; i++) {
+        over.push_back(Person{.name = std::format("Person{}", i), .age = 20 + (i % 60)});
+    }
+    auto insert_over = qs.insert(std::span<const Person>(over)).execute();
+    ASSERT_TRUE(insert_over.has_value()) << "Insert over boundary should succeed";
+    EXPECT_EQ(this->countPersons(), 223);
+
+    // 3. Batch erase all
+    auto all = this->selectAll();
+    ASSERT_TRUE(all.has_value());
+    std::vector<Person> all_vec(all.value().begin(), all.value().end());
+    auto                erase_result = qs.erase(std::span<const Person>(all_vec)).execute();
+    ASSERT_TRUE(erase_result.has_value()) << "Batch erase at boundary should succeed";
+    EXPECT_EQ(this->countPersons(), 0);
+}
+
+// Insert, selectively update and erase via WHERE, verify unaffected rows unchanged
+TYPED_TEST(QuerySetCrudLifecycleTest, FilteredLifecycle) {
+    using namespace storm::orm::where;
+    storm::QuerySet<Person, TypeParam> qs;
+
+    // 1. Insert mixed data
+    std::vector<Person> persons = {
+            {.name = "Alice", .age = 30, .is_active = true},
+            {.name = "Bob", .age = 20, .is_active = false},
+            {.name = "Charlie", .age = 35, .is_active = true},
+            {.name = "Dave", .age = 18, .is_active = false},
+    };
+    ASSERT_TRUE(qs.insert(std::span<const Person>(persons)).execute().has_value());
+    EXPECT_EQ(this->countPersons(), 4);
+
+    // 2. Select only active persons
+    auto active = qs.where(field<^^Person::is_active>() == true).select().execute();
+    ASSERT_TRUE(active.has_value());
+    EXPECT_EQ(static_cast<int>(active.value().size()), 2) << "Should have 2 active persons";
+
+    // 3. Erase only persons aged < 21
+    auto young = qs.where(field<^^Person::age>() < 21).select().execute();
+    ASSERT_TRUE(young.has_value());
+    std::vector<Person> young_vec(young.value().begin(), young.value().end());
+    ASSERT_EQ(young_vec.size(), 2u) << "Bob and Dave should be under 21";
+    ASSERT_TRUE(qs.erase(std::span<const Person>(young_vec)).execute().has_value());
+    EXPECT_EQ(this->countPersons(), 2) << "Alice and Charlie should remain";
+
+    // 4. Verify only Alice and Charlie remain
+    auto remaining = this->selectAll();
+    ASSERT_TRUE(remaining.has_value());
+    for (const auto& p : remaining.value()) {
+        EXPECT_GE(p.age, 21) << std::format("{} should not have been erased", p.name);
+    }
+
+    // 5. Erase remaining and confirm empty
+    std::vector<Person> rem_vec(remaining.value().begin(), remaining.value().end());
+    ASSERT_TRUE(qs.erase(std::span<const Person>(rem_vec)).execute().has_value());
+    EXPECT_EQ(this->countPersons(), 0);
+}
+
+// NOLINTEND(misc-use-internal-linkage,modernize-use-trailing-return-type,readability-named-parameter,readability-convert-member-functions-to-static)

--- a/tests/crud/test_insert_no_return.cpp
+++ b/tests/crud/test_insert_no_return.cpp
@@ -1,0 +1,152 @@
+#include <gtest/gtest.h>
+#include "test_db_helpers.h"
+#include <sqlite3.h>
+
+// NOLINTBEGIN(misc-use-internal-linkage,modernize-use-trailing-return-type,readability-named-parameter,readability-convert-member-functions-to-static)
+
+import storm;
+import <expected>;
+import <string>;
+import <optional>;
+import <span>;
+import <vector>;
+import <format>;
+
+#include "test_models.h" // NOSONAR cpp:S954
+#include "test_seed_helpers.h"
+#include "test_yaml_register.h"
+#include "test_parser.hpp"
+
+// =====================================================
+// InsertNoReturn tests — insert<ReturnId::No>
+// =====================================================
+template <typename ConnType> class InsertNoReturnTest : public StormTestFixture<Person, ConnType> {};
+
+TYPED_TEST_SUITE(InsertNoReturnTest, DatabaseTypes);
+
+TYPED_TEST(InsertNoReturnTest, SingleInsertNoReturnSucceeds) {
+    using ReturnId = storm::orm::statements::ReturnId;
+    storm::QuerySet<Person, TypeParam> qs;
+
+    Person const alice{.name = "Alice", .age = 30};
+    auto         result = qs.template insert<ReturnId::No>(alice).execute();
+
+    static_assert(
+            std::is_same_v<decltype(result), std::expected<void, typename TypeParam::Error>>,
+            "ReturnId::No should return std::expected<void, Error>"
+    );
+    ASSERT_TRUE(result.has_value()) << "insert<ReturnId::No> should succeed";
+
+    auto count = qs.count().execute();
+    ASSERT_TRUE(count.has_value());
+    EXPECT_EQ(count.value(), 1) << "Should have 1 row after insert";
+}
+
+TYPED_TEST(InsertNoReturnTest, SingleInsertYesReturnsId) {
+    using ReturnId = storm::orm::statements::ReturnId;
+    storm::QuerySet<Person, TypeParam> qs;
+
+    Person const alice{.name = "Alice", .age = 30};
+    auto         result = qs.template insert<ReturnId::Yes>(alice).execute();
+
+    static_assert(
+            std::is_same_v<decltype(result), std::expected<int64_t, typename TypeParam::Error>>,
+            "ReturnId::Yes should return std::expected<int64_t, Error>"
+    );
+    ASSERT_TRUE(result.has_value());
+    EXPECT_GT(result.value(), 0) << "Should return a valid ID";
+}
+
+TYPED_TEST(InsertNoReturnTest, DefaultInsertReturnsId) {
+    storm::QuerySet<Person, TypeParam> qs;
+
+    Person const alice{.name = "Alice", .age = 30};
+    auto         result = qs.insert(alice).execute();
+
+    static_assert(
+            std::is_same_v<decltype(result), std::expected<int64_t, typename TypeParam::Error>>,
+            "Default insert should return std::expected<int64_t, Error>"
+    );
+    ASSERT_TRUE(result.has_value());
+    EXPECT_GT(result.value(), 0);
+}
+
+TYPED_TEST(InsertNoReturnTest, InsertNoReturnDataIntegrity) {
+    using ReturnId = storm::orm::statements::ReturnId;
+    storm::QuerySet<Person, TypeParam> qs;
+
+    Person const alice{.name = "Alice", .age = 30, .salary = 75000.0, .is_active = true, .department = "Engineering"};
+    auto         result = qs.template insert<ReturnId::No>(alice).execute();
+    ASSERT_TRUE(result.has_value());
+
+    auto rows = qs.select().execute();
+    ASSERT_TRUE(rows.has_value());
+    ASSERT_EQ(rows.value().size(), 1);
+
+    const auto& row = *rows.value().begin();
+    EXPECT_EQ(row.name, "Alice");
+    EXPECT_EQ(row.age, 30);
+    EXPECT_DOUBLE_EQ(row.salary, 75000.0);
+    EXPECT_TRUE(row.is_active);
+    EXPECT_EQ(row.department, "Engineering");
+}
+
+TYPED_TEST(InsertNoReturnTest, MultipleInsertNoReturn) {
+    using ReturnId = storm::orm::statements::ReturnId;
+    storm::QuerySet<Person, TypeParam> qs;
+
+    Person const alice{.name = "Alice", .age = 30};
+    Person const bob{.name = "Bob", .age = 25};
+    Person const charlie{.name = "Charlie", .age = 35};
+
+    ASSERT_TRUE(qs.template insert<ReturnId::No>(alice).execute().has_value());
+    ASSERT_TRUE(qs.template insert<ReturnId::No>(bob).execute().has_value());
+    ASSERT_TRUE(qs.template insert<ReturnId::No>(charlie).execute().has_value());
+
+    auto count = qs.count().execute();
+    ASSERT_TRUE(count.has_value());
+    EXPECT_EQ(count.value(), 3);
+}
+
+TYPED_TEST(InsertNoReturnTest, InsertNoReturnToSql) {
+    using ReturnId = storm::orm::statements::ReturnId;
+    storm::QuerySet<Person, TypeParam> qs;
+
+    Person const alice{.name = "Alice", .age = 30};
+    auto         sql = qs.template insert<ReturnId::No>(alice).to_sql();
+    ASSERT_TRUE(sql.has_value());
+
+    EXPECT_TRUE(sql.value().contains("INSERT INTO")) << "SQL should contain INSERT INTO";
+    EXPECT_FALSE(sql.value().contains("RETURNING")) << "SQL should NOT contain RETURNING";
+}
+
+TYPED_TEST(InsertNoReturnTest, InsertYesToSqlHasReturning) {
+    using ReturnId = storm::orm::statements::ReturnId;
+    storm::QuerySet<Person, TypeParam> qs;
+
+    Person const alice{.name = "Alice", .age = 30};
+    auto         sql = qs.template insert<ReturnId::Yes>(alice).to_sql();
+    ASSERT_TRUE(sql.has_value());
+
+    EXPECT_TRUE(sql.value().contains("RETURNING")) << "SQL should contain RETURNING";
+}
+
+TYPED_TEST(InsertNoReturnTest, MixedInsertModes) {
+    using ReturnId = storm::orm::statements::ReturnId;
+    storm::QuerySet<Person, TypeParam> qs;
+
+    Person const alice{.name = "Alice", .age = 30};
+    auto         id_result = qs.template insert<ReturnId::Yes>(alice).execute();
+    ASSERT_TRUE(id_result.has_value());
+    EXPECT_GT(id_result.value(), 0);
+
+    Person const bob{.name = "Bob", .age = 25};
+    auto         void_result = qs.template insert<ReturnId::No>(bob).execute();
+    ASSERT_TRUE(void_result.has_value());
+
+    auto count = qs.count().execute();
+    ASSERT_TRUE(count.has_value());
+    EXPECT_EQ(count.value(), 2);
+}
+
+// NOLINTEND(misc-use-internal-linkage,modernize-use-trailing-return-type,readability-named-parameter,readability-convert-member-functions-to-static)


### PR DESCRIPTION
## Summary

- Add `test_crud_lifecycle.cpp` with `QuerySetCrudLifecycleTest` covering the full CRUD lifecycle per the checklist in CLAUDE.md:
  - `FullLifecycle`: single-row insert → verify → update → erase → verify empty
  - `BatchLifecycle`: batch insert → verify → batch update → batch erase → verify empty
  - `AllFieldTypesLifecycle`: all field types round-trip (int, string, double, bool, optional<int>, optional<string>, blob)
  - `BoundaryBatchLifecycle`: 111 rows (exact 999-param SQLite boundary) + 112 rows (over boundary, two chunks)
  - `FilteredLifecycle`: WHERE-based select/erase, verifies unaffected rows unchanged
- Extract `InsertNoReturnTest` to `test_insert_no_return.cpp` to keep file sizes under the 600-line limit
- Refactor `test_crud.cpp`: extract `insert_persons_range()` helper to eliminate duplicate setup-batch blocks

## Test plan

- [x] All 5 new lifecycle tests pass on SQLite
- [x] PostgreSQL skips gracefully when server unavailable
- [x] Pre-commit hook passes (clang-format, clang-tidy, full test suite, coverage)

Closes #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)