### PR TITLE
refactor(bench): remove dead code from sizes.cppm and base.cppm

### DIFF
--- a/benchmarks/base.cppm
+++ b/benchmarks/base.cppm
@@ -22,11 +22,9 @@ export module storm_benchmark_base;
 
 import storm;
 
-import <cstddef>;
 import <format>;
 import <iostream>;
 import <meta>;
-import <string_view>;
 import <vector>;
 
 export namespace storm::benchmark {
@@ -38,53 +36,6 @@ export namespace storm::benchmark {
         auto& conn = storm::QuerySet<Model>::get_default_connection();
         return conn->get();
     }
-
-    // ========================================================================
-    // OperationDispatcher: Compile-time binding of operation to method
-    // ========================================================================
-    enum class OperationType { Insert, UpdatePK, Delete, Select };
-
-    template <OperationType Op> struct OperationDispatcher;
-
-    // INSERT operation specialization
-    template <> struct OperationDispatcher<OperationType::Insert> {
-        static constexpr auto name() -> std::string_view {
-            return "INSERT";
-        }
-
-        template <typename QS, typename Data> static auto call(QS& qs, const Data& data) {
-            return qs.insert(data);
-        }
-    };
-
-    // UPDATE operation specialization
-    template <> struct OperationDispatcher<OperationType::UpdatePK> {
-        static constexpr auto name() -> std::string_view {
-            return "UPDATE by PK";
-        }
-
-        template <typename QS, typename Data> static auto call(QS& qs, const Data& data) {
-            return qs.update(data);
-        }
-    };
-
-    // DELETE operation specialization
-    template <> struct OperationDispatcher<OperationType::Delete> {
-        static constexpr auto name() -> std::string_view {
-            return "DELETE";
-        }
-
-        template <typename QS, typename Data> static auto call(QS& qs, const Data& data) {
-            return qs.erase(data);
-        }
-    };
-
-    // SELECT operation specialization
-    template <> struct OperationDispatcher<OperationType::Select> {
-        static constexpr auto name() -> std::string_view {
-            return "SELECT WHERE";
-        }
-    };
 
     // CRTP base class for data-driven benchmarks (Insert, UpdateByPK)
     // BatchSize is now a runtime parameter for fair comparison with Storm ORM
@@ -124,16 +75,6 @@ export namespace storm::benchmark {
                     .salary    = 30000.0 + (index * 1000.0),
                     .is_active = (index % 2 == 0)
             };
-        }
-
-        // Execute statement, reset, return success count
-        static auto step_and_reset(sqlite3_stmt* stmt, [[maybe_unused]] sqlite3* db, int rows) -> int {
-            if (sqlite3_step(stmt) == SQLITE_DONE) {
-                sqlite3_reset(stmt);
-                return rows;
-            }
-            sqlite3_reset(stmt);
-            return 0;
         }
 
       public:
@@ -180,42 +121,12 @@ export namespace storm::benchmark {
             const auto& selected = select_result.value();
             size_t      i        = 0;
             for (const auto& row : selected) {
-                if (i >= data().size())
+                if (i >= data().size()) {
                     break;
+                }
                 data()[i].id = row.id;
                 i++;
             }
-        }
-
-        // ====================================================================
-        // Unified print_info() with compile-time operation name
-        // ====================================================================
-        template <OperationType Op> auto print_info_unified() const -> void {
-            constexpr std::string_view op_name = OperationDispatcher<Op>::name();
-            if (batch_size_ == 1)
-                std::cout << "Operation: " << op_name << " (single row)\n";
-            else
-                std::cout << "Operation: " << op_name << " (batch, " << batch_size_ << " rows per operation)\n";
-        }
-
-        // ====================================================================
-        // Unified execute() with compile-time operation dispatch
-        // Runtime batch size check (same as Storm ORM for fair comparison)
-        // ====================================================================
-        template <OperationType Op> auto execute_unified(int iterations) -> int {
-            int total = 0;
-            if (batch_size_ == 1) {
-                for (int i = 0; i < iterations; i++) {
-                    OperationDispatcher<Op>::call(qs(), data()[i]).execute();
-                    total++;
-                }
-            } else {
-                for (int i = 0; i < iterations; i++) {
-                    OperationDispatcher<Op>::call(qs(), data()).execute();
-                    total += data().size();
-                }
-            }
-            return total;
         }
     };
 

--- a/benchmarks/sizes.cppm
+++ b/benchmarks/sizes.cppm
@@ -1,11 +1,6 @@
 // storm_benchmark_sizes
 //
-// Compile-time size profiles for benchmark categories: standard / smoke / edge
-// arrays for batch + dataset operations, plus iteration calculators. Pure
-// constexpr — no SQLite, no reflection, no model deps — so it converts cleanly
-// to a leaf module with no GMF preprocessing required.
-//
-// Was: benchmarks/sizes.hpp (textual header with `inline constexpr` arrays).
+// Batch size arrays for INSERT/UPDATE/DELETE benchmarks.
 // Issue #221 — Phase 2 of the benchmark module conversion.
 
 module;
@@ -13,149 +8,16 @@ module;
 export module storm_benchmark_sizes;
 
 import <array>;
-import <format>;
-import <span>;
-import <string>;
-import <string_view>;
 
 export namespace storm::benchmark::sizes {
 
     // Standard batch sizes for INSERT/UPDATE/DELETE operations
     inline constexpr std::array BATCH_STANDARD = {1, 10, 100, 500, 1000, 5000, 10000, 50000, 100000};
 
-    // Smoke batch sizes — representative subset for fast regression detection
-    inline constexpr std::array BATCH_SMOKE = {1, 100, 1000};
-
     // Edge case sizes for INSERT (SQLite chunk boundary: 999/4 fields = 249)
     inline constexpr std::array BATCH_INSERT_EDGE = {248, 249, 250};
 
-    // Smoke edge sizes — just the boundary value
-    inline constexpr std::array BATCH_INSERT_EDGE_SMOKE = {249};
-
     // Edge case sizes for UPDATE (999/5 fields = 199)
     inline constexpr std::array BATCH_UPDATE_EDGE = {198, 199, 200};
-
-    // Smoke edge sizes — just the boundary value
-    inline constexpr std::array BATCH_UPDATE_EDGE_SMOKE = {199};
-
-    // Standard dataset sizes for SELECT/JOIN/DISTINCT operations
-    inline constexpr std::array DATASET_STANDARD = {100, 1000, 10000, 100000};
-
-    // Smoke dataset sizes — small + medium only
-    inline constexpr std::array DATASET_SMOKE = {100, 10000};
-
-    // Dataset sizes for aggregate tests (≥10000 for reliable COUNT(*) efficiency)
-    inline constexpr std::array DATASET_SMALL = {10000, 50000};
-
-    // Smoke aggregate sizes — single representative size
-    inline constexpr std::array DATASET_SMALL_SMOKE = {10000};
-
-    // Calculate iterations inversely proportional to batch size
-    // Larger batches get fewer iterations to maintain consistent total work
-    constexpr auto iterations_for_batch(int size) -> int {
-        if (size <= 1)
-            return 10000;
-        if (size <= 10)
-            return 1000;
-        if (size <= 100)
-            return 100;
-        if (size <= 250)
-            return 50; // Edge case tests
-        if (size <= 500)
-            return 20;
-        if (size <= 1000)
-            return 10;
-        if (size <= 5000)
-            return 2;
-        return 1; // 10000+ rows
-    }
-
-    // Calculate iterations inversely proportional to dataset size
-    constexpr auto iterations_for_dataset(int size) -> int {
-        if (size <= 100)
-            return 10000;
-        if (size <= 1000)
-            return 1000;
-        if (size <= 10000)
-            return 100;
-        return 10; // 100000+ rows
-    }
-
-    // Calculate iterations for aggregate operations
-    constexpr auto iterations_for_aggregate(int size) -> int {
-        if (size <= 1000)
-            return 10000;
-        if (size <= 10000)
-            return 5000;
-        if (size <= 50000)
-            return 500;
-        return 100; // 100000+ rows
-    }
-
-    // Size profile enumeration for compile-time dispatch
-    enum class SizeProfile {
-        None,            // Non-scaled test, run once with fixed parameters
-        BatchStandard,   // Standard batch sizes
-        BatchInsertEdge, // INSERT chunk boundary tests
-        BatchUpdateEdge, // UPDATE chunk boundary tests
-        DatasetStandard, // Standard dataset sizes
-        DatasetSmall     // Small dataset sizes (for aggregates)
-    };
-
-    // Convert string to SizeProfile
-    constexpr auto profile_from_string(std::string_view str) -> SizeProfile {
-        using enum SizeProfile;
-        if (str == "batch_standard")
-            return BatchStandard;
-        if (str == "batch_insert_edge")
-            return BatchInsertEdge;
-        if (str == "batch_update_edge")
-            return BatchUpdateEdge;
-        if (str == "dataset_standard")
-            return DatasetStandard;
-        if (str == "dataset_small")
-            return DatasetSmall;
-        return None;
-    }
-
-    // Get size arrays for the current mode (smoke = reduced subset)
-    inline auto batch_standard_sizes(bool smoke) -> std::span<const int> {
-        if (smoke)
-            return BATCH_SMOKE;
-        return BATCH_STANDARD;
-    }
-
-    inline auto batch_insert_edge_sizes(bool smoke) -> std::span<const int> {
-        if (smoke)
-            return BATCH_INSERT_EDGE_SMOKE;
-        return BATCH_INSERT_EDGE;
-    }
-
-    inline auto batch_update_edge_sizes(bool smoke) -> std::span<const int> {
-        if (smoke)
-            return BATCH_UPDATE_EDGE_SMOKE;
-        return BATCH_UPDATE_EDGE;
-    }
-
-    inline auto dataset_standard_sizes(bool smoke) -> std::span<const int> {
-        if (smoke)
-            return DATASET_SMOKE;
-        return DATASET_STANDARD;
-    }
-
-    inline auto dataset_small_sizes(bool smoke) -> std::span<const int> {
-        if (smoke)
-            return DATASET_SMALL_SMOKE;
-        return DATASET_SMALL;
-    }
-
-    // Get test name suffix for a given size
-    // Returns "_single" for batch_size=1, otherwise "_{size}"
-    inline auto get_name_suffix(int size, bool is_batch) -> std::string {
-        if (is_batch && size == 1) {
-            return "_single";
-        }
-        return std::format("_{}", size);
-    }
 
 } // namespace storm::benchmark::sizes


### PR DESCRIPTION
## Summary

- `sizes.cppm`: reduced to the 3 arrays that `register.cpp` actually uses (`BATCH_STANDARD`, `BATCH_INSERT_EDGE`, `BATCH_UPDATE_EDGE`). Removed smoke arrays, dataset arrays, `SizeProfile` enum, `profile_from_string`, five accessor functions, three `iterations_for_*` functions, `get_name_suffix`, and four now-unused imports.
- `base.cppm`: removed `OperationDispatcher` (all 4 specialisations), `print_info_unified`, `execute_unified`, `step_and_reset`, and the now-unused imports `<cstddef>` and `<string_view>`. The derived benchmarks do their own `if constexpr` dispatch — none of these helpers were ever called.

Net: −230 lines, no behaviour change.

Also includes the rebase picking up the `query_builder.hpp` setop fix (Closes #260) that was blocking the release bench build.

## Test plan

- [x] `cmake --build --preset ninja-release --target storm_bench` — clean
- [x] Pre-commit: clang-format + clang-tidy — clean

Closes #259

🤖 Generated with [Claude Code](https://claude.com/claude-code)