### PR TITLE
refactor(tidy): diff-mode + fail-loud + scheduled sweep (#262)

### DIFF
--- a/.claude/agents/shell.md
+++ b/.claude/agents/shell.md
@@ -88,11 +88,14 @@ These scripts have project-specific conventions — understand them before modif
 - When re-enabled: detects C++ changes → builds with build-wrapper → runs sonar-scanner → polls CE task → checks quality gate
 - Currently just prints a notice and exits 0
 
-**`scripts/run_clang_tidy.sh`** — Runs clang-tidy on staged files only:
+**`scripts/run_clang_tidy.sh`** — Three modes (default `--diff`):
+- `--diff` (default) — warns only on lines staged in `git diff --cached`. Uses clang-tidy-diff.py.
+- `--full` — whole-file scan, staged files only (pre-#262 default; opt-in via `STORM_TIDY_FULL=1`).
+- `--all` — full-tree sweep, used by the weekly `clang-tidy-sweep` CI workflow (report-only).
 - Options: `--fix` (auto-apply fixes), `-j N` (parallel jobs, default: all cores)
 - Requires release build (`cmake --preset ninja-release`) for `compile_commands.json`
-- C++26 module files (`.cppm`, `tests/*.cpp`, `benchmarks/*.cpp`) are skipped — clang-tidy crashes on them
-- Exits non-zero on warnings or errors (warnings block commits)
+- Skips for parse-failure are limited to `tests/*`, `benchmarks/*`, `fuzz/*`, `shared/*`, `src/orm/query_builder.hpp`. `src/*.cppm` parse cleanly since 2026-05-11 — a parse failure there now fails loudly.
+- Exits non-zero on warnings/errors that affect the current mode's scope.
 
 **`scripts/sonarcloud-check.sh`** — Branch-aware SonarCloud quality gate:
 - Branch mode (develop/master/main): checks full project — all existing issues

--- a/.github/workflows/clang-tidy-sweep.yml
+++ b/.github/workflows/clang-tidy-sweep.yml
@@ -1,0 +1,75 @@
+name: clang-tidy weekly sweep
+
+# Scheduled full-tree clang-tidy sweep — report-only.
+# See Issue #262 for rationale.
+#
+# Runs ./scripts/run_clang_tidy.sh --all and writes the result to the workflow
+# run's Summary tab. Does NOT gate develop merges (yet) — opt-in gating is
+# deferred. The point is to surface accumulated drift within a week instead
+# of within months, which is what triggered Issue #262 in the first place.
+
+on:
+  schedule:
+    # Mondays 04:00 UTC — chosen to land before the European working day,
+    # giving the team a fresh report at the start of each week.
+    - cron: '0 4 * * 1'
+  workflow_dispatch: {}
+
+jobs:
+  sweep:
+    name: Full-tree clang-tidy
+    runs-on: ubuntu-24.04
+    container:
+      # Same pinned storm-ci image as ci.yml — keep digests in sync when bumping.
+      image: ghcr.io/spiritecosse/storm-ci@sha256:68eaac686d20d926e7f7cd4c8582d540e7377d4392443f748299c771d346de63
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Link clang-p2996 next to source dir
+        run: ln -sfn /opt/clang-p2996 "$(dirname "$GITHUB_WORKSPACE")/clang-p2996"
+
+      - name: Configure (release)
+        run: cmake --preset ninja-release
+
+      - name: Build (release)
+        # Sweep needs compile_commands.json from the release build. We build
+        # the library + tests targets so all TUs end up in compile_commands.json.
+        run: ./scripts/build-with-retry.sh ninja-release
+
+      - name: Run clang-tidy --all (report-only)
+        id: sweep
+        continue-on-error: true
+        run: |
+          set +e
+          ./scripts/run_clang_tidy.sh --all 2>&1 | tee /tmp/sweep.log
+          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+
+      - name: Post summary
+        if: always()
+        run: |
+          {
+            echo "## clang-tidy weekly sweep"
+            echo ""
+            echo "**Mode:** \`--all\` (full-tree, report-only)"
+            echo "**Exit code:** ${{ steps.sweep.outputs.exit_code }}"
+            echo ""
+            # Pull the summary block ("📊 Summary:" through the rule line) and
+            # the first 50 unique issues, if any.
+            if grep -q "📊 Summary" /tmp/sweep.log; then
+              echo '### Summary'
+              echo '```'
+              awk '/📊 Summary/{f=1} f' /tmp/sweep.log | head -20
+              echo '```'
+            fi
+            if grep -q "📋 Issues found" /tmp/sweep.log; then
+              echo ''
+              echo '### Issues (first 50)'
+              echo '```'
+              awk '/📋 Issues found/{f=1; next} f && /━━━━/{exit} f' /tmp/sweep.log | head -50
+              echo '```'
+            fi
+            echo ''
+            echo "_Full log available in the workflow run logs._"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/commit.sh
+++ b/commit.sh
@@ -218,8 +218,15 @@ if [[ "$RUN_CMAKE_FORMAT" == true ]]; then
 fi
 
 # --- Step 3: clang-tidy ---
+# Default to --diff mode (issue #262): only block on warnings touching staged
+# lines, so pre-existing drift in unrelated files doesn't block unrelated work.
+# Set STORM_TIDY_FULL=1 to force whole-file staged scan (the pre-#262 behavior).
 if [[ "$RUN_TIDY" == true ]]; then
-    run_step "clang-tidy --fix" ./scripts/run_clang_tidy.sh --fix || true
+    if [[ -n "$STORM_TIDY_FULL" ]]; then
+        run_step "clang-tidy --full --fix" ./scripts/run_clang_tidy.sh --full --fix || true
+    else
+        run_step "clang-tidy --diff --fix" ./scripts/run_clang_tidy.sh --diff --fix || true
+    fi
 fi
 
 # --- Re-stage files modified by format/tidy ---

--- a/docs/README.md
+++ b/docs/README.md
@@ -52,6 +52,7 @@ Welcome to Storm ORM - a modern C++26 ORM library using compile-time reflection 
 - **[Compiler Attributes](development/COMPILER_ATTRIBUTES.md)** - Guide for using hot, flatten, and always_inline attributes
 - **[Compiler Issues](development/COMPILER_ISSUES.md)** - Known workarounds for clang-p2996
 - **[Formatting](development/FORMATTING.md)** - clang-format and cmake-format targets, pre-commit integration, and `.clang-format` settings
+- **[Pre-Commit](development/PRE_COMMIT.md)** - clang-tidy modes (`--diff` / `--full` / `--all`), weekly sweep, parse-failure handling
 - **[Sanitizers](development/SANITIZERS.md)** - ASAN+UBSAN and TSAN presets, what each sanitizer catches, MSAN status
 - **[Benchmark Dashboard](development/BENCHMARK_DASHBOARD.md)** - Real-time TUI for storm_bench: setup, schema, backup/restore, troubleshooting
 

--- a/docs/development/PRE_COMMIT.md
+++ b/docs/development/PRE_COMMIT.md
@@ -1,0 +1,128 @@
+# Pre-Commit Hook
+
+Storm's pre-commit hook (`commit.sh`) runs format → clang-tidy → tests → coverage.
+This page documents the **clang-tidy** stage in detail, because it has three
+modes with different scopes.
+
+## The three clang-tidy modes
+
+| Mode | What it scans | Where it runs | Blocks on |
+|---|---|---|---|
+| `--diff` *(default)* | Lines staged in the current commit (`git diff --cached`) | Local pre-commit | New warnings on staged lines |
+| `--full` | Whole files that are staged | Local pre-commit (opt-in) | Any warning in any staged file |
+| `--all` | Every C++ file in the tree | Scheduled CI (Mondays 04:00 UTC) | Nothing — report only |
+
+### `--diff` mode (default)
+
+The pre-commit default since Issue #262. It pipes `git diff -U0 --cached` into
+`clang-tidy-diff.py` from the clang-p2996 toolchain. The diagnostic engine only
+emits warnings on lines the staged commit actually touches.
+
+**Mechanically:** clang-tidy always parses the whole translation unit — C++
+type resolution needs the full file. `--diff` mode does not change that. It
+sets `-line-filter` on the clang-tidy invocation, so clang-tidy still walks
+every AST node but suppresses the diagnostic when the source location is
+outside the staged hunks. `--diff` and `--full` therefore have roughly the
+same per-file CPU cost — the difference is output policy, not parse scope.
+
+**Why this is the default:** an author who edits one function in a 600-line
+module shouldn't have to fix unrelated accumulated drift before they can commit
+their change. Drift cleanup happens on its own schedule (see `--all`).
+
+```bash
+./scripts/run_clang_tidy.sh --diff          # check-only
+./scripts/run_clang_tidy.sh --diff --fix    # apply auto-fixes, then re-check
+```
+
+What can still block your commit in `--diff` mode:
+
+- A warning on a line you added or changed.
+- A new warning that a fix on an adjacent line uncovered.
+
+What will **not** block your commit:
+
+- Pre-existing warnings on lines you didn't touch — even in the same file.
+
+### `--full` mode
+
+The pre-#262 default. Scans whole files that are staged. Useful when you are
+deliberately cleaning up drift in a specific module and want clang-tidy to
+report everything in that file, not just your delta.
+
+```bash
+./scripts/run_clang_tidy.sh --full --fix          # local one-off
+STORM_TIDY_FULL=1 git commit -m "..."             # force --full in pre-commit
+```
+
+`--full` is **not** the pre-commit default any more. It blocks the commit on
+any pre-existing drift in a file you happen to touch, which punishes the
+wrong author. Use `--diff` for everyday work.
+
+### `--all` mode
+
+Whole-tree sweep. Runs on the `clang-tidy weekly sweep` workflow every Monday
+at 04:00 UTC, and on demand via `workflow_dispatch`. Output goes to the
+workflow run's **Summary** tab.
+
+```bash
+./scripts/run_clang_tidy.sh --all                 # run locally (slow)
+```
+
+**Report-only.** The sweep does **not** gate merges on `develop`. Its job is
+to surface accumulated drift within a week instead of within months — the gap
+that let 48 warnings accumulate over ~3 months before Issue #262.
+
+Gating `--all` is an opt-in goal once the existing baseline is clean.
+
+## Parse failures on `src/*.cppm`
+
+Since the 2026-05-11 clang-p2996 rebuild, every `src/*.cppm` parses cleanly
+under clang-tidy. If clang-tidy reports `Found compiler error` on a `src/`
+module file, **`run_clang_tidy.sh` will now fail loudly** with:
+
+```
+❌ <file> (PARSE FAILURE — toolchain or build state is broken)
+   clang-tidy could not parse this file. Re-run cmake --preset
+   ninja-release and rebuild before retrying. See Issue #262.
+```
+
+The cause is almost always one of:
+
+1. Stale `build/release/` from before a clang-p2996 update — `rm -rf build/release && cmake --preset ninja-release && cmake --build --preset ninja-release`.
+2. A regression in the clang-p2996 binary — file an upstream issue and fall back to `--full` with the affected `.cppm` added back to `is_cpp26_module_file`'s skip list (in `scripts/run_clang_tidy.sh`).
+
+**Silent skipping is gone.** The unconditional `*.cppm` skip in
+`is_cpp26_module_file` was the root cause of Issue #262 — clang-tidy could
+parse those files for months before anyone noticed, and the accumulated drift
+all surfaced at once when the build state changed.
+
+Skip list now covers only files that genuinely can't be parsed standalone:
+
+- `tests/*`, `benchmarks/*`, `fuzz/*`, `shared/*` — import Storm modules
+- `src/orm/query_builder.hpp` — pseudo-module header that needs `import storm;`
+
+## Author workflow
+
+### When your PR introduces a new warning
+
+`--diff` will catch it on commit. Either fix the warning, or — if the warning
+is wrong and the check needs an exception — update `.clang-tidy` in the same
+PR with a clear inline comment explaining why.
+
+### When the weekly sweep reports new drift
+
+The sweep is report-only. There is no automatic ticket. If you see new entries
+when checking the Summary tab, open a focused cleanup PR or file an issue —
+similar to how PR #263 cleaned the post-#262 baseline.
+
+### Bypassing pre-commit
+
+Don't. Use `STORM_TIDY_FULL=1` to widen the scope, or fix the warning, or
+adjust `.clang-tidy`. `--no-verify` is forbidden by repo convention
+(see [CLAUDE.md](../../CLAUDE.md) Critical Safety Rules).
+
+## Related
+
+- [Issue #262](https://github.com/spiritEcosse/storm/issues/262) — structural fix for silent drift
+- [PR #263](https://github.com/spiritEcosse/storm/pull/263) — cleanup of the 48 accumulated warnings
+- [FORMATTING.md](FORMATTING.md) — clang-format / cmake-format stages of the same hook

--- a/docs/development/PRE_COMMIT.md
+++ b/docs/development/PRE_COMMIT.md
@@ -89,10 +89,10 @@ module file, **`run_clang_tidy.sh` will now fail loudly** with:
 The cause is almost always one of:
 
 1. Stale `build/release/` from before a clang-p2996 update — `rm -rf build/release && cmake --preset ninja-release && cmake --build --preset ninja-release`.
-2. A regression in the clang-p2996 binary — file an upstream issue and fall back to `--full` with the affected `.cppm` added back to `is_cpp26_module_file`'s skip list (in `scripts/run_clang_tidy.sh`).
+2. A regression in the clang-p2996 binary — file an upstream issue and fall back to `--full` with the affected `.cppm` added back to `is_known_unparseable`'s skip list (in `scripts/run_clang_tidy.sh`).
 
 **Silent skipping is gone.** The unconditional `*.cppm` skip in
-`is_cpp26_module_file` was the root cause of Issue #262 — clang-tidy could
+`is_known_unparseable` was the root cause of Issue #262 — clang-tidy could
 parse those files for months before anyone noticed, and the accumulated drift
 all surfaced at once when the build state changed.
 

--- a/scripts/run_clang_tidy.sh
+++ b/scripts/run_clang_tidy.sh
@@ -1,6 +1,15 @@
 #!/bin/bash
-# Run clang-tidy on staged files (git diff --cached)
-# Usage: ./run_clang_tidy.sh [--fix] [--all] [-j N]
+# Run clang-tidy. Three modes — pick one (or none, default is --diff):
+#
+#   --diff   (default)  Diff-mode — only warnings on lines touched by the
+#                       staged commit (git diff --cached) block. Pre-existing
+#                       warnings on other lines are out of scope. This is the
+#                       pre-commit default.
+#   --full              Full-file scan, staged files only. Block on any warning
+#                       in any staged file (including pre-existing drift).
+#                       Used to be the default before Issue #262.
+#   --all               Full-file scan, ALL C++ files. Used by the scheduled
+#                       weekly CI sweep to detect accumulated drift.
 #
 # Prerequisites:
 #   - Release build with compile_commands.json: cmake --preset ninja-release
@@ -8,30 +17,19 @@
 #
 # Options:
 #   --fix   Apply suggested fixes automatically (use with caution)
-#   --all   Check ALL C++ source files (not just staged files)
 #   -j N    Number of parallel jobs (default: all cores)
 
 set -e
 
 CLANG_TIDY="../clang-p2996/build/bin/clang-tidy"
+CLANG_TIDY_DIFF="../clang-p2996/clang-tools-extra/clang-tidy/tool/clang-tidy-diff.py"
 BUILD_DIR="build/release"
 COMPILE_COMMANDS="$BUILD_DIR/compile_commands.json"
 CLANG_TIDY_CONFIG=".clang-tidy"
 
-# Known patterns for files that use C++26 modules/reflection features not supported by clang-tidy
-# These files will show a specific message instead of "crashed"
-# clang-tidy fails on these due to: __has_feature parsing, std::meta::info, ^^ splice operator, import statements
-#
-# Patterns:
-#   - All .cppm files (C++26 modules not supported by clang-tidy)
-#   - All test files (they import Storm modules)
-#   - All benchmark files (they import Storm modules)
-#
-# Only files that DON'T import Storm modules can be checked (currently none in this project)
-
 # Parse arguments
 FIX_FLAG=""
-CHECK_ALL=false
+MODE="diff"   # diff | full | all
 JOBS=$(nproc)
 
 while [[ $# -gt 0 ]]; do
@@ -40,8 +38,16 @@ while [[ $# -gt 0 ]]; do
             FIX_FLAG="-fix"
             shift
             ;;
+        --diff)
+            MODE="diff"
+            shift
+            ;;
+        --full)
+            MODE="full"
+            shift
+            ;;
         --all)
-            CHECK_ALL=true
+            MODE="all"
             shift
             ;;
         -j)
@@ -66,6 +72,12 @@ if [[ ! -x "$CLANG_TIDY" ]]; then
     exit 1
 fi
 
+if [[ "$MODE" == "diff" && ! -f "$CLANG_TIDY_DIFF" ]]; then
+    echo "❌ Error: clang-tidy-diff.py not found at $CLANG_TIDY_DIFF" >&2
+    echo "   Required for --diff mode. Re-run with --full or --all, or fix the path." >&2
+    exit 1
+fi
+
 if [[ ! -f "$CLANG_TIDY_CONFIG" ]]; then
     echo "❌ Error: .clang-tidy config not found at $CLANG_TIDY_CONFIG" >&2
     exit 1
@@ -75,11 +87,11 @@ echo "🔍 Running clang-tidy using .clang-tidy configuration..."
 echo "   Config file: $CLANG_TIDY_CONFIG"
 echo "   Build directory: $BUILD_DIR"
 echo "   Parallel jobs: $JOBS"
-if [[ "$CHECK_ALL" == true ]]; then
-    echo "   Scope: ALL C++ source files"
-else
-    echo "   Scope: staged files (git diff --cached)"
-fi
+case "$MODE" in
+    diff) echo "   Scope: staged lines only (git diff --cached, lines added/changed)" ;;
+    full) echo "   Scope: staged files (whole-file scan)" ;;
+    all)  echo "   Scope: ALL C++ source files (sweep)" ;;
+esac
 if [[ -n "$FIX_FLAG" ]]; then
     echo "   Mode: AUTO-FIX enabled"
 else
@@ -87,8 +99,80 @@ else
 fi
 echo ""
 
-# Collect C++ source files
-if [[ "$CHECK_ALL" == true ]]; then
+# ─── --diff mode short path ─────────────────────────────────────────────────
+# Pipe `git diff -U0 --cached` through clang-tidy-diff.py — it only emits
+# diagnostics on lines the staged commit touches. Pre-existing warnings on
+# other lines are out of scope. See Issue #262 for rationale.
+if [[ "$MODE" == "diff" ]]; then
+    DIFF_OUT=$(mktemp)
+    trap "rm -f $DIFF_OUT" EXIT
+
+    # -p1 strips the a/ b/ prefix that `git diff` prepends to paths.
+    # -iregex limits the scan to C++ sources we actually want clang-tidy on
+    # (note: clang-tidy-diff.py doesn't understand our skip-list, so files
+    # under tests/ etc. will be attempted; we filter the output after).
+    DIFF_FIX=""
+    [[ -n "$FIX_FLAG" ]] && DIFF_FIX="-fix"
+
+    set +e
+    git diff -U0 --cached \
+        | python3 "$CLANG_TIDY_DIFF" \
+            -clang-tidy-binary "$CLANG_TIDY" \
+            -p1 \
+            -path "$BUILD_DIR" \
+            -config-file "$CLANG_TIDY_CONFIG" \
+            -iregex '.*\.(cpp|cppm|h|hpp)' \
+            -j "$JOBS" \
+            -timeout 60 \
+            -quiet \
+            $DIFF_FIX \
+            2>&1 | tee "$DIFF_OUT"
+    DIFF_RC=${PIPESTATUS[1]}
+    set -e
+
+    # Stage any auto-fixes so the re-check sees them
+    [[ -n "$FIX_FLAG" ]] && git add -u 2>/dev/null || true
+
+    # clang-tidy-diff.py prints "No relevant changes found." when nothing in
+    # the diff matches the regex. That's a clean pass.
+    if grep -q "No relevant changes found" "$DIFF_OUT"; then
+        echo ""
+        echo "✅ clang-tidy --diff: no staged C++ lines to check"
+        exit 0
+    fi
+
+    # Count actual diagnostics — clang-tidy-diff.py's exit code is unreliable
+    # across versions (it may return 0 even with warnings).
+    DIFF_WARN=$(grep -c ": warning:" "$DIFF_OUT" || true)
+    DIFF_ERR=$(grep -c ": error:" "$DIFF_OUT" || true)
+    # Strip out errors from C++26 module/reflection parse failures in headers —
+    # they are noise in diff mode, not signal on the staged lines.
+    DIFF_ERR_REAL=$(grep ": error:" "$DIFF_OUT" | grep -v -E "(module|import|reflect|std::meta|consteval)" | wc -l || true)
+
+    echo ""
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo "📊 --diff summary:"
+    echo "   Warnings on staged lines: $DIFF_WARN"
+    echo "   Errors on staged lines:   $DIFF_ERR (real: $DIFF_ERR_REAL)"
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+    if [[ "$DIFF_WARN" -gt 0 || "$DIFF_ERR_REAL" -gt 0 ]]; then
+        if [[ -n "$FIX_FLAG" ]]; then
+            # Auto-fix pass complete — re-run check-only to confirm clean.
+            echo ""
+            echo "🔄 Re-checking after auto-fix..."
+            FIX_FLAG="" exec "$0" --diff
+        fi
+        echo "❌ clang-tidy --diff: new warnings/errors on staged lines"
+        exit 1
+    fi
+
+    echo "✅ clang-tidy --diff: staged lines are clean"
+    exit 0
+fi
+
+# ─── --full and --all modes: file-based scan ────────────────────────────────
+if [[ "$MODE" == "all" ]]; then
     FILES=$(find src tests benchmarks \( -name '*.cpp' -o -name '*.cppm' -o -name '*.h' -o -name '*.hpp' \) 2>/dev/null \
         | grep -v 'third_party' \
         | sort)
@@ -100,7 +184,7 @@ else
 fi
 
 if [[ -z "$FILES" ]]; then
-    if [[ "$CHECK_ALL" == true ]]; then
+    if [[ "$MODE" == "all" ]]; then
         echo "✅ No C++ files found — clang-tidy skipped"
     else
         echo "✅ No staged C++ files — clang-tidy skipped"
@@ -119,24 +203,19 @@ trap "rm -rf $TEMP_DIR" EXIT
 # Export variables for subshells
 export CLANG_TIDY BUILD_DIR FIX_FLAG TEMP_DIR
 
-# Function to check if file uses C++26 modules/reflection (pattern-based)
-# Returns 0 (true) if file is expected to fail clang-tidy
+# Known-skip list: files clang-tidy cannot parse and we accept that.
+#
+# Returns 0 (true) if file is expected to fail clang-tidy parsing.
+#
+# Rationale: src/*.cppm parse cleanly since the 2026-05-11 clang-p2996 rebuild,
+# so they are NOT on this list anymore. A parse failure on a src/*.cppm now
+# means the toolchain or build state is broken — see Issue #262.
+#
+# Files we still accept as unparseable:
+#   - tests/*, benchmarks/*, fuzz/*, shared/* — import storm modules
+#   - src/orm/query_builder.hpp — pseudo-module header that needs `import storm;`
 is_cpp26_module_file() {
     local file="$1"
-
-    # All .cppm files are C++26 modules
-    if [[ "$file" == *.cppm ]]; then
-        return 0
-    fi
-
-    # All files under tests/, benchmarks/, fuzz/ use C++26 modules/reflection
-    # (directly or transitively via includes like <meta>, std::meta::info, etc.)
-    # Exception: mock files that don't use modules are handled by the caller —
-    # they parse successfully and never reach this function's "known skip" path.
-    #
-    # src/orm/query_builder.hpp is a pseudo-module header: it uses ^^, consteval
-    # reflection, and must be #included after `import storm;`. It cannot be
-    # parsed standalone by clang-tidy. Add it to the known-skip list.
     case "$file" in
         tests/*|benchmarks/*|fuzz/*|shared/*) return 0 ;;
         src/orm/query_builder.hpp) return 0 ;;
@@ -215,10 +294,15 @@ run_tidy() {
             sed -i '/: error:/d' "$outfile"
             sed -i '/Found compiler error/d' "$outfile"
         else
-            # Non-module file with only compile errors - unexpected
-            echo "  ⚠ $file (parse error - UNEXPECTED)" >&2
+            # Parse failure on a file we expect to be parseable (e.g. src/*.cppm
+            # since the 2026-05-11 clang-p2996 rebuild). Surface it loudly — it
+            # almost always means the build state is stale or the toolchain
+            # regressed. Silent skipping here was the root cause of Issue #262.
+            echo "  ❌ $file (PARSE FAILURE — toolchain or build state is broken)" >&2
+            echo "     clang-tidy could not parse this file. Re-run cmake --preset" >&2
+            echo "     ninja-release and rebuild before retrying. See Issue #262." >&2
             echo "crashed" > "$statusfile"
-            echo "" > "$outfile"
+            # Keep the original error in the outfile so the summary can print it.
         fi
     elif [[ "$has_crash" == true ]]; then
         # Crashed after processing - may still have useful warnings
@@ -296,7 +380,9 @@ if [[ $ERRORS -gt 0 ]]; then
     echo "❌ clang-tidy found errors"
     exit 1
 elif [[ $UNEXPECTED_CRASHES -gt 0 ]]; then
-    echo "❌ clang-tidy crashed on unexpected files (update is_cpp26_module_file if valid)"
+    echo "❌ clang-tidy could not parse $UNEXPECTED_CRASHES file(s) — toolchain or build state may be stale"
+    echo "   Try: rm -rf build/release && cmake --preset ninja-release && cmake --build --preset ninja-release"
+    echo "   See: https://github.com/spiritEcosse/storm/issues/262"
     exit 1
 elif [[ $WARNINGS -gt 0 ]]; then
     if [[ -n "$FIX_FLAG" ]]; then

--- a/scripts/run_clang_tidy.sh
+++ b/scripts/run_clang_tidy.sh
@@ -220,7 +220,7 @@ export CLANG_TIDY BUILD_DIR FIX_FLAG TEMP_DIR
 # Files we still accept as unparseable:
 #   - tests/*, benchmarks/*, fuzz/*, shared/* — import storm modules
 #   - src/orm/query_builder.hpp — pseudo-module header that needs `import storm;`
-is_cpp26_module_file() {
+is_known_unparseable() {
     local file="$1"
     case "$file" in
         tests/*|benchmarks/*|fuzz/*|shared/*) return 0 ;;
@@ -228,7 +228,7 @@ is_cpp26_module_file() {
         *) return 1 ;;
     esac
 }
-export -f is_cpp26_module_file
+export -f is_known_unparseable
 
 # Files clang-tidy must NEVER touch — even when it can parse them cleanly.
 # Used to short-circuit run_tidy() so clang-tidy --fix never mutates the file.
@@ -287,7 +287,7 @@ run_tidy() {
     grep -q ": warning:" "$outfile" 2>/dev/null && has_warnings=true
 
     if [[ "$has_compile_error" == true ]]; then
-        if is_cpp26_module_file "$file"; then
+        if is_known_unparseable "$file"; then
             # Known C++26 module file with compile errors - skip entirely
             # Warnings from partial parsing are unreliable (false positives)
             echo "  ✓ $file (C++26 modules - skipped)"
@@ -320,7 +320,7 @@ run_tidy() {
             sed -i '/PLEASE submit a bug report/,$d' "$outfile"
         else
             # Crashed with no warnings
-            if is_cpp26_module_file "$file"; then
+            if is_known_unparseable "$file"; then
                 echo "  ✓ $file (C++26 modules - skipped)"
                 echo "known" > "$statusfile"
             else

--- a/scripts/run_clang_tidy.sh
+++ b/scripts/run_clang_tidy.sh
@@ -21,6 +21,8 @@
 
 set -e
 
+readonly RULE='━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━'
+
 CLANG_TIDY="../clang-p2996/build/bin/clang-tidy"
 CLANG_TIDY_DIFF="../clang-p2996/clang-tools-extra/clang-tidy/tool/clang-tidy-diff.py"
 BUILD_DIR="build/release"
@@ -91,6 +93,10 @@ case "$MODE" in
     diff) echo "   Scope: staged lines only (git diff --cached, lines added/changed)" ;;
     full) echo "   Scope: staged files (whole-file scan)" ;;
     all)  echo "   Scope: ALL C++ source files (sweep)" ;;
+    *)
+        echo "❌ Internal error: unknown MODE '$MODE'" >&2
+        exit 2
+        ;;
 esac
 if [[ -n "$FIX_FLAG" ]]; then
     echo "   Mode: AUTO-FIX enabled"
@@ -150,11 +156,11 @@ if [[ "$MODE" == "diff" ]]; then
     DIFF_ERR_REAL=$(grep ": error:" "$DIFF_OUT" | grep -v -E "(module|import|reflect|std::meta|consteval)" | wc -l || true)
 
     echo ""
-    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo "$RULE"
     echo "📊 --diff summary:"
     echo "   Warnings on staged lines: $DIFF_WARN"
     echo "   Errors on staged lines:   $DIFF_ERR (real: $DIFF_ERR_REAL)"
-    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo "$RULE"
 
     if [[ "$DIFF_WARN" -gt 0 || "$DIFF_ERR_REAL" -gt 0 ]]; then
         if [[ -n "$FIX_FLAG" ]]; then
@@ -339,7 +345,7 @@ echo ""
 echo "$FILES" | xargs -P "$JOBS" -I {} bash -c 'run_tidy "$@"' _ {}
 
 echo ""
-echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "$RULE"
 
 # Collect and display results (filter out "N warnings generated" noise)
 WARNINGS=$(cat "$TEMP_DIR"/*.out 2>/dev/null | grep -c ": warning:") || WARNINGS=0
@@ -358,7 +364,7 @@ if [[ $ERRORS -gt 0 ]] || [[ $WARNINGS -gt 0 ]]; then
     echo ""
 fi
 
-echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "$RULE"
 echo "📊 Summary:"
 echo "   Files checked: $FILE_COUNT"
 echo "   Files passed: $FILES_OK"
@@ -368,7 +374,7 @@ if [[ $UNEXPECTED_CRASHES -gt 0 ]]; then
 fi
 echo "   Warnings: $WARNINGS"
 echo "   Errors: $ERRORS"
-echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "$RULE"
 
 # Exit logic:
 # 1. Errors always fail


### PR DESCRIPTION
## Summary

- **Phase 1** — `run_clang_tidy.sh` fails loudly on `src/*.cppm` parse errors instead of silently dropping them. Skip list tightened to files that genuinely can't be parsed standalone (`tests/*`, `benchmarks/*`, `fuzz/*`, `shared/*`, `src/orm/query_builder.hpp`).
- **Phase 2** — `--diff` mode (via `clang-tidy-diff.py`) is the new pre-commit default. Only warnings on staged lines block the commit. `--full` (whole-file scan on staged files) is opt-in via `STORM_TIDY_FULL=1`.
- **Phase 3** — `clang-tidy-sweep.yml` runs `--all` weekly (Mondays 04:00 UTC) and on `workflow_dispatch`. Output lands in the workflow run's Summary tab. Report-only — does not gate develop.
- **Phase 4** — `docs/development/PRE_COMMIT.md` covers the three modes, parse-failure policy, and author workflow.

## Why

Issue #262 root cause: the silent `*.cppm` auto-skip in `is_cpp26_module_file` masked 48 warnings for ~3 months until the 2026-05-11 clang-p2996 rebuild surfaced them all at once. Fail-loud + scheduled `--all` sweep + diff-mode default prevent the same drift pattern from recurring.

## Test plan

- [x] **E2E Scenario A** (block on new warning): stage `indexes.cppm` with a `readability-operators-representation` violation → `--diff` reports 3 warnings on staged lines, exit 1.
- [x] **E2E Scenario B** (pass when only pre-existing): stage whitespace-only change in same `indexes.cppm` → `--diff` reports 0 warnings on staged lines (ignoring ~167k pre-existing on untouched lines), exit 0.
- [x] **E2E Scenario B'** (no C++ staged): pre-commit hook on this PR's own commit — all staged files are shell/yaml/md, `commit.sh` correctly skipped format/tidy/tests/coverage. Verified locally.
- [ ] CI workflows pass (clang-tidy-sweep is on a cron, not part of PR gate — verify manually after merge).
- [ ] SonarCloud `Storm Strict` gate is clean on new code (no `.cpp`/`.cppm` lines in this PR, so should be a no-op).

## Notes

- Existing `.clang-tidy` config is preserved verbatim — no rule changes.
- `--diff` parses the whole TU (C++ type resolution needs the full file). It uses `-line-filter` to suppress diagnostics outside the staged hunks. Documented in `PRE_COMMIT.md` to avoid the "isn't this redundant?" question.
- Phase 3 sweep runs `cmake --preset ninja-release` first so `compile_commands.json` exists. Same `storm-ci` digest pin as `ci.yml`; bump both together when the image rebuilds.

Closes #262

🤖 Generated with [Claude Code](https://claude.com/claude-code)