### PR TITLE
docs(lint): rewrite misleading LINT-EXCLUDE rationale (#264)

### DIFF
--- a/src/db/pool.cppm
+++ b/src/db/pool.cppm
@@ -1,7 +1,7 @@
 module;
 
 // LINT-EXCLUDE-FILE: duplicate, complexity, length
-// Pre-existing structural debt tracked under storm issue #264.
+// Boilerplate-pattern duplicates accepted (see #264 finding).
 
 #include <condition_variable>
 #include <mutex>

--- a/src/db/sqlite.cppm
+++ b/src/db/sqlite.cppm
@@ -1,7 +1,7 @@
 module;
 
 // LINT-EXCLUDE-FILE: duplicate
-// Pre-existing structural debt tracked under storm issue #264.
+// Boilerplate-pattern duplicates accepted (see #264 finding).
 
 #include <sqlite3.h>
 

--- a/src/orm/schema.cppm
+++ b/src/orm/schema.cppm
@@ -1,7 +1,7 @@
 module;
 
 // LINT-EXCLUDE-FILE: duplicate, complexity, length
-// Pre-existing structural debt tracked under storm issue #264.
+// Boilerplate-pattern duplicates accepted (see #264 finding).
 
 #include <meta>
 

--- a/src/orm/statements/aggregate.cppm
+++ b/src/orm/statements/aggregate.cppm
@@ -1,7 +1,7 @@
 module;
 
 // LINT-EXCLUDE-FILE: file-size, duplicate
-// Pre-existing structural debt tracked under storm issue #264.
+// Single cohesive class template; thresholds intentionally relaxed (see #264 finding).
 
 #include <meta>
 #include <plf_hive/plf_hive.h>

--- a/src/orm/statements/base.cppm
+++ b/src/orm/statements/base.cppm
@@ -1,7 +1,7 @@
 module;
 
 // LINT-EXCLUDE-FILE: file-size, duplicate, complexity, length
-// Pre-existing structural debt tracked under storm issue #264.
+// Single cohesive class template; thresholds intentionally relaxed (see #264 finding).
 
 #include <meta>
 

--- a/src/orm/statements/distinct.cppm
+++ b/src/orm/statements/distinct.cppm
@@ -1,7 +1,7 @@
 module;
 
 // LINT-EXCLUDE-FILE: duplicate
-// Pre-existing structural debt tracked under storm issue #264.
+// Boilerplate-pattern duplicates accepted (see #264 finding).
 
 #include <meta>
 #include <utility>

--- a/src/orm/statements/erase.cppm
+++ b/src/orm/statements/erase.cppm
@@ -1,7 +1,7 @@
 module;
 
 // LINT-EXCLUDE-FILE: duplicate
-// Pre-existing structural debt tracked under storm issue #264.
+// Boilerplate-pattern duplicates accepted (see #264 finding).
 
 #include <meta>
 

--- a/src/orm/statements/insert.cppm
+++ b/src/orm/statements/insert.cppm
@@ -1,8 +1,7 @@
 module;
 
 // LINT-EXCLUDE-FILE: file-size, duplicate, complexity, length
-// Pre-existing structural debt tracked under storm issue #264.
-// Removed once #264's refactor phases land (split + duplicate extraction).
+// Single cohesive class template; thresholds intentionally relaxed (see #264 finding).
 
 #include <meta>
 

--- a/src/orm/statements/join.cppm
+++ b/src/orm/statements/join.cppm
@@ -1,7 +1,7 @@
 module;
 
 // LINT-EXCLUDE-FILE: duplicate
-// Pre-existing structural debt tracked under storm issue #264.
+// Boilerplate-pattern duplicates accepted (see #264 finding).
 
 #include <meta>
 #include <cassert>

--- a/src/orm/statements/select.cppm
+++ b/src/orm/statements/select.cppm
@@ -1,8 +1,7 @@
 module;
 
 // LINT-EXCLUDE-FILE: file-size, duplicate, complexity, length
-// Pre-existing structural debt tracked under storm issue #264.
-// Removed once #264's refactor phases land (split + duplicate extraction).
+// Single cohesive class template; thresholds intentionally relaxed (see #264 finding).
 
 #include <meta>
 #include <plf_hive/plf_hive.h>

--- a/src/orm/statements/setop.cppm
+++ b/src/orm/statements/setop.cppm
@@ -1,7 +1,7 @@
 module;
 
 // LINT-EXCLUDE-FILE: duplicate
-// Pre-existing structural debt tracked under storm issue #264.
+// Boilerplate-pattern duplicates accepted (see #264 finding).
 
 #include <meta>
 #include <plf_hive/plf_hive.h>

--- a/src/orm/statements/update.cppm
+++ b/src/orm/statements/update.cppm
@@ -1,8 +1,7 @@
 module;
 
 // LINT-EXCLUDE-FILE: duplicate, complexity
-// Pre-existing structural debt tracked under storm issue #264.
-// Removed once #264's refactor phases land.
+// Single cohesive class template; thresholds intentionally relaxed (see #264 finding).
 
 #include <meta>
 

--- a/src/orm/utilities.cppm
+++ b/src/orm/utilities.cppm
@@ -1,7 +1,7 @@
 module;
 
 // LINT-EXCLUDE-FILE: complexity, length
-// Pre-existing structural debt tracked under storm issue #264.
+// Boilerplate-pattern duplicates accepted (see #264 finding).
 
 #include <meta>
 #include <uuid.h>

--- a/src/orm/where.cppm
+++ b/src/orm/where.cppm
@@ -1,8 +1,7 @@
 module;
 
 // LINT-EXCLUDE-FILE: file-size, duplicate, complexity
-// Pre-existing structural debt tracked under storm issue #264.
-// Removed once #264's refactor phases land.
+// Single cohesive class template; thresholds intentionally relaxed (see #264 finding).
 
 #include <meta>
 


### PR DESCRIPTION
## Summary

Rewrites the `// Pre-existing structural debt tracked under storm issue #264. / Removed once #264's refactor phases land` rationale on 14 `.cppm` files. After the Phase 2 finding (postgresql split landed in #275, but insert/select/where/update aren't clean split candidates — single class templates with perf-critical hot paths), the old wording was misleading: it promised future removal that isn't actually planned.

## Per-category replacement

**Statement-class files** (`base`, `insert`, `select`, `update`, `aggregate`, `where`):
```
// Single cohesive class template; thresholds intentionally relaxed (see #264 finding).
```

**Multi-type files** (`sqlite`, `pool`, `schema`, `utilities`, `setop`, `erase`, `distinct`, `join`):
```
// Boilerplate-pattern duplicates accepted (see #264 finding).
```

Both reference the Phase 2 finding posted at https://github.com/spiritEcosse/storm/issues/264#issuecomment-4462154303 instead of promising removal that isn't coming.

## Why

The previous wording told future contributors "this will be cleaned up soon" — which is no longer true. The honest framing matches what we actually decided after analyzing all 4 phase-2 candidates: postgresql.cppm was the only clean split; the other three are single cohesive class templates whose splits would add template noise and risk ~2% perf regressions.

No code change. Pure rationale rewrite.

## Test plan

- [x] All 1908 unit tests pass (SQLite + PostgreSQL, ninja-debug)
- [x] clang-format clean
- [x] clang-tidy --diff clean
- [ ] SonarCloud gate (run /sonarcloud-status after CI)

Part of #264 (issue stays open — Phase 3 audit pending; this PR doesn't close it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)