### PR TITLE
refactor(schema): extract shared CREATE INDEX tail into append_index_sql (#277 part 2)

### DIFF
--- a/src/orm/schema.cppm
+++ b/src/orm/schema.cppm
@@ -1,7 +1,7 @@
 module;
 
-// LINT-EXCLUDE-FILE: duplicate, complexity, length
-// Boilerplate-pattern duplicates accepted (see #264 finding).
+// LINT-EXCLUDE-FILE: complexity, length
+// `duplicate` removed in #277 Phase 3 (shared append_index_sql helper).
 
 #include <meta>
 
@@ -327,6 +327,27 @@ export namespace storm::orm::schema {
         // Index SQL buffer — generous for "CREATE UNIQUE INDEX IF NOT EXISTS idx_<table>_<field> ON <table>(<field>)"
         static constexpr size_t INDEX_SQL_BUFFER = 256;
 
+        // Append the shared tail of a CREATE INDEX statement:
+        //   <prefix>idx_<table>_<field><suffix> ON <table>(<field><column_suffix>)
+        // The three callers differ only in the leading keyword ("CREATE INDEX" vs
+        // "CREATE UNIQUE INDEX") and in whether FK fields get the "_id" decoration.
+        template <typename SqlT>
+        static consteval void append_index_sql(
+                SqlT& sql, std::string_view prefix, std::string_view field_name, std::string_view column_suffix
+        ) {
+            sql.append(prefix);
+            sql.append(Base::table_name_);
+            sql.append("_");
+            sql.append(field_name);
+            sql.append(column_suffix);
+            sql.append(" ON ");
+            sql.append(Base::table_name_);
+            sql.append("(");
+            sql.append(field_name);
+            sql.append(column_suffix);
+            sql.append(")");
+        }
+
         // Build CREATE INDEX SQL for a single field at compile-time
         template <size_t Index> static consteval auto build_create_index_sql() {
             ConstexprString<INDEX_SQL_BUFFER> sql;
@@ -335,35 +356,11 @@ export namespace storm::orm::schema {
             if constexpr (!Base::needs_index(member)) {
                 return sql;
             } else if constexpr (Base::is_unique_field(member)) {
-                sql.append("CREATE UNIQUE INDEX IF NOT EXISTS idx_");
-                sql.append(Base::table_name_);
-                sql.append("_");
-                sql.append(std::meta::identifier_of(member));
-                sql.append(" ON ");
-                sql.append(Base::table_name_);
-                sql.append("(");
-                sql.append(std::meta::identifier_of(member));
-                sql.append(")");
+                append_index_sql(sql, "CREATE UNIQUE INDEX IF NOT EXISTS idx_", std::meta::identifier_of(member), "");
             } else if constexpr (Base::is_fk_field(member)) {
-                sql.append("CREATE INDEX IF NOT EXISTS idx_");
-                sql.append(Base::table_name_);
-                sql.append("_");
-                sql.append(std::meta::identifier_of(member));
-                sql.append("_id ON ");
-                sql.append(Base::table_name_);
-                sql.append("(");
-                sql.append(std::meta::identifier_of(member));
-                sql.append("_id)");
+                append_index_sql(sql, "CREATE INDEX IF NOT EXISTS idx_", std::meta::identifier_of(member), "_id");
             } else {
-                sql.append("CREATE INDEX IF NOT EXISTS idx_");
-                sql.append(Base::table_name_);
-                sql.append("_");
-                sql.append(std::meta::identifier_of(member));
-                sql.append(" ON ");
-                sql.append(Base::table_name_);
-                sql.append("(");
-                sql.append(std::meta::identifier_of(member));
-                sql.append(")");
+                append_index_sql(sql, "CREATE INDEX IF NOT EXISTS idx_", std::meta::identifier_of(member), "");
             }
             return sql;
         }


### PR DESCRIPTION
## Summary

Second PR in the #277 series (after #278 / insert.cppm).

Three branches in `build_create_index_sql` (unique / fk / plain) shared the body shape `<prefix>idx_<table>_<field><suffix> ON <table>(<field><suffix>)` — only the leading keyword and the optional `_id` column suffix differed. Pulled the shared shape into a small `static consteval append_index_sql` helper. Each branch reduces to one line.

`duplicate` removed from `LINT-EXCLUDE-FILE` on this file. Other tags (`complexity`, `length`) unchanged for this phase.

Net: line-neutral (-29/+26 after clang-format) but 3 → 0 audit-hook duplicate-blocks.

Refs #277. Does NOT close — 12 more files still pending.

## Test plan

- [x] `ninja-debug` builds clean, 79 schema/FK/index tests pass
- [x] `ninja-asan-ubsan` builds clean, same 79 tests pass, no sanitizer findings
- [x] `ninja-tsan` builds clean, same 79 tests pass, no data-race findings
- [x] Full pre-commit suite via `commit.sh` (clang-format + clang-tidy `--diff --fix` + 1908 ctest) passes in 14s
- [x] `STORM_SKIP_COVERAGE=1` used per #268/#269 — CI's SonarCloud step is the coverage gate
- [x] consteval helper, no runtime path touched — bench unaffected
- [ ] SonarCloud quality gate (verify post-push)
- [ ] CI jobs (ninja-debug × 4, ninja-asan-ubsan, ninja-tsan, ninja-msan) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)