### PR TITLE
refactor(join): extract for_each_fk_field helper for consteval index folds (#277 part 3)

### DIFF
--- a/src/orm/statements/join.cppm
+++ b/src/orm/statements/join.cppm
@@ -1,8 +1,5 @@
 module;
 
-// LINT-EXCLUDE-FILE: duplicate
-// Boilerplate-pattern duplicates accepted (see #264 finding).
-
 #include <meta>
 #include <cassert>
 
@@ -168,6 +165,14 @@ export namespace storm::orm::statements {
             return result;
         }
 
+        // Iterate the FK indices [0, fk_count_) and invoke `body.template operator()<I>()` for each.
+        // Used by the consteval SQL-builder helpers; encapsulates the index-sequence fold.
+        template <typename Body> static consteval void for_each_fk_field(const Body& body) {
+            [&]<size_t... Is>(std::index_sequence<Is...> /*unused*/) {
+                (body.template operator()<Is>(), ...);
+            }(std::make_index_sequence<fk_count_>{});
+        }
+
         static consteval auto calculate_select_fields_size() -> size_t {
             size_t total = 0;
 
@@ -180,19 +185,14 @@ export namespace storm::orm::statements {
             }
 
             // FK fields
-            [&]<size_t... Is>(std::index_sequence<Is...> /*unused*/) {
-                (
-                        [&]<size_t I>() {
-                            total += 2; // ", "
-                            [&]<size_t... FieldIs>(std::index_sequence<FieldIs...> /*unused*/) {
-                                ((total += (FieldIs > 0 ? 2 : 0) + 3 + 1 +
-                                           std::meta::identifier_of(FKBase_at<I>::all_members_[FieldIs]).size()),
-                                 ...);
-                            }(std::make_index_sequence<FKBase_at<I>::field_count_>{});
-                        }.template operator()<Is>(),
-                        ...
-                );
-            }(std::make_index_sequence<fk_count_>{});
+            for_each_fk_field([&]<size_t I>() {
+                total += 2; // ", "
+                [&]<size_t... FieldIs>(std::index_sequence<FieldIs...> /*unused*/) {
+                    ((total += (FieldIs > 0 ? 2 : 0) + 3 + 1 +
+                               std::meta::identifier_of(FKBase_at<I>::all_members_[FieldIs]).size()),
+                     ...);
+                }(std::make_index_sequence<FKBase_at<I>::field_count_>{});
+            });
 
             return total + utilities::sql_len::SMALL_BUFFER;
         }
@@ -216,25 +216,20 @@ export namespace storm::orm::statements {
             }
 
             // FK fields
-            [&]<size_t... Is>(std::index_sequence<Is...> /*unused*/) {
-                (
-                        [&]<size_t I>() {
-                            result.append(", ");
-                            [&]<size_t... FieldIs>(std::index_sequence<FieldIs...> /*unused*/) {
-                                // NOLINTNEXTLINE(misc-const-correctness) - first_in_table IS modified in fold expression
-                                bool first_in_table = true;
-                                (((first_in_table ? (void)0 : result.append(", ")),
-                                  result.append("t"),
-                                  result.append_digit(I + 2),
-                                  result.append("."),
-                                  result.append(std::meta::identifier_of(FKBase_at<I>::all_members_[FieldIs])),
-                                  first_in_table = false),
-                                 ...);
-                            }(std::make_index_sequence<FKBase_at<I>::field_count_>{});
-                        }.template operator()<Is>(),
-                        ...
-                );
-            }(std::make_index_sequence<fk_count_>{});
+            for_each_fk_field([&]<size_t I>() {
+                result.append(", ");
+                [&]<size_t... FieldIs>(std::index_sequence<FieldIs...> /*unused*/) {
+                    // NOLINTNEXTLINE(misc-const-correctness) - first_in_table IS modified in fold expression
+                    bool first_in_table = true;
+                    (((first_in_table ? (void)0 : result.append(", ")),
+                      result.append("t"),
+                      result.append_digit(I + 2),
+                      result.append("."),
+                      result.append(std::meta::identifier_of(FKBase_at<I>::all_members_[FieldIs])),
+                      first_in_table = false),
+                     ...);
+                }(std::make_index_sequence<FKBase_at<I>::field_count_>{});
+            });
 
             return result;
         }


### PR DESCRIPTION
## Summary

Third PR in the #277 series (after #278 / insert.cppm, #279 / schema.cppm).

Two consteval helpers in `join.cppm` (`calculate_select_fields_size`, `build_select_fields_array`) hand-rolled the same `index_sequence` fold to iterate FK fields:

```cpp
[&]<size_t... Is>(std::index_sequence<Is...>) {
    ([&]<size_t I>() { ... }.template operator()<Is>(), ...);
}(std::make_index_sequence<fk_count_>{});
```

Wrapped the scaffold in a small `for_each_fk_field(body)` helper that takes the generic template lambda by `const&` and invokes it for each FK index. Each call site shrinks to `for_each_fk_field([&]<size_t I>() { ... });`.

`LINT-EXCLUDE-FILE` line removed entirely — `duplicate` was the only tag this file carried.

Net: -5 lines, 4 → 0 audit-hook duplicate-blocks.

Refs #277. Does NOT close — 11 more files still pending.

## Test plan

- [x] `ninja-debug` builds clean, 62 JOIN + FK tests pass
- [x] `ninja-asan-ubsan` builds clean, same 62 tests pass, no sanitizer findings
- [x] `ninja-tsan` builds clean, same 62 tests pass, no data-race findings
- [x] Full pre-commit suite via `commit.sh` (clang-format + clang-tidy `--diff --fix` + 1908 ctest) passes in 14s
- [x] `STORM_SKIP_COVERAGE=1` used per #268/#269 — CI's SonarCloud step is the coverage gate
- [x] consteval helper, no runtime path touched — bench unaffected
- [ ] SonarCloud quality gate (verify post-push)
- [ ] CI jobs (ninja-debug × 4, ninja-asan-ubsan, ninja-tsan, ninja-msan) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)