### PR TITLE
refactor(where): drop duplicate tag — BindParamsVisitor centralises type-erased cast (#277)

### DIFF
--- a/docs/development/CODE_QUALITY.md
+++ b/docs/development/CODE_QUALITY.md
@@ -17,8 +17,8 @@ When a file's `duplicate` tag is removed by extraction, its `LINT-EXCLUDE-FILE` 
 | `src/orm/schema.cppm` | extracted (#279) | `append_index_sql` helper for the shared `CREATE INDEX` tail |
 | `src/orm/statements/join.cppm` | extracted (#280) | `for_each_fk_field<F>` consteval helper |
 | `src/orm/statements/select.cppm` | extracted (#281) | `build_sql()` reused by `to_sql`/`prepare_statement`/`rows_generator`; `QueryBase::forward()` collapses the 5-arg forwarder block in `Query`/`FirstQuery`/`GetQuery`; `make_first_or_get<Proxy>` consolidates the `query_first`/`query_get` bodies; coroutine step-loop in `rows_generator` no longer branches before the loop; `step_first_row()` helper de-duplicates the first-step triage in `execute_single_row` / `execute_exact_one` |
-| `src/orm/statements/base.cppm` | extracted (this PR) | `for_each_field_name<SkipPK>` consteval iterator drives both the size-calculator and the list-builder; `bind_bulk_objects_impl<SkipPK>` unifies the two bulk binders; `bind_expr_or_reset` shares the bind-or-reset tail of `bind_where_params` / `bind_having_params` |
-| `src/orm/where.cppm` | pending | — |
+| `src/orm/statements/base.cppm` | extracted (#283) | `for_each_field_name<SkipPK>` consteval iterator drives both the size-calculator and the list-builder; `bind_bulk_objects_impl<SkipPK>` unifies the two bulk binders; `bind_expr_or_reset` shares the bind-or-reset tail of `bind_where_params` / `bind_having_params` |
+| `src/orm/where.cppm` | extracted (this PR) | `BindParamsVisitor` casts the type-erased statement pointer once and calls each Expr's small `bind_impl(StmtType*, int&)`. `make_null_check_expr(name, is_null)` consolidates the `is_null` / `is_not_null` bodies of `CollatedField` and `Field` |
 | `src/orm/statements/update.cppm` | pending | — |
 | `src/orm/statements/aggregate.cppm` | pending | — |
 | `src/db/pool.cppm` | pending | — |

--- a/src/orm/where.cppm
+++ b/src/orm/where.cppm
@@ -1,7 +1,9 @@
 module;
 
-// LINT-EXCLUDE-FILE: file-size, duplicate, complexity
+// LINT-EXCLUDE-FILE: file-size, complexity
 // Single cohesive class template; thresholds intentionally relaxed (see #264 finding).
+// `duplicate` removed in #277 Phase 3 (BindParamsVisitor casts the type-erased pointer once and calls each Expr's
+// bind_impl; make_null_check_expr shared by CollatedField/Field).
 
 #include <meta>
 
@@ -92,9 +94,8 @@ export namespace storm::orm::where {
         }
 
         template <typename StmtType, typename ErrorType>
-        [[nodiscard]] __attribute__((always_inline)) auto
-        bind_params_direct(ErasedStatementPtr stmt_ptr, int& param_index) const -> std::expected<void, ErrorType> {
-            auto* stmt = static_cast<StmtType*>(stmt_ptr);
+        [[nodiscard]] __attribute__((always_inline)) auto bind_impl(StmtType* stmt, int& param_index) const
+                -> std::expected<void, ErrorType> {
             return utilities::bind_parameter_value<StmtType, ErrorType>(*stmt, param_index++, value_);
         }
     };
@@ -109,8 +110,7 @@ export namespace storm::orm::where {
         }
 
         template <typename StmtType, typename ErrorType>
-        [[nodiscard]] __attribute__((always_inline)) auto
-        bind_params_direct(ErasedStatementPtr /*stmt_ptr*/, int& /*param_index*/) const
+        [[nodiscard]] __attribute__((always_inline)) auto bind_impl(StmtType* /*stmt*/, int& /*param_index*/) const
                 -> std::expected<void, ErrorType> {
             return {};
         }
@@ -126,9 +126,8 @@ export namespace storm::orm::where {
         }
 
         template <typename StmtType, typename ErrorType>
-        [[nodiscard]] __attribute__((always_inline)) auto
-        bind_params_direct(ErasedStatementPtr stmt_ptr, int& param_index) const -> std::expected<void, ErrorType> {
-            auto* stmt = static_cast<StmtType*>(stmt_ptr);
+        [[nodiscard]] __attribute__((always_inline)) auto bind_impl(StmtType* stmt, int& param_index) const
+                -> std::expected<void, ErrorType> {
             return stmt->bind_text(param_index++, pattern_);
         }
     };
@@ -144,15 +143,12 @@ export namespace storm::orm::where {
         }
 
         template <typename StmtType, typename ErrorType>
-        [[nodiscard]] __attribute__((hot)) auto bind_params_direct(ErasedStatementPtr stmt_ptr, int& param_index) const
+        [[nodiscard]] __attribute__((hot)) auto bind_impl(StmtType* stmt, int& param_index) const
                 -> std::expected<void, ErrorType> {
-            auto* stmt = static_cast<StmtType*>(stmt_ptr);
-            // Bind min value
             if (auto result = utilities::bind_parameter_value<StmtType, ErrorType>(*stmt, param_index++, min_val_);
                 !result) {
                 return result;
             }
-            // Bind max value
             return utilities::bind_parameter_value<StmtType, ErrorType>(*stmt, param_index++, max_val_);
         }
     };
@@ -172,9 +168,8 @@ export namespace storm::orm::where {
         }
 
         template <typename StmtType, typename ErrorType>
-        [[nodiscard]] __attribute__((hot)) auto bind_params_direct(ErasedStatementPtr stmt_ptr, int& param_index) const
+        [[nodiscard]] __attribute__((hot)) auto bind_impl(StmtType* stmt, int& param_index) const
                 -> std::expected<void, ErrorType> {
-            auto* stmt = static_cast<StmtType*>(stmt_ptr);
             for (const auto& value : values_) {
                 if (auto result = utilities::bind_parameter_value<StmtType, ErrorType>(*stmt, param_index++, value);
                     !result) {
@@ -270,9 +265,11 @@ export namespace storm::orm::where {
             return bind_params_direct<StmtType, ErrorType>(*expr.right, stmt_ptr, *param_index);
         }
 
-        // All other expression types have their own bind_params_direct() method
+        // Every other Expr type exposes a small `bind_impl(StmtType*, int&)`.
+        // The type-erased pointer cast used to be duplicated in each Expr's own
+        // `bind_params_direct` — that's the duplicate this visitor now centralises.
         template <typename T> [[nodiscard]] auto operator()(const T& expr) const -> std::expected<void, ErrorType> {
-            return expr.template bind_params_direct<StmtType, ErrorType>(stmt_ptr, *param_index);
+            return expr.template bind_impl<StmtType, ErrorType>(static_cast<StmtType*>(stmt_ptr), *param_index);
         }
     };
 
@@ -329,6 +326,18 @@ export namespace storm::orm::where {
     template <typename T>
     concept NullableField = requires { typename T::value_type; };
 
+    // Free helpers for null-check expression construction. Both CollatedField
+    // and Field used to spell out the four nullable methods (is_null, is_not_null,
+    // operator==(nullopt_t), operator!=(nullopt_t)) body-for-body identical.
+    // Now both classes route through these one-line helpers.
+    [[nodiscard]] inline auto make_null_check_expr(std::string field_name, bool is_null) -> Expr {
+        return Expr(
+                std::make_shared<ExpressionVariant>(
+                        NullCheckExpr{.field_name_ = std::move(field_name), .is_null_ = is_null}
+                )
+        );
+    }
+
     // CollatedField proxy - wraps field name with COLLATE clause
     // Created via field<^^Person::name>().collate(Collate::NoCase)
     // All comparison operators produce SQL like: "name COLLATE NOCASE = ?"
@@ -374,32 +383,12 @@ export namespace storm::orm::where {
             return make_comparison(CompOp::LessEqual, std::forward<V>(value));
         }
 
-        [[nodiscard]] auto is_null() const -> Expr
-            requires NullableField<FieldType>
-        {
-            return Expr(
-                    std::make_shared<ExpressionVariant>(NullCheckExpr{.field_name_ = collated_name_, .is_null_ = true})
-            );
-        }
-
-        [[nodiscard]] auto is_not_null() const -> Expr
-            requires NullableField<FieldType>
-        {
-            return Expr(
-                    std::make_shared<ExpressionVariant>(NullCheckExpr{.field_name_ = collated_name_, .is_null_ = false})
-            );
-        }
-
-        auto operator==(std::nullopt_t /*unused*/) const -> Expr
-            requires NullableField<FieldType>
-        {
-            return is_null();
-        }
-        auto operator!=(std::nullopt_t /*unused*/) const -> Expr
-            requires NullableField<FieldType>
-        {
-            return is_not_null();
-        }
+        // clang-format off
+        [[nodiscard]] auto is_null()     const -> Expr requires NullableField<FieldType> { return make_null_check_expr(collated_name_, true); }
+        [[nodiscard]] auto is_not_null() const -> Expr requires NullableField<FieldType> { return make_null_check_expr(collated_name_, false); }
+        auto operator==(std::nullopt_t /*unused*/)  const -> Expr requires NullableField<FieldType> { return is_null(); }
+        auto operator!=(std::nullopt_t /*unused*/)  const -> Expr requires NullableField<FieldType> { return is_not_null(); }
+        // clang-format on
 
         [[nodiscard]] auto like(std::string_view pattern) const -> Expr {
             return Expr(
@@ -497,36 +486,12 @@ export namespace storm::orm::where {
         }
 
         // NULL check methods — constrained to std::optional<T> fields only
-        [[nodiscard]] auto is_null() const -> Expr
-            requires NullableField<FieldType>
-        {
-            return Expr(
-                    std::make_shared<ExpressionVariant>(
-                            NullCheckExpr{.field_name_ = std::string(field_name_sv), .is_null_ = true}
-                    )
-            );
-        }
-
-        [[nodiscard]] auto is_not_null() const -> Expr
-            requires NullableField<FieldType>
-        {
-            return Expr(
-                    std::make_shared<ExpressionVariant>(
-                            NullCheckExpr{.field_name_ = std::string(field_name_sv), .is_null_ = false}
-                    )
-            );
-        }
-
-        auto operator==(std::nullopt_t /*unused*/) const -> Expr
-            requires NullableField<FieldType>
-        {
-            return is_null();
-        }
-        auto operator!=(std::nullopt_t /*unused*/) const -> Expr
-            requires NullableField<FieldType>
-        {
-            return is_not_null();
-        }
+        // clang-format off
+        [[nodiscard]] auto is_null()     const -> Expr requires NullableField<FieldType> { return make_null_check_expr(std::string(field_name_sv), true); }
+        [[nodiscard]] auto is_not_null() const -> Expr requires NullableField<FieldType> { return make_null_check_expr(std::string(field_name_sv), false); }
+        auto operator==(std::nullopt_t /*unused*/)  const -> Expr requires NullableField<FieldType> { return is_null(); }
+        auto operator!=(std::nullopt_t /*unused*/)  const -> Expr requires NullableField<FieldType> { return is_not_null(); }
+        // clang-format on
 
         // Special methods - return VARIANT-BASED Expr
         [[nodiscard]] auto like(std::string_view pattern) const -> Expr {


### PR DESCRIPTION
## Summary
- Phase 3 of #277 for \`src/orm/where.cppm\`. Drops the \`duplicate\` tag by centralising the type-erased statement-pointer cast in the dispatching visitor.

## What changed in \`where.cppm\`

* **\`BindParamsVisitor\`** now does \`static_cast<StmtType*>(stmt_ptr)\` once and calls each Expr's small \`bind_impl(StmtType*, int&)\`. Each Expr type (\`ComparisonExpr\`, \`NullCheckExpr\`, \`LikeExpr\`, \`BetweenExpr\`, \`InExpression\`) used to spell out the same 4-line \`bind_params_direct<StmtType, ErrorType>\` signature + cast prologue. The Expr structs trim down to just their type-specific binding body. \`LogicalExpr\`'s recursive case is unchanged.
* **\`make_null_check_expr(field_name, is_null)\`** consolidates the \`is_null\` / \`is_not_null\` bodies of \`CollatedField\` and \`Field\`, which were otherwise textually identical.
* The \`operator==(std::nullopt_t)\` / \`operator!=(std::nullopt_t)\` proxies were already one-liners delegating to \`is_null\` / \`is_not_null\`.

The new \`LINT-EXCLUDE-FILE\` reads \`file-size, complexity\` (no \`duplicate\`) with both policy comments.

Also updates \`docs/development/CODE_QUALITY.md\` with the per-file disposition.

## Test plan
- [x] \`ninja-debug\` build clean
- [x] \`ninja-release\` build clean
- [x] \`ctest --preset ninja-debug-sqlite\`: 1908 / 1908 passed
- [x] \`ninja-asan-ubsan\` + \`ninja-tsan\` builds clean
- [x] ASAN+UBSAN and TSAN test runs: 1355 / 1355 passed with \`UnifiedYamlTest/SQLite.*\` filtered (pre-existing crash on develop)

## Notes
- Stacks against \`develop\` independently from PRs #281 (select.cppm) and #283 (base.cppm).

Refs #277

🤖 Generated with [Claude Code](https://claude.com/claude-code)