### PR TITLE
refactor(pool): drop duplicate tag — extract count_entries(pred) helper (#277)

### DIFF
--- a/docs/development/CODE_QUALITY.md
+++ b/docs/development/CODE_QUALITY.md
@@ -20,8 +20,8 @@ When a file's `duplicate` tag is removed by extraction, its `LINT-EXCLUDE-FILE` 
 | `src/orm/statements/base.cppm` | extracted (#283) | `for_each_field_name<SkipPK>` consteval iterator drives both the size-calculator and the list-builder; `bind_bulk_objects_impl<SkipPK>` unifies the two bulk binders; `bind_expr_or_reset` shares the bind-or-reset tail of `bind_where_params` / `bind_having_params` |
 | `src/orm/where.cppm` | extracted (#284) | `BindParamsVisitor` casts the type-erased statement pointer once and calls each Expr's small `bind_impl(StmtType*, int&)`. `make_null_check_expr(name, is_null)` consolidates the `is_null`/`is_not_null` bodies of `CollatedField` and `Field` |
 | `src/orm/statements/update.cppm` | extracted (#285) | `ensure_cached_stmt()` and `reset_bind_execute()` member helpers replace the inline cache-prepare + reset/bind/execute blocks repeated across `execute(span)` / `execute_single_row` / `execute_single_optimized`; `QueryBase::sql()` consolidates the `static auto sql() -> std::string { return update_sql_string; }` body shared by `SingleQuery` and `BulkQuery` proxies |
-| `src/orm/statements/aggregate.cppm` | extracted (this PR) | `append_group_by_tail(sql)` folds the `if constexpr (HasGroupBy) { if (having_expr_) insert_having_clause(sql); append_modifiers(sql); }` block that used to repeat across `execute_where` / `execute_join` / `execute_where_join` |
-| `src/db/pool.cppm` | pending | — |
+| `src/orm/statements/aggregate.cppm` | extracted (#286) | `append_group_by_tail(sql)` folds the `if constexpr (HasGroupBy) { if (having_expr_) insert_having_clause(sql); append_modifiers(sql); }` block that used to repeat across `execute_where` / `execute_join` / `execute_where_join` |
+| `src/db/pool.cppm` | extracted (this PR) | `count_entries(pred)` helper takes the lock and counts entries matching a predicate. `available()` and `in_use()` collapse to one-line predicate calls |
 | `src/orm/statements/erase.cppm` | pending | — |
 | `src/orm/statements/distinct.cppm` | pending | — |
 | `src/orm/statements/setop.cppm` | pending | — |

--- a/src/db/pool.cppm
+++ b/src/db/pool.cppm
@@ -1,7 +1,7 @@
 module;
 
-// LINT-EXCLUDE-FILE: duplicate, complexity, length
-// Boilerplate-pattern duplicates accepted (see #264 finding).
+// LINT-EXCLUDE-FILE: complexity, length
+// `duplicate` removed in #277 Phase 3 (count_entries(pred) helper shared by available() / in_use() counters).
 
 #include <condition_variable>
 #include <mutex>
@@ -147,26 +147,30 @@ export namespace storm::db {
                 return static_cast<int>(entries_.size());
             }
 
-            [[nodiscard]] auto available() const -> int {
+            // Count entries matching a predicate. The available() / in_use()
+            // counters used to repeat the lock + loop + count body verbatim;
+            // they now differ only in which entries pass the predicate.
+            //
+            // NOLINTBEGIN(readability-use-anyofallof) — explicit loop to avoid
+            // `import <algorithm>`; clang-p2996 clang-scan-deps SIGSEGVs on atomic_ref.h
+            template <typename Pred> [[nodiscard]] auto count_entries(Pred pred) const -> int {
                 std::lock_guard lock(mutex_);
                 int             count = 0;
                 for (const auto& entry : entries_) {
-                    if (!entry.in_use) {
+                    if (pred(entry)) {
                         ++count;
                     }
                 }
                 return count;
             }
+            // NOLINTEND(readability-use-anyofallof)
+
+            [[nodiscard]] auto available() const -> int {
+                return count_entries([](const auto& entry) { return !entry.in_use; });
+            }
 
             [[nodiscard]] auto in_use() const -> int {
-                std::lock_guard lock(mutex_);
-                int             count = 0;
-                for (const auto& entry : entries_) {
-                    if (entry.in_use) {
-                        ++count;
-                    }
-                }
-                return count;
+                return count_entries([](const auto& entry) { return entry.in_use; });
             }
 
             auto shutdown() -> void {


### PR DESCRIPTION
## Summary
- Phase 3 of #277 for \`src/db/pool.cppm\`. Drops the \`duplicate\` tag.

## What changed

**\`count_entries(pred)\`** takes the lock, walks \`entries_\`, and counts elements matching a predicate. \`available()\` and \`in_use()\` were otherwise identical — same lock, same loop, same counter, differing only in which entries pass. They collapse to one-line predicate calls.

Keeps the existing \`NOLINT(readability-use-anyofallof)\` trail — the explicit loop avoids \`import <algorithm>\` (clang-p2996 clang-scan-deps SIGSEGVs on atomic_ref.h under ninja-release).

The new \`LINT-EXCLUDE-FILE\` reads \`complexity, length\` (no \`duplicate\`) with the trail comment.

## Test plan
- [x] \`ninja-debug\` build clean
- [x] \`ctest --preset ninja-debug-sqlite\`: 1908 / 1908 passed
- [x] \`ninja-asan-ubsan\` + \`ninja-tsan\` builds clean
- [x] ASAN+UBSAN and TSAN test runs: 1355 / 1355 passed with \`UnifiedYamlTest/SQLite.*\` filtered (pre-existing crash on develop)

Refs #277

🤖 Generated with [Claude Code](https://claude.com/claude-code)