### PR TITLE
refactor(erase): drop LINT-EXCLUDE-FILE — extract delete_prefix_size + append_delete_prefix (#277)

### DIFF
--- a/docs/development/CODE_QUALITY.md
+++ b/docs/development/CODE_QUALITY.md
@@ -21,8 +21,8 @@ When a file's `duplicate` tag is removed by extraction, its `LINT-EXCLUDE-FILE` 
 | `src/orm/where.cppm` | extracted (#284) | `BindParamsVisitor` casts the type-erased statement pointer once and calls each Expr's small `bind_impl(StmtType*, int&)`. `make_null_check_expr(name, is_null)` consolidates the `is_null`/`is_not_null` bodies of `CollatedField` and `Field` |
 | `src/orm/statements/update.cppm` | extracted (#285) | `ensure_cached_stmt()` and `reset_bind_execute()` member helpers replace the inline cache-prepare + reset/bind/execute blocks repeated across `execute(span)` / `execute_single_row` / `execute_single_optimized`; `QueryBase::sql()` consolidates the `static auto sql() -> std::string { return update_sql_string; }` body shared by `SingleQuery` and `BulkQuery` proxies |
 | `src/orm/statements/aggregate.cppm` | extracted (#286) | `append_group_by_tail(sql)` folds the `if constexpr (HasGroupBy) { if (having_expr_) insert_having_clause(sql); append_modifiers(sql); }` block that used to repeat across `execute_where` / `execute_join` / `execute_where_join` |
-| `src/db/pool.cppm` | extracted (this PR) | `count_entries(pred)` helper takes the lock and counts entries matching a predicate. `available()` and `in_use()` collapse to one-line predicate calls |
-| `src/orm/statements/erase.cppm` | pending | — |
+| `src/db/pool.cppm` | extracted (#287) | `count_entries(pred)` helper takes the lock and counts entries matching a predicate. `available()` and `in_use()` collapse to one-line predicate calls |
+| `src/orm/statements/erase.cppm` | extracted (this PR) | `delete_prefix_size()` + `append_delete_prefix(buf)` consteval helpers share the `"DELETE FROM <table> WHERE <pk_name>"` prefix between the single-row and bulk DELETE SQL builders — only the tail differs (`" = ?"` vs `" IN ("`) |
 | `src/orm/statements/distinct.cppm` | pending | — |
 | `src/orm/statements/setop.cppm` | pending | — |
 | `src/db/sqlite.cppm` | pending | — |

--- a/src/orm/statements/erase.cppm
+++ b/src/orm/statements/erase.cppm
@@ -1,7 +1,7 @@
 module;
 
-// LINT-EXCLUDE-FILE: duplicate
-// Boilerplate-pattern duplicates accepted (see #264 finding).
+// `duplicate` removed in #277 Phase 3 (delete_prefix_size + append_delete_prefix helpers shared by single-row and bulk
+// DELETE SQL builders).
 
 #include <meta>
 
@@ -37,18 +37,29 @@ export namespace storm::orm::statements {
         using Error      = typename ConnType::Error;
         using Statement  = typename ConnType::Statement;
 
-        // Compile-time single DELETE SQL size calculation
-        static consteval auto calculate_single_delete_sql_size() -> size_t {
+        // Common prefix size: "DELETE FROM <table> WHERE <pk_name>". Both the
+        // single-row and the bulk DELETE size calculators used to spell this
+        // out; their only difference is the tail (" = ?" vs " IN (").
+        static consteval auto delete_prefix_size() -> size_t {
             using utilities::sql_len::DELETE_FROM;
             using utilities::sql_len::WHERE;
-            size_t size = 0;
-            size += DELETE_FROM; // "DELETE FROM "
-            size += Base::table_name_.size();
-            size += WHERE; // " WHERE "
-            size += Base::pk_name_.size();
-            size += 4; // " = ?"
-            size += 1; // null terminator
-            return size;
+            return DELETE_FROM + Base::table_name_.size() + WHERE + Base::pk_name_.size();
+        }
+
+        // Compile-time single DELETE SQL size calculation
+        static consteval auto calculate_single_delete_sql_size() -> size_t {
+            return delete_prefix_size() + 4 + 1; // " = ?" + null terminator
+        }
+
+        // Append the shared "DELETE FROM <table> WHERE <pk_name>" prefix.
+        // The single-row builder appends "= ?" after; the bulk builder appends
+        // " IN (". Centralising the prefix removes the textual duplicate the
+        // hook flagged.
+        template <typename Buf> static consteval auto append_delete_prefix(Buf& buf) -> void {
+            buf.append("DELETE FROM ");
+            buf.append(Base::table_name_);
+            buf.append(" WHERE ");
+            buf.append(Base::pk_name_);
         }
 
         // Build single DELETE SQL at compile-time using ConstexprString
@@ -56,13 +67,8 @@ export namespace storm::orm::statements {
             // NOLINTNEXTLINE(cppcoreguidelines-init-variables) - constexpr IS initialized
             constexpr size_t          sql_size = calculate_single_delete_sql_size() + utilities::sql_len::LARGE_BUFFER;
             ConstexprString<sql_size> result;
-
-            result.append("DELETE FROM ");
-            result.append(Base::table_name_);
-            result.append(" WHERE ");
-            result.append(Base::pk_name_);
+            append_delete_prefix(result);
             result.append(" = ?");
-
             return result;
         }
 
@@ -85,17 +91,7 @@ export namespace storm::orm::statements {
       private:
         // Compile-time bulk DELETE prefix calculation
         static consteval auto calculate_bulk_delete_prefix_size() -> size_t {
-            using utilities::sql_len::DELETE_FROM;
-            using utilities::sql_len::IN_OPEN;
-            using utilities::sql_len::WHERE;
-            size_t size = 0;
-            size += DELETE_FROM; // "DELETE FROM "
-            size += Base::table_name_.size();
-            size += WHERE; // " WHERE "
-            size += Base::pk_name_.size();
-            size += IN_OPEN; // " IN ("
-            size += 1;       // null terminator
-            return size;
+            return delete_prefix_size() + utilities::sql_len::IN_OPEN + 1; // " IN (" + null terminator
         }
 
         // Build bulk DELETE prefix at compile-time using ConstexprString
@@ -103,13 +99,8 @@ export namespace storm::orm::statements {
             // NOLINTNEXTLINE(cppcoreguidelines-init-variables) - constexpr IS initialized
             constexpr size_t prefix_size = calculate_bulk_delete_prefix_size() + utilities::sql_len::LARGE_BUFFER;
             ConstexprString<prefix_size> result;
-
-            result.append("DELETE FROM ");
-            result.append(Base::table_name_);
-            result.append(" WHERE ");
-            result.append(Base::pk_name_);
+            append_delete_prefix(result);
             result.append(" IN (");
-
             return result;
         }
 


### PR DESCRIPTION
## Summary
- Phase 3 of #277 for \`src/orm/statements/erase.cppm\`. Removes the \`LINT-EXCLUDE-FILE\` directive entirely (only \`duplicate\` was excluded on develop).

## What changed

* **\`delete_prefix_size()\`** — consteval helper returning the shared "DELETE FROM \<table\> WHERE \<pk_name\>" prefix's character count.
* **\`append_delete_prefix(buf)\`** — consteval helper appending the prefix into any ConstexprString buffer.

\`calculate_single_delete_sql_size\` and \`calculate_bulk_delete_prefix_size\` now reduce to one-line additions on the helper. \`build_single_delete_sql_array\` and \`build_bulk_delete_prefix\` use the appender + their type-specific tail (\`" = ?"\` vs \`" IN ("\`).

## Test plan
- [x] \`ninja-debug\` build clean
- [x] \`ctest --preset ninja-debug-sqlite\`: 1908 / 1908 passed
- [x] \`ninja-asan-ubsan\` + \`ninja-tsan\` builds clean
- [x] ASAN+UBSAN and TSAN test runs: 1355 / 1355 passed with \`UnifiedYamlTest/SQLite.*\` filtered (pre-existing crash on develop)

Refs #277

🤖 Generated with [Claude Code](https://claude.com/claude-code)