### PR TITLE
refactor(distinct): drop LINT-EXCLUDE-FILE — extract build_field_list_with_prefix (#277)

### DIFF
--- a/docs/development/CODE_QUALITY.md
+++ b/docs/development/CODE_QUALITY.md
@@ -22,8 +22,8 @@ When a file's `duplicate` tag is removed by extraction, its `LINT-EXCLUDE-FILE` 
 | `src/orm/statements/update.cppm` | extracted (#285) | `ensure_cached_stmt()` and `reset_bind_execute()` member helpers replace the inline cache-prepare + reset/bind/execute blocks repeated across `execute(span)` / `execute_single_row` / `execute_single_optimized`; `QueryBase::sql()` consolidates the `static auto sql() -> std::string { return update_sql_string; }` body shared by `SingleQuery` and `BulkQuery` proxies |
 | `src/orm/statements/aggregate.cppm` | extracted (#286) | `append_group_by_tail(sql)` folds the `if constexpr (HasGroupBy) { if (having_expr_) insert_having_clause(sql); append_modifiers(sql); }` block that used to repeat across `execute_where` / `execute_join` / `execute_where_join` |
 | `src/db/pool.cppm` | extracted (#287) | `count_entries(pred)` helper takes the lock and counts entries matching a predicate. `available()` and `in_use()` collapse to one-line predicate calls |
-| `src/orm/statements/erase.cppm` | extracted (this PR) | `delete_prefix_size()` + `append_delete_prefix(buf)` consteval helpers share the `"DELETE FROM <table> WHERE <pk_name>"` prefix between the single-row and bulk DELETE SQL builders — only the tail differs (`" = ?"` vs `" IN ("`) |
-| `src/orm/statements/distinct.cppm` | pending | — |
+| `src/orm/statements/erase.cppm` | extracted (#288) | `delete_prefix_size()` + `append_delete_prefix(buf)` consteval helpers share the `"DELETE FROM <table> WHERE <pk_name>"` prefix between the single-row and bulk DELETE SQL builders — only the tail differs (`" = ?"` vs `" IN ("`) |
+| `src/orm/statements/distinct.cppm` | extracted (this PR) | `build_field_list_with_prefix<Extra>(prefix, seq)` consteval helper shared by `build_field_list_constexpr` (no prefix) and `build_join_field_list_constexpr` (`"t1."` per field) |
 | `src/orm/statements/setop.cppm` | pending | — |
 | `src/db/sqlite.cppm` | pending | — |
 | `src/db/postgresql_statement.cppm` | pending | — |

--- a/src/orm/statements/distinct.cppm
+++ b/src/orm/statements/distinct.cppm
@@ -1,7 +1,7 @@
 module;
 
-// LINT-EXCLUDE-FILE: duplicate
-// Boilerplate-pattern duplicates accepted (see #264 finding).
+// `duplicate` removed in #277 Phase 3 (build_field_list_with_prefix consteval helper shared by JOIN/non-JOIN field-list
+// builders).
 
 #include <meta>
 #include <utility>
@@ -97,14 +97,20 @@ export namespace storm::orm::statements {
             }
         }
 
-        // Compile-time field list generation (returns ConstexprString)
-        template <size_t... Is>
-        static consteval auto build_field_list_constexpr(std::index_sequence<Is...> /*unused*/) {
-            constexpr size_t total_size = calculate_field_list_size(std::make_index_sequence<NumFields>{});
+        // Build a "<prefix>col1, <prefix>col2, ..." field list at compile time.
+        // The non-JOIN list uses no prefix; the JOIN list uses "t1.". The two
+        // builders used to spell the loop out independently.
+        template <size_t Extra, size_t... Is>
+        static consteval auto
+        build_field_list_with_prefix(std::string_view prefix, std::index_sequence<Is...> /*unused*/) {
+            constexpr size_t total_size = calculate_field_list_size(std::make_index_sequence<NumFields>{}) + Extra;
             ConstexprString<total_size + 10> result;
-            auto                             append_field = [&result]<size_t I>() {
+            auto                             append_field = [&result, prefix]<size_t I>() {
                 if constexpr (I > 0) {
                     result.append(", ");
+                }
+                if (!prefix.empty()) {
+                    result.append(prefix);
                 }
                 append_column_name<I>(result);
             };
@@ -112,24 +118,17 @@ export namespace storm::orm::statements {
             return result;
         }
 
+        // Compile-time field list generation (no alias prefix)
+        template <size_t... Is> static consteval auto build_field_list_constexpr(std::index_sequence<Is...> seq) {
+            return build_field_list_with_prefix<0, Is...>("", seq);
+        }
+
         // Pre-computed field list for use in non-JOIN path
         static constexpr auto field_list_constexpr_ = build_field_list_constexpr(std::make_index_sequence<NumFields>{});
 
         // Compile-time field list with "t1." table alias prefix for JOIN queries
-        template <size_t... Is>
-        static consteval auto build_join_field_list_constexpr(std::index_sequence<Is...> /*unused*/) {
-            constexpr size_t total_size = calculate_field_list_size(std::make_index_sequence<NumFields>{}) +
-                                          (NumFields * 3); // "t1." per field
-            ConstexprString<total_size + 10> result;
-            auto                             append_field = [&result]<size_t I>() {
-                if constexpr (I > 0) {
-                    result.append(", ");
-                }
-                result.append("t1.");
-                append_column_name<I>(result);
-            };
-            (append_field.template operator()<Is>(), ...);
-            return result;
+        template <size_t... Is> static consteval auto build_join_field_list_constexpr(std::index_sequence<Is...> seq) {
+            return build_field_list_with_prefix<NumFields * 3, Is...>("t1.", seq);
         }
 
         static constexpr auto join_field_list_constexpr_ =


### PR DESCRIPTION
## Summary
- Phase 3 of #277 for \`src/orm/statements/distinct.cppm\`. Removes the \`LINT-EXCLUDE-FILE\` directive entirely.

## What changed

**\`build_field_list_with_prefix<Extra>(prefix, seq)\`** is a consteval helper that runs the fold once. \`build_field_list_constexpr\` calls it with an empty prefix; \`build_join_field_list_constexpr\` calls it with \`"t1."\` and \`NumFields * 3\` extra bytes. The non-JOIN and JOIN builders used to spell the same fold-expression loop out independently.

## Test plan
- [x] \`ninja-debug\` build clean
- [x] \`ctest --preset ninja-debug-sqlite\`: 1908 / 1908 passed
- [x] \`ninja-asan-ubsan\` + \`ninja-tsan\` builds clean
- [x] ASAN+UBSAN and TSAN: 1355 / 1355 passed with \`UnifiedYamlTest/SQLite.*\` filtered (pre-existing crash on develop)

Refs #277

🤖 Generated with [Claude Code](https://claude.com/claude-code)