### PR TITLE
refactor(sqlite): drop LINT-EXCLUDE-FILE — no current duplicates (#277)

### DIFF
--- a/docs/development/CODE_QUALITY.md
+++ b/docs/development/CODE_QUALITY.md
@@ -24,8 +24,8 @@ When a file's `duplicate` tag is removed by extraction, its `LINT-EXCLUDE-FILE` 
 | `src/db/pool.cppm` | extracted (#287) | `count_entries(pred)` helper takes the lock and counts entries matching a predicate. `available()` and `in_use()` collapse to one-line predicate calls |
 | `src/orm/statements/erase.cppm` | extracted (#288) | `delete_prefix_size()` + `append_delete_prefix(buf)` consteval helpers share the `"DELETE FROM <table> WHERE <pk_name>"` prefix between the single-row and bulk DELETE SQL builders — only the tail differs (`" = ?"` vs `" IN ("`) |
 | `src/orm/statements/distinct.cppm` | extracted (#289) | `build_field_list_with_prefix<Extra>(prefix, seq)` consteval helper shared by `build_field_list_constexpr` (no prefix) and `build_join_field_list_constexpr` (`"t1."` per field) |
-| `src/orm/statements/setop.cppm` | extracted (this PR) | `add_operand(op, type)` folds the `union_`/`union_all`/`except_`/`intersect_` bodies; `ready_statement()` runs the prepare/reset/bind dance shared by `execute()` and `to_sql()` |
-| `src/db/sqlite.cppm` | pending | — |
+| `src/orm/statements/setop.cppm` | extracted (#290) | `add_operand(op, type)` folds the `union_`/`union_all`/`except_`/`intersect_` bodies; `ready_statement()` shares the prepare/reset/bind dance between `execute()` and `to_sql()` |
+| `src/db/sqlite.cppm` | tag dropped (this PR) | No duplicate blocks today — the directive was carried over from earlier `LINT-EXCLUDE-FILE` rollout but had no current effect. Drop it outright |
 | `src/db/postgresql_statement.cppm` | pending | — |
 
 ## Accepted duplicates

--- a/src/db/sqlite.cppm
+++ b/src/db/sqlite.cppm
@@ -1,8 +1,5 @@
 module;
 
-// LINT-EXCLUDE-FILE: duplicate
-// Boilerplate-pattern duplicates accepted (see #264 finding).
-
 #include <sqlite3.h>
 
 export module storm_db_sqlite;


### PR DESCRIPTION
## Summary
- Phase 3 of #277 for \`src/db/sqlite.cppm\`. Drops the \`LINT-EXCLUDE-FILE\` directive outright.

The audit found zero duplicate blocks today — the directive was a carry-over from the initial Phase 1 rollout that no longer matched any real code.

## Test plan
- [x] \`ninja-debug\` build clean
- [x] \`ctest --preset ninja-debug-sqlite\`: 1908 / 1908 passed
- [x] \`ninja-asan-ubsan\` + \`ninja-tsan\` builds clean
- [x] ASAN+UBSAN and TSAN: 1355 / 1355 passed with \`UnifiedYamlTest/SQLite.*\` filtered (pre-existing crash on develop)

Refs #277

🤖 Generated with [Claude Code](https://claude.com/claude-code)