### PR TITLE
refactor(pg-statement): drop LINT-EXCLUDE-FILE — extract bind_text_value (#277, final)

### DIFF
--- a/docs/development/CODE_QUALITY.md
+++ b/docs/development/CODE_QUALITY.md
@@ -25,8 +25,8 @@ When a file's `duplicate` tag is removed by extraction, its `LINT-EXCLUDE-FILE` 
 | `src/orm/statements/erase.cppm` | extracted (#288) | `delete_prefix_size()` + `append_delete_prefix(buf)` consteval helpers share the `"DELETE FROM <table> WHERE <pk_name>"` prefix between the single-row and bulk DELETE SQL builders — only the tail differs (`" = ?"` vs `" IN ("`) |
 | `src/orm/statements/distinct.cppm` | extracted (#289) | `build_field_list_with_prefix<Extra>(prefix, seq)` consteval helper shared by `build_field_list_constexpr` (no prefix) and `build_join_field_list_constexpr` (`"t1."` per field) |
 | `src/orm/statements/setop.cppm` | extracted (#290) | `add_operand(op, type)` folds the `union_`/`union_all`/`except_`/`intersect_` bodies; `ready_statement()` shares the prepare/reset/bind dance between `execute()` and `to_sql()` |
-| `src/db/sqlite.cppm` | tag dropped (this PR) | No duplicate blocks today — the directive was carried over from earlier `LINT-EXCLUDE-FILE` rollout but had no current effect. Drop it outright |
-| `src/db/postgresql_statement.cppm` | pending | — |
+| `src/db/sqlite.cppm` | tag dropped (#291) | No duplicate blocks today — the directive was carried over from earlier `LINT-EXCLUDE-FILE` rollout but had no current effect |
+| `src/db/postgresql_statement.cppm` | extracted (this PR) | `bind_text_value(idx, std::string)` helper folds the `ensure_param_slot → assign → update_param_ptrs` dance shared by `bind_int` / `bind_int64` / `bind_text` |
 
 ## Accepted duplicates
 

--- a/src/db/postgresql_statement.cppm
+++ b/src/db/postgresql_statement.cppm
@@ -1,9 +1,7 @@
 module;
 
-// LINT-EXCLUDE-FILE: duplicate
-// bind_int/bind_int64/bind_text share a 4-line shape; refactor deferred to
-// storm issue #264 Phase 3 (extract bind_typed<T> helper). Move-op duplication
-// already eliminated via the swap idiom above.
+// `duplicate` removed in #277 Phase 3 (bind_text_value(idx, std::string) helper shared by
+// bind_int/bind_int64/bind_text).
 
 #include <libpq-fe.h>
 
@@ -76,31 +74,34 @@ export namespace storm::db::postgresql {
         Statement(const Statement&)                    = delete;
         auto operator=(const Statement&) -> Statement& = delete;
 
-        // Parameter binding - accumulate as text strings for PQexecPrepared
+        // Parameter binding - accumulate as text strings for PQexecPrepared.
+        // bind_text_value(idx, std::string) is the shared core; bind_int /
+        // bind_int64 / bind_text used to spell out the same
+        // `ensure_param_slot → assign → update_param_ptrs` dance.
+        __attribute__((always_inline)) auto bind_text_value(int index, std::string value) noexcept -> void {
+            ensure_param_slot(index);
+            param_values_[index - 1] = std::move(value);
+            update_param_ptrs(index);
+        }
+
         template <typename = void>
         [[nodiscard]] __attribute__((always_inline)) auto bind_int(int index, int value) noexcept
                 -> std::expected<void, Error> {
-            ensure_param_slot(index);
-            param_values_[index - 1] = std::to_string(value);
-            update_param_ptrs(index);
+            bind_text_value(index, std::to_string(value));
             return {};
         }
 
         template <typename = void>
         [[nodiscard]] __attribute__((always_inline)) auto bind_text(int index, std::string_view value) noexcept
                 -> std::expected<void, Error> {
-            ensure_param_slot(index);
-            param_values_[index - 1] = std::string(value);
-            update_param_ptrs(index);
+            bind_text_value(index, std::string(value));
             return {};
         }
 
         template <typename = void>
         [[nodiscard]] __attribute__((always_inline)) auto bind_int64(int index, int64_t value) noexcept
                 -> std::expected<void, Error> {
-            ensure_param_slot(index);
-            param_values_[index - 1] = std::to_string(value);
-            update_param_ptrs(index);
+            bind_text_value(index, std::to_string(value));
             return {};
         }
 


### PR DESCRIPTION
## Summary
- Phase 3 of #277 for \`src/db/postgresql_statement.cppm\` — **final file** in the umbrella audit.

## What changed

**\`bind_text_value(idx, std::string)\`** folds the \`ensure_param_slot → assign → update_param_ptrs\` dance shared by \`bind_int\`, \`bind_int64\`, and \`bind_text\`. Each public binder is now a one-line wrapper around the shared core; the "refactor deferred to #264 Phase 3" trail comment can go.

\`postgresql_statement.cppm\` carried only \`LINT-EXCLUDE-FILE: duplicate\` on develop — that directive is now removed entirely.

## Phase 3 wrap-up

This PR closes out the Phase 3 audit. Together with PRs #278/#279/#280 (already merged) and #281/#283/#284/#285/#286/#287/#288/#289/#290/#291 (this batch), every file listed in #277's "Per-file checklist" has had its \`duplicate\` tag removed by extraction.

Once all PRs land, the umbrella issue #277 can finally close.

## Test plan
- [x] \`ninja-debug\` build clean
- [x] \`ctest --preset ninja-debug-sqlite\`: 1908 / 1908 passed
- [x] \`ninja-asan-ubsan\` + \`ninja-tsan\` builds clean
- [x] ASAN+UBSAN and TSAN: 1355 / 1355 passed with \`UnifiedYamlTest/SQLite.*\` filtered (pre-existing crash on develop)

Refs #277

🤖 Generated with [Claude Code](https://claude.com/claude-code)