### PR TITLE
chore(lint): drop stale .lint-skip entries — no source changes (Phase 5a of #295)

### DIFF
--- a/.lint-skip
+++ b/.lint-skip
@@ -3,11 +3,9 @@
 # Globs are relative to this file (the repo root) and use Python pathlib.Path.glob semantics.
 # Rationale per file lives in docs/development/CODE_QUALITY.md.
 
-src/orm/statements/insert.cppm:    file-size, complexity, length
+src/orm/statements/insert.cppm:    file-size
 src/orm/statements/select.cppm:    file-size, complexity, length
 src/orm/statements/base.cppm:      file-size, complexity, length
-src/orm/where.cppm:                file-size, complexity
-src/orm/statements/update.cppm:    complexity
 src/orm/statements/aggregate.cppm: file-size
 src/orm/schema.cppm:                complexity, length
 src/orm/utilities.cppm:             complexity, length

--- a/docs/development/CODE_QUALITY.md
+++ b/docs/development/CODE_QUALITY.md
@@ -84,3 +84,41 @@ For each constant in `~/.claude/hooks/smell_types.py`, the question is: *did Pha
 - **`MAX_PARAMETERS = 6` — keep.** Phase 3 reported zero `parameters` violations on `src/*.cppm`. No exclusions exist. No tuning needed.
 
 **Conclusion:** all 7 constants stay at their current values. The stop-gap `LINT-EXCLUDE-FILE` mechanism in the hook is removed and replaced by `.lint-skip` at the repo root.
+
+## Phase 5 audit (#295) — `.lint-skip` shrink
+
+Phase 4 ended with 9 entries in `.lint-skip` across three tags (`file-size`, `complexity`, `length`). Phase 5's policy: for every `(file, tag)` pair, either remove the tag (refactor lands or threshold no longer fires) or document a `Kept →` reason here.
+
+### Stale-entry sweep — first PR
+
+Re-running the hook against the Phase 4 `.lint-skip` showed several entries no longer fire **at the current threshold values** (`MAX_COMPLEXITY = 10`, `MAX_FUNCTION_LINES = 60`, `MAX_FILE_LINES = 600`). These were dropped without source changes. The headroom column shows how close the file sits to today's threshold — if Phase 4's threshold decisions are ever revisited downward, these files may need their tags back or a real refactor.
+
+| File | Tag | Disposition | Evidence (today's thresholds) | Headroom |
+|---|---|---|---|---|
+| `src/orm/statements/update.cppm` | `complexity` | **dropped (entire line removed)** | Lizard reports max CCN = 7. Phase 3 PR #285 already extracted helpers that reduced complexity; the tag was carried over from before that work landed | 3 CCN points |
+| `src/orm/where.cppm` | `file-size` | **dropped (entire line removed)** | File is 574 lines. Phase 3 PR #284 trimmed it below 600 | 26 lines |
+| `src/orm/where.cppm` | `complexity` | **dropped** | Lizard reports zero functions over CCN 10 | N/A (no offender today) |
+| `src/orm/statements/insert.cppm` | `complexity` | **dropped** | Lizard reports max CCN = 7 (Phase 3 PR #278 already split the big consteval builder) | 3 CCN points |
+| `src/orm/statements/insert.cppm` | `length` | **dropped** | Lizard reports max function = 33 lines | 27 lines |
+
+After this sweep, `.lint-skip` shrank from 9 entries (across 9 files) to 7 entries (across 7 files), and the project's full hook pass is still clean against today's thresholds.
+
+### Remaining entries (Phase 5 work plan)
+
+Each row below is a separate sub-PR per the issue's "one PR per file per tag" rule.
+
+| File | Tag | Hook says | Phase 5 sub-PR target |
+|---|---|---|---|
+| `src/orm/statements/select.cppm` | `complexity` | 1 function @ CCN 19 | refactor |
+| `src/orm/statements/select.cppm` | `length` | 1 function @ 66 lines | refactor (likely same fn as complexity) |
+| `src/orm/statements/select.cppm` | `file-size` | 612 lines | bench-gated `Kept →` candidate (Phase 2 finding) |
+| `src/orm/statements/base.cppm` | `complexity` | 1 function @ CCN 40 | refactor |
+| `src/orm/statements/base.cppm` | `length` | 1 function @ 130 lines | refactor |
+| `src/orm/statements/base.cppm` | `file-size` | 832 lines | bench-gated `Kept →` candidate |
+| `src/orm/statements/aggregate.cppm` | `file-size` | 693 lines | refactor candidate (no Phase 2 finding) |
+| `src/orm/schema.cppm` | `complexity` | 1 function @ CCN 63 | refactor |
+| `src/orm/schema.cppm` | `length` | 1 function @ 146 lines | refactor |
+| `src/orm/utilities.cppm` | `complexity` | 1 function @ CCN 39 | refactor |
+| `src/orm/utilities.cppm` | `length` | 1 function @ 114 lines | refactor |
+| `src/db/pool.cppm` | `complexity` | 1 function @ CCN 13 | refactor (smallest delta — likely first) |
+| `src/db/pool.cppm` | `length` | 1 function @ 70 lines | refactor (same fn) |


### PR DESCRIPTION
## Summary

First sub-PR for the Phase 5 `.lint-skip` shrink (#295). Pure cleanup — **no C++ source changes**.

Re-ran `lizard` against every entry in `.lint-skip` at today's thresholds (`MAX_COMPLEXITY=10`, `MAX_FUNCTION_LINES=60`, `MAX_FILE_LINES=600`) and found 5 tags that no longer fire. They're leftovers from before Phase 3 refactors (#278, #284, #285) trimmed the offenders below threshold.

## Changes

`.lint-skip` shrinks from 9 entries (9 files) → 7 entries (7 files):

| File | Tag dropped | Why it's stale now | Headroom |
|---|---|---|---|
| `src/orm/statements/update.cppm` | `complexity` (entire line) | Max CCN = 7 after #285 | 3 CCN points |
| `src/orm/where.cppm` | `file-size` (entire line) | File is 574 lines after #284 | 26 lines |
| `src/orm/where.cppm` | `complexity` | Zero functions over CCN 10 | n/a |
| `src/orm/statements/insert.cppm` | `complexity` | Max CCN = 7 after #278 | 3 CCN points |
| `src/orm/statements/insert.cppm` | `length` | Max function 33 lines | 27 lines |

`insert.cppm` keeps only its `file-size` tag (608 lines, still over 600).

## Issue boxes ticked on #295

- complexity: `insert.cppm`, `where.cppm`, `update.cppm`
- length: `insert.cppm`
- file-size: `where.cppm`

5 of 19 acceptance boxes closed by this PR.

## Docs

`docs/development/CODE_QUALITY.md` gains a Phase 5 audit section listing each dropped tag with the threshold value it's measured against + per-file headroom, plus a work plan for the remaining `(file, tag)` pairs that need real refactors (`select`, `base`, `schema`, `utilities`, `pool`, `aggregate`).

## Threshold caveat

The dispositions are tied to today's threshold values. Lowering `MAX_COMPLEXITY` below 7 or `MAX_FILE_LINES` below 574 would bring some tags back. Headroom is documented per file so a future tuner sees the risk before pulling the lever.

## Verification

- Pre-commit hook auto-skipped (no C++/cmake files touched).
- `lizard.analyze_file()` re-run against all 9 originally-listed files — every remaining tag is real (fires today); every dropped tag is stale.
- No source code modified → no bench / sanitizer impact.

## Test plan

- [ ] SonarCloud gate passes (no new code → expect a no-op pass)
- [ ] All CI jobs green
- [ ] Manual check that `.lint-skip` still flags the 7 remaining entries

Refs #295

🤖 Generated with [Claude Code](https://claude.com/claude-code)