### PR TITLE
refactor(pool): extract try_grow + wait_for_idle from checkout (Phase 5a of #295)

### DIFF
--- a/.lint-skip
+++ b/.lint-skip
@@ -9,4 +9,3 @@ src/orm/statements/base.cppm:      file-size, complexity, length
 src/orm/statements/aggregate.cppm: file-size
 src/orm/schema.cppm:                complexity, length
 src/orm/utilities.cppm:             complexity, length
-src/db/pool.cppm:                   complexity, length

--- a/docs/development/CODE_QUALITY.md
+++ b/docs/development/CODE_QUALITY.md
@@ -103,6 +103,12 @@ Re-running the hook against the Phase 4 `.lint-skip` showed several entries no l
 
 After this sweep, `.lint-skip` shrank from 9 entries (across 9 files) to 7 entries (across 7 files), and the project's full hook pass is still clean against today's thresholds.
 
+### Real-refactor sub-PRs
+
+| PR | File | Tag(s) dropped | Helper(s) introduced | Before → after |
+|---|---|---|---|---|
+| TBD | `src/db/pool.cppm` | `complexity`, `length` (entire line removed) | `try_grow(lock)` + `wait_for_idle(lock, deadline)` extract grow- and wait-paths out of `checkout` | `checkout`: CCN 13 → 5, length 70 → 19 |
+
 ### Remaining entries (Phase 5 work plan)
 
 Each row below is a separate sub-PR per the issue's "one PR per file per tag" rule.
@@ -120,5 +126,3 @@ Each row below is a separate sub-PR per the issue's "one PR per file per tag" ru
 | `src/orm/schema.cppm` | `length` | 1 function @ 146 lines | refactor |
 | `src/orm/utilities.cppm` | `complexity` | 1 function @ CCN 39 | refactor |
 | `src/orm/utilities.cppm` | `length` | 1 function @ 114 lines | refactor |
-| `src/db/pool.cppm` | `complexity` | 1 function @ CCN 13 | refactor (smallest delta — likely first) |
-| `src/db/pool.cppm` | `length` | 1 function @ 70 lines | refactor (same fn) |

--- a/src/db/pool.cppm
+++ b/src/db/pool.cppm
@@ -8,6 +8,7 @@ module;
 export module storm_db_pool;
 import storm_db_concept;
 import <expected>;
+import <optional>;
 import <string_view>;
 import <string>;
 import <memory>;
@@ -64,69 +65,18 @@ export namespace storm::db {
                 if (shutdown_) {
                     return std::unexpected(Error{-1, "Pool is shut down"});
                 }
-
-                // Evict expired idle connections before searching
                 evict_expired();
-
-                // Try to find an idle connection
-                auto* entry = find_idle();
-                if (entry != nullptr) {
+                if (auto* entry = find_idle(); entry != nullptr) {
                     return entry;
                 }
-
-                // Try to grow the pool
-                if (static_cast<int>(entries_.size()) < config_.max_connections) {
-                    // Release lock during potentially slow open()
-                    lock.unlock();
-                    auto result = ConnType::open(conninfo_);
-                    lock.lock();
-
-                    if (shutdown_) {
-                        return std::unexpected(Error{-1, "Pool is shut down"});
-                    }
-
-                    if (!result) {
-                        return std::unexpected(result.error());
-                    }
-
-                    // Re-check: another thread may have grown the pool while we were unlocked
-                    if (static_cast<int>(entries_.size()) >= config_.max_connections) {
-                        // Pool reached max — discard new connection, try to find an idle one
-                        auto* idle = find_idle();
-                        if (idle != nullptr) {
-                            return idle;
-                        }
-                        // Fall through to wait/fail logic
-                    } else {
-                        auto now = Clock::now();
-                        entries_.emplace_back(std::make_unique<ConnType>(std::move(result.value())), true, now, now);
-                        return entries_.back().conn.get();
-                    }
+                if (auto grown = try_grow(lock); grown.has_value()) {
+                    return *grown;
                 }
-
-                // Pool exhausted — wait or fail
                 if (config_.checkout_timeout_ms == 0) {
                     return std::unexpected(Error{-1, "Pool exhausted (timeout=0)"});
                 }
-
                 auto deadline = Clock::now() + std::chrono::milliseconds(config_.checkout_timeout_ms);
-
-                while (true) {
-                    if (cv_.wait_until(lock, deadline) == std::cv_status::timeout) {
-                        return std::unexpected(Error{-1, "Pool checkout timed out"});
-                    }
-
-                    if (shutdown_) {
-                        return std::unexpected(Error{-1, "Pool is shut down"});
-                    }
-
-                    evict_expired();
-
-                    auto* found = find_idle();
-                    if (found != nullptr) {
-                        return found;
-                    }
-                }
+                return wait_for_idle(lock, deadline);
             }
 
             auto checkin(ConnType* conn) -> void {
@@ -246,6 +196,57 @@ export namespace storm::db {
                     return it->conn.get();
                 }
                 return nullptr;
+            }
+
+            // Try to add a new connection to the pool. Releases `lock` while opening
+            // (which can be slow) and re-acquires it before returning.
+            //
+            // Return value semantics:
+            //   - has_value() == true  → terminal result: success (ConnType*) OR error
+            //   - has_value() == false → caller should fall through to wait/timeout path
+            //                            (pool was already at max when called, or
+            //                             reached max via another thread during open())
+            auto try_grow(std::unique_lock<std::mutex>& lock) -> std::optional<std::expected<ConnType*, Error>> {
+                if (static_cast<int>(entries_.size()) >= config_.max_connections) {
+                    return std::nullopt;
+                }
+                lock.unlock();
+                auto result = ConnType::open(conninfo_);
+                lock.lock();
+
+                if (shutdown_) {
+                    return std::expected<ConnType*, Error>{std::unexpected(Error{-1, "Pool is shut down"})};
+                }
+                if (!result) {
+                    return std::expected<ConnType*, Error>{std::unexpected(result.error())};
+                }
+                // Re-check: another thread may have grown the pool while we were unlocked
+                if (static_cast<int>(entries_.size()) >= config_.max_connections) {
+                    if (auto* idle = find_idle(); idle != nullptr) {
+                        return std::expected<ConnType*, Error>{idle};
+                    }
+                    return std::nullopt; // Fall through to wait
+                }
+                auto now = Clock::now();
+                entries_.emplace_back(std::make_unique<ConnType>(std::move(result.value())), true, now, now);
+                return std::expected<ConnType*, Error>{entries_.back().conn.get()};
+            }
+
+            // Block on cv_ until an idle entry is available, deadline hits, or shutdown.
+            auto wait_for_idle(std::unique_lock<std::mutex>& lock, TimePoint deadline)
+                    -> std::expected<ConnType*, Error> {
+                while (true) {
+                    if (cv_.wait_until(lock, deadline) == std::cv_status::timeout) {
+                        return std::unexpected(Error{-1, "Pool checkout timed out"});
+                    }
+                    if (shutdown_) {
+                        return std::unexpected(Error{-1, "Pool is shut down"});
+                    }
+                    evict_expired();
+                    if (auto* found = find_idle(); found != nullptr) {
+                        return found;
+                    }
+                }
             }
 
             auto create_entry() -> std::expected<void, Error> {


### PR DESCRIPTION
## Summary

Phase 5a sub-PR for #295. `PoolCore::checkout` was at CCN 13 / 70 lines, holding three orthogonal stages (quick-find, grow, wait) in one function. Extract the grow- and wait-paths into helpers so `checkout()` reads as the straight-line policy.

**Stacked on #296** — base is `feature/295-lint-skip-stale-cleanup`. Will retarget to `develop` once #296 merges.

## Changes

| Function | CCN | Length |
|---|---|---|
| `checkout` (before) | 13 | 70 |
| `checkout` (after) | **5** | **19** |
| `try_grow` (new, private) | 6 | 25 |
| `wait_for_idle` (new, private) | 5 | 15 |

```cpp
auto checkout() -> std::expected<ConnType*, Error> {
    std::unique_lock lock(mutex_);
    if (shutdown_) return std::unexpected(Error{-1, "Pool is shut down"});
    evict_expired();
    if (auto* entry = find_idle(); entry != nullptr) return entry;
    if (auto grown = try_grow(lock); grown.has_value()) return *grown;
    if (config_.checkout_timeout_ms == 0)
        return std::unexpected(Error{-1, "Pool exhausted (timeout=0)"});
    auto deadline = Clock::now() + std::chrono::milliseconds(config_.checkout_timeout_ms);
    return wait_for_idle(lock, deadline);
}
```

`try_grow` returns `std::optional<std::expected<ConnType*, Error>>` — value = terminal result (success or error), nullopt = fall through to wait. This keeps the three states distinct without conflating "no growth possible" with "growth failed".

## .lint-skip + docs

- Drops `pool.cppm: complexity, length` entry from `.lint-skip`. Lizard now reports 0 violations on `pool.cppm`.
- Updates `docs/development/CODE_QUALITY.md` Phase 5 audit section with this PR's row.

## Boxes ticked on #295

- complexity: `src/db/pool.cppm`
- length: `src/db/pool.cppm`

## Verification

- `ninja-debug` `Pool*` tests: **34/34 pass** (same as develop baseline)
- `ninja-tsan` `Pool*` tests: **34/34 pass, no thread warnings** — important since `checkout` is the only mutex+cv path
- Pre-commit hook: clang-format ✓, clang-tidy --diff ✓, ctest full suite **1908/1908 pass**
- Hook re-run on `pool.cppm`: 0 violations

Note: running `./storm_tests` directly (not via ctest) hits a pre-existing segfault inside `AggregateTest/0.*` — reproducible on develop with no source changes. Tracked as #297. ctest dodges it by running each test in its own process.

## Performance

No bench run for this PR — the refactor introduces two private member function calls in a path that already does a `prepare_cached()` lookup and (in the hot case) returns from `find_idle()` without entering `try_grow`. The new functions are private, defined inline in the same class template, and called from a single site — the compiler will inline them. No perf cliff expected.

## Test plan

- [ ] CI green: ninja-debug, ninja-asan-ubsan, ninja-tsan
- [ ] After merge: rebase #295 follow-up branches on develop

Refs #295

🤖 Generated with [Claude Code](https://claude.com/claude-code)