### PR TITLE
refactor(select): extract prepare_statement hot-path helpers (Phase 5a of #295)

### DIFF
--- a/.lint-skip
+++ b/.lint-skip
@@ -4,7 +4,7 @@
 # Rationale per file lives in docs/development/CODE_QUALITY.md.
 
 src/orm/statements/insert.cppm:    file-size
-src/orm/statements/select.cppm:    file-size, complexity, length
+src/orm/statements/select.cppm:    file-size
 src/orm/statements/base.cppm:      file-size, complexity, length
 src/orm/statements/aggregate.cppm: file-size
 src/orm/schema.cppm:                complexity, length

--- a/docs/development/CODE_QUALITY.md
+++ b/docs/development/CODE_QUALITY.md
@@ -108,6 +108,7 @@ After this sweep, `.lint-skip` shrank from 9 entries (across 9 files) to 7 entri
 | PR | File | Tag(s) dropped | Helper(s) introduced | Before → after |
 |---|---|---|---|---|
 | TBD | `src/db/pool.cppm` | `complexity`, `length` (entire line removed) | `try_grow(lock)` + `wait_for_idle(lock, deadline)` extract grow- and wait-paths out of `checkout` | `checkout`: CCN 13 → 5, length 70 → 19 |
+| TBD | `src/orm/statements/select.cppm` | `complexity`, `length` (kept `file-size`) | `prepare_simple_path()`, `rebind_where_only()`, `prepare_and_bind()`, `bind_where_or_propagate()`, plus `is_simple_select()` / `can_use_addr_fast_path()` predicates lift the three dispatch arms out of the hot `prepare_statement` (all `__attribute__((always_inline))`) | `prepare_statement`: CCN 19 → 5, length 66 → 22 |
 
 ### Remaining entries (Phase 5 work plan)
 
@@ -115,8 +116,6 @@ Each row below is a separate sub-PR per the issue's "one PR per file per tag" ru
 
 | File | Tag | Hook says | Phase 5 sub-PR target |
 |---|---|---|---|
-| `src/orm/statements/select.cppm` | `complexity` | 1 function @ CCN 19 | refactor |
-| `src/orm/statements/select.cppm` | `length` | 1 function @ 66 lines | refactor (likely same fn as complexity) |
 | `src/orm/statements/select.cppm` | `file-size` | 612 lines | bench-gated `Kept →` candidate (Phase 2 finding) |
 | `src/orm/statements/base.cppm` | `complexity` | 1 function @ CCN 40 | refactor |
 | `src/orm/statements/base.cppm` | `length` | 1 function @ 130 lines | refactor |

--- a/src/orm/statements/select.cppm
+++ b/src/orm/statements/select.cppm
@@ -424,50 +424,51 @@ export namespace storm::orm::statements {
         // Unified approach: simple SELECT uses dedicated cache, all others use string-based cache
         // OPTIMIZATION: WHERE expression address caching - skips SQL building AND param binding
         // when the same expression is used repeatedly (sqlite3_reset preserves bindings)
-        [[nodiscard]] __attribute__((always_inline)) auto prepare_statement(
-                const std::optional<JoinStatementWrapper>& join_wrapper,
-                const orm::where::ExpressionVariantPtr&    where_expr,
-                const std::optional<int>&                  limit,
-                const std::optional<int>&                  offset,
-                const std::optional<OrderByWrapper>&       order_by_wrapper
-        ) -> std::expected<Statement*, Error> {
-            const bool has_modifiers = order_by_wrapper.has_value() || limit.has_value() || offset.has_value();
-
-            // Fast path: simple SELECT (static SQL, no building needed)
-            if (!where_expr && !join_wrapper && !has_modifiers) {
-                if (cached_simple_stmt_ == nullptr) {
-                    auto prepare_result = conn_->prepare_cached(get_select_sql());
-                    if (!prepare_result) [[unlikely]] {
-                        return std::unexpected(prepare_result.error());
-                    }
-                    cached_simple_stmt_ = *prepare_result;
-                }
-                return cached_simple_stmt_;
+        // Bind WHERE parameters to cached_stmt_ and return any binding error in the
+        // shape callers expect. Shared between rebind_where_only (PG fast path) and
+        // prepare_and_bind (dynamic path).
+        [[nodiscard]] __attribute__((always_inline)) auto
+        bind_where_or_propagate(const orm::where::ExpressionVariantPtr& where_expr) -> std::expected<void, Error> {
+            auto bind_result = Base::template bind_where_params<Statement, Error>(cached_stmt_, where_expr);
+            if (!bind_result) [[unlikely]] {
+                return std::unexpected(bind_result.error());
             }
+            return {};
+        }
 
-            // Fast path: WHERE expression address unchanged — skip SQL building entirely
-            const void* where_addr = where_expr ? static_cast<const void*>(&(*where_expr)) : nullptr;
-            if (cached_stmt_ != nullptr && where_addr == cached_where_addr_ && where_addr != nullptr) {
-                // Rebind only if backend clears params on reset (PostgreSQL does, SQLite doesn't)
-                if constexpr (!Statement::preserves_bindings) { // LCOV_EXCL_START — if constexpr: only instantiated for
-                                                                // PostgreSQL; fast-path return below untested for
-                                                                // execute_one
-                    auto bind_result = Base::template bind_where_params<Statement, Error>(cached_stmt_, where_expr);
-                    if (!bind_result) [[unlikely]] {
-                        return std::unexpected(bind_result.error());
-                    }
+        // Fast path: simple SELECT (no WHERE / JOIN / modifiers). Prepares the static
+        // SQL once and caches the Statement* on the first call.
+        [[nodiscard]] __attribute__((always_inline)) auto prepare_simple_path() -> std::expected<Statement*, Error> {
+            if (cached_simple_stmt_ == nullptr) {
+                auto prepare_result = conn_->prepare_cached(get_select_sql());
+                if (!prepare_result) [[unlikely]] {
+                    return std::unexpected(prepare_result.error());
                 }
-                return cached_stmt_;
-            } // LCOV_EXCL_STOP
+                cached_simple_stmt_ = *prepare_result;
+            }
+            return cached_simple_stmt_;
+        }
 
-            // Dynamic path: build SQL and cache by string comparison.
-            // build_sql() is always_inline — keeps the same codegen as the
-            // previously-inlined SQL builder (see #264 Phase 2 finding).
-            // NOTE: Do NOT add sql.reserve() here - benchmarks show ~2% regression due to
-            // extra function call overhead outweighing reallocation savings for typical SQL sizes
-            std::string sql = build_sql(join_wrapper, where_expr, limit, offset, order_by_wrapper);
+        // Fast path: same WHERE expression as the last call — skip SQL building.
+        // Rebinds parameters only if the backend clears bindings on reset (PostgreSQL).
+        [[nodiscard]] __attribute__((always_inline)) auto
+        rebind_where_only(const orm::where::ExpressionVariantPtr& where_expr) -> std::expected<Statement*, Error> {
+            if constexpr (!Statement::preserves_bindings) { // LCOV_EXCL_START — if constexpr: only instantiated for
+                                                            // PostgreSQL; fast-path return below untested for
+                                                            // execute_one
+                if (auto r = bind_where_or_propagate(where_expr); !r) {
+                    return std::unexpected(r.error());
+                }
+            }
+            return cached_stmt_;
+        } // LCOV_EXCL_STOP
 
-            // Get or prepare cached statement
+        // Dynamic path: prepare-or-reuse statement keyed by SQL string, then bind WHERE
+        // params if any. Always_inline so the call site keeps the same codegen as the
+        // previously-inlined builder (see #264 Phase 2 finding).
+        [[nodiscard]] __attribute__((always_inline)) auto
+        prepare_and_bind(std::string sql, const orm::where::ExpressionVariantPtr& where_expr)
+                -> std::expected<Statement*, Error> {
             if (cached_stmt_ == nullptr || cached_sql_ != sql) {
                 auto prepare_result = conn_->prepare_cached(sql);
                 if (!prepare_result) [[unlikely]] {
@@ -476,19 +477,56 @@ export namespace storm::orm::statements {
                 cached_stmt_ = *prepare_result;
                 cached_sql_  = std::move(sql);
             }
-
-            // Bind WHERE params if needed
             if (where_expr) {
-                auto bind_result = Base::template bind_where_params<Statement, Error>(cached_stmt_, where_expr);
-                if (!bind_result) [[unlikely]] {
-                    return std::unexpected(bind_result.error());
+                if (auto r = bind_where_or_propagate(where_expr); !r) {
+                    return std::unexpected(r.error());
                 }
             }
-
-            // Cache the WHERE expression address for fast-path on next call
-            cached_where_addr_ = where_addr;
-
             return cached_stmt_;
+        }
+
+        // Each of the three stage-selectors lives in its own consteval-friendly
+        // inline helper. Pulling the boolean expressions out of prepare_statement
+        // keeps its cyclomatic complexity to one branch per dispatch arm.
+        [[nodiscard]] __attribute__((always_inline)) static auto is_simple_select(
+                const std::optional<JoinStatementWrapper>& join_wrapper,
+                const orm::where::ExpressionVariantPtr&    where_expr,
+                const std::optional<int>&                  limit,
+                const std::optional<int>&                  offset,
+                const std::optional<OrderByWrapper>&       order_by_wrapper
+        ) -> bool {
+            const bool has_modifiers = order_by_wrapper.has_value() || limit.has_value() || offset.has_value();
+            const bool has_filters   = where_expr || join_wrapper.has_value();
+            return !has_filters && !has_modifiers;
+        }
+
+        [[nodiscard]] __attribute__((always_inline)) auto can_use_addr_fast_path(const void* where_addr) const -> bool {
+            const bool have_cache = cached_stmt_ != nullptr && cached_where_addr_ != nullptr;
+            return have_cache && where_addr == cached_where_addr_;
+        }
+
+        [[nodiscard]] __attribute__((always_inline)) auto prepare_statement(
+                const std::optional<JoinStatementWrapper>& join_wrapper,
+                const orm::where::ExpressionVariantPtr&    where_expr,
+                const std::optional<int>&                  limit,
+                const std::optional<int>&                  offset,
+                const std::optional<OrderByWrapper>&       order_by_wrapper
+        ) -> std::expected<Statement*, Error> {
+            if (is_simple_select(join_wrapper, where_expr, limit, offset, order_by_wrapper)) {
+                return prepare_simple_path();
+            }
+            const void* where_addr = where_expr ? static_cast<const void*>(&(*where_expr)) : nullptr;
+            if (can_use_addr_fast_path(where_addr)) {
+                return rebind_where_only(where_expr);
+            }
+            // NOTE: Do NOT add sql.reserve() here - benchmarks show ~2% regression due to
+            // extra function call overhead outweighing reallocation savings for typical SQL sizes
+            auto stmt =
+                    prepare_and_bind(build_sql(join_wrapper, where_expr, limit, offset, order_by_wrapper), where_expr);
+            if (stmt) {
+                cached_where_addr_ = where_addr;
+            }
+            return stmt;
         }
 
         // =====================================================================


### PR DESCRIPTION
## Summary

Phase 5a sub-PR for #295. `SelectStatement::prepare_statement` was at CCN 19 / 66 lines, holding three orthogonal dispatch arms (simple-SELECT cache, WHERE-address fast path, dynamic SQL build+prepare+bind) in one function. Lift each arm into its own private `always_inline` helper.

**Stacked on #298** — base is `feature/295-pool-complexity`. Retargets to `develop` once the parent merges.

## Changes

| Function | CCN | Length |
|---|---|---|
| `prepare_statement` (before) | 19 | 66 |
| `prepare_statement` (after) | **5** | **22** |
| `prepare_simple_path` (new) | 3 | 10 |
| `rebind_where_only` (new) | 4 | 12 |
| `prepare_and_bind` (new) | 6 | 18 |
| `bind_where_or_propagate` (new) | 3 | 8 |
| `is_simple_select` (new) | 5 | 11 |
| `can_use_addr_fast_path` (new) | 3 | 4 |

All six helpers carry `__attribute__((always_inline))` so the call site keeps the same codegen as the previously-inlined builder. The Phase 2 finding (#264 comment 4462154303) warns about ~2% regression from extra call overhead in this exact path — bench-gated below to confirm the inline hints actually held.

## `.lint-skip` + docs

Drops `complexity, length` from `src/orm/statements/select.cppm` (keeps `file-size` — file is 633 lines, still over 600). Phase 5 docs table gains this PR's row.

Lizard on `select.cppm` post-refactor:
- max CCN: **7** (`rows_generator`, untouched) — under limit 10
- max length: **42 lines** — under limit 60
- file size: 633 lines — still over 600 (separate sub-PR)

## Boxes ticked on #295

- complexity: `src/orm/statements/select.cppm`
- length: `src/orm/statements/select.cppm`

## Verification

- `ninja-debug` `SelectTest*` : **8/8 pass** (baseline)
- broader subset (SelectTest+QuerySet+Join+Where+OrderBy+Distinct+GroupBy): **135/135 pass**
- pre-commit hook ctest: **1908/1908 pass**
- `ninja-tsan` (SelectTest+QuerySet+Join+Where): **44/44 pass, no thread warnings**
- Hook re-run on `select.cppm`: 0 violations for complexity, length, duplicate

### Bench-gate (Phase 2 perf finding)

5 repetitions, `--benchmark_min_time=0.5s`, `Storm/SELECT/select`:

| N | Baseline median | Refactor median | Δ |
|---|---|---|---|
| 100 | 19010 ns | 18966 ns | **-0.23%** |
| 1000 | 190328 ns | 189003 ns | **-0.70%** |
| 10000 | 1918037 ns | 1889729 ns | **-1.48%** |
| 100000 | 19734984 ns | 19637647 ns | **-0.49%** |

**Refactor is within noise — slight improvement at every size.** The `always_inline` hints folded the helpers back into `prepare_statement`'s hot path, so the Phase 2 perf finding (~2% regression on function-call overhead) does not apply here.

## Test plan

- [ ] CI green: ninja-debug, ninja-asan-ubsan, ninja-tsan
- [ ] After parent merge: retarget base to `develop` and re-rebase

Refs #295

🤖 Generated with [Claude Code](https://claude.com/claude-code)