### PR TITLE
refactor(base): dispatch extract_column_value by storage class (Phase 5a of #295)

### DIFF
--- a/.lint-skip
+++ b/.lint-skip
@@ -5,7 +5,7 @@
 
 src/orm/statements/insert.cppm:    file-size
 src/orm/statements/select.cppm:    file-size
-src/orm/statements/base.cppm:      file-size, complexity, length
+src/orm/statements/base.cppm:      file-size
 src/orm/statements/aggregate.cppm: file-size
 src/orm/schema.cppm:                complexity, length
 src/orm/utilities.cppm:             complexity, length

--- a/docs/development/CODE_QUALITY.md
+++ b/docs/development/CODE_QUALITY.md
@@ -109,6 +109,7 @@ After this sweep, `.lint-skip` shrank from 9 entries (across 9 files) to 7 entri
 |---|---|---|---|---|
 | TBD | `src/db/pool.cppm` | `complexity`, `length` (entire line removed) | `try_grow(lock)` + `wait_for_idle(lock, deadline)` extract grow- and wait-paths out of `checkout` | `checkout`: CCN 13 → 5, length 70 → 19 |
 | TBD | `src/orm/statements/select.cppm` | `complexity`, `length` (kept `file-size`) | `prepare_simple_path()`, `rebind_where_only()`, `prepare_and_bind()`, `bind_where_or_propagate()`, plus `is_simple_select()` / `can_use_addr_fast_path()` predicates lift the three dispatch arms out of the hot `prepare_statement` (all `__attribute__((always_inline))`) | `prepare_statement`: CCN 19 → 5, length 66 → 22 |
+| TBD | `src/orm/statements/base.cppm` | `complexity`, `length` (kept `file-size`) | `is_int_stored_v` / `is_int64_stored_v` / `is_integer_stored_v` / `is_floating_stored_v` / `is_blob_stored_v` / `is_text_stored_v` predicates group source types by storage class; `read_text_view()`, `extract_int_like()`, `extract_floating_like()`, `extract_enum()`, `extract_text_like()`, `extract_blob_like()` helpers handle one storage class each (all `__attribute__((always_inline))`) | `extract_column_value`: CCN 40 → 10, length 130 → 34 |
 
 ### Remaining entries (Phase 5 work plan)
 
@@ -117,8 +118,6 @@ Each row below is a separate sub-PR per the issue's "one PR per file per tag" ru
 | File | Tag | Hook says | Phase 5 sub-PR target |
 |---|---|---|---|
 | `src/orm/statements/select.cppm` | `file-size` | 612 lines | bench-gated `Kept →` candidate (Phase 2 finding) |
-| `src/orm/statements/base.cppm` | `complexity` | 1 function @ CCN 40 | refactor |
-| `src/orm/statements/base.cppm` | `length` | 1 function @ 130 lines | refactor |
 | `src/orm/statements/base.cppm` | `file-size` | 832 lines | bench-gated `Kept →` candidate |
 | `src/orm/statements/aggregate.cppm` | `file-size` | 693 lines | refactor candidate (no Phase 2 finding) |
 | `src/orm/schema.cppm` | `complexity` | 1 function @ CCN 63 | refactor |

--- a/src/orm/statements/base.cppm
+++ b/src/orm/statements/base.cppm
@@ -392,134 +392,163 @@ export namespace storm::orm::statements {
             );
         }
 
-        // Shared column extraction utility - returns value of specified type from given column index
-        // Handles: int, int64_t, uint64_t, short, float, double, bool, string, optional<T>, vector<uint8_t>
-        // NOLINTBEGIN(readability-function-cognitive-complexity) — type-dispatch over every supported
-        // SQL column type; merging would hide each branch's distinct extraction call.
+        // ---- Storage-class predicates ---------------------------------------------------
+        // Each predicate groups the source types that share one extract_* backend call.
+        // Used by extract_column_value() to dispatch by storage class, not by source type.
+
+        template <typename FT>
+        static constexpr bool is_int_stored_v =
+                std::is_same_v<FT, int> || std::is_same_v<FT, short> || std::is_same_v<FT, unsigned short> ||
+                std::is_same_v<FT, unsigned int> || std::is_same_v<FT, signed char> ||
+                std::is_same_v<FT, unsigned char> || std::is_same_v<FT, char>;
+
+        template <typename FT>
+        static constexpr bool is_int64_stored_v =
+                std::is_same_v<FT, int64_t> || std::is_same_v<FT, long> || std::is_same_v<FT, long long> ||
+                std::is_same_v<FT, uint64_t> || std::is_same_v<FT, unsigned long> ||
+                std::is_same_v<FT, unsigned long long>;
+
+        template <typename FT> static constexpr bool is_integer_stored_v = is_int_stored_v<FT> || is_int64_stored_v<FT>;
+
+        template <typename FT>
+        static constexpr bool is_floating_stored_v = std::is_same_v<FT, double> || std::is_same_v<FT, float>;
+
+        template <typename FT>
+        static constexpr bool is_blob_stored_v =
+                std::is_same_v<FT, std::vector<uint8_t>> || std::is_same_v<FT, std::vector<unsigned char>> ||
+                std::is_same_v<FT, std::vector<std::byte>>;
+
+        template <typename FT>
+        static constexpr bool is_text_stored_v = std::is_same_v<FT, std::chrono::year_month_day> ||
+                                                 std::is_same_v<FT, std::chrono::system_clock::time_point> ||
+                                                 std::is_same_v<FT, std::filesystem::path> ||
+                                                 std::is_same_v<FT, utilities::UUID> || std::is_same_v<FT, std::string>;
+
+        // ---- Storage-class extraction helpers --------------------------------------------
+        // Each helper handles one storage class. extract_column_value() dispatches to
+        // exactly one helper per FieldType. All marked always_inline so the call site
+        // collapses to the same machine code as the inlined branch did before.
+
+        template <typename Statement>
+        [[nodiscard]] __attribute__((always_inline)) static auto read_text_view(Statement* stmt, int col_idx) noexcept
+                -> std::string_view {
+            const unsigned char* text = stmt->extract_text_ptr(col_idx);
+            if (text == nullptr) {
+                return {};
+            }
+            return std::string_view(reinterpret_cast<const char*>(text), stmt->extract_bytes(col_idx));
+        }
+
+        template <typename FieldType, typename Statement>
+        [[nodiscard]] __attribute__((always_inline)) static auto extract_int_like(Statement* stmt, int col_idx) noexcept
+                -> FieldType {
+            if constexpr (is_int_stored_v<FieldType>) {
+                return static_cast<FieldType>(stmt->extract_int(col_idx));
+            } else {
+                static_assert(is_int64_stored_v<FieldType>, "extract_int_like: caller must pre-check storage class");
+                return static_cast<FieldType>(stmt->extract_int64(col_idx));
+            }
+        }
+
         template <typename FieldType, typename Statement>
         [[nodiscard]] __attribute__((always_inline)) static auto
-        extract_column_value(Statement* stmt, int col_idx) noexcept -> FieldType { // NOSONAR
-            // Handle std::optional types first
+        extract_floating_like(Statement* stmt, int col_idx) noexcept -> FieldType {
+            if constexpr (std::is_same_v<FieldType, double>) {
+                return stmt->extract_double(col_idx);
+            } else {
+                static_assert(
+                        std::is_same_v<FieldType, float>, "extract_floating_like: caller must pre-check storage class"
+                );
+                return stmt->extract_float(col_idx);
+            }
+        }
+
+        template <typename FieldType, typename Statement>
+        [[nodiscard]] __attribute__((always_inline)) static auto extract_enum(Statement* stmt, int col_idx) noexcept
+                -> FieldType {
+            using Underlying = std::underlying_type_t<FieldType>;
+            if constexpr (sizeof(Underlying) <= sizeof(int)) {
+                return static_cast<FieldType>(stmt->extract_int(col_idx));
+            } else {
+                return static_cast<FieldType>(stmt->extract_int64(col_idx));
+            }
+        }
+
+        template <typename FieldType, typename Statement>
+        [[nodiscard]] __attribute__((always_inline)) static auto
+        extract_text_like(Statement* stmt, int col_idx) noexcept -> FieldType {
+            const std::string_view view = read_text_view(stmt, col_idx);
+            if constexpr (std::is_same_v<FieldType, std::chrono::year_month_day>) {
+                if (view.empty()) {
+                    return FieldType{}; // LCOV_EXCL_LINE — NOT NULL column, defensive fallback
+                }
+                return utilities::chrono_conv::string_to_ymd(view);
+            } else if constexpr (std::is_same_v<FieldType, std::chrono::system_clock::time_point>) {
+                if (view.empty()) {
+                    return FieldType{}; // LCOV_EXCL_LINE — NOT NULL column, defensive fallback
+                }
+                return utilities::chrono_conv::string_to_tp(view);
+            } else if constexpr (std::is_same_v<FieldType, std::filesystem::path>) {
+                if (view.empty()) {
+                    return FieldType{}; // LCOV_EXCL_LINE — NOT NULL column, defensive fallback
+                }
+                return std::filesystem::path(std::string(view));
+            } else if constexpr (std::is_same_v<FieldType, utilities::UUID>) {
+                if (view.empty()) {
+                    return FieldType{}; // LCOV_EXCL_LINE — NOT NULL column, defensive fallback
+                }
+                return utilities::UUID{std::string(view)};
+            } else {
+                static_assert(std::is_same_v<FieldType, std::string>, "extract_text_like: unhandled text storage type");
+                return FieldType(view);
+            }
+        }
+
+        template <typename FieldType, typename Statement>
+        [[nodiscard]] __attribute__((always_inline)) static auto
+        extract_blob_like(Statement* stmt, int col_idx) noexcept -> FieldType {
+            const void* blob = stmt->extract_blob_ptr(col_idx);
+            const int   size = stmt->extract_bytes(col_idx);
+            if (blob == nullptr || size <= 0) {
+                return FieldType{};
+            }
+            using Byte       = typename FieldType::value_type;
+            const auto* data = static_cast<const Byte*>(blob);
+            return FieldType(data, data + size);
+        }
+
+        // Shared column extraction utility — returns value of specified type from given
+        // column index. Dispatches by storage class to one of the extract_* helpers above.
+        // Supported FieldType groups: optional<T>, bool, int-stored ints, int64-stored
+        // ints, enum, double, float, chrono duration, text-stored types, blob-stored types.
+        template <typename FieldType, typename Statement>
+        [[nodiscard]] __attribute__((always_inline)) static auto
+        extract_column_value(Statement* stmt, int col_idx) noexcept -> FieldType {
             if constexpr (utilities::is_optional_v<FieldType>) {
                 using InnerType = typename FieldType::value_type;
                 if (stmt->is_null(col_idx)) {
                     return std::nullopt;
                 }
-                InnerType inner_value = extract_column_value<InnerType>(stmt, col_idx);
-                return FieldType{std::move(inner_value)};
-            }
-            // Boolean type (stored as INTEGER 0/1)
-            else if constexpr (std::is_same_v<FieldType, bool>) {
+                return FieldType{extract_column_value<InnerType>(stmt, col_idx)};
+            } else if constexpr (std::is_same_v<FieldType, bool>) {
                 return stmt->extract_bool(col_idx);
-            }
-            // Integer types
-            else if constexpr (std::is_same_v<FieldType, int>) {
-                return stmt->extract_int(col_idx);
-            } else if constexpr (std::is_same_v<FieldType, int64_t> || std::is_same_v<FieldType, long> ||
-                                 std::is_same_v<FieldType, long long> || std::is_same_v<FieldType, uint64_t> ||
-                                 std::is_same_v<FieldType, unsigned long> ||
-                                 std::is_same_v<FieldType, unsigned long long>) {
-                return static_cast<FieldType>(stmt->extract_int64(col_idx));
-            } else if constexpr (std::is_same_v<FieldType, short> || std::is_same_v<FieldType, unsigned short> ||
-                                 std::is_same_v<FieldType, unsigned int>) {
-                return static_cast<FieldType>(stmt->extract_int(col_idx));
-            }
-            // Char types (stored as INTEGER)
-            else if constexpr (std::is_same_v<FieldType, signed char> || std::is_same_v<FieldType, unsigned char> ||
-                               std::is_same_v<FieldType, char>) {
-                return static_cast<FieldType>(stmt->extract_int(col_idx));
-            }
-            // Enum types (stored as INTEGER via underlying type)
-            else if constexpr (std::is_enum_v<FieldType>) {
-                using Underlying = std::underlying_type_t<FieldType>;
-                if constexpr (sizeof(Underlying) <= sizeof(int)) {
-                    return static_cast<FieldType>(stmt->extract_int(col_idx));
-                } else {
-                    return static_cast<FieldType>(stmt->extract_int64(col_idx));
-                }
-            }
-            // Floating point types
-            else if constexpr (std::is_same_v<FieldType, double>) {
-                return stmt->extract_double(col_idx);
-            } else if constexpr (std::is_same_v<FieldType, float>) {
-                return stmt->extract_float(col_idx);
-            }
-            // Chrono date type (stored as TEXT "YYYY-MM-DD")
-            else if constexpr (std::is_same_v<FieldType, std::chrono::year_month_day>) {
-                const unsigned char* text = stmt->extract_text_ptr(col_idx);
-                if (text) {
-                    int len = stmt->extract_bytes(col_idx);
-                    return utilities::chrono_conv::string_to_ymd(
-                            std::string_view(reinterpret_cast<const char*>(text), len)
-                    );
-                }
-                return FieldType{}; // LCOV_EXCL_LINE — NOT NULL column, defensive fallback
-            }
-            // Chrono datetime type (stored as TEXT "YYYY-MM-DD HH:MM:SS")
-            else if constexpr (std::is_same_v<FieldType, std::chrono::system_clock::time_point>) {
-                const unsigned char* text = stmt->extract_text_ptr(col_idx);
-                if (text) {
-                    int len = stmt->extract_bytes(col_idx);
-                    return utilities::chrono_conv::string_to_tp(
-                            std::string_view(reinterpret_cast<const char*>(text), len)
-                    );
-                }
-                return FieldType{}; // LCOV_EXCL_LINE — NOT NULL column, defensive fallback
-            }
-            // Chrono duration types (stored as INTEGER — raw count)
-            else if constexpr (utilities::is_chrono_duration_v<FieldType>) {
+            } else if constexpr (is_integer_stored_v<FieldType>) {
+                return extract_int_like<FieldType>(stmt, col_idx);
+            } else if constexpr (std::is_enum_v<FieldType>) {
+                return extract_enum<FieldType>(stmt, col_idx);
+            } else if constexpr (is_floating_stored_v<FieldType>) {
+                return extract_floating_like<FieldType>(stmt, col_idx);
+            } else if constexpr (utilities::is_chrono_duration_v<FieldType>) {
                 return FieldType{static_cast<typename FieldType::rep>(stmt->extract_int64(col_idx))};
-            }
-            // Filesystem path (stored as TEXT)
-            else if constexpr (std::is_same_v<FieldType, std::filesystem::path>) {
-                const unsigned char* text = stmt->extract_text_ptr(col_idx);
-                if (text) {
-                    int len = stmt->extract_bytes(col_idx);
-                    return std::filesystem::path(std::string(reinterpret_cast<const char*>(text), len));
-                }
-                return FieldType{}; // LCOV_EXCL_LINE — NOT NULL column, defensive fallback
-            }
-            // BLOB types
-            else if constexpr (std::is_same_v<FieldType, std::vector<uint8_t>> ||
-                               std::is_same_v<FieldType, std::vector<unsigned char>>) {
-                const void* blob = stmt->extract_blob_ptr(col_idx);
-                const int   size = stmt->extract_bytes(col_idx);
-                if (blob && size > 0) {
-                    const auto* data = static_cast<const uint8_t*>(blob);
-                    return FieldType(data, data + size);
-                }
-                return FieldType{};
-            }
-            // BLOB type (std::vector<std::byte>)
-            else if constexpr (std::is_same_v<FieldType, std::vector<std::byte>>) {
-                const void* blob = stmt->extract_blob_ptr(col_idx);
-                const int   size = stmt->extract_bytes(col_idx);
-                if (blob && size > 0) {
-                    const auto* data = static_cast<const std::byte*>(blob);
-                    return FieldType(data, data + size);
-                }
-                return FieldType{};
-            }
-            // UUID type (stored as TEXT)
-            else if constexpr (std::is_same_v<FieldType, utilities::UUID>) {
-                const unsigned char* text = stmt->extract_text_ptr(col_idx);
-                if (text) {
-                    int len = stmt->extract_bytes(col_idx);
-                    return utilities::UUID{std::string(reinterpret_cast<const char*>(text), len)};
-                }
-                return FieldType{}; // LCOV_EXCL_LINE — NOT NULL column, defensive fallback
-            }
-            // String types
-            else if constexpr (std::is_same_v<FieldType, std::string>) {
-                const unsigned char* text = stmt->extract_text_ptr(col_idx);
-                if (text) {
-                    int len = stmt->extract_bytes(col_idx);
-                    return FieldType(reinterpret_cast<const char*>(text), len);
-                }
-                return FieldType{};
+            } else if constexpr (is_text_stored_v<FieldType>) {
+                return extract_text_like<FieldType>(stmt, col_idx);
+            } else if constexpr (is_blob_stored_v<FieldType>) {
+                return extract_blob_like<FieldType>(stmt, col_idx);
             } else {
+                // FieldType-dependent false so the assertion only fires when this
+                // branch is selected (i.e. when none of the supported groups matched).
                 static_assert(
-                        std::is_same_v<FieldType, int> || std::is_same_v<FieldType, std::string>,
+                        !std::is_same_v<FieldType, FieldType>,
                         "Unsupported field type for column extraction. Supported types: "
                         "int, int64_t, long, short, char, unsigned variants, enum, "
                         "float, double, bool, std::string, chrono types, "
@@ -528,7 +557,6 @@ export namespace storm::orm::statements {
                 );
             }
         }
-        // NOLINTEND(readability-function-cognitive-complexity)
 
         // =====================================================================
         // COLUMN EXTRACTION HELPERS - Moved here from SelectStatement so that


### PR DESCRIPTION
## Summary

Phase 5a sub-PR for #295. `BaseStatement::extract_column_value` was at CCN 40 / 130 lines — a long `if constexpr` chain with one branch per source type (16+ branches across int, long, char, enum, float, double, bool, string, chrono ymd/tp/duration, filesystem::path, UUID, two `std::vector<…>` blob flavours, and `std::optional<T>`).

The CCN wasn't a runtime cost — only one branch survives compilation per `FieldType` — but the source-level density tripped the smell hook and the function was hard to navigate.

**Stacked on #299** — base is `feature/295-select-complexity`. Will retarget to `develop` once the parent merges.

## Approach: group by storage class

Source types that share the same `stmt->extract_X()` backend call collapse into one outer branch. The inner helper picks the right call for that specific source type. Same generated code, far less source-level dispatch.

### Predicates added (`static constexpr bool ..._v`)

| Predicate | Source types covered |
|---|---|
| `is_int_stored_v<T>` | `int`, `short`, `unsigned short`, `unsigned int`, `signed/unsigned char`, `char` |
| `is_int64_stored_v<T>` | `int64_t`, `long`, `long long`, `uint64_t`, `unsigned long`, `unsigned long long` |
| `is_integer_stored_v<T>` | union of the two above |
| `is_floating_stored_v<T>` | `double`, `float` |
| `is_text_stored_v<T>` | `chrono::year_month_day`, `chrono::system_clock::time_point`, `filesystem::path`, `utilities::UUID`, `std::string` |
| `is_blob_stored_v<T>` | `std::vector<uint8_t>`, `std::vector<unsigned char>`, `std::vector<std::byte>` |

### Storage-class helpers (all `__attribute__((always_inline))`)

- `read_text_view(stmt, idx)` — shared `text_ptr + bytes → string_view` (empty if null)
- `extract_int_like<T>(stmt, idx)` — `extract_int` or `extract_int64` by storage class
- `extract_floating_like<T>(stmt, idx)` — `extract_double` or `extract_float`
- `extract_enum<T>(stmt, idx)` — `sizeof`-dispatch to int or int64
- `extract_text_like<T>(stmt, idx)` — construct T from the shared `string_view` (empty fallback)
- `extract_blob_like<T>(stmt, idx)` — shared `blob_ptr + bytes` loop, parameterised on `T::value_type`

### Before → after

| Function | CCN | Length |
|---|---|---|
| `extract_column_value` (before) | **40** | **130** |
| `extract_column_value` (after) | **10** | **34** |
| `extract_text_like` (helper) | 9 | 28 |
| `extract_blob_like` (helper) | 3 | 9 |
| `read_text_view` (helper) | 2 | 5 |
| Other new helpers | ≤ 5 | ≤ 12 |

The `NOLINTBEGIN(readability-function-cognitive-complexity)` block and `// NOSONAR` comment around the old function are gone — the new shape doesn't need them.

The fallback `static_assert` now uses a `FieldType`-dependent `false` predicate (`!std::is_same_v<FieldType, FieldType>`) so it only fires when none of the storage groups match. The old predicate (`is_same_v<T,int> || is_same_v<T,std::string>`) was logically wrong and added one CCN point on top.

## `.lint-skip` + docs

- Drops `complexity, length` from `src/orm/statements/base.cppm`. Keeps `file-size` (832 lines, separate sub-PR).
- `docs/development/CODE_QUALITY.md` Phase 5 audit table gains this PR's row.

## Boxes ticked on #295

- complexity: `src/orm/statements/base.cppm`
- length: `src/orm/statements/base.cppm`

## Verification

- `ctest --preset ninja-debug`: **1908/1908 pass**
- Direct binary `SelectTest + OptionalAggregateTest + QuerySetCrudLifecycleTest + DistinctTest` subset (178 tests, half SQLite, half PG-skipped): **89/89 SQLite pass**
- `ninja-tsan` subset (40 tests): **20/20 SQLite pass, no thread warnings**
- Hook re-run on `base.cppm`: 0 complexity, 0 length, 0 duplicate violations

### Bench-gate

5 reps, `--benchmark_min_time=1s`, `Storm/SELECT/select`:

| N | Baseline median | Refactor median | Δ |
|---|---|---|---|
| 1,000 | 191,563 ns | 189,751 ns | **-0.95%** |
| 10,000 | 1,909,508 ns | 1,919,576 ns | **+0.53%** |

Both within ±1%. The `always_inline` hints on every helper let the compiler fold the storage-class dispatch back into the same machine code as the original per-source-type branching. The Phase 2 ~2% threshold is respected.

## Flaky test note

`MockPoolTest.Checkout_ShutdownDuringWait` was observed flaky during verification — passes 4/5 times in isolation, reproducible on develop without any source change. Filed as #300. Not a regression introduced by this PR.

## Test plan

- [ ] CI green: ninja-debug, ninja-asan-ubsan, ninja-tsan
- [ ] After parent merge: retarget base to `develop` and re-rebase

Refs #295

🤖 Generated with [Claude Code](https://claude.com/claude-code)