### PR TITLE
test(pool): make Checkout_ShutdownDuringWait deterministic (#300)

### DIFF
--- a/tests/db/test_pool.cpp
+++ b/tests/db/test_pool.cpp
@@ -15,6 +15,7 @@ import <thread>;
 import <vector>;
 import <atomic>;
 import <chrono>;
+import <latch>;
 
 #include "test_models.h" // NOSONAR cpp:S954
 
@@ -930,32 +931,33 @@ TEST_F(MockPoolTest, Checkout_ShutdownDuringWait) {
     auto c1 = pool->checkout();
     ASSERT_TRUE(c1.has_value());
 
-    // Waiter thread blocks inside cv_.wait_until() because the only connection is held by c1.
+    // Deterministic sequence (no timing races, fixes #300):
+    //   1. Waiter starts and counts down `waiter_started` immediately before calling
+    //      checkout(). Main blocks on that latch — guarantees the waiter is at (or
+    //      microseconds away from) cv_.wait_until before we proceed.
+    //   2. Main spawns shutdown_thread. shutdown() sets shutdown_ = true, notify_all()s,
+    //      then blocks on cv_.wait until in_use == 0 (c1 still holds the only conn).
+    //   3. Whichever thread reaches the mutex first, the waiter's checkout() will see
+    //      shutdown_ == true — either via the early-return at the top of checkout()
+    //      (if shutdown_thread ran first) or via the shutdown_ re-check inside
+    //      wait_for_idle (if the waiter ran first). Either way: got_error == true.
+    //   4. waiter.join() returns once the waiter has set got_error.
+    //   5. Only then we reset c1, which lets shutdown_thread's cv_.wait observe
+    //      in_use == 0 and complete.
     std::atomic<bool> got_error{false};
-    std::thread       waiter([&pool, &got_error] {
+    std::latch        waiter_started{1};
+    std::thread       waiter([&pool, &got_error, &waiter_started] {
+        waiter_started.count_down();
         auto c    = pool->checkout();
         got_error = !c.has_value();
     });
 
-    // Spawn shutdown in a separate thread BEFORE returning c1. shutdown() will:
-    //   1. Set shutdown_ = true and notify_all() — wakes the waiter, which sees shutdown_
-    //      and returns an error.
-    //   2. Block on cv_.wait until c1 is returned (still in_use).
-    // Then we return c1 → shutdown_thread completes. This sequencing makes the test
-    // deterministic regardless of how quickly the waiter reached cv_.wait_until() —
-    // the previous version had a 50ms sleep race (#300).
+    waiter_started.wait();
     std::thread shutdown_thread([&pool] { pool->shutdown(); });
 
-    // Give shutdown a chance to set shutdown_ and notify the waiter. This sleep does
-    // not need to be precise: even if shutdown_ is set after the waiter wakes from
-    // c1's checkin notify, the waiter's loop in wait_for_idle re-checks shutdown_ on
-    // every iteration. The only requirement is that shutdown_thread runs before c1's
-    // reset triggers checkin → notify → waiter retry.
-    std::this_thread::sleep_for(std::chrono::milliseconds(50));
-
-    c1->reset(); // Return c1 → shutdown_thread completes its cv_.wait.
-    shutdown_thread.join();
     waiter.join();
+    c1->reset(); // Return c1 → shutdown_thread's cv_.wait predicate becomes true.
+    shutdown_thread.join();
     EXPECT_TRUE(got_error);
 }
 


### PR DESCRIPTION
## Summary

Replaces the 50 ms timing sleep in `MockPoolTest.Checkout_ShutdownDuringWait` with a `std::latch` + strict join ordering. The pool module itself is unchanged — this was a **false-negative test flake**, not a real bug.

## Root cause

The test relied on `sleep_for(50ms)` to let `shutdown_thread` acquire the mutex and set `shutdown_ = true` before `c1->reset()` ran. When the OS scheduler delayed the shutdown thread past 50 ms, `c1->reset()` returned the connection first, the waiter saw an idle slot, and `got_error` ended up `false`.

## Fix

1. Waiter signals a `std::latch` immediately before calling `pool->checkout()`.
2. Main waits on the latch, then spawns `shutdown_thread`.
3. Main joins the **waiter first** — guaranteeing the waiter has observed `shutdown_ = true` via either `checkout()`'s early-return or `wait_for_idle()`'s re-check.
4. Only then resets `c1`, which lets `shutdown_thread`'s `cv_.wait` predicate become true.

No more sleeps; no production-code changes.

## Test plan

- [x] 200 sequential repeats (`--gtest_repeat=200`) — all pass
- [x] 8 parallel × 20 repeats (contended scheduler) — all pass
- [x] TSAN (`ninja-tsan`) — clean, no data races
- [x] ASAN + UBSAN (`ninja-asan-ubsan`) — clean
- [x] Full `ctest --preset ninja-debug` — 1908/1908 pass

Closes #300

🤖 Generated with [Claude Code](https://claude.com/claude-code)