### PR TITLE
fix(error): make Error non-allocating; enable bugprone-exception-escape

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -21,10 +21,6 @@
 #   function argument (e.g. `make_shared<T>(std::move(param))`) — clang-tidy doesn't see through it.
 # - cppcoreguidelines-avoid-non-const-global-variables: fires on consteval lambdas inside concept
 #   definitions; concepts are not variables.
-# - bugprone-exception-escape: noexcept functions in postgresql_statement.cppm call vector::resize
-#   (pre-reserved to MAX_DB_VARIABLES so OOM is practically impossible) and construct Error values
-#   with std::string message fields. Error{code, msg} construction itself can throw bad_alloc, making
-#   it impossible to write a catch block that satisfies this check without changing the Error type.
 # - cppcoreguidelines-pro-type-vararg: std::snprintf is the only portable way to format doubles
 #   with %.17g precision; std::format alternative is not available in noexcept hot paths.
 #
@@ -48,7 +44,6 @@ Checks: >
   bugprone-*,
   -bugprone-argument-comment,
   -bugprone-easily-swappable-parameters,
-  -bugprone-exception-escape,
   cert-*,
   -cert-err33-c,
   -cert-err58-cpp,

--- a/src/db/concept.cppm
+++ b/src/db/concept.cppm
@@ -1,6 +1,8 @@
 module;
 
 export module storm_db_concept;
+import <array>;
+import <cstring>;
 import <expected>;
 import <string_view>;
 import <string>;
@@ -9,6 +11,35 @@ import <cstddef>;
 import <functional>;
 
 export namespace storm::db {
+
+    // Error type for database operations.
+    // Non-allocating: stores the message inline so construction is noexcept and Error can
+    // be returned from noexcept catch blocks without risking bad_alloc (issue #316).
+    struct Error {
+        static constexpr std::size_t kMaxMessageLen = 255;
+
+        int                                  code_{0};
+        std::array<char, kMaxMessageLen + 1> message_buf_{};
+        std::size_t                          message_len_{0};
+
+        Error() noexcept = default;
+
+        Error(int code, std::string_view msg) noexcept : code_{code} {
+            const std::size_t n = msg.size() < kMaxMessageLen ? msg.size() : kMaxMessageLen;
+            if (n > 0) {
+                std::memcpy(message_buf_.data(), msg.data(), n);
+            }
+            message_buf_[n] = '\0';
+            message_len_    = n;
+        }
+
+        [[nodiscard]] constexpr auto code() const noexcept -> int {
+            return code_;
+        }
+        [[nodiscard]] constexpr auto message() const noexcept -> std::string_view {
+            return std::string_view{message_buf_.data(), message_len_};
+        }
+    };
 
     // Forward declarations for concept requirements
     template <typename T> struct ConnectionTraits;

--- a/src/db/postgresql_error.cppm
+++ b/src/db/postgresql_error.cppm
@@ -1,40 +1,11 @@
 module;
 
 export module storm_db_postgresql_error;
-import <array>;
-import <cstddef>;
-import <cstring>;
-import <string_view>;
+import storm_db_concept;
 
 export namespace storm::db::postgresql {
 
-    // Error type for database operations.
-    // Non-allocating: stores the message inline so construction is noexcept and Error can
-    // be returned from noexcept catch blocks without risking bad_alloc (issue #316).
-    struct Error {
-        static constexpr std::size_t kMaxMessageLen = 255;
-
-        int                                  code_{0};
-        std::array<char, kMaxMessageLen + 1> message_buf_{};
-        std::size_t                          message_len_{0};
-
-        Error() noexcept = default;
-
-        Error(int code, std::string_view msg) noexcept : code_{code} {
-            const std::size_t n = msg.size() < kMaxMessageLen ? msg.size() : kMaxMessageLen;
-            if (n > 0) {
-                std::memcpy(message_buf_.data(), msg.data(), n);
-            }
-            message_buf_[n] = '\0';
-            message_len_    = n;
-        }
-
-        [[nodiscard]] constexpr auto code() const noexcept -> int {
-            return code_;
-        }
-        [[nodiscard]] constexpr auto message() const noexcept -> std::string_view {
-            return std::string_view{message_buf_.data(), message_len_};
-        }
-    };
+    // Error type — shared across backends, defined in storm_db_concept (issue #316).
+    using Error = storm::db::Error;
 
 } // namespace storm::db::postgresql

--- a/src/db/postgresql_error.cppm
+++ b/src/db/postgresql_error.cppm
@@ -1,21 +1,39 @@
 module;
 
 export module storm_db_postgresql_error;
-import <string>;
+import <array>;
+import <cstddef>;
+import <cstring>;
 import <string_view>;
 
 export namespace storm::db::postgresql {
 
-    // Error type for database operations
+    // Error type for database operations.
+    // Non-allocating: stores the message inline so construction is noexcept and Error can
+    // be returned from noexcept catch blocks without risking bad_alloc (issue #316).
     struct Error {
-        int         code_;
-        std::string message_;
+        static constexpr std::size_t kMaxMessageLen = 255;
+
+        int                                  code_{0};
+        std::array<char, kMaxMessageLen + 1> message_buf_{};
+        std::size_t                          message_len_{0};
+
+        Error() noexcept = default;
+
+        Error(int code, std::string_view msg) noexcept : code_{code} {
+            const std::size_t n = msg.size() < kMaxMessageLen ? msg.size() : kMaxMessageLen;
+            if (n > 0) {
+                std::memcpy(message_buf_.data(), msg.data(), n);
+            }
+            message_buf_[n] = '\0';
+            message_len_    = n;
+        }
 
         [[nodiscard]] constexpr auto code() const noexcept -> int {
             return code_;
         }
         [[nodiscard]] constexpr auto message() const noexcept -> std::string_view {
-            return message_;
+            return std::string_view{message_buf_.data(), message_len_};
         }
     };
 

--- a/src/db/postgresql_statement.cppm
+++ b/src/db/postgresql_statement.cppm
@@ -80,11 +80,20 @@ export namespace storm::db::postgresql {
         Statement(const Statement&)                    = delete;
         auto operator=(const Statement&) -> Statement& = delete;
 
-        // Shared core for all text-based bind paths.
-        __attribute__((always_inline)) auto bind_text_value(int index, std::string_view value) noexcept -> void {
-            ensure_param_slot(index);
-            param_values_[index - 1].assign(value);
-            update_param_ptrs(index);
+        // Shared core for all text-based bind paths. Propagates OOM as Error rather than
+        // throwing through noexcept — see issue #316.
+        [[nodiscard]] __attribute__((always_inline)) auto bind_text_value(int index, std::string_view value) noexcept
+                -> std::expected<void, Error> {
+            try {
+                if (auto slot = ensure_param_slot(index); !slot) {
+                    return std::unexpected(slot.error());
+                }
+                param_values_[index - 1].assign(value);
+                update_param_ptrs(index);
+                return {};
+            } catch (...) {
+                return std::unexpected(Error{-1, "out of memory binding parameter"});
+            }
         }
 
         template <typename = void>
@@ -96,8 +105,7 @@ export namespace storm::db::postgresql {
         template <typename = void>
         [[nodiscard]] __attribute__((always_inline)) auto bind_text(int index, std::string_view value) noexcept
                 -> std::expected<void, Error> {
-            bind_text_value(index, value);
-            return {};
+            return bind_text_value(index, value);
         }
 
         template <typename = void>
@@ -105,8 +113,7 @@ export namespace storm::db::postgresql {
                 -> std::expected<void, Error> {
             std::array<char, 22> buf{}; // max int64: 20 digits + sign + null
             std::snprintf(buf.data(), buf.size(), "%lld", static_cast<long long>(value));
-            bind_text_value(index, std::string_view{buf.data()});
-            return {};
+            return bind_text_value(index, std::string_view{buf.data()});
         }
 
         template <typename = void>
@@ -115,13 +122,14 @@ export namespace storm::db::postgresql {
             // snprintf with %.17g for full double precision (17 significant digits)
             std::array<char, 32> buf{};
             std::snprintf(buf.data(), buf.size(), "%.17g", value);
-            bind_text_value(index, std::string_view{buf.data()});
-            return {};
+            return bind_text_value(index, std::string_view{buf.data()});
         }
 
         template <typename = void>
         [[nodiscard]] __attribute__((always_inline)) auto bind_null(int index) noexcept -> std::expected<void, Error> {
-            ensure_param_slot(index);
+            if (auto slot = ensure_param_slot(index); !slot) {
+                return std::unexpected(slot.error());
+            }
             param_values_[index - 1].clear();
             param_ptrs_[index - 1]    = nullptr; // NULL parameter
             param_lengths_[index - 1] = 0;
@@ -133,14 +141,20 @@ export namespace storm::db::postgresql {
         [[nodiscard]] __attribute__((always_inline)) auto
         bind_blob(int index, const void* data, size_t size) noexcept // NOSONAR(cpp:S5008) - PostgreSQL BLOB API
                 -> std::expected<void, Error> {
-            ensure_param_slot(index);
-            if (data != nullptr && size > 0) {
-                // Store binary data as-is, use binary format
-                param_values_[index - 1] =
-                        std::string(static_cast<const char*>(data), size); // NOSONAR(cpp:S5008) - Binary data
-            } else {
-                // Empty blob - use empty string (non-NULL, zero-length)
-                param_values_[index - 1].clear();
+            if (auto slot = ensure_param_slot(index); !slot) {
+                return std::unexpected(slot.error());
+            }
+            try {
+                if (data != nullptr && size > 0) {
+                    // Store binary data as-is, use binary format
+                    param_values_[index - 1]
+                            .assign(static_cast<const char*>(data), size); // NOSONAR(cpp:S5008) - Binary data
+                } else {
+                    // Empty blob - use empty string (non-NULL, zero-length)
+                    param_values_[index - 1].clear();
+                }
+            } catch (...) {
+                return std::unexpected(Error{-1, "out of memory binding blob"});
             }
             param_ptrs_[index - 1]    = param_values_[index - 1].c_str();
             param_lengths_[index - 1] = static_cast<int>(size);
@@ -167,7 +181,7 @@ export namespace storm::db::postgresql {
 
             const ExecStatusType status = PQresultStatus(result_);
             if (status != PGRES_COMMAND_OK && status != PGRES_TUPLES_OK) [[unlikely]] {
-                const std::string msg = PQerrorMessage(conn_);
+                const char* msg = PQerrorMessage(conn_);
                 clear_result();
                 return std::unexpected(Error{static_cast<int>(status), msg});
             }
@@ -219,12 +233,15 @@ export namespace storm::db::postgresql {
 
         template <typename = void> __attribute__((always_inline)) auto finalize() noexcept -> void {
             if (conn_ != nullptr && !stmt_name_.empty()) {
-                const std::string dealloc = "DEALLOCATE " + stmt_name_;
-                PGresult*         res     = PQexec(conn_, dealloc.c_str());
+                // PostgreSQL identifiers are bounded by NAMEDATALEN (63 chars + NUL by spec),
+                // so a stack buffer for "DEALLOCATE <name>" can never overflow and never throws.
+                std::array<char, 11 + 64 + 1> buf{};
+                std::snprintf(buf.data(), buf.size(), "DEALLOCATE %s", stmt_name_.c_str());
+                PGresult* res = PQexec(conn_, buf.data());
                 if (res != nullptr) {
                     PQclear(res);
                 }
-                stmt_name_.clear();
+                stmt_name_.clear(); // std::string::clear is noexcept
             }
             clear_result();
         }
@@ -374,7 +391,7 @@ export namespace storm::db::postgresql {
                                     reinterpret_cast<const unsigned char*>(hex_str) + hex_len);
                     blob_decoded_size_ = static_cast<size_t>(hex_len);
                 }
-            } catch (const std::bad_alloc&) {
+            } catch (...) {
                 blob_decoded_size_ = 0;
                 return nullptr;
             }
@@ -422,15 +439,23 @@ export namespace storm::db::postgresql {
             param_count_ = 0;
         }
 
-        auto ensure_param_slot(int index) noexcept -> void {
-            const auto idx = static_cast<size_t>(index);
-            if (idx > param_values_.size()) {
-                param_values_.resize(idx);
-                param_ptrs_.resize(idx, nullptr);
-                param_lengths_.resize(idx, 0);
-                param_formats_.resize(idx, 0); // Text format by default
+        // Grows the param slot vectors to cover `index`. The constructor reserve()'s capacity
+        // to MAX_DB_VARIABLES, so resize never reallocates in practice; the try/catch covers the
+        // theoretically-possible bad_alloc and propagates it through std::expected — issue #316.
+        [[nodiscard]] auto ensure_param_slot(int index) noexcept -> std::expected<void, Error> {
+            try {
+                const auto idx = static_cast<size_t>(index);
+                if (idx > param_values_.size()) {
+                    param_values_.resize(idx);
+                    param_ptrs_.resize(idx, nullptr);
+                    param_lengths_.resize(idx, 0);
+                    param_formats_.resize(idx, 0); // Text format by default
+                }
+                param_count_ = std::max(param_count_, index);
+                return {};
+            } catch (...) {
+                return std::unexpected(Error{-1, "out of memory growing param slots"});
             }
-            param_count_ = std::max(param_count_, index);
         }
 
         auto update_param_ptrs(int index) noexcept -> void {

--- a/src/db/sqlite.cppm
+++ b/src/db/sqlite.cppm
@@ -12,7 +12,9 @@ import <unordered_map>;
 import <unordered_set>;
 import <vector>;
 import <array>;
+import <cstddef>;
 import <cstdint>;
+import <cstring>;
 import <tuple>;
 
 export namespace storm::db::sqlite {
@@ -31,16 +33,32 @@ export namespace storm::db::sqlite {
         }
     };
 
-    // Error type for database operations
+    // Error type for database operations.
+    // Non-allocating: stores the message inline so construction is noexcept and Error can
+    // be returned from noexcept catch blocks without risking bad_alloc (issue #316).
     struct Error {
-        int         code_;
-        std::string message_;
+        static constexpr std::size_t kMaxMessageLen = 255;
+
+        int                                  code_{0};
+        std::array<char, kMaxMessageLen + 1> message_buf_{};
+        std::size_t                          message_len_{0};
+
+        Error() noexcept = default;
+
+        Error(int code, std::string_view msg) noexcept : code_{code} {
+            const std::size_t n = msg.size() < kMaxMessageLen ? msg.size() : kMaxMessageLen;
+            if (n > 0) {
+                std::memcpy(message_buf_.data(), msg.data(), n);
+            }
+            message_buf_[n] = '\0';
+            message_len_    = n;
+        }
 
         [[nodiscard]] constexpr auto code() const noexcept -> int {
             return code_;
         }
         [[nodiscard]] constexpr auto message() const noexcept -> std::string_view {
-            return message_;
+            return std::string_view{message_buf_.data(), message_len_};
         }
     };
 

--- a/src/db/sqlite.cppm
+++ b/src/db/sqlite.cppm
@@ -12,9 +12,7 @@ import <unordered_map>;
 import <unordered_set>;
 import <vector>;
 import <array>;
-import <cstddef>;
 import <cstdint>;
-import <cstring>;
 import <tuple>;
 
 export namespace storm::db::sqlite {
@@ -33,34 +31,8 @@ export namespace storm::db::sqlite {
         }
     };
 
-    // Error type for database operations.
-    // Non-allocating: stores the message inline so construction is noexcept and Error can
-    // be returned from noexcept catch blocks without risking bad_alloc (issue #316).
-    struct Error {
-        static constexpr std::size_t kMaxMessageLen = 255;
-
-        int                                  code_{0};
-        std::array<char, kMaxMessageLen + 1> message_buf_{};
-        std::size_t                          message_len_{0};
-
-        Error() noexcept = default;
-
-        Error(int code, std::string_view msg) noexcept : code_{code} {
-            const std::size_t n = msg.size() < kMaxMessageLen ? msg.size() : kMaxMessageLen;
-            if (n > 0) {
-                std::memcpy(message_buf_.data(), msg.data(), n);
-            }
-            message_buf_[n] = '\0';
-            message_len_    = n;
-        }
-
-        [[nodiscard]] constexpr auto code() const noexcept -> int {
-            return code_;
-        }
-        [[nodiscard]] constexpr auto message() const noexcept -> std::string_view {
-            return std::string_view{message_buf_.data(), message_len_};
-        }
-    };
+    // Error type — shared across backends, defined in storm_db_concept (issue #316).
+    using Error = storm::db::Error;
 
     // Forward declaration
     class Connection;

--- a/tests/errors/test_error_construction.cpp
+++ b/tests/errors/test_error_construction.cpp
@@ -1,0 +1,73 @@
+#include <gtest/gtest.h>
+#include <array>
+#include <cstddef>
+#include <string>
+#include <string_view>
+#include <type_traits>
+
+import storm_db_sqlite;
+import storm_db_postgresql_error;
+
+namespace {
+
+    using SqliteError = storm::db::sqlite::Error;
+    using PgError     = storm::db::postgresql::Error;
+
+    // Both Error types must be noexcept-constructible from (int, string_view) so they
+    // can be returned inside noexcept catch blocks without re-throwing bad_alloc.
+    // This is the core invariant that unblocks bugprone-exception-escape.
+    static_assert(std::is_nothrow_constructible_v<SqliteError, int, std::string_view>);
+    static_assert(std::is_nothrow_constructible_v<PgError, int, std::string_view>);
+
+    // Trivially copyable so the compiler can memcpy expected<T, Error> through return slots
+    // without invoking user-defined operations.
+    static_assert(std::is_trivially_copyable_v<SqliteError>);
+    static_assert(std::is_trivially_copyable_v<PgError>);
+
+    TEST(ErrorConstruction, SqliteFromLiteral) {
+        const SqliteError err{42, "boom"};
+        EXPECT_EQ(err.code(), 42);
+        EXPECT_EQ(err.message(), std::string_view{"boom"});
+    }
+
+    TEST(ErrorConstruction, PostgresFromLiteral) {
+        const PgError err{42, "boom"};
+        EXPECT_EQ(err.code(), 42);
+        EXPECT_EQ(err.message(), std::string_view{"boom"});
+    }
+
+    TEST(ErrorConstruction, SqliteFromEmptyMessage) {
+        const SqliteError err{0, ""};
+        EXPECT_TRUE(err.message().empty());
+    }
+
+    TEST(ErrorConstruction, PostgresFromEmptyMessage) {
+        const PgError err{0, ""};
+        EXPECT_TRUE(err.message().empty());
+    }
+
+    TEST(ErrorConstruction, SqliteTruncatesOverlongMessage) {
+        const std::string big(1000, 'x');
+        const SqliteError err{-1, big};
+        EXPECT_LE(err.message().size(), std::size_t{255});
+        EXPECT_GT(err.message().size(), std::size_t{0});
+        EXPECT_EQ(err.message().front(), 'x');
+        EXPECT_EQ(err.message().back(), 'x');
+    }
+
+    TEST(ErrorConstruction, PostgresTruncatesOverlongMessage) {
+        const std::string big(1000, 'y');
+        const PgError     err{-1, big};
+        EXPECT_LE(err.message().size(), std::size_t{255});
+        EXPECT_GT(err.message().size(), std::size_t{0});
+        EXPECT_EQ(err.message().front(), 'y');
+        EXPECT_EQ(err.message().back(), 'y');
+    }
+
+    TEST(ErrorConstruction, SqliteAcceptsCStringFromBackend) {
+        const char*       backend_msg = "no such table";
+        const SqliteError err{1, backend_msg};
+        EXPECT_EQ(err.message(), std::string_view{"no such table"});
+    }
+
+} // namespace

--- a/tests/query/test_expected_transform.cpp
+++ b/tests/query/test_expected_transform.cpp
@@ -47,7 +47,7 @@ TYPED_TEST(ExpectedTransformTest, HiveToVectorViaTransformMoves) {
         return std::forward<decltype(hive)>(hive) | std::views::as_rvalue | std::ranges::to<std::vector<Person>>();
     });
 
-    ASSERT_TRUE(vec_result.has_value()) << "Query failed: " << vec_result.error().message_;
+    ASSERT_TRUE(vec_result.has_value()) << "Query failed: " << vec_result.error().message();
     EXPECT_EQ(vec_result.value().size(), 25U);
 }
 
@@ -58,7 +58,7 @@ TYPED_TEST(ExpectedTransformTest, EmptyResultTransformYieldsEmptyVector) {
         return std::forward<decltype(hive)>(hive) | std::views::as_rvalue | std::ranges::to<std::vector<Person>>();
     });
 
-    ASSERT_TRUE(vec_result.has_value()) << "Query failed: " << vec_result.error().message_;
+    ASSERT_TRUE(vec_result.has_value()) << "Query failed: " << vec_result.error().message();
     EXPECT_TRUE(vec_result.value().empty());
 }
 
@@ -71,7 +71,7 @@ TYPED_TEST(ExpectedTransformTest, ChainViewsInsideTransformMoves) {
                std::ranges::to<std::vector<std::string>>();
     });
 
-    ASSERT_TRUE(names_result.has_value()) << "Query failed: " << names_result.error().message_;
+    ASSERT_TRUE(names_result.has_value()) << "Query failed: " << names_result.error().message();
     EXPECT_EQ(names_result.value().size(), 25U);
     for (const auto& name : names_result.value()) {
         EXPECT_FALSE(name.empty());
@@ -85,7 +85,7 @@ TYPED_TEST(ExpectedTransformTest, TransformPreservesWhereFilter) {
         return std::forward<decltype(hive)>(hive) | std::views::as_rvalue | std::ranges::to<std::vector<Person>>();
     });
 
-    ASSERT_TRUE(vec_result.has_value()) << "Query failed: " << vec_result.error().message_;
+    ASSERT_TRUE(vec_result.has_value()) << "Query failed: " << vec_result.error().message();
     EXPECT_GT(vec_result.value().size(), 0U);
     for (const auto& p : vec_result.value()) {
         EXPECT_GT(p.age, 35);
@@ -96,7 +96,7 @@ TYPED_TEST(ExpectedTransformTest, TransformPreservesWhereFilter) {
 TYPED_TEST(ExpectedTransformTest, TransformPropagatesErrorWithoutInvokingLambda) {
     using Error = typename TypeParam::Error;
 
-    std::expected<plf::hive<Person>, Error> failed{std::unexpect, Error{.code_ = 42, .message_ = "synthetic failure"}};
+    std::expected<plf::hive<Person>, Error> failed{std::unexpect, Error{42, "synthetic failure"}};
 
     bool lambda_invoked = false;
     auto result         = std::move(failed).transform([&lambda_invoked](auto&& hive) {
@@ -106,8 +106,8 @@ TYPED_TEST(ExpectedTransformTest, TransformPropagatesErrorWithoutInvokingLambda)
 
     EXPECT_FALSE(lambda_invoked);
     ASSERT_FALSE(result.has_value());
-    EXPECT_EQ(result.error().code_, 42);
-    EXPECT_EQ(result.error().message_, "synthetic failure");
+    EXPECT_EQ(result.error().code(), 42);
+    EXPECT_EQ(result.error().message(), "synthetic failure");
 }
 
 // NOLINTEND(misc-const-correctness,cppcoreguidelines-rvalue-reference-param-not-moved)

--- a/tests/query/test_rows.cpp
+++ b/tests/query/test_rows.cpp
@@ -32,7 +32,7 @@ TYPED_TEST(RowsTest, BasicIteration) {
     QuerySet<Person, TypeParam> qs;
     int                         count = 0;
     for (auto&& result : qs.rows()) {
-        ASSERT_TRUE(result.has_value()) << "Row error: " << result.error().message_;
+        ASSERT_TRUE(result.has_value()) << "Row error: " << result.error().message();
         ++count;
     }
     EXPECT_EQ(count, 25);


### PR DESCRIPTION
## Summary
- Replaces `std::string message_` in both `sqlite::Error` and `postgresql::Error` with a fixed-size buffer (`std::array<char, 256>` + length). Construction is now `noexcept`, so Errors can be returned from `noexcept` catch blocks without risking `bad_alloc`.
- Re-enables `bugprone-exception-escape` in `.clang-tidy` and removes the suppression comment block.
- Fixes the 5 findings the newly-enabled check surfaced in `postgresql_statement.cppm` honestly — no `NOLINT`, no silent swallow:
  - `execute()`: pass `PQerrorMessage` as `const char*` (no allocation).
  - `finalize()`: build `"DEALLOCATE <name>"` with `snprintf` into a stack buffer; PG `NAMEDATALEN` bounds the identifier.
  - `bind_text_value`, `bind_null`, `bind_blob`, `ensure_param_slot`: propagate OOM as `std::expected<void, Error>{Error{-1, "out of memory ..."}}`.
  - `extract_blob_ptr`: widen `catch (const std::bad_alloc&)` to `catch (...)`.
- `Error::message()` keeps returning `std::string_view`, so every consumer (`.empty()`, `.find()`, `ostream <<`) keeps working unchanged.

## Trade-offs
- Stack size: `expected<T, Error>` returns grow from ~48 bytes to ~280 bytes. Cold path (error path), but applies to the *success* slot too since `expected` is a tagged union.
- 256-byte buffer chosen after explicit discussion — covers every real SQLite/PG error message; truncates silently otherwise.

## Test plan
- [x] 7 new tests in `tests/errors/test_error_construction.cpp` — `static_assert` for `is_nothrow_constructible_v`, `is_trivially_copyable_v`, plus runtime checks for literal/empty/truncation/`const char*` paths.
- [x] Failing-first proven: tests don't compile against `std::string`-backed Error.
- [x] Full suite: 1915 / 1915 pass.
- [x] `clang-tidy --all` clean (1 pre-existing unrelated warning in `benchmarks/register.cpp`).
- [ ] SonarCloud gate
- [ ] CI: ninja-debug, ninja-asan-ubsan, ninja-tsan

Closes #316

🤖 Generated with [Claude Code](https://claude.com/claude-code)