### PR TITLE
refactor(where): drop raw pointer in BindParamsVisitor (#312)

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -29,9 +29,11 @@
 #   (src/orm/where.cppm, src/orm/utilities.cppm). Disabled globally — not just test files.
 #
 # ORM-specific Exclusions (issue #262 — added after clang-p2996 rebuild surfaced 48 pre-existing warnings):
-# - cppcoreguidelines-avoid-const-or-ref-data-members: Storm's INSERT/UPDATE/ERASE statement classes
-#   return short-lived dispatcher functors (struct SingleQuery { Stmt& stmt; const T& obj; ...}) that
-#   intentionally hold references. The non-assignability the check warns about is the desired property.
+# - cppcoreguidelines-avoid-const-or-ref-data-members: Storm's INSERT/UPDATE/ERASE/SELECT statement
+#   classes return short-lived dispatcher functors (struct SingleQuery { Stmt& stmt; const T& obj; ...})
+#   that intentionally hold references. The non-assignability the check warns about is the desired
+#   property; the factory methods use [[clang::lifetimebound]] for dangling protection. Re-enabling the
+#   check would force a refactor of insert/update/erase/select dispatcher proxies (~13 sites).
 # - cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers: chronically noisy on legitimate
 #   buffer sizes (32, 64), base-10 parsing constants, and ConstexprString capacity tuning.
 # - bugprone-easily-swappable-parameters: noisy on (limit, offset) / (left, right) parameter pairs

--- a/src/orm/where.cppm
+++ b/src/orm/where.cppm
@@ -249,38 +249,35 @@ export namespace storm::orm::where {
         }
     };
 
-    // Visitor for bind_params_direct() - called via std::visit
-    template <typename StmtType, typename ErrorType> struct BindParamsVisitor {
-        ErasedStatementPtr stmt_ptr;
-        int* param_index; // Pointer instead of reference (cppcoreguidelines-avoid-const-or-ref-data-members)
-
-        [[nodiscard]] auto operator()(const LogicalExpr& expr) const -> std::expected<void, ErrorType> {
-            // Recursive case: bind left then right
-            if (auto result = bind_params_direct<StmtType, ErrorType>(*expr.left, stmt_ptr, *param_index); !result) {
-                return result;
-            }
-            return bind_params_direct<StmtType, ErrorType>(*expr.right, stmt_ptr, *param_index);
-        }
-
-        // Every other Expr type exposes a small `bind_impl(StmtType*, int&)`.
-        // The type-erased pointer cast used to be duplicated in each Expr's own
-        // `bind_params_direct` — that's the duplicate this visitor now centralises.
-        template <typename T> [[nodiscard]] auto operator()(const T& expr) const -> std::expected<void, ErrorType> {
-            return expr.template bind_impl<StmtType, ErrorType>(static_cast<StmtType*>(stmt_ptr), *param_index);
-        }
-    };
-
     // Main visitor entry points (called by users and recursively by LogicalExpr)
     [[nodiscard]] inline auto to_sql(const ExpressionVariant& expr) -> std::string {
         return std::visit(ToSqlVisitor{}, expr);
     }
 
+    // bind_params_direct uses a lambda visitor that captures param_index by reference,
+    // so no raw pointer/reference data members are required.
+    // Every Expr type exposes a small `bind_impl(StmtType*, int&)`. The type-erased
+    // pointer cast used to be duplicated in each Expr's own `bind_params_direct` — that's
+    // the duplicate this visitor now centralises.
     template <typename StmtType, typename ErrorType>
     [[nodiscard]] inline auto
     bind_params_direct(const ExpressionVariant& expr, ErasedStatementPtr stmt_ptr, int& param_index)
             -> std::expected<void, ErrorType> {
         return std::visit(
-                BindParamsVisitor<StmtType, ErrorType>{.stmt_ptr = stmt_ptr, .param_index = &param_index}, expr
+                [stmt_ptr, &param_index](const auto& node) -> std::expected<void, ErrorType> {
+                    using NodeT = std::remove_cvref_t<decltype(node)>;
+                    if constexpr (std::is_same_v<NodeT, LogicalExpr>) {
+                        if (auto result = bind_params_direct<StmtType, ErrorType>(*node.left, stmt_ptr, param_index);
+                            !result) {
+                            return result;
+                        }
+                        return bind_params_direct<StmtType, ErrorType>(*node.right, stmt_ptr, param_index);
+                    } else {
+                        return node
+                                .template bind_impl<StmtType, ErrorType>(static_cast<StmtType*>(stmt_ptr), param_index);
+                    }
+                },
+                expr
         );
     }
 


### PR DESCRIPTION
## Summary

- Replace `BindParamsVisitor` struct (which stored `int* param_index` as a workaround for `cppcoreguidelines-avoid-const-or-ref-data-members`) with a generic lambda inside `bind_params_direct` that captures `param_index` by reference.
- The `LogicalExpr` recursion vs leaf `bind_impl` dispatch is now done via `if constexpr` on `std::remove_cvref_t<decltype(node)>` inside the lambda.

## Scope decision (option 1 in discussion)

The `.clang-tidy` exclusion is **kept**, but for a narrower reason. The dispatcher proxies in `insert.cppm`, `update.cppm`, `erase.cppm`, and `select.cppm` (`SingleQuery`, `VoidQuery`, `BulkQuery`) still hold `Stmt&` + `const T&` references **intentionally** — the factories use `[[clang::lifetimebound]]` for dangling protection, and non-assignability is the desired property.

Re-enabling the check globally would force a refactor of ~13 sites across four statement classes. That's out of scope for #312. Comment in `.clang-tidy` updated to reflect the narrower justification.

## Definition of Done (from #312)

- [x] `BindParamsVisitor` has no raw pointer members (the struct is gone entirely)
- [ ] `cppcoreguidelines-avoid-const-or-ref-data-members` exclusion removed from `.clang-tidy` — **intentionally kept**; see scope decision above
- [x] All existing tests pass (1915/1915)
- [x] No new clang-tidy warnings (`run_clang_tidy.sh` --diff: 0 warnings on staged lines)

## Test plan

- [x] `ninja-debug` build clean
- [x] 1915/1915 tests pass (SQLite + PostgreSQL)
- [x] `clang-tidy --diff` on staged lines: 0 warnings

Closes #312

🤖 Generated with [Claude Code](https://claude.com/claude-code)