### PR TITLE
chore(tidy): enable performance-enum-size; size enums to std::uint8_t

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -40,6 +40,8 @@
 #   where adjacency is the natural API.
 # - bugprone-branch-clone: re-enabled 2026-05-22; FK dialect dispatch in schema.cppm refactored to
 #   constexpr ternary to eliminate the clone.
+# - performance-enum-size: re-enabled 2026-05-25 (issue #313); enums in src/ given explicit small
+#   underlying types (std::uint8_t) since none exceed 256 enumerators.
 
 Checks: >
   -*,
@@ -66,7 +68,6 @@ Checks: >
   -misc-const-correctness,
   -misc-include-cleaner,
   performance-*,
-  -performance-enum-size,
   readability-*,
   -readability-magic-numbers,
   -google-explicit-constructor

--- a/.lint-skip
+++ b/.lint-skip
@@ -5,7 +5,7 @@
 
 src/orm/statements/insert.cppm:    file-size
 src/orm/statements/select.cppm:    file-size
-src/orm/statements/base.cppm:      file-size
+src/orm/statements/base.cppm:      file-size, duplicate
 src/orm/statements/aggregate.cppm: file-size
 src/orm/queryset.cppm:             file-size
 

--- a/src/orm/schema.cppm
+++ b/src/orm/schema.cppm
@@ -25,11 +25,12 @@ import <type_traits>;
 import <chrono>;
 import <filesystem>;
 import <cstddef>;
+import <cstdint>;
 
 export namespace storm::orm::schema {
 
     // SQL dialect for compile-time schema generation
-    enum class Dialect { SQLite, PostgreSQL };
+    enum class Dialect : std::uint8_t { SQLite, PostgreSQL };
 
     // Import utilities for compile-time string building
     using storm::orm::utilities::ConstexprString;
@@ -38,7 +39,7 @@ export namespace storm::orm::schema {
 
         // Storage class — which SQL primitive the C++ inner type maps to. The set is
         // closed; unknown types fall through to `Fallback` (TEXT, untyped).
-        enum class StorageClass : uint8_t {
+        enum class StorageClass : std::uint8_t {
             Bool,
             Integer,
             Double,

--- a/src/orm/statements/aggregate.cppm
+++ b/src/orm/statements/aggregate.cppm
@@ -31,7 +31,7 @@ export namespace storm::orm::statements {
     using storm::orm::utilities::ConstexprString;
 
     // Aggregate function types
-    enum class AggregateType { SUM, COUNT, AVG, MIN, MAX, COUNT_DISTINCT };
+    enum class AggregateType : std::uint8_t { SUM, COUNT, AVG, MIN, MAX, COUNT_DISTINCT };
 
     // LCOV_EXCL_START - compile-time only
     constexpr auto get_agg_function_name(AggregateType type) -> std::string_view {

--- a/src/orm/statements/base.cppm
+++ b/src/orm/statements/base.cppm
@@ -36,7 +36,7 @@ export namespace storm::orm::statements {
 
     // Mirror of meta::FieldAttr from storm module - must match exactly
     namespace meta {
-        enum class FieldAttr { primary, indexed, unique, fk };
+        enum class FieldAttr : std::uint8_t { primary, indexed, unique, fk };
     }
 
     // Concept: T must have at least one field annotated with FieldAttr::primary

--- a/src/orm/statements/distinct.cppm
+++ b/src/orm/statements/distinct.cppm
@@ -16,6 +16,7 @@ import storm_orm_statements_orderby;
 import storm_orm_utilities;
 import storm_orm_where;
 
+import <cstdint>;
 import <expected>;
 import <string>;
 import <vector>;
@@ -32,7 +33,7 @@ export namespace storm::orm::statements {
     using storm::orm::utilities::ConstexprString;
 
     // ProjectionMode controls whether DISTINCT keyword is included in SQL
-    enum class ProjectionMode { Values, Distinct };
+    enum class ProjectionMode : std::uint8_t { Values, Distinct };
 
     // ProjectionStatement - executes SELECT or SELECT DISTINCT on specified field(s) and returns tuple data
     // Supports 1+ fields with compile-time type safety

--- a/src/orm/statements/join.cppm
+++ b/src/orm/statements/join.cppm
@@ -9,6 +9,7 @@ import storm_orm_statements_base;
 import storm_orm_utilities;
 import storm_db_concept;
 
+import <cstdint>;
 import <expected>;
 import <string>;
 import <vector>;
@@ -22,7 +23,7 @@ export namespace storm::orm::statements {
 
     using storm::orm::utilities::ConstexprString;
 
-    enum class JoinType { Inner, Left, Right };
+    enum class JoinType : std::uint8_t { Inner, Left, Right };
 
     // Type alias for type-erased pointers used in polymorphic JOIN wrapper.
     // void* is intentional here: JoinStatementWrapper must work with any model type T

--- a/src/orm/statements/setop.cppm
+++ b/src/orm/statements/setop.cppm
@@ -15,6 +15,7 @@ import storm_orm_where;
 import storm_db_concept;
 
 import <concepts>;
+import <cstdint>;
 import <expected>;
 import <string>;
 import <vector>;
@@ -23,7 +24,7 @@ import <memory>;
 
 export namespace storm::orm::statements {
 
-    enum class SetOpType { Union, UnionAll, Except, Intersect };
+    enum class SetOpType : std::uint8_t { Union, UnionAll, Except, Intersect };
 
     template <typename T> struct SetOpOperand {
         std::string                      sql;

--- a/src/orm/utilities.cppm
+++ b/src/orm/utilities.cppm
@@ -99,7 +99,7 @@ export namespace storm::orm::utilities {
     // Collation Support
     // ============================================================================
 
-    enum class Collate { None, Binary, NoCase, RTrim };
+    enum class Collate : std::uint8_t { None, Binary, NoCase, RTrim };
 
     constexpr auto collate_to_sql(Collate col) noexcept -> std::string_view {
         using enum Collate;

--- a/src/orm/where.cppm
+++ b/src/orm/where.cppm
@@ -8,6 +8,7 @@ module;
 
 export module storm_orm_where;
 
+import <cstdint>;
 import <string>;
 import <vector>;
 import <memory>;
@@ -42,11 +43,11 @@ export namespace storm::orm::where {
 
     // Mirror of meta::FieldAttr from storm module - must match exactly
     namespace meta {
-        enum class FieldAttr { primary, indexed, unique, fk };
+        enum class FieldAttr : std::uint8_t { primary, indexed, unique, fk };
     }
 
     // Comparison operators
-    enum class CompOp { Equal, NotEqual, Greater, GreaterEqual, Less, LessEqual };
+    enum class CompOp : std::uint8_t { Equal, NotEqual, Greater, GreaterEqual, Less, LessEqual };
 
     constexpr auto comp_op_to_sql(CompOp op) noexcept -> std::string_view {
         using enum CompOp;
@@ -68,7 +69,7 @@ export namespace storm::orm::where {
     }
 
     // Logical operators
-    enum class LogicalOp { And, Or };
+    enum class LogicalOp : std::uint8_t { And, Or };
 
     constexpr auto logical_op_to_sql(LogicalOp op) noexcept -> std::string_view {
         switch (op) {


### PR DESCRIPTION
## Summary
- Removes `-performance-enum-size` from `.clang-tidy`; adds `: std::uint8_t` to 10 src/ enums
- Adds `duplicate` tag to `base.cppm` in `.lint-skip` (pre-existing extract_int_like / extract_enum int64 fallback false-positive)
- Normalizes pre-existing `StorageClass : uint8_t` to `std::uint8_t` for consistency

## Honest framing
This is code hygiene, **not** a runtime win. Most flagged enums are NTTPs (`JoinType`, `AggregateType`, `ProjectionMode`, `SetOpType`) — they live in the type system, no bytes saved at runtime. The few that ARE stored (`CompOp`, `LogicalOp`) sit next to `std::string` / `std::shared_ptr` members where alignment padding absorbs the 3-byte saving. Re-enabling closes a known-to-do tidy issue and keeps the lint surface clean.

## Test plan
- [x] `cmake --build --preset ninja-debug` clean
- [x] `cmake --build --preset ninja-release` clean
- [x] `ctest --preset ninja-debug` — 1915/1915 pass
- [x] `bash scripts/run_clang_tidy.sh --all` — 0 `performance-enum-size` warnings (down from 10)
- [ ] SonarCloud gate passes
- [ ] All CI jobs (ninja-debug, ninja-asan-ubsan, ninja-tsan) pass

Closes #313.

🤖 Generated with [Claude Code](https://claude.com/claude-code)