### PR TITLE
build(libcxx): symlink build/share/libc++/v1 to build/modules/c++/v1

### DIFF
--- a/cmake/libcxx.cmake
+++ b/cmake/libcxx.cmake
@@ -10,6 +10,23 @@ set(LIBCXX_BUILD_INCLUDE_DIR
     "${LIBCXX_ROOT}/build/include/x86_64-unknown-linux-gnu/c++/v1")
 message(STATUS "Using custom libcxx from: ${LIBCXX_ROOT}")
 
+# clang-p2996's libc++.modules.json declares source-path ../../share/libc++/v1/
+# but the build actually places std.cppm / std.compat.cppm under
+# build/modules/c++/v1/. Bridge the two layouts with a symlink so CMake's
+# `import std;` support can find the sources. See issue #326.
+set(_storm_libcxx_modules_dir "${LIBCXX_ROOT}/build/modules/c++/v1")
+set(_storm_libcxx_share_parent "${LIBCXX_ROOT}/build/share/libc++")
+set(_storm_libcxx_share_link "${_storm_libcxx_share_parent}/v1")
+if(EXISTS "${_storm_libcxx_modules_dir}"
+   AND NOT IS_SYMLINK "${_storm_libcxx_share_link}"
+   AND NOT IS_DIRECTORY "${_storm_libcxx_share_link}")
+  file(MAKE_DIRECTORY "${_storm_libcxx_share_parent}")
+  file(CREATE_LINK "${_storm_libcxx_modules_dir}" "${_storm_libcxx_share_link}"
+       SYMBOLIC)
+  message(STATUS "Created libc++ modules symlink: ${_storm_libcxx_share_link}"
+                 " -> ${_storm_libcxx_modules_dir}")
+endif()
+
 add_compile_options(-nostdinc++ -I${LIBCXX_INCLUDE_DIR}
                     -I${LIBCXX_BUILD_INCLUDE_DIR})
 

--- a/docs/development/COMPILER_ISSUES.md
+++ b/docs/development/COMPILER_ISSUES.md
@@ -94,6 +94,27 @@ std::string str{cs.data.data(), cs.len};
 sqlite3_column_count(stmt->handle())
 ```
 
+### 7. clang-p2996 libc++ Modules Layout Mismatch
+
+**Symptom** (when enabling CMake's `import std;` support):
+```
+CMake Error: Cannot find source file:
+  <LIBCXX_ROOT>/build/share/libc++/v1/std.compat.cppm
+```
+
+**Cause**: `<LIBCXX_ROOT>/build/lib/x86_64-…/libc++.modules.json` declares the
+sources at `share/libc++/v1/std.cppm`, but the build places them under
+`build/modules/c++/v1/`. Plain libc++ installs expose them via `share/`; the
+clang-p2996 build directory does not.
+
+**Workaround**: `cmake/libcxx.cmake` creates a symlink
+`build/share/libc++/v1 -> build/modules/c++/v1` at configure time. The logic
+is idempotent and won't overwrite a real directory if one exists.
+
+**Related**: Issue [#326](https://github.com/spiritEcosse/storm/issues/326)
+tracks the staged migration from per-header `import std.<sub>;` to a single
+`import std;`.
+
 ## Debugging Tips
 
 1. **Clean build**: `rm -rf build/ && cmake --preset ninja-debug`

--- a/scripts/tests/test_libcxx_modules_symlink.sh
+++ b/scripts/tests/test_libcxx_modules_symlink.sh
@@ -31,17 +31,22 @@ fail() {
     echo "  FAIL: $msg"
     FAIL=$((FAIL+1))
     FAILED_TESTS+=("$CURRENT_TAG")
+    return 0
 }
 
 pass() {
     local msg="$1"
     echo "  PASS: $msg"
     PASS=$((PASS+1))
+    return 0
 }
 
 mtime_of() {
     local path="$1"
-    stat -c '%Y' "$path" 2>/dev/null || stat -f '%m' "$path"
+    local mtime
+    mtime="$(stat -c '%Y' "$path" 2>/dev/null || stat -f '%m' "$path")"
+    echo "$mtime"
+    return 0
 }
 
 make_fake_libcxx_root() {

--- a/scripts/tests/test_libcxx_modules_symlink.sh
+++ b/scripts/tests/test_libcxx_modules_symlink.sh
@@ -1,0 +1,164 @@
+#!/bin/bash
+# Tests for cmake/libcxx.cmake symlink behavior (issue #326, phase 1).
+#
+# Strategy: build a fake LIBCXX_ROOT layout in a temp dir, invoke
+# cmake/libcxx.cmake from a minimal harness CMakeLists, and assert the
+# symlink (or its absence) per scenario.
+#
+# Each scenario is a function named scenario_<tag>. The dispatcher loop
+# below handles all per-test boilerplate (tmpdir, fake root, cmake invoke,
+# cleanup) so scenarios only encode their setup tweaks and assertions.
+
+set -u
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+LIBCXX_CMAKE="$REPO_ROOT/cmake/libcxx.cmake"
+
+PASS=0
+FAIL=0
+FAILED_TESTS=()
+
+# Per-scenario state, populated by the dispatcher before calling the scenario.
+TMP=""
+LIBCXX=""
+LINK_PATH=""
+LINK_TARGET=""
+HARNESS_RC=0
+CURRENT_TAG=""
+
+fail() {
+    local msg="$1"
+    echo "  FAIL: $msg"
+    FAIL=$((FAIL+1))
+    FAILED_TESTS+=("$CURRENT_TAG")
+}
+
+pass() {
+    local msg="$1"
+    echo "  PASS: $msg"
+    PASS=$((PASS+1))
+}
+
+mtime_of() {
+    stat -c '%Y' "$1" 2>/dev/null || stat -f '%m' "$1"
+}
+
+make_fake_libcxx_root() {
+    local root="$1"
+    mkdir -p "$root/build/modules/c++/v1" \
+             "$root/build/include/c++/v1" \
+             "$root/build/include/x86_64-unknown-linux-gnu/c++/v1" \
+             "$root/build/lib/x86_64-unknown-linux-gnu"
+    : > "$root/build/modules/c++/v1/std.cppm"
+    : > "$root/build/modules/c++/v1/std.compat.cppm"
+}
+
+run_harness() {
+    local workdir="$1" libcxx_root="$2"
+    mkdir -p "$workdir"
+    cat > "$workdir/CMakeLists.txt" <<EOF
+cmake_minimum_required(VERSION 3.30)
+project(libcxx_symlink_harness NONE)
+set(LIBCXX_ROOT "$libcxx_root")
+include("$LIBCXX_CMAKE")
+EOF
+    (cd "$workdir" && cmake -B build . > cmake.log 2>&1)
+}
+
+# Dispatcher: prepares tmpdir + fake root, calls hook_pre (optional setup
+# the scenario wants before cmake runs), runs cmake, then calls the scenario
+# function for assertions.
+run_scenario() {
+    local tag="$1"
+    CURRENT_TAG="$tag"
+    echo "TEST: $tag"
+
+    TMP="$(mktemp -d)"
+    LIBCXX="$TMP/libcxx"
+    LINK_PATH="$LIBCXX/build/share/libc++/v1"
+    LINK_TARGET="$LIBCXX/build/modules/c++/v1"
+    make_fake_libcxx_root "$LIBCXX"
+
+    if declare -F "pre_$tag" > /dev/null; then
+        "pre_$tag"
+    fi
+
+    HARNESS_RC=0
+    run_harness "$TMP/harness" "$LIBCXX" || HARNESS_RC=$?
+
+    "scenario_$tag"
+
+    rm -rf "$TMP"
+}
+
+# ---- scenarios ------------------------------------------------------------
+
+scenario_creates_symlink_when_missing() {
+    if [[ $HARNESS_RC -ne 0 ]]; then
+        fail "cmake configure failed; see $TMP/harness/cmake.log"; return
+    fi
+    if [[ ! -L "$LINK_PATH" ]]; then
+        fail "expected symlink at $LINK_PATH, but it does not exist"; return
+    fi
+    local target
+    target="$(readlink "$LINK_PATH")"
+    if [[ "$target" != "$LINK_TARGET" ]]; then
+        fail "symlink points to '$target', expected '$LINK_TARGET'"; return
+    fi
+    if [[ ! -f "$LINK_PATH/std.cppm" ]]; then
+        fail "symlink does not resolve std.cppm"; return
+    fi
+    pass "symlink created and resolves correctly"
+}
+
+pre_idempotent_when_symlink_exists() {
+    mkdir -p "$LIBCXX/build/share/libc++"
+    ln -sfn "$LINK_TARGET" "$LINK_PATH"
+    SAVED_MTIME="$(mtime_of "$LINK_PATH")"
+}
+
+scenario_idempotent_when_symlink_exists() {
+    if [[ $HARNESS_RC -ne 0 ]]; then
+        fail "cmake configure failed; see $TMP/harness/cmake.log"; return
+    fi
+    local after
+    after="$(mtime_of "$LINK_PATH")"
+    if [[ "$SAVED_MTIME" != "$after" ]]; then
+        fail "existing correct symlink was modified (mtime changed)"; return
+    fi
+    pass "existing correct symlink was left untouched"
+}
+
+pre_refuses_when_share_is_real_dir() {
+    mkdir -p "$LINK_PATH"
+    : > "$LINK_PATH/keep.txt"
+}
+
+scenario_refuses_when_share_is_real_dir() {
+    # cmake may or may not FATAL_ERROR here, but it MUST NOT clobber the dir.
+    if [[ -L "$LINK_PATH" ]]; then
+        fail "real directory was replaced with a symlink"; return
+    fi
+    if [[ ! -f "$LINK_PATH/keep.txt" ]]; then
+        fail "existing content under share/libc++/v1 was destroyed"; return
+    fi
+    pass "real directory at share/libc++/v1 was preserved"
+}
+
+# ---- run ------------------------------------------------------------------
+
+for tag in \
+    creates_symlink_when_missing \
+    idempotent_when_symlink_exists \
+    refuses_when_share_is_real_dir
+do
+    run_scenario "$tag"
+done
+
+echo
+echo "Results: $PASS passed, $FAIL failed"
+if [[ $FAIL -gt 0 ]]; then
+    echo "Failed tests: ${FAILED_TESTS[*]}"
+    exit 1
+fi
+exit 0

--- a/scripts/tests/test_libcxx_modules_symlink.sh
+++ b/scripts/tests/test_libcxx_modules_symlink.sh
@@ -40,7 +40,8 @@ pass() {
 }
 
 mtime_of() {
-    stat -c '%Y' "$1" 2>/dev/null || stat -f '%m' "$1"
+    local path="$1"
+    stat -c '%Y' "$path" 2>/dev/null || stat -f '%m' "$path"
 }
 
 make_fake_libcxx_root() {
@@ -51,6 +52,7 @@ make_fake_libcxx_root() {
              "$root/build/lib/x86_64-unknown-linux-gnu"
     : > "$root/build/modules/c++/v1/std.cppm"
     : > "$root/build/modules/c++/v1/std.compat.cppm"
+    return 0
 }
 
 run_harness() {
@@ -62,7 +64,9 @@ project(libcxx_symlink_harness NONE)
 set(LIBCXX_ROOT "$libcxx_root")
 include("$LIBCXX_CMAKE")
 EOF
-    (cd "$workdir" && cmake -B build . > cmake.log 2>&1)
+    local rc=0
+    (cd "$workdir" && cmake -B build . > cmake.log 2>&1) || rc=$?
+    return "$rc"
 }
 
 # Dispatcher: prepares tmpdir + fake root, calls hook_pre (optional setup
@@ -89,6 +93,7 @@ run_scenario() {
     "scenario_$tag"
 
     rm -rf "$TMP"
+    return 0
 }
 
 # ---- scenarios ------------------------------------------------------------
@@ -115,6 +120,7 @@ pre_idempotent_when_symlink_exists() {
     mkdir -p "$LIBCXX/build/share/libc++"
     ln -sfn "$LINK_TARGET" "$LINK_PATH"
     SAVED_MTIME="$(mtime_of "$LINK_PATH")"
+    return 0
 }
 
 scenario_idempotent_when_symlink_exists() {
@@ -132,6 +138,7 @@ scenario_idempotent_when_symlink_exists() {
 pre_refuses_when_share_is_real_dir() {
     mkdir -p "$LINK_PATH"
     : > "$LINK_PATH/keep.txt"
+    return 0
 }
 
 scenario_refuses_when_share_is_real_dir() {


### PR DESCRIPTION
## Summary

Phase 1 of the `import std;` migration tracked in #326.

clang-p2996's `libc++.modules.json` declares `source-path ../../share/libc++/v1/std.cppm`, but the build places `std.cppm` / `std.compat.cppm` under `build/modules/c++/v1/`. CMake's `CXX_MODULE_STD` support reads the descriptor literally, so any project that enables `import std;` fails with *"Cannot find source file …/share/libc++/v1/std.compat.cppm"*.

This PR bridges the two layouts with an idempotent symlink created at configure time by `cmake/libcxx.cmake`. No compile flags change — only `LIBCXX_ROOT` filesystem state. Phase 2 (tools/ + `-fmodules` removal + first real `import std;` consumer) ships in a follow-up PR.

## Why this is configure-time only

* `file(CREATE_LINK ... SYMBOLIC)` runs once when CMake processes `libcxx.cmake`.
* Guarded by `EXISTS modules/c++/v1` AND `NOT IS_SYMLINK share/libc++/v1` AND `NOT IS_DIRECTORY share/libc++/v1` — so a real directory at the target path is left intact.
* The compile graph is unchanged. Sanitizer presets exercise the same code paths and can't reveal anything new.

## Test plan

- [x] New unit harness `scripts/tests/test_libcxx_modules_symlink.sh` — 3 scenarios:
  - creates the symlink when missing
  - leaves an existing correct symlink alone (mtime preserved)
  - refuses to clobber a real directory at the target path
- [x] Tests fail before implementation (TDD), pass after
- [x] Manually deleted the symlink to confirm `cmake --preset ninja-debug` recreates it
- [x] `cmake --build --preset ninja-debug` clean
- [x] `cmake --build --preset ninja-release` clean
- [x] `ctest --preset ninja-debug` — 1924/1924 passed
- [x] Pre-commit hook (cmake-format, tests, coverage 100%) green

## Docs

`docs/development/COMPILER_ISSUES.md` gains a new section #7 documenting the layout mismatch + the symlink workaround, linked to #326.

Refs #326

🤖 Generated with [Claude Code](https://claude.com/claude-code)