### PR TITLE
build(import-std): isolated probe target for CMake plumbing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,24 @@
 cmake_minimum_required(VERSION 3.30)
+
+# Gate for CMake's experimental `import std;` support. Must be set BEFORE
+# project(). The UUID is CMake-version-specific — see issue #326. Verified for
+# CMake 4.3.3. Bump UUID if the minimum-supported CMake changes.
+set(CMAKE_EXPERIMENTAL_CXX_IMPORT_STD "451f2fe2-a8a2-47c3-bc32-94786d8fc91b")
+
+# Pin the import-std descriptor to clang-p2996's libc++.modules.json before
+# project(). Without this, CMake's auto-detection picks up the host GCC's
+# /usr/lib64/libstdc++.modules.json and tries to build bits/std.cc against our
+# libc++ include paths — which fails. See issue #326.
+#
+# LIBCXX_ROOT is passed via preset/-D, so we resolve the JSON path the same way
+# cmake/libcxx.cmake does, but without including it (project() must run first
+# for that). Falls back to letting CMake auto-detect when LIBCXX_ROOT is unset
+# (e.g. plain library configures, where import-std is not used).
+if(DEFINED LIBCXX_ROOT)
+  set(CMAKE_CXX_STDLIB_MODULES_JSON
+      "${LIBCXX_ROOT}/build/lib/x86_64-unknown-linux-gnu/libc++.modules.json")
+endif()
+
 project(storm)
 
 set(CMAKE_CXX_STANDARD 26)
@@ -80,6 +100,8 @@ option(ENABLE_TESTS "Enable testing support" OFF)
 option(ENABLE_BENCH "Enable benchmarking with sqlite_orm" OFF)
 option(ENABLE_COVERAGE "Enable code coverage (requires LLVM tools)" OFF)
 option(ENABLE_TOOLS "Build CLI tools (storm-schema, etc.)" OFF)
+option(ENABLE_IMPORT_STD_PROBE
+       "Build the import-std probe (issue #326 phase 2)" OFF)
 
 # coverage flags must be set before test targets are compiled
 include(cmake/coverage.cmake)
@@ -91,6 +113,7 @@ include(cmake/sanitizers.cmake)
 include(cmake/fuzz.cmake)
 include(cmake/format.cmake)
 include(cmake/tools.cmake)
+include(cmake/import_std_probe.cmake)
 
 # ── Build summary ─────────────────────────────────────────────────────────────
 

--- a/cmake/import_std_probe.cmake
+++ b/cmake/import_std_probe.cmake
@@ -1,0 +1,24 @@
+# Isolated probe target for the `import std;` migration (issue #326, phase 2).
+#
+# Verifies the CMake plumbing end-to-end: * the
+# CMAKE_EXPERIMENTAL_CXX_IMPORT_STD UUID gate is accepted, * libc++.modules.json
+# is discoverable (depends on the symlink set up by cmake/libcxx.cmake), * a
+# target with CXX_MODULE_STD ON builds and runs against the project's custom
+# libc++.
+#
+# The probe deliberately does NOT call apply_clang_flags(), so the -fmodules /
+# -fbuiltin-module-map flags that conflict with C++20 named modules are kept out
+# of this TU. It also does NOT link libstorm — that isolation is the whole point
+# of phase 2.
+
+if(NOT ENABLE_IMPORT_STD_PROBE)
+  return()
+endif()
+
+add_executable(storm_import_std_probe
+               "${CMAKE_SOURCE_DIR}/tools/import_std_probe.cpp")
+
+target_compile_features(storm_import_std_probe PRIVATE cxx_std_26)
+set_target_properties(storm_import_std_probe PROPERTIES CXX_MODULE_STD ON)
+
+message(STATUS "import-std probe enabled (storm_import_std_probe)")

--- a/docs/development/COMPILER_ISSUES.md
+++ b/docs/development/COMPILER_ISSUES.md
@@ -115,6 +115,37 @@ is idempotent and won't overwrite a real directory if one exists.
 tracks the staged migration from per-header `import std.<sub>;` to a single
 `import std;`.
 
+### 8. CMake Picks libstdc++ Instead of libc++ for `import std`
+
+**Symptom** (when `ENABLE_IMPORT_STD_PROBE=ON` or any target with
+`CXX_MODULE_STD ON`):
+
+```
+[2/11] Scanning /usr/include/c++/16.1.1/bits/std.compat.cc for CXX dependencies
+[3/11] Scanning /usr/include/c++/16.1.1/bits/std.cc for CXX dependencies
+FAILED: CMakeFiles/__cmake_cxx_std_26.dir/usr/include/c++/16.1.1/bits/std.cc.o.ddi
+…
+/usr/include/c++/16.1.1/bits/std.cc:26:10: fatal error: 'bits/stdc++.h' file not found
+```
+
+**Cause**: CMake's `Clang-CXX-CXXImportStd.cmake` runs `clang++
+-print-file-name=libstdc++.modules.json` when `CMAKE_CXX_STANDARD_LIBRARY`
+isn't explicitly `libc++`. Clang resolves that against the host GCC's
+`/usr/lib64/libstdc++.modules.json` and CMake then tries to compile GCC's
+`bits/std.cc` with `-nostdinc++` and our libc++ include paths, which breaks
+on `bits/stdc++.h`.
+
+Pinning `CMAKE_CXX_STANDARD_LIBRARY` alone is not enough — the variable
+isn't always consulted, and `CMAKE_CXX_STDLIB_MODULES_JSON` (CMake 4.2+) is
+the direct override.
+
+**Workaround**: top-level `CMakeLists.txt` sets
+`CMAKE_CXX_STDLIB_MODULES_JSON` to clang-p2996's
+`build/lib/x86_64-unknown-linux-gnu/libc++.modules.json` before `project()`,
+guarded by `if(DEFINED LIBCXX_ROOT)`.
+
+**Related**: Issue [#326](https://github.com/spiritEcosse/storm/issues/326).
+
 ## Debugging Tips
 
 1. **Clean build**: `rm -rf build/ && cmake --preset ninja-debug`

--- a/scripts/tests/test_import_std_probe.sh
+++ b/scripts/tests/test_import_std_probe.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+# Tests for the import-std probe target (issue #326, phase 2).
+#
+# Builds the probe target with ENABLE_IMPORT_STD_PROBE=ON in an
+# isolated build dir, runs it, and asserts the expected stdout.
+# Skipped silently when LIBCXX_ROOT is unset (CI matrix safety).
+
+set -u
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PROBE_TARGET="storm_import_std_probe"
+EXPECTED="import std: ok"
+
+PASS=0
+FAIL=0
+FAILED_TESTS=()
+CURRENT_TAG=""
+
+fail() {
+    local message="$1"
+    echo "  FAIL: $message"
+    FAIL=$((FAIL+1))
+    FAILED_TESTS+=("$CURRENT_TAG")
+    return 0
+}
+
+pass() {
+    local message="$1"
+    echo "  PASS: $message"
+    PASS=$((PASS+1))
+    return 0
+}
+
+resolve_libcxx_root() {
+    if [[ -n "${LIBCXX_ROOT:-}" ]]; then
+        echo "$LIBCXX_ROOT"
+        return
+    fi
+    # Fall back to the project's conventional location (../clang-p2996).
+    local candidate
+    candidate="$(cd "$REPO_ROOT/.." && pwd)/clang-p2996"
+    if [[ -d "$candidate/build/modules/c++/v1" ]]; then
+        echo "$candidate"
+    fi
+}
+
+configure_and_build() {
+    local workdir="$1" libcxx_root="$2"
+    mkdir -p "$workdir"
+    cmake -S "$REPO_ROOT" -B "$workdir" \
+        -G Ninja \
+        -DCMAKE_C_COMPILER="$libcxx_root/build/bin/clang" \
+        -DCMAKE_CXX_COMPILER="$libcxx_root/build/bin/clang++" \
+        -DCMAKE_CXX_COMPILER_CLANG_SCAN_DEPS="$libcxx_root/build/bin/clang-scan-deps" \
+        -DLIBCXX_ROOT="$libcxx_root" \
+        -DENABLE_IMPORT_STD_PROBE=ON \
+        -DENABLE_TESTS=OFF \
+        -DENABLE_BENCH=OFF \
+        -DENABLE_COVERAGE=OFF \
+        -DENABLE_TOOLS=OFF \
+        > "$workdir/cmake.log" 2>&1 || return 1
+    cmake --build "$workdir" --target "$PROBE_TARGET" \
+        > "$workdir/build.log" 2>&1 || return 2
+}
+
+test_probe_builds_and_runs() {
+    CURRENT_TAG="probe_builds_and_runs"
+    echo "TEST: $CURRENT_TAG"
+
+    local libcxx_root
+    libcxx_root="$(resolve_libcxx_root)"
+    if [[ -z "$libcxx_root" ]]; then
+        echo "  SKIP: LIBCXX_ROOT not set and ../clang-p2996 not present"
+        return
+    fi
+
+    local workdir
+    workdir="$(mktemp -d)"
+    trap "rm -rf $workdir" RETURN
+
+    local rc=0
+    configure_and_build "$workdir" "$libcxx_root" || rc=$?
+    if [[ $rc -ne 0 ]]; then
+        fail "configure/build failed (rc=$rc); see $workdir/{cmake,build}.log"
+        cp -r "$workdir" /tmp/import_std_probe_failure || true
+        echo "  (logs copied to /tmp/import_std_probe_failure)"
+        return
+    fi
+
+    local bin
+    bin="$(find "$workdir" -name "$PROBE_TARGET" -type f -executable | head -1)"
+    if [[ -z "$bin" ]]; then
+        fail "probe binary not found under $workdir"
+        return
+    fi
+
+    local out
+    out="$("$bin")" || { fail "probe exited non-zero: $out"; return; }
+    if [[ "$out" != "$EXPECTED" ]]; then
+        fail "probe stdout mismatch: got '$out', expected '$EXPECTED'"
+        return
+    fi
+
+    pass "probe configured, built, and printed expected output"
+}
+
+test_probe_builds_and_runs
+
+echo
+echo "Results: $PASS passed, $FAIL failed"
+if [[ $FAIL -gt 0 ]]; then
+    echo "Failed tests: ${FAILED_TESTS[*]}"
+    exit 1
+fi
+exit 0

--- a/tools/import_std_probe.cpp
+++ b/tools/import_std_probe.cpp
@@ -1,0 +1,14 @@
+// Phase-2 probe for issue #326: validates that `import std;` builds and
+// links against clang-p2996 + libc++ via CMake's CXX_MODULE_STD support.
+//
+// This target is intentionally isolated: it does NOT import storm and does
+// NOT link any third-party library. If it builds and prints the expected
+// line, the std-module plumbing (UUID gate, libc++.modules.json,
+// share/libc++/v1 symlink, no-fmodules invocation) is correct.
+
+import std;
+
+auto main() -> int {
+    std::println("import std: ok");
+    return 0;
+}


### PR DESCRIPTION
## Summary

Phase 2 of #326, **reframed** from the original plan.

The issue's original phase 2 was \"tools/\" (storm-schema). That tool does `import storm;`, so converting it to `import std;` would have forced dropping `-fmodules -fbuiltin-module-map` from `apply_clang_flags()` globally — touching every target that calls it (libstorm itself + tests + benchmarks + fuzz) **before** there was any evidence the CMake plumbing was sound.

This PR ships an isolated probe instead. It exercises only the CMake side of the migration with zero coupling to libstorm:

- `tools/import_std_probe.cpp` — minimal `.cpp` doing `import std;` + `std::println(...)`.
- `cmake/import_std_probe.cmake` — gated by `ENABLE_IMPORT_STD_PROBE` (default OFF). Sets `CXX_MODULE_STD ON` on the probe target only. Does NOT call `apply_clang_flags()`, so the `-fmodules` collision is sidestepped.
- `CMakeLists.txt` — adds the two CMake-version-specific gates that have to live before `project()`: `CMAKE_EXPERIMENTAL_CXX_IMPORT_STD` (UUID) and `CMAKE_CXX_STDLIB_MODULES_JSON` (path to clang-p2996's `libc++.modules.json`, so CMake doesn't accidentally pick GCC's libstdc++ JSON and try to compile `bits/std.cc` against our `-nostdinc++` flags).

This is stacked on #327 (phase 1, symlink). Merge order: #327 → this PR.

## Two CMake gotchas worth calling out

Both documented in `docs/development/COMPILER_ISSUES.md` (new sections #7 from phase 1 and #8 added here):

1. **UUID gate must precede `project()`.** Setting it after raises *\"Experimental \`import std\` support not enabled when detecting toolchain; it must be set before \`CXX\` is enabled\"*.
2. **`CMAKE_CXX_STANDARD_LIBRARY \"libc++\"` is not enough.** CMake's `Clang-CXX-CXXImportStd.cmake` references that variable but only as a switch — actual JSON discovery uses `clang++ -print-file-name=libstdc++.modules.json` which lands on the host GCC tree. The fix is to set `CMAKE_CXX_STDLIB_MODULES_JSON` directly to clang-p2996's libc++ JSON. Pin must happen before `project()`.

## What this PR does NOT do

- Does NOT drop `-fmodules -fbuiltin-module-map` from `apply_clang_flags()`. That's the next phase.
- Does NOT convert any existing source to `import std;`.
- Does NOT enable the probe in any CI preset. Build it with `-DENABLE_IMPORT_STD_PROBE=ON` if you want to repro the green path.

## Test plan

- [x] `scripts/tests/test_import_std_probe.sh` — TDD; failed before implementation, passes after. Builds the probe, runs it, asserts \`import std: ok\` stdout.
- [x] `scripts/tests/test_libcxx_modules_symlink.sh` (phase 1) still passes.
- [x] `cmake --preset ninja-debug` + `cmake --build --preset ninja-debug -j1` (per the documented PCM-cache-corruption workaround for fresh builds — the SIGSEGV reproduces on develop too).
- [x] `ctest --preset ninja-debug` — **1924/1924 passed.**
- [x] Pre-commit hook (clang-format, cmake-format, clang-tidy, tests, coverage 100%) green.

Refs #326

🤖 Generated with [Claude Code](https://claude.com/claude-code)