### PR TITLE
build(libcxx): promote reflection flags to global compile options

### DIFF
--- a/cmake/libcxx.cmake
+++ b/cmake/libcxx.cmake
@@ -13,13 +13,29 @@ message(STATUS "Using custom libcxx from: ${LIBCXX_ROOT}")
 add_compile_options(-nostdinc++ -I${LIBCXX_INCLUDE_DIR}
                     -I${LIBCXX_BUILD_INCLUDE_DIR})
 
+# Reflection flags must be GLOBAL, not per-target. Clang hashes compile flags
+# into the module-cache key and also stamps them into every PCM. If the flags
+# differ between the producer of a PCM and a consumer that imports it, clang
+# refuses to load the PCM with a "configuration mismatch / Reflection was
+# disabled in precompiled file" diagnostic.
+#
+# Putting reflection flags inside apply_clang_flags() (target_compile_options)
+# meant they didn't propagate to every PCM producer — most notably any
+# auto-generated CMake-internal targets that build .pcm files. Promoting them
+# here via add_compile_options() guarantees uniform reflection state across
+# every TU and every PCM in the project.
+add_compile_options(-freflection -fannotation-attributes -fexpansion-statements)
+
 add_link_options(
   -nostdlib++ -L${LIBCXX_ROOT}/build/lib/x86_64-unknown-linux-gnu
   -Wl,-rpath,${LIBCXX_ROOT}/build/lib/x86_64-unknown-linux-gnu -lc++ -lc++abi
   -lunwind)
 
 function(apply_clang_flags target_name)
-  target_compile_options(
-    ${target_name} PRIVATE -fmodules -fbuiltin-module-map -freflection
-                           -fannotation-attributes -fexpansion-statements)
+  # Clang-modules (header-unit) support — required for any TU containing `import
+  # <header>;` lines. Kept per-target rather than global because a future
+  # migration may want to turn the Clang-modules path off for individual targets
+  # without touching the whole tree. The reflection flags this helper used to
+  # also add are now global (see above).
+  target_compile_options(${target_name} PRIVATE -fmodules -fbuiltin-module-map)
 endfunction()


### PR DESCRIPTION
## Summary

`apply_clang_flags()` previously added `-freflection -fannotation-attributes -fexpansion-statements` via `target_compile_options(... PRIVATE ...)`. These flags get stamped into every PCM and into the module-cache key, so a TU that imports a PCM built with a different reflection state fails to load it with:

```
error: Reflection was disabled in precompiled file '<…>.pcm' but is currently enabled
error: module file <…>.pcm cannot be loaded due to a configuration mismatch
```

Per-target placement made the flag set fragile: any PCM producer that isn't a direct caller of `apply_clang_flags()` would build PCMs *without* reflection. Right now there are no such producers, so the bug isn't biting on `develop` — but it would the moment we add one (CMake-internal targets, future helper wrappers, etc.). Promoting reflection to `add_compile_options()` removes a class of latent PCM-hash drift before it has a chance to bite.

`apply_clang_flags()` still owns `-fmodules -fbuiltin-module-map` since those control the Clang-modules header-unit path, which a future migration may want to disable per-target.

## What I discovered

While working on the `import std;` migration (#326), I tried to add a target that calls both `apply_clang_flags()` and `CXX_MODULE_STD ON`. The CMake-internal `__cmake_cxx_std_26` target that builds `std.pcm` inherits global `add_compile_options()` but **not** per-target options of consumers. Result: `std.pcm` was built without `-freflection`, the consumer was compiled with `-freflection`, and clang rejected the PCM at import time.

That migration hit unrelated walls and is paused, but this finding is a real architectural improvement that stands on its own — hence the standalone PR onto `develop`, not stacked on the #326 chain.

## What this PR is NOT

- Not part of the `import std;` migration. No new feature.
- No code changes. No test changes. No new flags.
- Same flag set as before — just moved from `target_compile_options(PRIVATE)` to `add_compile_options()`.

## Test plan

All four presets rebuilt from scratch (with `-j1` per the documented scan-deps race on a cold PCM cache):

- [x] `cmake --preset ninja-debug` + build + `ctest`: **1924/1924 passed**
- [x] `cmake --preset ninja-release` + build: clean
- [x] `cmake --preset ninja-asan-ubsan` + build: clean
- [x] `cmake --preset ninja-tsan` + build: clean
- [x] Pre-commit hook (cmake-format, tests, coverage 100%): green

🤖 Generated with [Claude Code](https://claude.com/claude-code)