### PR TITLE
test(pool): replace synchronization sleeps with std::latch (#307)

### DIFF
--- a/tests/db/test_pool.cpp
+++ b/tests/db/test_pool.cpp
@@ -19,11 +19,13 @@ namespace {
 
     // Controls MockPoolConnection behavior (global, not thread-safe — tests are sequential)
     struct MockConfig {
-        bool open_should_fail = false;
-        bool is_open_returns  = true;
-        int  open_fail_after  = -1; // fail after N successful opens (-1 = never)
-        int  open_call_count  = 0;
-        int  open_delay_ms    = 0; // artificial delay in open() to test race conditions
+        bool        open_should_fail = false;
+        bool        is_open_returns  = true;
+        int         open_fail_after  = -1; // fail after N successful opens (-1 = never)
+        int         open_call_count  = 0;
+        int         open_delay_ms    = 0;       // artificial delay in open() to test race conditions
+        std::latch* open_entered     = nullptr; // counted down on entry to open() (lock already released)
+        std::latch* open_release     = nullptr; // if set, open() blocks on it before returning
     };
 
     inline auto mock_config() -> MockConfig& {
@@ -79,6 +81,17 @@ struct MockPoolConnection {
     [[nodiscard]] static auto open(std::string_view /*unused*/) -> std::expected<MockPoolConnection, Error> {
         auto& cfg = mock_config();
         ++cfg.open_call_count;
+        // Signal that open() was entered — the caller has already released the pool
+        // lock at this point, so a waiter can deterministically acquire it (e.g. to
+        // call shutdown() before this open() returns). See Checkout_ShutdownDuringGrow.
+        if (cfg.open_entered != nullptr) {
+            cfg.open_entered->count_down();
+        }
+        // Optional handshake: block until the test releases us (e.g. after it has run
+        // shutdown() while we hold no lock). Deterministic alternative to open_delay_ms.
+        if (cfg.open_release != nullptr) {
+            cfg.open_release->wait();
+        }
         if (cfg.open_delay_ms > 0) {
             std::this_thread::sleep_for(std::chrono::milliseconds(cfg.open_delay_ms));
         }
@@ -354,13 +367,17 @@ TYPED_TEST(PoolExhaustionTest, Checkout_WaitsForReturn) {
     ASSERT_TRUE(c1.has_value());
 
     std::atomic<bool> got_connection{false};
-    std::thread       worker([&pool, &got_connection] {
+    std::latch        worker_started{1};
+    std::thread       worker([&pool, &got_connection, &worker_started] {
+        worker_started.count_down();
         auto c         = pool->checkout();
         got_connection = c.has_value();
     });
 
-    // Release after 100ms — worker should succeed
-    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    // Deterministic: wait until the worker is at checkout(), then release c1. The
+    // worker either finds the freed conn via find_idle() or is woken by checkin's
+    // notify_one() — both yield success (#307, replaces a 100ms sync sleep).
+    worker_started.wait();
     c1->reset(); // Releases the shared_ptr, triggering checkin
     worker.join();
     EXPECT_TRUE(got_connection);
@@ -401,15 +418,19 @@ TYPED_TEST(PoolExhaustionTest, Checkout_WaitsAndReusesReturned) {
     TypeParam const* original_raw = c1->get();
 
     std::atomic<TypeParam*> worker_raw{nullptr};
-    std::thread             worker([&pool, &worker_raw] {
+    std::latch              worker_started{1};
+    std::thread             worker([&pool, &worker_raw, &worker_started] {
+        worker_started.count_down();
         auto c = pool->checkout();
         if (c.has_value()) {
             worker_raw = c->get();
         }
     });
 
-    // Release after 100ms — worker gets the SAME connection back (reuse, not new)
-    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    // Deterministic: wait until the worker is at checkout(), then release c1. With
+    // max=1 only one connection ever exists, so the worker gets the SAME one back
+    // (reuse, not new) under every interleaving (#307, replaces a 100ms sync sleep).
+    worker_started.wait();
     c1->reset();
     worker.join();
 
@@ -471,13 +492,18 @@ TYPED_TEST(PoolShutdownTest, Shutdown_WaitsForReturns) {
     ASSERT_TRUE(conn.has_value());
 
     std::atomic<bool> shutdown_done{false};
-    std::thread       shutdown_thread([&pool, &shutdown_done] {
+    std::latch        shutdown_started{1};
+    std::thread       shutdown_thread([&pool, &shutdown_done, &shutdown_started] {
+        shutdown_started.count_down();
         pool->shutdown();
         shutdown_done = true;
     });
 
-    // Shutdown should block until connection is returned
-    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    // Deterministic: shutdown() blocks in cv_.wait until in_use == 0, so shutdown_done
+    // cannot become true while `conn` is held — regardless of how far the thread has
+    // progressed. The latch only confirms the thread is running before we assert
+    // (#307, replaces a 50ms sync sleep).
+    shutdown_started.wait();
     EXPECT_FALSE(shutdown_done);
 
     conn->reset(); // Return connection
@@ -978,23 +1004,35 @@ TEST_F(MockPoolTest, Checkout_EvictsStaleConnection) {
 
 // Lines 83-84: shutdown detected after relocking in checkout grow path
 TEST_F(MockPoolTest, Checkout_ShutdownDuringGrow) {
-    // open() takes 100ms — gives time for shutdown() to run while lock is released
-    mock_config().open_delay_ms = 100;
-    auto pool                   = storm::db::ConnectionPool<MockPoolConnection>::create(
+    // Two latches make the relock-then-see-shutdown branch deterministic without any
+    // timing guess: open() signals `in_open` on entry (lock already released), then
+    // blocks on `open_release` until the test has run shutdown().
+    std::latch in_open{1};
+    std::latch open_release{1};
+    auto&      cfg   = mock_config();
+    cfg.open_entered = &in_open;
+    cfg.open_release = &open_release;
+    auto pool        = storm::db::ConnectionPool<MockPoolConnection>::create(
             "mock://db", {.min_connections = 0, .max_connections = 3}
     );
     ASSERT_TRUE(pool.has_value());
 
-    // Thread does checkout → releases lock → open() sleeps 100ms
+    // grower: checkout → try_grow releases lock → open() signals in_open, then blocks
     std::atomic<bool> checkout_failed{false};
     std::thread       grower([&pool, &checkout_failed] {
         auto c          = pool->checkout();
         checkout_failed = !c.has_value();
     });
 
-    // Shutdown while grower is in open() (lock released)
-    std::this_thread::sleep_for(std::chrono::milliseconds(30));
+    // Deterministic ordering (no sleeps):
+    //   1. in_open.wait() blocks until the grower is INSIDE open() — try_grow has
+    //      already released the pool lock, so shutdown() can take it immediately.
+    //   2. shutdown() sets shutdown_ = true and (min=0, nothing in use) returns.
+    //   3. open_release lets open() return; the grower re-locks, sees shutdown_ ==
+    //      true, and checkout fails (covers pool.cppm try_grow shutdown branch, #307).
+    in_open.wait();
     pool->shutdown();
+    open_release.count_down();
     grower.join();
     EXPECT_TRUE(checkout_failed);
 }


### PR DESCRIPTION
## Summary

Four pool tests used `std::this_thread::sleep_for(...)` as a **synchronization** primitive — "wait long enough for the other thread to reach a code point". This is the same flake pattern that #300/#305 fixed in `Checkout_ShutdownDuringWait`. Each was a potential future #300. This replaces every in-scope sync sleep with a `std::latch` + deterministic ordering.

## Changes (per site)

| Test | Was | Now |
|---|---|---|
| `Checkout_WaitsForReturn` | 100ms sleep | latch + join — success holds under every interleaving (find_idle or checkin notify_one) |
| `Checkout_WaitsAndReusesReturned` | 100ms sleep | latch + join — max=1 guarantees same conn reused regardless of timing |
| `Shutdown_WaitsForReturns` | 50ms sleep | latch confirms thread started; shutdown's `cv_.wait(in_use==0)` makes the negative assert deterministic while conn is held |
| `Checkout_ShutdownDuringGrow` | 30ms sleep **+ 100ms open_delay** | mock `open()` signals an `open_entered` latch on entry (pool lock already released) and blocks on `open_release`; the test waits, runs `shutdown()`, then releases — the grower re-locks and **deterministically** sees `shutdown_ == true` |

The last site is the notable one: the before-checkout latch alone was a *coverage regression* (the old sleep gave the grower a head start into `open()`, covering `pool.cppm` `try_grow`'s shutdown branch). The in-`open()` handshake removes **both** the 30ms sync sleep **and** the 100ms `open_delay` guess, and covers that branch deterministically rather than by timing luck.

## Out of scope (left untouched)

- The `open_delay_ms` mock feature itself and the `PoolLifetimeTest` family — these wait for real `steady_clock` expiry.

## Verification

- ✅ 200 sequential repeats — 0 failures
- ✅ 8 × 20 parallel repeats — 0 failures
- ✅ TSAN clean ×20 — 0 races
- ✅ ASAN+UBSAN clean ×20 — 0 errors
- ✅ Coverage 100% (6057/6057 lines)
- ✅ Full `ctest --preset ninja-debug` — 1924/1924 passed

Closes #307

🤖 Generated with [Claude Code](https://claude.com/claude-code)