### PR TITLE
test(pool): assert shutdown-specific error in Checkout_ShutdownDuringWait (#306)

### DIFF
--- a/tests/db/test_pool.cpp
+++ b/tests/db/test_pool.cpp
@@ -958,16 +958,19 @@ TEST_F(MockPoolTest, Checkout_ShutdownDuringWait) {
     //   3. Whichever thread reaches the mutex first, the waiter's checkout() will see
     //      shutdown_ == true — either via the early-return at the top of checkout()
     //      (if shutdown_thread ran first) or via the shutdown_ re-check inside
-    //      wait_for_idle (if the waiter ran first). Either way: got_error == true.
-    //   4. waiter.join() returns once the waiter has set got_error.
+    //      wait_for_idle (if the waiter ran first). Either way: the shutdown error.
+    //   4. waiter.join() returns once the waiter has set got_shutdown_error.
     //   5. Only then we reset c1, which lets shutdown_thread's cv_.wait observe
     //      in_use == 0 and complete.
-    std::atomic<bool> got_error{false};
+    // Assert the *shutdown* error specifically, not just any error (#306): a
+    // checkout_timeout_ms expiry would also return an error, silently turning
+    // this test into a no-op if shutdown_thread is starved past the timeout.
+    std::atomic<bool> got_shutdown_error{false};
     std::latch        waiter_started{1};
-    std::thread       waiter([&pool, &got_error, &waiter_started] {
+    std::thread       waiter([&pool, &got_shutdown_error, &waiter_started] {
         waiter_started.count_down();
-        auto c    = pool->checkout();
-        got_error = !c.has_value();
+        auto c             = pool->checkout();
+        got_shutdown_error = !c.has_value() && c.error().message().contains("shut down");
     });
 
     waiter_started.wait();
@@ -976,7 +979,7 @@ TEST_F(MockPoolTest, Checkout_ShutdownDuringWait) {
     waiter.join();
     c1->reset(); // Return c1 → shutdown_thread's cv_.wait predicate becomes true.
     shutdown_thread.join();
-    EXPECT_TRUE(got_error);
+    EXPECT_TRUE(got_shutdown_error);
 }
 
 // Lines 232-234: find_idle() erases stale connection (is_open() == false)


### PR DESCRIPTION
## Summary

`MockPoolTest.Checkout_ShutdownDuringWait` previously asserted only that the
blocked waiter's `checkout()` returned **some** error. But `wait_for_idle()`
has two error paths — `"Pool is shut down"` (the path under test) and
`"Pool checkout timed out"` (the 5s `checkout_timeout_ms` expiry). If
`shutdown_thread` is starved past the timeout (overloaded box, scheduler
hiccup, future startup delays), the timeout fires and the test **passes for
the wrong reason** — silently a no-op.

This change matches the shutdown message specifically
(`c.error().message().contains("shut down")`), so a timeout-path pass now
fails the assertion.

## Verification

- Debug: 200 sequential repeats + 8×50 parallel-load runs — all pass
- TSAN: 50× clean (no data races)
- ASAN+UBSAN: 50× clean
- Full `*Pool*` suite: 41 passed (PG-backed skipped; PG not running)
- Pre-commit: clang-format, clang-tidy, 1924/1924 tests, 100% coverage

Test-only change; no source touched, so no benchmark needed.

## Definition of done

- [x] `got_error` replaced by an assertion that specifically matches the shutdown error message
- [x] 200 sequential repeats + parallel-load runs still pass

Closes #306

🤖 Generated with [Claude Code](https://claude.com/claude-code)