### PR TITLE
refactor(cache): drop vestigial mutable on Statement L2 cache fields (#272)

### DIFF
--- a/docs/architecture/OVERVIEW.md
+++ b/docs/architecture/OVERVIEW.md
@@ -145,7 +145,7 @@ Unified caching across UPDATE/DELETE/SELECT:
 
 ```cpp
 template <typename T> class XStatement {
-    mutable Statement* cached_stmt_ = nullptr;
+    Statement* cached_stmt_ = nullptr;
 
     auto execute_optimized(const T& obj) {
         if (!cached_stmt_) {

--- a/docs/architecture/STATEMENT_CACHING.md
+++ b/docs/architecture/STATEMENT_CACHING.md
@@ -34,9 +34,9 @@ Statement caches the prepared SQLite statement:
 
 ```cpp
 template <typename T> class SelectStatement {
-    mutable Statement* cached_stmt_ = nullptr;
+    Statement* cached_stmt_ = nullptr;  // plain field — no `mutable`
 
-    auto execute_optimized() {
+    auto execute_optimized() {          // non-const: it mutates the cache
         if (!cached_stmt_) {
             cached_stmt_ = *conn_.prepare_cached(get_sql());
         }
@@ -50,6 +50,11 @@ template <typename T> class SelectStatement {
     }
 };
 ```
+
+The `cached_*_stmt_` pointers are **plain (non-`mutable`) fields**. Every method
+that writes them is non-`const`, so const-correctness is preserved at the
+Statement level — a `const SelectStatement&` cannot mutate the cache. See
+[Const-correctness — why no `mutable` at Level 2](#const-correctness--why-no-mutable-at-level-2).
 
 **Benefits**:
 - Avoids SQL parsing
@@ -115,8 +120,8 @@ SelectStatement uses separate caches for simple SELECT vs JOIN queries:
 
 ```cpp
 template <typename T> class SelectStatement {
-    mutable Statement* cached_stmt_ = nullptr;       // Simple SELECT
-    mutable Statement* cached_join_stmt_ = nullptr;  // JOIN SELECT
+    Statement* cached_stmt_ = nullptr;       // Simple SELECT
+    Statement* cached_join_stmt_ = nullptr;  // JOIN SELECT
 
     template <typename JoinStmt = void>
     auto execute_optimized(JoinStmt* join_stmt = nullptr) {
@@ -192,6 +197,49 @@ pinned in memory across cache growth, so the raw `Statement*` pointers held at
 Level 2 stay valid as long as the underlying entry is not erased. This removes
 the hidden capacity contract that pre-Issue-#215 code relied on (reserve 32
 slots and hope no one grows past that).
+
+## Const-correctness — why no `mutable` at Level 2
+
+**Decision (Issue #272):** The Level 2 cache pointers in
+`InsertStatement`, `UpdateStatement`, `EraseStatement`, and `SelectStatement`
+are **plain fields, not `mutable`**.
+
+### Background
+
+Issue #272 was opened to address a const-correctness concern inherited from
+#215: the four Statement classes carried `mutable Statement*` cache pointers so
+that `const` methods could mutate the cache. The issue proposed three structural
+fixes (opt-in caching, a thread-local side-table, or a non-const wrapper).
+
+### What we found
+
+By the time #272 was picked up, that premise no longer held. Every method that
+writes a `cached_*_stmt_` field — `ensure_cached_stmt`, `prepare_simple_path`,
+`prepare_and_bind`, `prepare_statement`, `execute_one`, `execute_get_fast`,
+`reset`, `invalidate_cache`, and the `execute*` paths — is already **non-`const`**.
+The Statement objects are reached from `QuerySet` through `*unique_ptr`, which
+yields a non-const `Statement&` even from a `const` getter, so callers never need
+a `const` method to mutate the cache. The `mutable` keyword on all 11 cache
+fields (2 in insert, 1 in update, 2 in erase, 6 in select) was therefore **dead
+state** — a leftover from the pre-#215 `execute_optimized() const` design.
+
+### What we did
+
+Removed `mutable` from all 11 fields. This makes const-correctness real at the
+Statement level (`const SelectStatement&` can no longer mutate its cache) at zero
+cost: removing `mutable` from a field that no `const` method writes is a no-op at
+codegen. Verified by clean Debug/ASAN+UBSAN/TSAN builds (1929 tests) and an
+unchanged Core benchmark profile.
+
+None of the three structural options were needed — they all existed to absorb a
+const-mutation that does not occur. The remaining intentional const-boundary is at
+**Level 1**: `QuerySet` holds `mutable std::unique_ptr<…Statement>` and lazily
+constructs each Statement from a `const` getter. That `mutable` is load-bearing
+(lazy init from `const` query methods) and is out of scope for #272.
+
+> **Cache statistics/metrics** (parent #215 acceptance criterion #6) remain a
+> separate, unimplemented feature tracked under #214/#215 — not part of this
+> change.
 
 ## Thread Safety
 

--- a/docs/development/ADDING_FEATURES.md
+++ b/docs/development/ADDING_FEATURES.md
@@ -64,7 +64,7 @@ If the operation will be repeated, add caching:
 ```cpp
 template <typename T>
 class YourOperationStatement : private BaseStatement<T> {
-    mutable Statement* cached_stmt_ = nullptr;
+    Statement* cached_stmt_ = nullptr;
 
     auto execute_single_optimized(const T& obj) {
         if (!cached_stmt_) {

--- a/docs/development/PERFORMANCE_GUIDELINES.md
+++ b/docs/development/PERFORMANCE_GUIDELINES.md
@@ -185,7 +185,7 @@ auto execute_one(const T& obj) {
 ```cpp
 class SomeStatement {
     // Member to cache statement pointer
-    mutable Statement* cached_stmt_ = nullptr;
+    Statement* cached_stmt_ = nullptr;
 
     auto execute_one(const T& obj) {
         if (!cached_stmt_) {

--- a/docs/development/PERFORMANCE_TIPS.md
+++ b/docs/development/PERFORMANCE_TIPS.md
@@ -195,8 +195,8 @@ while (sqlite3_step(raw_stmt) == SQLITE_ROW) {
 
 ```cpp
 // Inside statement class
-mutable const void* cached_expr_addr_ = nullptr;
-mutable Statement* cached_stmt_ = nullptr;
+const void* cached_expr_addr_ = nullptr;
+Statement* cached_stmt_ = nullptr;
 
 auto execute(const WhereExpr& expr) {
     const void* expr_addr = static_cast<const void*>(expr.get());

--- a/docs/features/CRUD_OPERATIONS.md
+++ b/docs/features/CRUD_OPERATIONS.md
@@ -137,7 +137,7 @@ UpdateStatement uses the 3-level caching pattern:
 
 ```cpp
 template <typename T> class UpdateStatement {
-    mutable Statement* cached_stmt_ = nullptr;
+    Statement* cached_stmt_ = nullptr;
 
     auto execute_single_optimized(const T& obj) {
         if (!cached_stmt_) {

--- a/docs/features/SELECT_QUERIES.md
+++ b/docs/features/SELECT_QUERIES.md
@@ -95,7 +95,7 @@ template <class T> class QuerySet {
 
 // Level 2: Statement caches prepared statement
 template <typename T> class SelectStatement {
-    mutable Statement* cached_stmt_ = nullptr;
+    Statement* cached_stmt_ = nullptr;
 
     auto execute_optimized() {
         if (!cached_stmt_) {

--- a/src/orm/statements/erase.cppm
+++ b/src/orm/statements/erase.cppm
@@ -433,8 +433,8 @@ export namespace storm::orm::statements {
         std::shared_ptr<ConnType> conn_;
         // Raw pointers into Connection::statement_cache_ (pointer-stable via
         // unique_ptr<Statement> value type, Issue #215).
-        mutable Statement* cached_single_stmt_   = nullptr;
-        mutable Statement* cached_max_bulk_stmt_ = nullptr;
+        Statement* cached_single_stmt_   = nullptr;
+        Statement* cached_max_bulk_stmt_ = nullptr;
     };
 
 } // namespace storm::orm::statements

--- a/src/orm/statements/insert.cppm
+++ b/src/orm/statements/insert.cppm
@@ -594,8 +594,8 @@ export namespace storm::orm::statements {
         // Raw pointers obtained from Connection::prepare_cached(). Pointer
         // stability across cache growth is guaranteed by the
         // `unique_ptr<Statement>` value type in StatementCache (Issue #215).
-        mutable Statement* cached_insert_returning_stmt_ = nullptr;
-        mutable Statement* cached_insert_stmt_           = nullptr;
+        Statement* cached_insert_returning_stmt_ = nullptr;
+        Statement* cached_insert_stmt_           = nullptr;
     };
 
 } // namespace storm::orm::statements

--- a/src/orm/statements/select.cppm
+++ b/src/orm/statements/select.cppm
@@ -625,18 +625,18 @@ export namespace storm::orm::statements {
         std::shared_ptr<ConnType> conn_;
 
         // Cache for simple SELECT (static SQL, compile-time constant)
-        mutable Statement* cached_simple_stmt_ = nullptr;
+        Statement* cached_simple_stmt_ = nullptr;
 
         // Cache for first() fast path (SELECT ... LIMIT 1, pre-built static SQL)
-        mutable Statement* cached_first_stmt_ = nullptr;
+        Statement* cached_first_stmt_ = nullptr;
 
         // Cache for get() fast path (SELECT ... LIMIT 2, pre-built static SQL)
-        mutable Statement* cached_get_stmt_ = nullptr;
+        Statement* cached_get_stmt_ = nullptr;
 
         // Cache for dynamic queries (WHERE, JOIN, modifiers) - validated by SQL comparison
-        mutable Statement*  cached_stmt_       = nullptr;
-        mutable const void* cached_where_addr_ = nullptr; // WHERE expression address cache
-        mutable std::string cached_sql_;
+        Statement*  cached_stmt_       = nullptr;
+        const void* cached_where_addr_ = nullptr; // WHERE expression address cache
+        std::string cached_sql_;
     };
 
 } // namespace storm::orm::statements

--- a/src/orm/statements/update.cppm
+++ b/src/orm/statements/update.cppm
@@ -313,7 +313,7 @@ export namespace storm::orm::statements {
         std::shared_ptr<ConnType> conn_;
         // Raw pointer into Connection::statement_cache_; pointer-stable thanks
         // to the unique_ptr<Statement> value type (Issue #215).
-        mutable Statement* cached_update_stmt_ = nullptr;
+        Statement* cached_update_stmt_ = nullptr;
     };
 
 } // namespace storm::orm::statements


### PR DESCRIPTION
## Summary

Fixes #272. The four Statement classes (`InsertStatement`, `UpdateStatement`, `EraseStatement`, `SelectStatement`) carried `mutable Statement*` cache pointers — a leftover from the pre-#215 `execute_optimized() const` design.

**Key finding:** the issue's premise no longer holds. Every method that writes a `cached_*_stmt_` field is already **non-const**, and Statements are reached from `QuerySet` via `*unique_ptr` (yielding a non-const `Statement&` even from a const getter). So no const method mutates the cache — the `mutable` keyword was **dead state**.

## Change

- Removed `mutable` from all 11 cache fields (2 insert, 1 update, 2 erase, 6 select).
- This makes const-correctness real at the Statement level at **zero codegen cost** (removing `mutable` from a never-const-mutated field is a no-op).
- None of #272's three structural options (opt-in cache, side-table, wrapper) were needed — they all existed to absorb a const-mutation that does not occur.
- The only remaining cache-related `mutable` is at **Level 1** (`QuerySet`'s lazy `unique_ptr` getters), which is load-bearing and out of scope.
- Decision recorded in `docs/architecture/STATEMENT_CACHING.md` (new § "Const-correctness — why no `mutable` at Level 2"); stale `mutable Statement*` snippets across 6 other docs updated to match the real code.

## Verification

- ✅ Debug build + 1929 tests pass
- ✅ ASAN+UBSAN: 1929/1929
- ✅ TSAN: 1929/1929
- ✅ 100% line coverage (pre-commit gate)
- ✅ Core benchmarks (Release): unchanged profile, no regression

## DoD (all met)

- [x] Decision documented in `STATEMENT_CACHING.md`
- [x] `mutable` count in `src/orm/statements/*.cppm` drops (11 → 0 cache fields)
- [x] No bench regression (Core 8, ±5%)
- [x] Existing tests pass (Option 1 did not land, so no new prepare-path test required)

Closes #272

🤖 Generated with [Claude Code](https://claude.com/claude-code)