### PR TITLE
fix(bench-dashboard): re-read git branch/hash per BenchRun (#267)

### DIFF
--- a/benchmarks/dashboard/db.hpp
+++ b/benchmarks/dashboard/db.hpp
@@ -182,13 +182,31 @@ namespace {
 
     class DashboardDB {
       public:
+        // git_hash + branch are volatile: they change whenever the developer
+        // checks out a branch or commits while the daemon keeps running. They
+        // MUST be re-read per BenchRun, not cached at startup (Issue #267).
+        struct GitContext {
+            std::string git_hash;
+            std::string branch;
+        };
+
+        using GitCapture = std::function<GitContext()>;
+
+        // Default: read the working tree via git. Injectable for tests.
+        DashboardDB() : git_capture_{&capture_git_context} {}
+        explicit DashboardDB(GitCapture git_capture) : git_capture_{std::move(git_capture)} {}
+
         [[nodiscard]] auto insert_run(std::string_view filter, bool is_full_run)
                 -> std::expected<std::int64_t, std::string> {
             ensure_host_context();
 
+            // Re-read git on every run — the working tree may have moved since
+            // the daemon started or since the previous run (Issue #267).
+            const GitContext git = git_capture_();
+
             bench_dashboard::BenchRun row{};
-            row.git_hash    = host_.git_hash;
-            row.branch      = host_.branch;
+            row.git_hash    = git.git_hash;
+            row.branch      = git.branch;
             row.timestamp   = current_iso8601();
             row.hostname    = host_.hostname;
             row.compiler    = host_.compiler;
@@ -224,10 +242,17 @@ namespace {
             return {};
         }
 
+        // Read the current working-tree git state. Default GitCapture impl.
+        static auto capture_git_context() -> GitContext {
+            return {.git_hash = run_capture("git rev-parse --short HEAD 2>/dev/null"),
+                    .branch   = run_capture("git rev-parse --abbrev-ref HEAD 2>/dev/null")};
+        }
+
       private:
+        // Host-level metadata that is stable for the daemon's whole lifetime —
+        // unlike git state, hostname and compiler never change mid-run, so they
+        // stay cached.
         struct HostContext {
-            std::string git_hash;
-            std::string branch;
             std::string hostname;
             std::string compiler;
         };
@@ -236,12 +261,11 @@ namespace {
             if (host_initialised_)
                 return;
             host_initialised_ = true;
-            host_.git_hash    = run_capture("git rev-parse --short HEAD 2>/dev/null");
-            host_.branch      = run_capture("git rev-parse --abbrev-ref HEAD 2>/dev/null");
             host_.hostname    = run_capture("hostname -s 2>/dev/null");
             host_.compiler    = std::format("Clang {}.{}", __clang_major__, __clang_minor__);
         }
 
+        GitCapture  git_capture_;
         HostContext host_{};
         bool        host_initialised_{false};
     };

--- a/benchmarks/dashboard/main.cpp
+++ b/benchmarks/dashboard/main.cpp
@@ -155,6 +155,24 @@ namespace {
         return check_table_exists(storm::QuerySet<bench_dashboard::BenchResult>().count().execute(), opts.db_path);
     }
 
+    // Each BenchRun re-reads git_hash/branch from the working tree at insert
+    // time (Issue #267), so the daemon's CWD MUST be inside the storm git work
+    // tree. Fail loudly at startup otherwise — a daemon outside the repo would
+    // silently stamp every run with empty git metadata.
+    auto check_inside_git_worktree() -> int {
+        if (run_capture("git rev-parse --is-inside-work-tree 2>/dev/null") == "true") {
+            return 0;
+        }
+        std::
+                fprintf( // NOLINT(cppcoreguidelines-pro-type-vararg)
+                        stderr,
+                        "storm_bench_dashboard: current directory is not inside the storm git work tree.\n"
+                        "  Each bench run records the live git branch/hash, which needs a git working tree.\n"
+                        "  Start the dashboard from within the storm repository checkout.\n"
+                );
+        return 4;
+    }
+
     // Open the AF_UNIX listener. Returns 0 on success, 3 on bind failure.
     auto setup_socket(Options const& opts, bench_dashboard::SocketServer& server) -> int {
         const std::string_view socket_path = opts.socket_path.empty() ? bench_dashboard::wire::default_socket_path()
@@ -326,6 +344,9 @@ auto main(int argc, char** argv) -> int { // NOLINT(bugprone-exception-escape)
 
     install_signal_handlers();
 
+    if (const int rc = check_inside_git_worktree(); rc != 0) {
+        return rc;
+    }
     if (const int rc = ensure_db_parent_dir(opts.db_path); rc != 0) {
         return rc;
     }

--- a/docs/development/BENCHMARK_DASHBOARD.md
+++ b/docs/development/BENCHMARK_DASHBOARD.md
@@ -78,6 +78,8 @@ When a baseline run exists in the database, each streamed result is compared in 
 
 `--baseline auto` skips partial/filtered runs (`is_full_run = false`) so percentage deltas are always against a comparable full run. If no matching baseline is found, the dashboard prints a notice and runs without comparison.
 
+> **Git branch/hash are read per run, not at startup.** Each `BenchRun` row records the working-tree `branch` and `git_hash` at the moment the bench process connects, not when the daemon started (Issue #267). This means a long-lived daemon stays correct across `git checkout`/commits — `--baseline auto` always matches the branch the bench was actually run from. Because the labels come from `git rev-parse`, **the dashboard must be started from inside the storm git work tree**; if it is not, it fails loudly at startup (exit code 4) instead of stamping every run with empty git metadata.
+
 ### Delta column
 
 Each result line shows a delta column next to the latency:

--- a/tests/bench_dashboard/test_dashboard_run_branch.cpp
+++ b/tests/bench_dashboard/test_dashboard_run_branch.cpp
@@ -1,0 +1,80 @@
+// Regression test for Issue #267.
+//
+// The daemon used to capture git_hash/branch ONCE at startup
+// (ensure_host_context) and reuse the cached values for every BenchRun row.
+// If the developer switched branches or committed while the daemon ran, every
+// later run was mislabeled with the daemon's startup branch — which silently
+// corrupted `--baseline auto` (it filters runs by branch+host).
+//
+// The fix: re-read the git working-tree state on EACH insert_run, via an
+// injectable git-capture callable. This test injects a stub that returns a
+// different branch per call (A, B, A) and asserts the three BenchRun rows carry
+// distinct, per-call branch values — proving the value is re-read, not cached.
+
+#include <meta> // must precede the imports (Finding A) — db.hpp uses `^^`
+
+#include <gtest/gtest.h>
+
+import storm;
+import std;
+import storm.bench_dashboard.wire;
+
+#include "../../benchmarks/dashboard/models.hpp" // NOSONAR cpp:S954
+#include "../../benchmarks/dashboard/args.hpp"
+#include "../../benchmarks/dashboard/db.hpp"
+
+namespace {
+
+    // Materialise every BenchRun row ordered by id, ascending.
+    auto all_runs() -> std::vector<bench_dashboard::BenchRun> {
+        auto rows = storm::QuerySet<bench_dashboard::BenchRun>()
+                            .order_by<^^bench_dashboard::BenchRun::id>()
+                            .select()
+                            .execute()
+                            .transform([](auto&& hive) {
+                                return std::forward<decltype(hive)>(hive) | std::views::as_rvalue |
+                                       std::ranges::to<std::vector<bench_dashboard::BenchRun>>();
+                            });
+        return rows ? std::move(*rows) : std::vector<bench_dashboard::BenchRun>{};
+    }
+
+} // namespace
+
+class DashboardRunBranch : public ::testing::Test {
+  public:
+    void SetUp() override {
+        ASSERT_TRUE(storm::QuerySet<bench_dashboard::BenchRun>::set_default_connection(":memory:").has_value());
+        const auto& conn = storm::QuerySet<bench_dashboard::BenchRun>::get_default_connection();
+        ASSERT_TRUE((storm::orm::schema::SchemaStatement<bench_dashboard::BenchRun>::create_table_if_not_exists(conn)));
+    }
+
+    void TearDown() override {
+        storm::QuerySet<bench_dashboard::BenchRun>::clear_default_connection();
+    }
+};
+
+// Start the "daemon" on branch A, then bench on B, then bench on A again. Each
+// insert_run must re-read git, so the three rows carry the actual per-call
+// branch (A, B, A) — not the startup value (A, A, A).
+TEST_F(DashboardRunBranch, BranchReReadPerRun) {
+    std::vector<DashboardDB::GitContext> const script = {
+            {.git_hash = "aaaaaaa", .branch = "feature/A"},
+            {.git_hash = "bbbbbbb", .branch = "feature/B"},
+            {.git_hash = "ccccccc", .branch = "feature/A"},
+    };
+    std::size_t call = 0;
+    DashboardDB db{[&]() -> DashboardDB::GitContext { return script.at(call++); }};
+
+    for (std::size_t i = 0; i < script.size(); ++i) {
+        ASSERT_TRUE(db.insert_run("", /*is_full_run=*/true).has_value());
+    }
+
+    const auto runs = all_runs();
+    ASSERT_EQ(runs.size(), 3U);
+    EXPECT_EQ(runs[0].branch, "feature/A");
+    EXPECT_EQ(runs[0].git_hash, "aaaaaaa");
+    EXPECT_EQ(runs[1].branch, "feature/B");
+    EXPECT_EQ(runs[1].git_hash, "bbbbbbb");
+    EXPECT_EQ(runs[2].branch, "feature/A");
+    EXPECT_EQ(runs[2].git_hash, "ccccccc");
+}


### PR DESCRIPTION
## Problem

The dashboard daemon captured `git_hash`/`branch` **once at startup** (`ensure_host_context`) and reused the cached values for every `BenchRun`. Switching branches or committing while the daemon ran mislabeled every later run with the startup branch — silently corrupting `--baseline auto`, which filters runs by `branch`+`host`.

## Fix

- **`benchmarks/dashboard/db.hpp`** — Split `DashboardDB` host context: `hostname`/`compiler` stay cached (stable for the daemon's lifetime), while `git_hash`/`branch` are re-read on **every** `insert_run` via an injectable `GitCapture` callable.
- **`benchmarks/dashboard/main.cpp`** — Added a startup guard `check_inside_git_worktree()` that fails loudly (exit 4) when the daemon CWD is not inside the git work tree, since each run now relies on `git rev-parse` against the working tree.
- **`tests/bench_dashboard/test_dashboard_run_branch.cpp`** — Regression test: injects an A→B→A branch script across three `insert_run` calls and asserts the `BenchRun` rows carry distinct per-call values.
- **`docs/development/BENCHMARK_DASHBOARD.md`** — Documented per-run git capture + the CWD-must-be-inside-repo requirement.

## Verification

- TDD: the new test **fails** under the old caching behavior, **passes** with the fix.
- Full suite: 1931/1931 tests pass (SQLite + PG).
- ASAN+UBSAN and TSAN: Dashboard tests clean.
- Release build green; loud-failure path confirmed (exit 4 outside repo).
- Coverage 100%, clang-tidy `--diff` clean.

## Definition of done

- [x] `BenchRun.git_hash`/`branch` reflect the working tree at `run_start`, not daemon startup.
- [x] A test demonstrates distinct `branch` values across A→B→A.
- [x] `--baseline auto` picks the right run per actual current branch (the filter now matches the per-run branch label).
- [x] Documented the CWD-inside-work-tree assumption (fails loudly at startup otherwise).

Closes #267

🤖 Generated with [Claude Code](https://claude.com/claude-code)