### PR TITLE
fix(bench): fair INSERT benchmark — BenchPerson, accumulate rows, symmetric RETURNING

### DIFF
--- a/benchmarks/anchors_raw.cpp
+++ b/benchmarks/anchors_raw.cpp
@@ -225,7 +225,7 @@ namespace {
 
     // Shared single-row INSERT driver for both anchors. Builds the table, then
     // times insert_sql to a counter-named row per iteration (rows accumulate —
-    // no DELETE, no UNIQUE on name). step_row mirrors the dialect: plain INSERT
+    // no DELETE, no UNIQUE on name). returning mirrors the dialect: plain INSERT
     // steps once to SQLITE_DONE; RETURNING steps to SQLITE_ROW, reads the id,
     // then steps again to SQLITE_DONE. Setup is outside the timed loop to match
     // the Storm fixtures — only the bind + step is measured.

--- a/benchmarks/anchors_raw.cpp
+++ b/benchmarks/anchors_raw.cpp
@@ -14,7 +14,8 @@
  *   - Storm/WHERE/where_int_comparison_gt/N:10000
  *   - Storm/WHERE/where_bool_equality/N:10000
  *   - Storm/SELECT/select/N:10000
- *   - Storm/INSERT/insert/N:1
+ *   - Storm/INSERT/insert/N:1           (INSERT … RETURNING id)
+ *   - Storm/INSERT/insert_no_return/N:1 (plain INSERT)
  *
  * When STORM_BENCH_SOCKET is set, streams over the dashboard wire with
  * is_raw=true (run_start), producing the Storm-vs-raw baseline run.
@@ -222,11 +223,16 @@ namespace {
     }
     BENCHMARK(BM_Raw_Select_All)->Name("Storm/SELECT/select")->Arg(kSelectRows)->ArgName("N");
 
-    // Storm/INSERT/insert/N:1 — single-row INSERT throughput
-    auto BM_Raw_Insert_Single(benchmark::State& state) -> void {
+    // Shared single-row INSERT driver for both anchors. Builds the table, then
+    // times insert_sql to a counter-named row per iteration (rows accumulate —
+    // no DELETE, no UNIQUE on name). step_row mirrors the dialect: plain INSERT
+    // steps once to SQLITE_DONE; RETURNING steps to SQLITE_ROW, reads the id,
+    // then steps again to SQLITE_DONE. Setup is outside the timed loop to match
+    // the Storm fixtures — only the bind + step is measured.
+    auto run_insert_benchmark(benchmark::State& state, char const* insert_sql, bool returning) -> void {
         sqlite3* db = open_memory_db();
         exec(db, kCreatePerson);
-        sqlite3_stmt* ins = prepare(db, "INSERT INTO person(name, age, salary) VALUES(?,?,?)");
+        sqlite3_stmt* ins = prepare(db, insert_sql);
 
         int counter = 0;
         for (auto _ : state) {
@@ -234,7 +240,15 @@ namespace {
             sqlite3_bind_text(ins, 1, name.c_str(), -1, SQLITE_TRANSIENT);
             sqlite3_bind_int(ins, 2, 30);
             sqlite3_bind_double(ins, 3, 50'000.0);
-            if (sqlite3_step(ins) != SQLITE_DONE) {
+            if (returning) {
+                if (sqlite3_step(ins) != SQLITE_ROW) {
+                    die(db, "insert returning step");
+                }
+                benchmark::DoNotOptimize(sqlite3_column_int(ins, 0));
+                if (sqlite3_step(ins) != SQLITE_DONE) {
+                    die(db, "insert returning done");
+                }
+            } else if (sqlite3_step(ins) != SQLITE_DONE) {
                 die(db, "insert step");
             }
             sqlite3_reset(ins);
@@ -245,7 +259,20 @@ namespace {
         sqlite3_finalize(ins);
         sqlite3_close(db);
     }
-    BENCHMARK(BM_Raw_Insert_Single)->Name("Storm/INSERT/insert")->Arg(1)->ArgName("N");
+
+    // Storm/INSERT/insert_no_return/N:1 — plain INSERT, no RETURNING
+    auto BM_Raw_Insert_No_Return(benchmark::State& state) -> void {
+        run_insert_benchmark(state, "INSERT INTO person(name, age, salary) VALUES(?,?,?)", /*returning=*/false);
+    }
+    BENCHMARK(BM_Raw_Insert_No_Return)->Name("Storm/INSERT/insert_no_return")->Arg(1)->ArgName("N");
+
+    // Storm/INSERT/insert/N:1 — INSERT with RETURNING id (mirrors Storm's insert() path)
+    auto BM_Raw_Insert_Returning(benchmark::State& state) -> void {
+        run_insert_benchmark(
+                state, "INSERT INTO person(name, age, salary) VALUES(?,?,?) RETURNING id", /*returning=*/true
+        );
+    }
+    BENCHMARK(BM_Raw_Insert_Returning)->Name("Storm/INSERT/insert")->Arg(1)->ArgName("N");
 
 } // namespace
 

--- a/benchmarks/crud_benchmark.cppm
+++ b/benchmarks/crud_benchmark.cppm
@@ -10,9 +10,10 @@
 // are intentionally dropped here; raw anchors land in their own TU in Phase 4.
 //
 // Per-iteration semantics that drive the run_once() shape:
-//   * INSERT: Person has UNIQUE(name) — must clear the table before every
-//     iteration so the next bind doesn't trip on the previous row.
-//   * INSERT (no return): same constraint, same clear; uses the
+//   * INSERT: BenchPerson has no UNIQUE(name) — rows accumulate. Each
+//     iteration stamps a fresh counter-based name so the bind never collides,
+//     mirroring the raw SQLite anchor (no per-iteration table clear).
+//   * INSERT (no return): same accumulate-with-counter shape; uses the
 //     ReturnId::No path so RETURNING is not generated.
 //   * UPDATE_PK: rows seeded once in prepare(); each iteration re-issues the
 //     same parameterised UPDATE — no clear needed.
@@ -25,20 +26,12 @@
 
 module;
 
-// `sqlite3` typedef used in clear_table — base.cppm exports get_db() but the
-// SQLite types remain hidden behind its BMI.
-#include <sqlite3.h>
-
 // `<tuple>` + models.hpp must precede any `import` so reflection annotations
 // on Person/User/FKMessage are textually visible (clang-p2996 #262, see
 // feedback_cpp26_module_reflection_annotations).
 #include <tuple>
 
 #include "models.hpp"
-
-// std::meta:: is used in this module's purview; import std; does not export it
-// (issue #326 Finding A), so the reflection header must be textually included.
-#include <meta>
 
 export module storm_benchmark_crud;
 
@@ -53,6 +46,8 @@ export namespace storm::benchmark {
     class CrudBenchmark : public DataBenchmarkBase<CrudBenchmark<Model, test>, Model> {
         using Base = DataBenchmarkBase<CrudBenchmark<Model, test>, Model>;
 
+        int counter_ = 0;
+
         static consteval auto is_insert_op() -> bool {
             constexpr auto op = test.operation.view();
             return op == "insert" || op == "insert_no_return";
@@ -65,15 +60,6 @@ export namespace storm::benchmark {
         }
         static consteval auto is_delete_op() -> bool {
             return test.operation.view() == "delete_pk";
-        }
-
-        static auto clear_table() -> void {
-            sqlite3* db = get_db<Model>();
-            if (db == nullptr) {
-                return;
-            }
-            auto sql = std::format("DELETE FROM {}", std::meta::identifier_of(^^Model));
-            sqlite3_exec(db, sql.c_str(), nullptr, nullptr, nullptr);
         }
 
       public:
@@ -92,6 +78,13 @@ export namespace storm::benchmark {
                 };
             } else if constexpr (std::is_same_v<Model, User>) {
                 return Model{.id = 0, .name = std::format("User{}", i), .age = 20 + (i % 50)};
+            } else if constexpr (std::is_same_v<Model, BenchPerson>) {
+                return Model{
+                        .id     = 0,
+                        .name   = std::format("P{}", index),
+                        .age    = 20 + (index % 50),
+                        .salary = 30000.0 + (index * 1000.0),
+                };
             } else {
                 return Model{};
             }
@@ -99,8 +92,8 @@ export namespace storm::benchmark {
 
         auto prepare(int n) -> void {
             if constexpr (is_insert_op()) {
-                // INSERT seeds nothing — each iteration generates / inserts.
-                // Generate the dataset once; run_once() clears + re-inserts.
+                // INSERT seeds nothing — each iteration stamps fresh names and
+                // inserts. Generate the dataset once; rows accumulate.
                 Base::prepare(n);
             } else if constexpr (is_update_op()) {
                 Base::prepare_with_insert(n);
@@ -125,14 +118,14 @@ export namespace storm::benchmark {
         // execution, not consumption of the result.
         auto run_once() -> void {
             if constexpr (is_insert_no_return_op()) {
-                clear_table();
+                stamp_unique_names();
                 if (Base::batch_size() == 1) {
                     (void)Base::qs().template insert<storm::orm::statements::ReturnId::No>(Base::data()[0]).execute();
                 } else {
                     (void)Base::qs().template insert<storm::orm::statements::ReturnId::No>(Base::data()).execute();
                 }
             } else if constexpr (is_insert_op()) {
-                clear_table();
+                stamp_unique_names();
                 if (Base::batch_size() == 1) {
                     (void)Base::qs().insert(Base::data()[0]).execute();
                 } else {
@@ -158,6 +151,20 @@ export namespace storm::benchmark {
         }
 
       private:
+        // Stamp a fresh unique name on the rows an INSERT iteration will write
+        // so they accumulate without tripping a UNIQUE(name) constraint —
+        // mirrors what the raw SQLite anchor does (no per-iteration clear).
+        // Single-insert touches only data()[0]; batch touches every row.
+        auto stamp_unique_names() -> void {
+            if (Base::batch_size() == 1) {
+                Base::data()[0].name = std::format("P{}", counter_++);
+                return;
+            }
+            for (auto& obj : Base::data()) {
+                obj.name = std::format("P{}", counter_++);
+            }
+        }
+
         auto reinsert_for_delete() -> void {
             // Re-seed via the same path as the initial prepare_with_insert:
             // clear table → insert → select-back IDs. This sidesteps the

--- a/benchmarks/models.hpp
+++ b/benchmarks/models.hpp
@@ -33,4 +33,13 @@ namespace storm::benchmark {
         std::string                               text;
     };
 
+    // INSERT-benchmark model — no UNIQUE, no indexes; matches the raw SQLite
+    // anchor schema exactly so bulk inserts need no per-iteration DELETE.
+    struct BenchPerson {
+        [[= storm::meta::FieldAttr::primary]] int id;
+        std::string                               name;
+        int                                       age;
+        double                                    salary;
+    };
+
 } // namespace storm::benchmark

--- a/benchmarks/register.cpp
+++ b/benchmarks/register.cpp
@@ -53,6 +53,9 @@ namespace storm::benchmark {
         if (!storm::orm::schema::SchemaStatement<Person>::create_table_if_not_exists(conn).has_value()) {
             return false;
         }
+        if (!storm::orm::schema::SchemaStatement<BenchPerson>::create_table_if_not_exists(conn).has_value()) {
+            return false;
+        }
         if (!storm::orm::schema::SchemaStatement<User>::create_table_if_not_exists(conn).has_value()) {
             return false;
         }

--- a/benchmarks/registry.cppm
+++ b/benchmarks/registry.cppm
@@ -26,6 +26,7 @@ export module storm_benchmark_registry;
 import storm;
 
 export namespace storm::benchmark {
+    using ::storm::benchmark::BenchPerson;
     using ::storm::benchmark::FKMessage;
     using ::storm::benchmark::Person;
     using ::storm::benchmark::User;
@@ -65,6 +66,8 @@ export namespace storm::benchmark::registry {
             return fn.template operator()<FKMessage>();
         } else if constexpr (test.model == "User") {
             return fn.template operator()<User>();
+        } else if constexpr (test.model == "BenchPerson") {
+            return fn.template operator()<BenchPerson>();
         } else {
             return fn.template operator()<Person>();
         }

--- a/benchmarks/tests/benchmark_tests.yaml
+++ b/benchmarks/tests/benchmark_tests.yaml
@@ -66,21 +66,21 @@ tests:
   - name: insert
     category: INSERT
     description: INSERT operations with various batch sizes
-    model: Person
+    model: BenchPerson
     operation: insert
     size_profile: batch_standard
 
   - name: insert_no_return
     category: INSERT
     description: INSERT without RETURNING clause (no ID retrieval)
-    model: Person
+    model: BenchPerson
     operation: insert_no_return
     size_profile: batch_standard
 
   - name: insert_edge
     category: INSERT_EDGE
     description: INSERT at SQLite chunk boundary (999/4 fields = 249)
-    model: Person
+    model: BenchPerson
     operation: insert
     size_profile: batch_insert_edge
 


### PR DESCRIPTION
Closes #349

## Changes
- `BenchPerson` model added to `benchmarks/models.hpp` — no UNIQUE, no indexes, matches raw anchor schema exactly
- INSERT / insert_no_return / insert_edge tests switched to `BenchPerson` in YAML/JSON corpus
- Registry + initialize_db wired for `BenchPerson`
- `CrudBenchmark`: counter-based unique names per iteration via `stamp_unique_names()`, `clear_table()` removed from INSERT hot path — rows now accumulate like the raw anchor
- Raw anchors: plain INSERT renamed to `insert_no_return`; new `RETURNING id` anchor added for `insert`; shared `run_insert_benchmark` driver eliminates duplication

Both pairs (insert/insert_no_return) now measure identical workloads on Storm and raw sides.