### PR TITLE
fix(pg): capture PQstatus before PQfinish in Connection::open error path

### DIFF
--- a/src/db/postgresql_connection.cppm
+++ b/src/db/postgresql_connection.cppm
@@ -56,9 +56,10 @@ export namespace storm::db::postgresql {
             }
 
             if (PQstatus(raw_conn) != CONNECTION_OK) {
-                const std::string msg = PQerrorMessage(raw_conn);
+                const int         status = static_cast<int>(PQstatus(raw_conn));
+                const std::string msg    = PQerrorMessage(raw_conn);
                 PQfinish(raw_conn);
-                return std::unexpected(Error{static_cast<int>(PQstatus(raw_conn)), msg});
+                return std::unexpected(Error{status, msg});
             }
 
             return Connection{PGconnPtr{raw_conn}, config};

--- a/src/db/postgresql_connection.cppm
+++ b/src/db/postgresql_connection.cppm
@@ -56,7 +56,7 @@ export namespace storm::db::postgresql {
             }
 
             if (PQstatus(raw_conn) != CONNECTION_OK) {
-                const int         status = static_cast<int>(PQstatus(raw_conn));
+                const auto        status = static_cast<int>(PQstatus(raw_conn));
                 const std::string msg    = PQerrorMessage(raw_conn);
                 PQfinish(raw_conn);
                 return std::unexpected(Error{status, msg});

--- a/tests/mock_libpq/mock_libpq.cpp
+++ b/tests/mock_libpq/mock_libpq.cpp
@@ -18,6 +18,11 @@
 namespace {
 
     // Fake handles - store state for opaque PGconn/PGresult pointers
+    // Sentinel poison value written into a FakePGconn by PQfinish. It is NOT a
+    // real ConnStatusType; reading it back means production code touched the
+    // connection after PQfinish (the Issue #351 use-after-free).
+    constexpr int CONNECTION_BAD_AFTER_FINISH = 99;
+
     struct FakePGconn {
         int         status = CONNECTION_OK;
         std::string error_message;
@@ -238,8 +243,13 @@ auto PQstatus(const PGconn* conn) -> ConnStatusType {
 }
 
 auto PQfinish(const PGconn* conn) -> void {
-    (void)conn;
-    // Memory managed by g_fake_conns vector
+    // Memory stays owned by g_fake_conns, but poison the status so any
+    // PQstatus(conn) read AFTER PQfinish (a use-after-free in real libpq,
+    // Issue #351) is observable: it no longer returns the pre-finish value.
+    // The underlying FakePGconn is genuinely mutable (owned by g_fake_conns).
+    auto* mutable_conn = const_cast<PGconn*>(conn); // NOSONAR(cpp:S3630) NOLINT(cppcoreguidelines-pro-type-const-cast)
+    if (auto* fake = reinterpret_cast<FakePGconn*>(mutable_conn); fake)
+        fake->status = CONNECTION_BAD_AFTER_FINISH;
 }
 
 auto PQerrorMessage(const PGconn* conn) -> char* {

--- a/tests/mock_libpq/test_orm_pg_mock_errors.cpp
+++ b/tests/mock_libpq/test_orm_pg_mock_errors.cpp
@@ -68,8 +68,13 @@ namespace {
         auto result = PgConnection::open("host=localhost");
 
         ASSERT_FALSE(result.has_value());
-        // Error code is static_cast<int>(PQstatus(raw_conn)) after PQfinish
-        EXPECT_NE(result.error().code(), 0);
+        // Issue #351: the status MUST be captured before PQfinish(raw_conn).
+        // The mock poisons FakePGconn::status inside PQfinish, so a read of
+        // PQstatus(raw_conn) after the free would yield the poison value, not
+        // CONNECTION_BAD. Asserting the exact pre-finish status catches the
+        // use-after-free that ASAN flags against real libpq.
+        EXPECT_EQ(result.error().code(), CONNECTION_BAD);
+        EXPECT_EQ(result.error().message(), "Connection refused");
     }
 
     // ============================================================================


### PR DESCRIPTION
## Summary

Fixes a use-after-free in the PostgreSQL `Connection::open()` connection-failure path. `PQstatus(raw_conn)` was called **after** `PQfinish(raw_conn)` freed the `PGconn` struct (`src/db/postgresql_connection.cppm:58-61`). It usually "works" because libpq returns a cached enum, but it is UB and ASAN would flag it against real libpq.

The status is now captured into a local before `PQfinish`.

## Test (TDD, failing-first)

The libpq mock previously could not reproduce the bug — its `PQfinish` left memory untouched, so `PQstatus` always returned the same cached value. `PQfinish` now poisons `FakePGconn::status` so a post-finish read is observable as a distinct sentinel. `StatusReturnsBad` was tightened to assert the exact pre-finish status:

- **Before fix (RED):** `code()` returned the poison value `99` ≠ `CONNECTION_BAD` → FAILED
- **After fix (GREEN):** `code() == CONNECTION_BAD` → PASSED

## Verification

- Full debug suite: 1969/1969 pass
- `ninja-asan-ubsan`: 1969/1969 pass (clean on the failure path)
- Pre-commit gate (clang-format, clang-tidy --diff, tests, 100% coverage): all green

No docs/agent files reference this error path (grep found only a generic glossary entry in FUZZING.md).

Closes #351

🤖 Generated with [Claude Code](https://claude.com/claude-code)