### PR TITLE
fix(where): store comparison operands by owning value to prevent dangling bind (#352)

### DIFF
--- a/docs/features/WHERE_CLAUSES.md
+++ b/docs/features/WHERE_CLAUSES.md
@@ -48,6 +48,22 @@ auto results = QuerySet<Person>()
 | `<` | `<` | `age < 30` |
 | `<=` | `<=` | `age <= 30` |
 
+### Operand lifetime
+
+`where()` is deferred — the expression node is built now and the operand is bound only at
+`.select()`. Comparison operands are therefore stored **by owning value**: text operands
+(`std::string_view`, `const char*`, string literals) are copied into a `std::string` at
+construction. This means an expression survives the buffer it was built from:
+
+```cpp
+auto make_filter() {
+    std::string name = load_name();           // local buffer
+    return field<^^Person::name>() == name;    // operand is COPIED, not viewed
+}                                              // `name` is destroyed here — safe
+
+auto results = QuerySet<Person>().where(make_filter()).select();  // no dangling bind
+```
+
 ## String Operations
 
 ### LIKE pattern matching

--- a/src/orm/where.cppm
+++ b/src/orm/where.cppm
@@ -192,8 +192,6 @@ export namespace storm::orm::where {
                                        ComparisonExpr<double>,
                                        ComparisonExpr<float>,
                                        ComparisonExpr<std::string>,
-                                       ComparisonExpr<std::string_view>,
-                                       ComparisonExpr<const char*>,
                                        ComparisonExpr<bool>,
                                        NullCheckExpr,
                                        LikeExpr,
@@ -320,6 +318,32 @@ export namespace storm::orm::where {
         );
     }
 
+    // Normalize a comparison operand to the type actually stored in ExpressionVariant.
+    // The expression node can outlive the operand's source buffer (where() is deferred, #352),
+    // so text operands (string_view / const char* / char arrays) are copied into an owning
+    // std::string. Enum operands are stored as their underlying int. Everything else is decayed.
+    template <typename V> auto normalize_operand(V&& value) {
+        using D = std::decay_t<V>;
+        if constexpr (std::is_enum_v<D>) {
+            return static_cast<int>(static_cast<std::underlying_type_t<D>>(value));
+        } else if constexpr (std::is_convertible_v<D, std::string_view> && !std::is_same_v<D, std::string>) {
+            return std::string(std::string_view(std::forward<V>(value)));
+        } else {
+            return D{std::forward<V>(value)};
+        }
+    }
+
+    // Build a value-owning ComparisonExpr from any operand. See normalize_operand for the type rules.
+    template <typename V>
+    [[nodiscard]] auto make_comparison_expr(const std::string& field_name, CompOp op, V&& value) -> Expr {
+        auto stored = normalize_operand(std::forward<V>(value));
+        return Expr(
+                std::make_shared<ExpressionVariant>(ComparisonExpr<decltype(stored)>{
+                        .field_name_ = std::move(field_name), .op_ = op, .value_ = std::move(stored)
+                })
+        );
+    }
+
     // CollatedField proxy - wraps field name with COLLATE clause
     // Created via field<^^Person::name>().collate(Collate::NoCase)
     // All comparison operators produce SQL like: "name COLLATE NOCASE = ?"
@@ -398,11 +422,7 @@ export namespace storm::orm::where {
         }
 
         template <typename V> auto make_comparison(CompOp op, V&& value) const -> Expr {
-            return Expr(
-                    std::make_shared<ExpressionVariant>(ComparisonExpr<std::decay_t<V>>{
-                            .field_name_ = collated_name_, .op_ = op, .value_ = std::forward<V>(value)
-                    })
-            );
+            return where::make_comparison_expr(collated_name_, op, std::forward<V>(value));
         }
     };
 
@@ -508,22 +528,7 @@ export namespace storm::orm::where {
       private:
         // Helper: create comparison expression, converting enum values to int
         template <typename V> auto make_comp(CompOp op, V&& value) const -> Expr {
-            using D = std::decay_t<V>;
-            if constexpr (std::is_enum_v<D>) {
-                return Expr(
-                        std::make_shared<ExpressionVariant>(ComparisonExpr<int>{
-                                .field_name_ = std::string(field_name_sv),
-                                .op_         = op,
-                                .value_      = static_cast<int>(static_cast<std::underlying_type_t<D>>(value))
-                        })
-                );
-            } else {
-                return Expr(
-                        std::make_shared<ExpressionVariant>(ComparisonExpr<D>{
-                                .field_name_ = std::string(field_name_sv), .op_ = op, .value_ = std::forward<V>(value)
-                        })
-                );
-            }
+            return where::make_comparison_expr(std::string(field_name_sv), op, std::forward<V>(value));
         }
     };
 

--- a/tests/query/test_where_lifetime.cpp
+++ b/tests/query/test_where_lifetime.cpp
@@ -1,0 +1,90 @@
+#include <gtest/gtest.h>
+#include "test_db_helpers.h"
+
+// NOLINTBEGIN(misc-const-correctness,performance-unnecessary-value-param,performance-unnecessary-copy-initialization)
+
+import storm;
+import std;
+
+#include "test_models.h" // NOSONAR cpp:S954
+#include "test_seed_helpers.h"
+
+using namespace storm;
+using namespace storm::orm::where;
+
+// Lifetime safety for WHERE comparison operands (#352).
+//
+// QuerySet::where() is immutable/Django-style and deferred: an expression node can outlive the
+// buffer a text operand points at, and .select() binds the operand only later. ComparisonExpr used
+// to keep std::string_view / const char* operands by view, so a deferred bind read a dangling
+// buffer (use-after-free under ASAN). Text operands are now normalized to an owning std::string at
+// construction, so any deferred bind is safe.
+// Run the deferred WHERE and assert it returns exactly one Bob — the operand must have been copied,
+// not stored as a view into a buffer that has already been freed.
+template <typename ConnType> auto expect_single_bob(const Expr& expr) -> void {
+    QuerySet<Person, ConnType> queryset;
+    auto                       result = queryset.where(expr).select().execute();
+    ASSERT_TRUE(result.has_value()) << "Deferred bind failed: " << result.error().message();
+    ASSERT_EQ(result.value().size(), 1) << "Expected exactly 1 person named Bob";
+    EXPECT_EQ(result.value().begin()->name, "Bob");
+}
+
+template <typename ConnType> class WhereLifetimeTest : public StormTestFixture<Person, ConnType> {
+  protected:
+    auto on_after_setup(const std::shared_ptr<ConnType>&) -> void override {
+        ASSERT_TRUE((storm::test::batch_insert<Person, ConnType>(
+                std::vector<Person>(storm::test::PEOPLE_25.begin(), storm::test::PEOPLE_25.end())
+        )));
+    }
+};
+
+TYPED_TEST_SUITE(WhereLifetimeTest, DatabaseTypes);
+
+// Test: operand built from a string_view into a heap temporary survives a deferred bind.
+TYPED_TEST(WhereLifetimeTest, StringViewOperandSurvivesDeferredBind) {
+    // Build the expression from a string_view into a heap temporary, then let the temporary die.
+    Expr expr = [] {
+        auto             owner = std::make_unique<std::string>("Bob");
+        std::string_view view  = *owner;
+        return field<^^Person::name>() == view; // node must copy "Bob", not keep a view into *owner
+    }();
+    // `owner` is freed here; ASAN poisons its buffer.
+
+    expect_single_bob<TypeParam>(expr);
+}
+
+// Test: const char* operand from a heap buffer survives a deferred bind (char* alternative).
+TYPED_TEST(WhereLifetimeTest, CharPtrOperandSurvivesDeferredBind) {
+    Expr expr = [] {
+        auto        owner = std::make_unique<std::array<char, 4>>(std::array<char, 4>{'B', 'o', 'b', '\0'});
+        const char* ptr   = owner->data();
+        return field<^^Person::name>() == ptr; // node must copy "Bob", not keep the char*
+    }();
+
+    expect_single_bob<TypeParam>(expr);
+}
+
+// Test: collated comparison operand from a temporary string_view also survives a deferred bind.
+using SqliteConn = storm::db::sqlite::Connection;
+
+class WhereLifetimeCollateTest : public StormTestFixture<Person, SqliteConn> {
+  protected:
+    auto on_after_setup(const std::shared_ptr<SqliteConn>&) -> void override {
+        ASSERT_TRUE((storm::test::batch_insert<Person, SqliteConn>(
+                std::vector<Person>(storm::test::PEOPLE_25.begin(), storm::test::PEOPLE_25.end())
+        )));
+    }
+};
+
+TEST_F(WhereLifetimeCollateTest, CollatedStringViewOperandSurvivesDeferredBind) {
+    Expr expr = [] {
+        auto             owner = std::make_unique<std::string>("bob");
+        std::string_view view  = *owner;
+        return field<^^Person::name>().collate(storm::orm::utilities::Collate::NoCase) == view;
+    }();
+
+    // Case-insensitive match: "bob" finds "Bob".
+    expect_single_bob<SqliteConn>(expr);
+}
+
+// NOLINTEND(misc-const-correctness,performance-unnecessary-value-param,performance-unnecessary-copy-initialization)


### PR DESCRIPTION
## Summary

`ComparisonExpr<std::string_view>` and `ComparisonExpr<const char*>` stored the comparison operand **by view**, not by owning value. Because `QuerySet::where()` is deferred (Django-style), an expression node can outlive the buffer its view points at, so `.select()` bound a freed buffer — a **heap-use-after-free** under ASAN on the deferred path.

## Fix

- Normalize text operands (`string_view` / `const char*` / string literals) to an owning `std::string` at construction, via shared `normalize_operand` + `make_comparison_expr` helpers used by both `Field::make_comp` and `CollatedField::make_comparison`.
- Drop the `ComparisonExpr<std::string_view>` and `ComparisonExpr<const char*>` variant alternatives, making a dangling-operand node **unrepresentable** by the type system.

## Tests

New `tests/query/test_where_lifetime.cpp` (3 tests: `string_view`, `const char*`, collated) build operands from heap temporaries, free them, then deferred-bind. **Verified to UAF under ASAN before the fix**, pass after — on both SQLite and PostgreSQL.

## Verification

- `ctest ninja-debug`: 1974/1974 pass (SQLite + PG)
- `ninja-asan-ubsan`: full suite clean, 0 violations
- `ninja-tsan`: 1915/1915 pass, 0 data races
- Pre-commit: clang-format + clang-tidy + tests + **100% coverage** all green
- Release A/B bench on WHERE-JOIN path: deltas within cv (noise), no regression

Closes #352

🤖 Generated with [Claude Code](https://claude.com/claude-code)