### PR TITLE
fix(join): append_uint writes multi-digit table-alias numbers (>=10)

### DIFF
--- a/src/orm/statements/join.cppm
+++ b/src/orm/statements/join.cppm
@@ -120,13 +120,17 @@ export namespace storm::orm::statements {
 
         // Compile-time SQL generation with ConstexprString
         static consteval auto calculate_join_sql_size() -> std::size_t {
+            using utilities::numeric::digits_of;
             using utilities::sql_len::ON_EQUALS;
             using utilities::sql_len::SMALL_BUFFER;
             std::size_t total = 0;
 
+            // Per FK: <keyword><table> t<alias> ON t<alias>.<pk> = t1.<fk>_id
+            // The alias t<Is+2> appears twice — reserve its exact digit width both times.
             [&]<std::size_t... Is>(std::index_sequence<Is...> /*unused*/) {
-                ((total += get_join_keyword().size() + FKBase_at<Is>::table_name_.size() + 2 + 1 + 4 + 1 + 1 + 1 +
-                           FKBase_at<Is>::pk_name_.size() + ON_EQUALS + fk_field_names_[Is].size() + 3),
+                ((total += get_join_keyword().size() + FKBase_at<Is>::table_name_.size() + 2 + digits_of(Is + 2) + 5 +
+                           digits_of(Is + 2) + 1 + FKBase_at<Is>::pk_name_.size() + ON_EQUALS +
+                           fk_field_names_[Is].size() + 3),
                  ...);
             }(std::make_index_sequence<fk_count_>{});
 
@@ -141,9 +145,9 @@ export namespace storm::orm::statements {
                 ((result.append(get_join_keyword()),
                   result.append(FKBase_at<Is>::table_name_),
                   result.append(" t"),
-                  result.append_digit(Is + 2),
+                  result.append_uint(Is + 2),
                   result.append(" ON t"),
-                  result.append_digit(Is + 2),
+                  result.append_uint(Is + 2),
                   result.append("."),
                   result.append(FKBase_at<Is>::pk_name_),
                   result.append(" = t1."),
@@ -174,11 +178,11 @@ export namespace storm::orm::statements {
                 }
             }
 
-            // FK fields
+            // FK fields — each emits "t<alias>.<field>"; reserve the alias's exact digit width.
             for_each_fk_field([&]<std::size_t I>() {
                 total += 2; // ", "
                 [&]<std::size_t... FieldIs>(std::index_sequence<FieldIs...> /*unused*/) {
-                    ((total += (FieldIs > 0 ? 2 : 0) + 3 + 1 +
+                    ((total += (FieldIs > 0 ? 2 : 0) + 2 + utilities::numeric::digits_of(I + 2) +
                                std::meta::identifier_of(FKBase_at<I>::all_members_[FieldIs]).size()),
                      ...);
                 }(std::make_index_sequence<FKBase_at<I>::field_count_>{});
@@ -212,7 +216,7 @@ export namespace storm::orm::statements {
                     bool first_in_table = true;
                     (((first_in_table ? (void)0 : result.append(", ")),
                       result.append("t"),
-                      result.append_digit(I + 2),
+                      result.append_uint(I + 2),
                       result.append("."),
                       result.append(std::meta::identifier_of(FKBase_at<I>::all_members_[FieldIs])),
                       first_in_table = false),

--- a/src/orm/utilities.cppm
+++ b/src/orm/utilities.cppm
@@ -79,6 +79,19 @@ export namespace storm::orm::utilities {
     // Numeric constants
     namespace numeric {
         constexpr std::size_t MAX_SINGLE_DIGIT = 9; // Maximum single digit value (0-9)
+        // Decimal digits needed to render any std::size_t (2^64 - 1 has 20 digits).
+        constexpr std::size_t MAX_DECIMAL_DIGITS = 20;
+
+        // Number of decimal digits required to render `value` (digits_of(0) == 1).
+        // Used by compile-time SQL size estimators to reserve exact alias width.
+        constexpr auto digits_of(std::size_t value) -> std::size_t {
+            std::size_t digits = 1;
+            while (value > MAX_SINGLE_DIGIT) {
+                value /= 10;
+                ++digits;
+            }
+            return digits;
+        }
     } // namespace numeric
 
     // ============================================================================
@@ -494,13 +507,29 @@ export namespace storm::orm::utilities {
             return *this;
         }
 
-        // Append a single digit (0-9) for compile-time number formatting
-        constexpr auto append_digit(std::size_t digit) -> void {
-            if (digit <= numeric::MAX_SINGLE_DIGIT && len < N - 1) {
-                data[len] = '0' + static_cast<char>(digit);
-                ++len;
-                data[len] = '\0';
+        // Append the full decimal representation of an unsigned value for
+        // compile-time number formatting (handles multi-digit values, e.g. 10).
+        constexpr auto append_uint(std::size_t value) -> void {
+            if (value <= numeric::MAX_SINGLE_DIGIT) {
+                if (len < N - 1) {
+                    data[len] = '0' + static_cast<char>(value);
+                    ++len;
+                    data[len] = '\0';
+                }
+                return;
             }
+            // Build digits in reverse, then append in order.
+            std::array<char, numeric::MAX_DECIMAL_DIGITS> buf{};
+            std::size_t                                   count = 0;
+            while (value > 0) {
+                buf[count++] = static_cast<char>('0' + (value % 10));
+                value /= 10;
+            }
+            for (std::size_t i = count; i > 0 && len < N - 1; --i) {
+                data[len] = buf[i - 1];
+                ++len;
+            }
+            data[len] = '\0';
         }
         // LCOV_EXCL_STOP
 

--- a/tests/query/test_join_wide.cpp
+++ b/tests/query/test_join_wide.cpp
@@ -1,0 +1,102 @@
+#include <gtest/gtest.h>
+#include "test_db_helpers.h"
+
+// NOLINTBEGIN(misc-const-correctness)
+
+import storm;
+import std;
+
+using namespace storm;
+using namespace storm::orm::where;
+
+#include "test_models.h" // NOSONAR cpp:S954
+
+// ============================================================================
+// Regression #358 — table aliases are t<Is+2>, so a model with 9 FK fields
+// spans t2..t10. The 9th FK (Is == 8) must emit the two-digit alias "t10",
+// not a bare "t" (append_digit silently dropped values >= 10).
+// ============================================================================
+
+// Local model with 9 FK fields to Person — exercises the 8th+ joined FK (t10).
+struct WideJoin {
+    [[= storm::meta::FieldAttr::primary]] int id{};
+    [[= storm::meta::FieldAttr::fk]] Person   fk1;
+    [[= storm::meta::FieldAttr::fk]] Person   fk2;
+    [[= storm::meta::FieldAttr::fk]] Person   fk3;
+    [[= storm::meta::FieldAttr::fk]] Person   fk4;
+    [[= storm::meta::FieldAttr::fk]] Person   fk5;
+    [[= storm::meta::FieldAttr::fk]] Person   fk6;
+    [[= storm::meta::FieldAttr::fk]] Person   fk7;
+    [[= storm::meta::FieldAttr::fk]] Person   fk8;
+    [[= storm::meta::FieldAttr::fk]] Person   fk9;
+};
+
+template <typename ConnType> class WideJoinTest : public StormTestFixture<Person, ConnType, WideJoin> {};
+
+TYPED_TEST_SUITE(WideJoinTest, DatabaseTypes);
+
+// Attaches all 9 FK joins to a WideJoin QuerySet (single source for the FK pack).
+template <typename ConnType> auto join_all_nine(const QuerySet<WideJoin, ConnType>& qs) {
+    return qs.template join<
+            &WideJoin::fk1,
+            &WideJoin::fk2,
+            &WideJoin::fk3,
+            &WideJoin::fk4,
+            &WideJoin::fk5,
+            &WideJoin::fk6,
+            &WideJoin::fk7,
+            &WideJoin::fk8,
+            &WideJoin::fk9>();
+}
+
+// SQL structural check: the 9th FK alias must render as t10 (not bare "t").
+TYPED_TEST(WideJoinTest, NineFKsEmitTwoDigitAlias) {
+    QuerySet<WideJoin, TypeParam> qs;
+    auto                          sql = join_all_nine(qs).select().sql();
+
+    // 9th FK (Is == 8) → alias t10 in both the JOIN clause and the SELECT list.
+    EXPECT_TRUE(sql.contains("INNER JOIN Person t10 ON t10.id = t1.fk9_id"))
+            << "9th FK JOIN clause missing t10 alias:\n"
+            << sql;
+    EXPECT_TRUE(sql.contains("t10.id")) << "SELECT list missing t10 columns:\n" << sql;
+    // A bare " Person t ON" would be the dropped-digit bug.
+    EXPECT_FALSE(sql.contains(" Person t ON")) << "bare alias 't' leaked into JOIN:\n" << sql;
+}
+
+// Round-trip: insert one WideJoin row referencing 9 real Persons, JOIN them all
+// back and confirm the 9th FK (t10) is populated — proves the SQL is executable.
+TYPED_TEST(WideJoinTest, NineFKJoinRoundTrips) {
+    QuerySet<Person, TypeParam> person_qs;
+    std::array<int, 9>          person_ids{};
+    for (int i = 0; i < 9; ++i) {
+        Person const p{.name = std::format("WJ{}", i), .age = 20 + i};
+        auto         res = person_qs.insert(p).execute();
+        ASSERT_TRUE(res.has_value()) << res.error().message();
+        person_ids[static_cast<std::size_t>(i)] = static_cast<int>(res.value());
+    }
+
+    QuerySet<WideJoin, TypeParam> wj_qs;
+    WideJoin const                row{
+                           .fk1 = {.id = person_ids[0]},
+                           .fk2 = {.id = person_ids[1]},
+                           .fk3 = {.id = person_ids[2]},
+                           .fk4 = {.id = person_ids[3]},
+                           .fk5 = {.id = person_ids[4]},
+                           .fk6 = {.id = person_ids[5]},
+                           .fk7 = {.id = person_ids[6]},
+                           .fk8 = {.id = person_ids[7]},
+                           .fk9 = {.id = person_ids[8]}
+    };
+    auto ins = wj_qs.insert(row).execute();
+    ASSERT_TRUE(ins.has_value()) << ins.error().message();
+
+    auto results = join_all_nine(wj_qs).select().execute();
+    ASSERT_TRUE(results.has_value()) << results.error().message();
+    ASSERT_EQ(results.value().size(), 1U);
+
+    const auto& got = *results.value().begin();
+    EXPECT_EQ(got.fk1.name, "WJ0");
+    EXPECT_EQ(got.fk9.name, "WJ8") << "9th FK (alias t10) was not populated — broken SQL";
+}
+
+// NOLINTEND(misc-const-correctness)


### PR DESCRIPTION
## Summary

`ConstexprString::append_digit` only wrote a single decimal digit and **emitted nothing for values ≥ 10**. JOIN builds table aliases as `t<Is+2>`, so the 8th+ joined FK (`Is == 8` → `10`) produced a bare `t` instead of `t10` — silently broken / alias-colliding SQL, generated at compile time with no diagnostic. Sanitizers can't see it (wrong-but-valid string assembly).

Example of the broken output (9 FKs, before fix):
```
... INNER JOIN Person t9 ON t9.id = t1.fk8_id INNER JOIN Person t ON t.id = t1.fk9_id
```

## Fix

- `src/orm/utilities.cppm`: replace `append_digit` with a multi-digit `append_uint` that writes the full decimal representation; add `numeric::digits_of()` + `MAX_DECIMAL_DIGITS`.
- `src/orm/statements/join.cppm`: switch the 3 alias call sites to `append_uint`; make both size estimators (`calculate_join_sql_size`, `calculate_select_fields_size`) reserve the exact alias width via `digits_of(Is + 2)` instead of a hard-coded `1` (also corrects an under-counted `" ON t"` term).

## Tests

New `tests/query/test_join_wide.cpp` (TDD — written first, failed before the fix):
- **NineFKsEmitTwoDigitAlias** — joins 9 FK tables, asserts the SQL contains `INNER JOIN Person t10 ON t10.id = t1.fk9_id` and `t10.id`, and that no bare `t` alias leaks.
- **NineFKJoinRoundTrips** — inserts a 9-FK row referencing 9 real `Person`s, JOINs them all back, confirms the 9th FK (alias `t10`) is populated — proves the SQL is executable.

## Verification

- Full suite: **1978/1978 pass**, including both WideJoin tests on **SQLite + PostgreSQL**.
- **100% line coverage**, clang-format + clang-tidy clean (pre-commit gate passed).
- **ASAN+UBSAN** and **TSAN**: clean. (Change is consteval-only — no new runtime surface. MSAN is a known clang-p2996 + GTest false positive, continue-on-error in CI.)

Closes #358

🤖 Generated with [Claude Code](https://claude.com/claude-code)