### PR TITLE
fix(transaction): neutralize moved-from committed_ + redundant ROLLBACK (#353)

### DIFF
--- a/src/orm/transaction.cppm
+++ b/src/orm/transaction.cppm
@@ -47,13 +47,19 @@ export namespace storm::orm::utilities {
         auto operator=(const TransactionGuard&) -> TransactionGuard& = delete;
 
         TransactionGuard(TransactionGuard&& other) noexcept
-            : conn_(std::move(other.conn_)), committed_(other.committed_) {}
+            : conn_(std::move(other.conn_)), committed_(other.committed_) {
+            // Neutralize the source so a moved-from guard can never attempt a DB op,
+            // independent of std::move(shared_ptr) having nulled other.conn_.
+            other.committed_ = true;
+        }
 
         auto operator=(TransactionGuard&& other) noexcept -> TransactionGuard& {
             if (this != &other) {
                 rollback_if_needed();
                 conn_      = std::move(other.conn_);
                 committed_ = other.committed_;
+                // Neutralize the source so a moved-from guard can never rollback.
+                other.committed_ = true;
             }
             return *this;
         }
@@ -71,6 +77,9 @@ export namespace storm::orm::utilities {
 
             if (auto result = conn_->execute("COMMIT"); !result) {
                 (void)conn_->execute("ROLLBACK");
+                // Transaction is already rolled back; mark committed so the
+                // destructor does not issue a second, redundant ROLLBACK.
+                committed_ = true;
                 return std::unexpected(result.error());
             }
 

--- a/tests/mock_sqlite/test_orm_mock_errors.cpp
+++ b/tests/mock_sqlite/test_orm_mock_errors.cpp
@@ -2176,6 +2176,101 @@ namespace {
         EXPECT_EQ(result.error().code(), SQLITE_BUSY);
     }
 
+    TEST_F(ORMMockErrorTest, TransactionGuardCommitFailureDoesNotDoubleRollback) {
+        // #353 nit: commit() failure issues one in-commit() ROLLBACK; the
+        // destructor must NOT issue a second redundant ROLLBACK.
+        auto conn_result = db::sqlite::Connection::open(":memory:");
+        ASSERT_TRUE(conn_result.has_value());
+        auto conn = std::make_shared<db::sqlite::Connection>(std::move(*conn_result));
+
+        using TxnGuard = storm::orm::utilities::TransactionGuard<db::sqlite::Connection>;
+
+        // Step 1: BEGIN TRANSACTION (succeeds), Step 2: COMMIT (fails)
+        MockSqlite3Config::step_fails_on_call(2, SQLITE_BUSY);
+
+        {
+            auto txn = TxnGuard::begin(conn);
+            ASSERT_TRUE(txn.has_value());
+
+            auto result = txn->commit();
+            ASSERT_FALSE(result.has_value());
+
+            // After failed commit(): BEGIN(1) + COMMIT(2) + in-commit ROLLBACK(3) = 3 steps
+            EXPECT_EQ(MockSqlite3Config::get_step_call_count(), 3);
+            // Guard goes out of scope here → destructor must not ROLLBACK again
+        }
+
+        // Destructor must NOT have issued a second ROLLBACK (would make it 4)
+        EXPECT_EQ(MockSqlite3Config::get_step_call_count(), 3);
+    }
+
+    TEST_F(ORMMockErrorTest, TransactionGuardMoveCtorDoesNotRollbackMovedFrom) {
+        // #353: moving a guard must neutralize the source so destroying the
+        // moved-from object issues no ROLLBACK.
+        auto conn_result = db::sqlite::Connection::open(":memory:");
+        ASSERT_TRUE(conn_result.has_value());
+        auto conn = std::make_shared<db::sqlite::Connection>(std::move(*conn_result));
+
+        using TxnGuard = storm::orm::utilities::TransactionGuard<db::sqlite::Connection>;
+
+        // dst (live owner) outlives the inner scope where the moved-from source dies.
+        std::optional<TxnGuard> dst;
+        int                     after_begin = 0;
+
+        {
+            auto src_result = TxnGuard::begin(conn);
+            ASSERT_TRUE(src_result.has_value());
+            TxnGuard src = std::move(*src_result);
+
+            after_begin = MockSqlite3Config::get_step_call_count();
+
+            // Move-CONSTRUCT dst from src. src becomes moved-from.
+            dst.emplace(std::move(src));
+            // src is destroyed at scope exit → must not ROLLBACK.
+        }
+
+        // No ROLLBACK from the moved-from src destruction.
+        EXPECT_EQ(MockSqlite3Config::get_step_call_count(), after_begin);
+
+        // dst owns the live transaction → commit to clean up.
+        auto commit_result = dst->commit();
+        EXPECT_TRUE(commit_result.has_value());
+    }
+
+    TEST_F(ORMMockErrorTest, TransactionGuardMoveAssignDoesNotRollbackMovedFrom) {
+        // #353: move-assignment must neutralize the source so destroying the
+        // moved-from object issues no ROLLBACK.
+        auto conn_result = db::sqlite::Connection::open(":memory:");
+        ASSERT_TRUE(conn_result.has_value());
+        auto conn = std::make_shared<db::sqlite::Connection>(std::move(*conn_result));
+
+        using TxnGuard = storm::orm::utilities::TransactionGuard<db::sqlite::Connection>;
+
+        // Target guard already committed → its move-assign rollback_if_needed() is a no-op.
+        auto dst = TxnGuard::begin(conn);
+        ASSERT_TRUE(dst.has_value());
+        ASSERT_TRUE(dst->commit().has_value());
+
+        const int before_assign = MockSqlite3Config::get_step_call_count();
+
+        {
+            // Source guard lives only in this scope, moved into dst below.
+            auto src_result = TxnGuard::begin(conn);
+            ASSERT_TRUE(src_result.has_value());
+            TxnGuard src = std::move(*src_result);
+
+            *dst = std::move(src);
+            // src is now moved-from; its destruction at scope exit must not ROLLBACK.
+        }
+
+        // The BEGIN for src counts as one step; no extra ROLLBACK from moved-from destruction.
+        EXPECT_EQ(MockSqlite3Config::get_step_call_count(), before_assign + 1);
+
+        // dst now owns the live transaction → commit to clean up.
+        auto commit_result = dst->commit();
+        EXPECT_TRUE(commit_result.has_value());
+    }
+
     // ============================================================================
     // WHERE Expression Bind Error Tests
     // Covers bind failure paths in BetweenExpr, InExpression, LogicalExpr


### PR DESCRIPTION
## Summary

Fixes the fragile moved-from invariant in `TransactionGuard` and the redundant ROLLBACK on a failed `commit()`.

- **Move ctor / move-assign** now set `other.committed_ = true`, so a moved-from guard can never attempt a DB op — no longer relying solely on `std::move(shared_ptr)` nulling `conn_`.
- **`commit()` failure path** marks `committed_ = true` after the in-`commit()` ROLLBACK, so the destructor no longer fires a second, redundant ROLLBACK.

## Tests (TDD)

Added to `tests/mock_sqlite/test_orm_mock_errors.cpp`, counting ROLLBACK via `sqlite3_step` call count:

- `TransactionGuardCommitFailureDoesNotDoubleRollback` — **fails before the fix** (step count 4 vs expected 3), passes after. The genuinely observable bug.
- `TransactionGuardMoveCtorDoesNotRollbackMovedFrom` / `…MoveAssignDoesNotRollbackMovedFrom` — regression guards locking in the move invariant.

## Verification

- Full suite: 1984/1984 pass
- ASAN+UBSAN: green
- TSAN: green
- Coverage: 100%
- No `docs/` or agent files reference `TransactionGuard`; semantics documented in-code.

Closes #353

🤖 Generated with [Claude Code](https://claude.com/claude-code)