### PR TITLE
fix(sqlite): explicit Statement move ops null source raw_ (#354)

### DIFF
--- a/src/db/sqlite.cppm
+++ b/src/db/sqlite.cppm
@@ -42,9 +42,22 @@ export namespace storm::db::sqlite {
         // Destructor - unique_ptr handles cleanup via sqlite3_finalize
         ~Statement() = default;
 
-        // Move semantics
-        Statement(Statement&&)                    = default;
-        auto operator=(Statement&&) -> Statement& = default;
+        // Move semantics — explicit so the moved-from source nulls its cached
+        // raw_. A defaulted move copies raw_ while stmt_ goes null, leaving the
+        // source aliasing the statement now owned by the destination (issue
+        // #354). Keep the cached raw_ for hot-loop performance (CLAUDE.md).
+        Statement(Statement&& other) noexcept : stmt_(std::move(other.stmt_)), raw_(other.raw_) {
+            other.raw_ = nullptr;
+        }
+
+        auto operator=(Statement&& other) noexcept -> Statement& {
+            if (this != &other) {
+                stmt_      = std::move(other.stmt_);
+                raw_       = other.raw_;
+                other.raw_ = nullptr;
+            }
+            return *this;
+        }
 
         // Delete copy operations
         Statement(const Statement&)                    = delete;

--- a/tests/db/test_statement_move.cpp
+++ b/tests/db/test_statement_move.cpp
@@ -1,0 +1,77 @@
+#include <sqlite3.h>
+
+#include <gtest/gtest.h>
+
+import storm;
+import std;
+import storm_db_sqlite;
+
+using storm::db::sqlite::Statement;
+
+// ============================================================================
+// Statement move semantics (issue #354)
+//
+// Statement caches a raw sqlite3_stmt* in raw_ parallel to the owning
+// unique_ptr stmt_. With defaulted move ops, the move transferred stmt_ (source
+// stmt_ -> null) but COPIED raw_, leaving the moved-from source aliasing the
+// statement now owned by the destination. These tests pin the invariant that a
+// moved-from Statement exposes no usable handle (raw_ == nullptr), so calling a
+// method on it can never touch the destination's live statement.
+// ============================================================================
+
+namespace {
+
+    // Prepares one statement against a private in-memory db. The db is kept
+    // alive for the fixture's lifetime so the prepared statement stays valid.
+    class StatementMoveTest : public ::testing::Test {
+      public:
+        void SetUp() override {
+            ASSERT_EQ(sqlite3_open(":memory:", &db_), SQLITE_OK);
+        }
+
+        void TearDown() override {
+            sqlite3_close_v2(db_);
+        }
+
+        [[nodiscard]] auto prepare(const char* sql) const -> sqlite3_stmt* {
+            sqlite3_stmt* raw = nullptr;
+            EXPECT_EQ(sqlite3_prepare_v2(db_, sql, -1, &raw, nullptr), SQLITE_OK);
+            return raw;
+        }
+
+        sqlite3* db_ = nullptr;
+    };
+
+    // sqlite3_stmt is incomplete; viewing handles as void* keeps GTest's
+    // EqHelper off the bool-converting overload it picks for incomplete ptrs.
+    auto as_void(sqlite3_stmt* p) -> const void* {
+        return p;
+    }
+
+    // The destination must own the live statement; the moved-from source must
+    // null its cached raw_ so it can never alias the destination's statement.
+    TEST_F(StatementMoveTest, MoveCtorNullsSourceHandle) {
+        sqlite3_stmt* raw = prepare("SELECT 1");
+        Statement     src{raw};
+        ASSERT_EQ(src.handle(), raw);
+
+        Statement dst{std::move(src)};
+
+        EXPECT_EQ(as_void(dst.handle()), as_void(raw));
+        EXPECT_EQ(as_void(src.handle()), nullptr);
+    }
+
+    // Same invariant for move assignment.
+    TEST_F(StatementMoveTest, MoveAssignNullsSourceHandle) {
+        sqlite3_stmt* raw_src = prepare("SELECT 1");
+        sqlite3_stmt* raw_dst = prepare("SELECT 2");
+        Statement     src{raw_src};
+        Statement     dst{raw_dst};
+
+        dst = std::move(src);
+
+        EXPECT_EQ(as_void(dst.handle()), as_void(raw_src));
+        EXPECT_EQ(as_void(src.handle()), nullptr);
+    }
+
+} // namespace


### PR DESCRIPTION
## Summary

`Statement` caches a raw `sqlite3_stmt*` in `raw_` parallel to the owning `unique_ptr stmt_`. The defaulted move ops transferred `stmt_` (source → null) but **copied** `raw_`, leaving the moved-from `Statement` aliasing the statement now owned by the destination. The `raw_ == stmt_.get()` invariant was silently broken on the source — a latent UAF/aliasing hazard if any method is ever called on a moved-from `Statement`.

## Fix

Define explicit move ctor/assign that null `other.raw_` after moving `stmt_`. The cached `raw_` is kept for hot-loop performance (CLAUDE.md guidance), so this only touches the cold move path — the row-extraction hot loops are unchanged.

## Tests

Written first, failed first (defaulted move left the source aliasing the live statement). They assert a moved-from `Statement` exposes no usable handle (`handle() == nullptr`) for both move ctor and move assign, against a private prepared statement.

## Verification

- ✅ Full suite: 1986/1986 pass (SQLite + PostgreSQL)
- ✅ `ninja-asan-ubsan` clean on move + cache tests
- ✅ 100% line coverage
- ✅ Release benchmark unchanged (`Storm/SELECT` throughput in normal range) — move ops are off the hot path

Closes #354

🤖 Generated with [Claude Code](https://claude.com/claude-code)