### PR TITLE
fix(transaction): swallow throwing execute() in noexcept rollback paths (#360)

### DIFF
--- a/src/orm/transaction.cppm
+++ b/src/orm/transaction.cppm
@@ -76,7 +76,14 @@ export namespace storm::orm::utilities {
             }
 
             if (auto result = conn_->execute("COMMIT"); !result) {
-                (void)conn_->execute("ROLLBACK");
+                // Best-effort ROLLBACK. execute() is not noexcept (it builds a
+                // std::string / inserts into the statement cache and can throw
+                // std::bad_alloc under memory pressure); swallow any throw so it
+                // never escapes this noexcept function and calls std::terminate.
+                try {
+                    (void)conn_->execute("ROLLBACK");
+                } catch (...) { // NOSONAR(cpp:S2486) NOLINT(bugprone-empty-catch)
+                }
                 // Transaction is already rolled back; mark committed so the
                 // destructor does not issue a second, redundant ROLLBACK.
                 committed_ = true;
@@ -90,7 +97,15 @@ export namespace storm::orm::utilities {
       private:
         auto rollback_if_needed() noexcept -> void {
             if (conn_ && !committed_) {
-                (void)conn_->execute("ROLLBACK");
+                // Best-effort ROLLBACK during unwinding. execute() is not noexcept
+                // (it builds a std::string / inserts into the statement cache and
+                // can throw std::bad_alloc under memory pressure); swallow any
+                // throw so it never escapes this noexcept function — a throw here
+                // would call std::terminate (the throwing-destructor trap).
+                try {
+                    (void)conn_->execute("ROLLBACK");
+                } catch (...) { // NOSONAR(cpp:S2486) NOLINT(bugprone-empty-catch)
+                }
             }
         }
     };

--- a/tests/mock_sqlite/test_orm_mock_errors.cpp
+++ b/tests/mock_sqlite/test_orm_mock_errors.cpp
@@ -2272,6 +2272,112 @@ namespace {
     }
 
     // ============================================================================
+    // #360: noexcept rollback must not let a throwing execute() reach terminate.
+    //
+    // Connection::execute() is NOT noexcept — it constructs a std::string and
+    // can throw std::bad_alloc under memory pressure (esp. on the cached
+    // "ROLLBACK" path: prepare_cached map insert / make_unique). It is called
+    // from the noexcept rollback_if_needed() (destructor, move-assign) and from
+    // commit()'s best-effort ROLLBACK. A throw escaping a noexcept function calls
+    // std::terminate. These tests drive a connection whose execute("ROLLBACK")
+    // throws and confirm no terminate occurs.
+    // ============================================================================
+
+    // Minimal connection stub satisfying TransactionGuard<ConnType>'s contract:
+    // a nested Error type and execute(string_view) -> expected<void, Error>.
+    // execute("ROLLBACK") throws std::bad_alloc to emulate OOM during unwinding.
+    struct ThrowingRollbackConnection {
+        using Error = db::Error;
+
+        int  begin_calls        = 0;
+        int  commit_calls       = 0;
+        int  rollback_calls     = 0;
+        bool commit_should_fail = false;
+
+        [[nodiscard]] auto execute(std::string_view sql) -> std::expected<void, Error> {
+            if (sql == "BEGIN TRANSACTION") {
+                ++begin_calls;
+                return {};
+            }
+            if (sql == "COMMIT") {
+                ++commit_calls;
+                if (commit_should_fail) {
+                    return std::unexpected(Error{SQLITE_BUSY, "commit failed"});
+                }
+                return {};
+            }
+            if (sql == "ROLLBACK") {
+                ++rollback_calls;
+                throw std::bad_alloc{}; // emulates OOM building/caching the ROLLBACK statement
+            }
+            return {};
+        }
+    };
+
+    TEST_F(ORMMockErrorTest, TransactionGuardDestructorRollbackSwallowsThrow) {
+        // Guard destroyed without commit → rollback_if_needed() runs, execute()
+        // throws. The noexcept destructor must swallow it (no std::terminate).
+        auto conn = std::make_shared<ThrowingRollbackConnection>();
+
+        using TxnGuard = storm::orm::utilities::TransactionGuard<ThrowingRollbackConnection>;
+
+        {
+            auto txn = TxnGuard::begin(conn);
+            ASSERT_TRUE(txn.has_value());
+            // No commit() → destructor will ROLLBACK, which throws.
+        }
+
+        // Reached here without terminate → throw was swallowed. The attempt happened.
+        EXPECT_EQ(conn->rollback_calls, 1);
+    }
+
+    TEST_F(ORMMockErrorTest, TransactionGuardMoveAssignRollbackSwallowsThrow) {
+        // Move-assigning onto a live (uncommitted) guard triggers
+        // rollback_if_needed() on the target before adopting the source. That
+        // ROLLBACK throws; the noexcept operator=(&&) must swallow it.
+        auto conn = std::make_shared<ThrowingRollbackConnection>();
+
+        using TxnGuard = storm::orm::utilities::TransactionGuard<ThrowingRollbackConnection>;
+
+        auto dst_result = TxnGuard::begin(conn); // dst is live, uncommitted
+        ASSERT_TRUE(dst_result.has_value());
+        TxnGuard dst = std::move(*dst_result);
+
+        auto src_result = TxnGuard::begin(conn);
+        ASSERT_TRUE(src_result.has_value());
+        TxnGuard src = std::move(*src_result);
+
+        dst = std::move(src); // dst's pre-existing transaction is rolled back → throws
+
+        // Reached here without terminate → throw swallowed.
+        EXPECT_EQ(conn->rollback_calls, 1);
+
+        // dst now owns src's transaction (uncommitted) → its destructor will
+        // ROLLBACK again (throwing, swallowed) at scope exit.
+    }
+
+    TEST_F(ORMMockErrorTest, TransactionGuardCommitFailureRollbackSwallowsThrow) {
+        // commit() fails on COMMIT, then issues a best-effort ROLLBACK that
+        // throws. commit() is noexcept → the throw must be swallowed.
+        auto conn                = std::make_shared<ThrowingRollbackConnection>();
+        conn->commit_should_fail = true;
+
+        using TxnGuard = storm::orm::utilities::TransactionGuard<ThrowingRollbackConnection>;
+
+        auto txn = TxnGuard::begin(conn);
+        ASSERT_TRUE(txn.has_value());
+
+        auto result = txn->commit();
+        ASSERT_FALSE(result.has_value());
+        EXPECT_EQ(result.error().code(), SQLITE_BUSY);
+
+        // commit() attempted the best-effort ROLLBACK (which threw, swallowed),
+        // and marked committed_ so the destructor does not rollback again.
+        EXPECT_EQ(conn->commit_calls, 1);
+        EXPECT_EQ(conn->rollback_calls, 1);
+    }
+
+    // ============================================================================
     // WHERE Expression Bind Error Tests
     // Covers bind failure paths in BetweenExpr, InExpression, LogicalExpr
     // ============================================================================


### PR DESCRIPTION
## Summary

`TransactionGuard::rollback_if_needed()` (called from `~TransactionGuard` and `operator=(&&)`) and `commit()` are all `noexcept`, but each calls `conn_->execute("ROLLBACK")`, which is **not** `noexcept` — it builds a `std::string` and inserts into the statement cache, so it can throw `std::bad_alloc` under memory pressure. A throw escaping a `noexcept` function calls `std::terminate` (the throwing-destructor trap), on the already-failing transaction path.

## Fix

Wrap both ROLLBACK calls in `try { ... } catch (...) {}` for best-effort rollback during unwinding. Zero cost on the success path — the `try` only guards the already-failing rollback.

## Tests (TDD)

Added a `ThrowingRollbackConnection` stub whose `execute("ROLLBACK")` throws `std::bad_alloc`, driven through three paths:
- destructor rollback
- move-assign rollback (onto a live target)
- `commit()` failure best-effort rollback

**Before the fix** all three `std::terminate` (`libc++abi: terminating due to uncaught exception of type std::bad_alloc`). **After**, all pass.

## Verification

- 9/9 TransactionGuard tests pass (3 new + 6 from #353)
- Full suite: 1986/1986 pass, 100% coverage
- ASAN+UBSAN green, TSAN green on the throwing paths
- No docs/agent files document transaction exception-safety → nothing to update

Closes #360

🤖 Generated with [Claude Code](https://claude.com/claude-code)