### PR TITLE
fix(utilities): make SQLCache::find() lifetime contract explicit

### DIFF
--- a/src/orm/utilities.cppm
+++ b/src/orm/utilities.cppm
@@ -544,14 +544,24 @@ export namespace storm::orm::utilities {
         struct Entry {
             KeyType     key{};
             std::string sql;
+            // Distinguishes a populated slot from an unused one, so a legitimately
+            // empty value (or key == KeyType{}) is not mistaken for a free slot.
+            bool occupied = false;
         };
 
         std::array<Entry, CACHE_SIZE> entries{};
         std::size_t                   next_slot = 0; // For round-robin replacement
 
+        // Returns a pointer to the cached SQL for `key`, or nullptr if absent.
+        //
+        // Lifetime: the returned pointer is valid only until the next insert() or
+        // clear() on this thread. A subsequent insert() may reuse the same slot via
+        // round-robin replacement (entry.sql = std::move(sql)), invalidating the
+        // pointed-to contents. Consume it immediately, or copy the std::string if you
+        // need to hold it across a later insert/clear. The cache is thread_local.
         auto find(const KeyType& key) const -> const std::string* {
             for (const auto& entry : entries) {
-                if (entry.key == key && !entry.sql.empty()) {
+                if (entry.occupied && entry.key == key) {
                     return &entry.sql;
                 }
             }
@@ -559,23 +569,26 @@ export namespace storm::orm::utilities {
         }
 
         auto insert(KeyType key, std::string sql) -> void {
-            // Try to find empty slot first
+            // Try to find an unused slot first
             for (auto& entry : entries) {
-                if (entry.key == KeyType{} && entry.sql.empty()) {
-                    entry.key = std::move(key);
-                    entry.sql = std::move(sql);
+                if (!entry.occupied) {
+                    entry.key      = std::move(key);
+                    entry.sql      = std::move(sql);
+                    entry.occupied = true;
                     return;
                 }
             }
-            entries[next_slot].key = std::move(key);
-            entries[next_slot].sql = std::move(sql);
-            next_slot              = (next_slot + 1) % CACHE_SIZE;
+            entries[next_slot].key      = std::move(key);
+            entries[next_slot].sql      = std::move(sql);
+            entries[next_slot].occupied = true;
+            next_slot                   = (next_slot + 1) % CACHE_SIZE;
         }
 
         auto clear() -> void {
             for (auto& entry : entries) {
                 entry.key = KeyType{};
                 entry.sql.clear();
+                entry.occupied = false;
             }
             next_slot = 0;
         }

--- a/tests/mock_sqlite/test_orm_mock_errors.cpp
+++ b/tests/mock_sqlite/test_orm_mock_errors.cpp
@@ -3140,6 +3140,55 @@ namespace {
     }
 
     // ============================================================================
+    // SQLCache lifetime contract: find()'s pointer is valid only until the next
+    // insert/clear on this thread; a round-robin slot reuse invalidates it (#356)
+    // ============================================================================
+
+    TEST_F(ORMMockErrorTest, SQLCacheFindPointerInvalidatedBySlotReuse) {
+        storm::orm::utilities::SQLCache<std::size_t, 2> cache;
+
+        cache.insert(1, "SELECT 1");
+        cache.insert(2, "SELECT 2");
+
+        // Copy the value BEFORE the next insert — the documented-safe way to keep it.
+        const std::string* hit = cache.find(1);
+        ASSERT_NE(hit, nullptr);
+        const std::string copied = *hit;
+
+        // Round-robin reuses slot 0 (key 1) for key 3, invalidating `hit`'s contents.
+        cache.insert(3, "SELECT 3");
+
+        EXPECT_EQ(copied, "SELECT 1") << "Copy taken before insert stays valid";
+        EXPECT_EQ(cache.find(1), nullptr) << "Key 1 was evicted by slot reuse";
+        ASSERT_NE(cache.find(3), nullptr);
+        EXPECT_EQ(*cache.find(3), "SELECT 3");
+    }
+
+    // ============================================================================
+    // SQLCache: an occupied slot with a legitimately empty SQL value is distinct
+    // from an unused slot — find() returns it, insert() does not treat it as free
+    // (key == KeyType{} + empty value edge case, #356)
+    // ============================================================================
+
+    TEST_F(ORMMockErrorTest, SQLCacheOccupiedSlotWithEmptyValue) {
+        storm::orm::utilities::SQLCache<std::size_t, 4> cache;
+
+        // Key 0 (== KeyType{}) with an empty SQL string — the ambiguous case.
+        cache.insert(0, "");
+
+        const std::string* hit = cache.find(0);
+        ASSERT_NE(hit, nullptr) << "Occupied slot must be found even when value is empty";
+        EXPECT_EQ(*hit, "");
+
+        // A subsequent insert must NOT reuse the occupied key-0 slot as if it were free.
+        cache.insert(1, "SELECT 1");
+        ASSERT_NE(cache.find(0), nullptr) << "Key 0 must survive a later insert";
+        EXPECT_EQ(*cache.find(0), "");
+        ASSERT_NE(cache.find(1), nullptr);
+        EXPECT_EQ(*cache.find(1), "SELECT 1");
+    }
+
+    // ============================================================================
     // Raw Handle get() Test (#177)
     // Covers sqlite.cppm:454-458
     // ============================================================================


### PR DESCRIPTION
## Summary

`SQLCache::find()` returns a `const std::string*` into a round-robin slot array. A later same-thread `insert()` reuses that slot via `entry.sql = std::move(sql)`, invalidating the pointee. The cache is `thread_local` and all callers consume immediately, so there is **no live UAF today** — but the lifetime contract was implicit and unenforced.

This PR:
- **Documents the lifetime window** on `find()`: the returned pointer is valid only until the next `insert()`/`clear()` on this thread; copy the `std::string` to hold it longer. (By-value return was rejected — it adds a string copy on every cache hit and would regress the INSERT hot path.)
- **Adds an explicit `occupied` flag** to `Entry`, so a legitimately empty cached value (or `key == KeyType{}`) is no longer mistaken for an unused slot. Previously `find()` skipped empty values and `insert()` treated a key-0/empty slot as free.

## Tests (TDD)

- `SQLCacheOccupiedSlotWithEmptyValue` — failed first (RED) because `find(0)` returned `nullptr` for an occupied empty-value slot; passes after the `occupied` flag.
- `SQLCacheFindPointerInvalidatedBySlotReuse` — documents the round-robin slot-reuse contract (copy-before-insert stays valid; evicted key returns `nullptr`).

## Verification

- ✅ 1995/1995 tests pass (debug); 100% coverage
- ✅ SQLCache tests pass under ASAN/UBSAN and TSAN
- ✅ Benchmark unchanged (Release): INSERT ~5.7M items/s, cv 0.1–0.5% (bool check ≈ prior `empty()` check)

Closes #356

🤖 Generated with [Claude Code](https://claude.com/claude-code)