### PR TITLE
bench(anchors): extend raw INSERT anchors to the full BATCH_STANDARD sweep

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -80,11 +80,17 @@ STORM_BENCH_SOCKET=1 ./build/release/benchmarks/storm_anchors
 STORM_BENCH_SOCKET=1 ./build/release/benchmarks/storm_bench
 ```
 
-The raw baseline covers 4 pinned benchmarks (exact Google Benchmark names with `/N:` suffix):
+The raw baseline covers these pinned benchmarks (exact Google Benchmark names with `/N:` suffix):
 - `Storm/WHERE/where_int_comparison_gt/N:10000`
 - `Storm/WHERE/where_bool_equality/N:10000`
 - `Storm/SELECT/select/N:10000`
-- `Storm/INSERT/insert/N:1`
+- `Storm/INSERT/insert/N:<n>` and `Storm/INSERT/insert_no_return/N:<n>` for the full
+  `BATCH_STANDARD` sweep `{1, 10, 100, 500, 1000, 5000, 10000, 50000, 100000}`
+  (mirrors `benchmarks/sizes.cppm`). Each iteration inserts `n` rows the way Storm
+  does — one multi-row `VALUES` statement per chunk of 249 rows (`999 / 4` fields),
+  in a transaction only when `n` spans more than one chunk. `RETURNING id` is read
+  back only for `insert/N:1`, since the Storm fixture sends `N=1` through the
+  single-row `insert(obj)` path but `N>1` through the bulk `insert(span)` VOID path.
 
 Matched Storm rows show **efficiency as `NN.N% of raw`** (green ≥95%, red below); unmatched rows show `— (no raw)`. The session summary becomes `session: N/M matched · avg NN.N% of raw · target ≥95%`. The raw baseline is **reused across Storm sessions** — refresh is a manual step: re-run `storm_anchors`, then restart the dashboard with `--baseline raw:last`.
 

--- a/benchmarks/anchors_raw.cpp
+++ b/benchmarks/anchors_raw.cpp
@@ -14,8 +14,17 @@
  *   - Storm/WHERE/where_int_comparison_gt/N:10000
  *   - Storm/WHERE/where_bool_equality/N:10000
  *   - Storm/SELECT/select/N:10000
- *   - Storm/INSERT/insert/N:1           (INSERT … RETURNING id)
- *   - Storm/INSERT/insert_no_return/N:1 (plain INSERT)
+ *   - Storm/INSERT/insert/N:<n>            (insert() path)
+ *   - Storm/INSERT/insert_no_return/N:<n>  (insert<ReturnId::No>() path)
+ *     for every n in BATCH_STANDARD {1,10,100,500,1000,5000,10000,50000,100000}
+ *     (mirrors benchmarks/sizes.cppm). Each iteration inserts n rows as Storm
+ *     does: one multi-row VALUES statement per chunk of 249 rows (999 / 4-field
+ *     BenchPerson = max_allowed), wrapped in a transaction only when n spans
+ *     more than one chunk (insert.cppm execute_bulk vs execute_chunked_bulk_*).
+ *     RETURNING id is read back only for insert/N:1 — the Storm fixture sends
+ *     N=1 through single-row insert(obj).execute() (RETURNING) but N>1 through
+ *     the bulk insert(span).execute() VOID path (no RETURNING), so at N>1 the
+ *     two anchors are identical plain bulk inserts.
  *
  * When STORM_BENCH_SOCKET is set, streams over the dashboard wire with
  * is_raw=true (run_start), producing the Storm-vs-raw baseline run.
@@ -32,10 +41,13 @@
 
 #include "dashboard/reporter.h"
 
+#include <array>
+#include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <format>
 #include <string>
+#include <vector>
 
 namespace {
 
@@ -228,60 +240,175 @@ namespace {
     }
     BENCHMARK(BM_Raw_Select_All)->Name("Storm/SELECT/select")->Arg(kSelectRows)->ArgName("N");
 
-    // Shared single-row INSERT driver for both anchors. Builds the table, then
-    // times insert_sql to a counter-named row per iteration (rows accumulate —
-    // no DELETE, no UNIQUE on name). returning mirrors the dialect: plain INSERT
-    // steps once to SQLITE_DONE; RETURNING steps to SQLITE_ROW, reads the id,
-    // then steps again to SQLITE_DONE. Setup is outside the timed loop to match
-    // the Storm fixtures — only the bind + step is measured.
-    auto run_insert_benchmark(benchmark::State& state, char const* insert_sql, bool returning) -> void {
-        sqlite3* db = open_memory_db();
+    // Storm chunks a bulk INSERT at MAX_DB_VARIABLES / field_count_ rows. For the
+    // INSERT-benchmark model (BenchPerson: id + name + age + salary → field_count_
+    // = 4), that is 999 / 4 = 249 rows per multi-row VALUES statement
+    // (insert.cppm). N ≤ 249 → one bulk INSERT, no transaction (execute_bulk);
+    // N > 249 → BEGIN, one bulk INSERT per chunk, COMMIT (execute_chunked_bulk_*).
+    constexpr int kInsertChunkRows = 999 / 4;
+
+    // Build "INSERT INTO person(name, age, salary) VALUES (?,?,?),(?,?,?),..." for
+    // `rows` tuples, appending RETURNING id when `returning`. Mirrors Storm's
+    // multi-row VALUES SQL (insert.cppm build_bulk_insert_body).
+    auto build_bulk_insert_sql(int rows, bool returning) -> std::string {
+        std::string sql = "INSERT INTO person(name, age, salary) VALUES ";
+        for (int i = 0; i < rows; ++i) {
+            sql += (i == 0) ? "(?,?,?)" : ",(?,?,?)";
+        }
+        if (returning) {
+            sql += " RETURNING id";
+        }
+        return sql;
+    }
+
+    // Bind `rows` (name, age, salary) tuples into a prepared multi-row INSERT,
+    // 1-based placeholder per column. Names carry a per-call counter so rows
+    // accumulate without a UNIQUE collision (the table has no UNIQUE(name)),
+    // matching the Storm fixture's stamp_unique_names.
+    auto bind_bulk_rows(sqlite3_stmt* ins, int rows, int& counter) -> void {
+        for (int i = 0; i < rows; ++i) {
+            const std::string name = std::format("P{}", counter++);
+            const int         base = i * 3;
+            sqlite3_bind_text(ins, base + 1, name.c_str(), -1, SQLITE_TRANSIENT);
+            sqlite3_bind_int(ins, base + 2, 30);
+            sqlite3_bind_double(ins, base + 3, 50'000.0);
+        }
+    }
+
+    // Step a bound multi-row INSERT to completion. RETURNING yields one row per
+    // inserted tuple (read each id so the optimizer can't elide it) before
+    // SQLITE_DONE; plain INSERT steps straight to SQLITE_DONE.
+    auto step_bulk_insert(sqlite3* db, sqlite3_stmt* ins, bool returning) -> void {
+        if (returning) {
+            while (sqlite3_step(ins) == SQLITE_ROW) {
+                benchmark::DoNotOptimize(sqlite3_column_int(ins, 0));
+            }
+        } else if (sqlite3_step(ins) != SQLITE_DONE) {
+            die(db, "insert step");
+        }
+        sqlite3_reset(ins);
+    }
+
+    // How Storm splits an N-row bulk INSERT into chunks: `full_chunks` full
+    // statements of kInsertChunkRows each, plus a `remainder_rows` tail (0 when
+    // N divides evenly). `chunked` is true when N spans more than one chunk, the
+    // condition under which Storm wraps the inserts in a transaction. The two
+    // prepared statements (one per distinct chunk shape) are built once and
+    // reused across timed iterations, mirroring Storm's cached prepares.
+    struct InsertPlan {
+        sqlite3_stmt* full_stmt;
+        sqlite3_stmt* rem_stmt;
+        int           full_chunks;
+        int           remainder_rows;
+        bool          returning;
+        bool          chunked;
+    };
+
+    auto make_insert_plan(sqlite3* db, int n, bool returning) -> InsertPlan {
+        int const  full_chunks    = n / kInsertChunkRows;
+        int const  remainder_rows = n % kInsertChunkRows;
+        bool const chunked        = (full_chunks + (remainder_rows > 0 ? 1 : 0)) > 1;
+        return InsertPlan{
+                .full_stmt = full_chunks > 0 ? prepare(db, build_bulk_insert_sql(kInsertChunkRows, returning).c_str())
+                                             : nullptr,
+                .rem_stmt  = remainder_rows > 0 ? prepare(db, build_bulk_insert_sql(remainder_rows, returning).c_str())
+                                                : nullptr,
+                .full_chunks    = full_chunks,
+                .remainder_rows = remainder_rows,
+                .returning      = returning,
+                .chunked        = chunked,
+        };
+    }
+
+    // One timed batch: step every chunk in the plan, wrapped in BEGIN/COMMIT only
+    // when plan.chunked — matching Storm's execute_bulk (no txn) vs
+    // execute_chunked_bulk_* (txn) split.
+    auto run_insert_chunks(sqlite3* db, InsertPlan const& plan, int& counter) -> void {
+        if (plan.chunked) {
+            exec(db, "BEGIN");
+        }
+        for (int c = 0; c < plan.full_chunks; ++c) {
+            bind_bulk_rows(plan.full_stmt, kInsertChunkRows, counter);
+            step_bulk_insert(db, plan.full_stmt, plan.returning);
+        }
+        if (plan.rem_stmt != nullptr) {
+            bind_bulk_rows(plan.rem_stmt, plan.remainder_rows, counter);
+            step_bulk_insert(db, plan.rem_stmt, plan.returning);
+        }
+        if (plan.chunked) {
+            exec(db, "COMMIT");
+        }
+    }
+
+    // Shared batch INSERT driver for both anchors. Builds the table and the
+    // chunk plan once, then per timed iteration inserts state.range(0) rows the
+    // way Storm does (see run_insert_chunks). Only the bind + step + (optional)
+    // BEGIN/COMMIT is timed, mirroring the Storm fixture (setup outside the loop,
+    // cached prepares).
+    //
+    // `returning` selects the insert() vs insert_no_return() anchor, but RETURNING
+    // is only actually emitted at N=1. The Storm fixture dispatches N=1 through
+    // the single-row insert(obj).execute() path (RETURNING id, execute_single_*)
+    // and N>1 through the bulk insert(span).execute() VOID path — which has no
+    // RETURNING clause (queryset.cppm: the default bulk .execute() returns void).
+    // So at N>1 both anchors are plain bulk inserts; only N=1 of the insert
+    // anchor reads back an id.
+    auto run_insert_benchmark(benchmark::State& state, bool returning) -> void {
+        int const  n             = static_cast<int>(state.range(0));
+        bool const use_returning = returning && n == 1;
+        sqlite3*   db            = open_memory_db();
         exec(db, kCreatePerson);
-        sqlite3_stmt* ins = prepare(db, insert_sql);
+
+        InsertPlan const plan = make_insert_plan(db, n, use_returning);
 
         int counter = 0;
         for (auto _ : state) {
-            const std::string name = std::format("P{}", counter++);
-            sqlite3_bind_text(ins, 1, name.c_str(), -1, SQLITE_TRANSIENT);
-            sqlite3_bind_int(ins, 2, 30);
-            sqlite3_bind_double(ins, 3, 50'000.0);
-            if (returning) {
-                if (sqlite3_step(ins) != SQLITE_ROW) {
-                    die(db, "insert returning step");
-                }
-                benchmark::DoNotOptimize(sqlite3_column_int(ins, 0));
-                if (sqlite3_step(ins) != SQLITE_DONE) {
-                    die(db, "insert returning done");
-                }
-            } else if (sqlite3_step(ins) != SQLITE_DONE) {
-                die(db, "insert step");
-            }
-            sqlite3_reset(ins);
+            run_insert_chunks(db, plan, counter);
         }
-        state.SetItemsProcessed(state.iterations());
+        state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations()) * n);
         state.SetComplexityN(state.range(0));
 
-        sqlite3_finalize(ins);
+        if (plan.full_stmt != nullptr) {
+            sqlite3_finalize(plan.full_stmt);
+        }
+        if (plan.rem_stmt != nullptr) {
+            sqlite3_finalize(plan.rem_stmt);
+        }
         sqlite3_close(db);
     }
 
-    // Storm/INSERT/insert_no_return/N:1 — plain INSERT, no RETURNING
-    auto BM_Raw_Insert_No_Return(benchmark::State& state) -> void {
-        run_insert_benchmark(state, "INSERT INTO person(name, age, salary) VALUES(?,?,?)", /*returning=*/false);
-    }
-    BENCHMARK(BM_Raw_Insert_No_Return)->Name("Storm/INSERT/insert_no_return")->Arg(1)->ArgName("N");
+    // BATCH_STANDARD from benchmarks/sizes.cppm — the exact sweep Storm's INSERT
+    // benchmarks register, so the dashboard's (test_name, dataset_size) matcher
+    // pairs every Storm INSERT row with this raw baseline.
+    constexpr std::array kBatchStandard = {1, 10, 100, 500, 1000, 5000, 10000, 50000, 100000};
 
-    // Storm/INSERT/insert/N:1 — INSERT with RETURNING id (mirrors Storm's insert() path)
-    auto BM_Raw_Insert_Returning(benchmark::State& state) -> void {
-        run_insert_benchmark(
-                state, "INSERT INTO person(name, age, salary) VALUES(?,?,?) RETURNING id", /*returning=*/true
-        );
+    auto register_insert_anchor(char const* name, void (*fn)(benchmark::State&)) -> void {
+        auto* bench = benchmark::RegisterBenchmark(name, fn);
+        for (int n : kBatchStandard) {
+            bench->Arg(n);
+        }
+        bench->Complexity(benchmark::oN)->ArgName("N");
     }
-    BENCHMARK(BM_Raw_Insert_Returning)->Name("Storm/INSERT/insert")->Arg(1)->ArgName("N");
+
+    // Storm/INSERT/insert_no_return/N:<n> — plain bulk INSERT, no RETURNING
+    auto BM_Raw_Insert_No_Return(benchmark::State& state) -> void {
+        run_insert_benchmark(state, /*returning=*/false);
+    }
+
+    // Storm/INSERT/insert/N:<n> — bulk INSERT … RETURNING id (mirrors Storm's insert() path)
+    auto BM_Raw_Insert_Returning(benchmark::State& state) -> void {
+        run_insert_benchmark(state, /*returning=*/true);
+    }
 
 } // namespace
 
 auto main(int argc, char** argv) -> int { // NOLINT(bugprone-exception-escape)
+    // INSERT anchors register at runtime (not via the BENCHMARK macro) so the
+    // BATCH_STANDARD sweep can be applied programmatically. Must run before
+    // benchmark::Initialize / RunSpecifiedBenchmarks.
+    register_insert_anchor("Storm/INSERT/insert_no_return", &BM_Raw_Insert_No_Return);
+    register_insert_anchor("Storm/INSERT/insert", &BM_Raw_Insert_Returning);
+
     // Stream to the dashboard when STORM_BENCH_SOCKET is set, marking this run
     // raw (is_raw=true via STORM_BENCH_RAW, read by the reporter) so the
     // dashboard treats it as a Storm-vs-raw baseline. STORM_BENCH_SOCKET unset →


### PR DESCRIPTION
## Summary

Extends the raw SQLite INSERT anchors (`benchmarks/anchors_raw.cpp`) from a single `Storm/INSERT/insert/N:1` point to the full `BATCH_STANDARD` sweep, so the Storm-vs-raw dashboard has a matching raw baseline across every realistic batch size and for both INSERT variants. Before this, only N=1 (pure per-call overhead, nothing amortized) could be compared; all other sizes and `insert_no_return` rendered blank.

## What changed

- Replaced the single-row INSERT driver with a **batch-aware driver that mirrors Storm's execution exactly**:
  - inserts N rows as **one multi-row `VALUES` statement per chunk of 249 rows** (`999 / 4`-field `BenchPerson` = `max_allowed`), matching `insert.cppm`'s chunking;
  - wraps inserts in `BEGIN`/`COMMIT` **only when N spans more than one chunk** (`execute_bulk` vs `execute_chunked_bulk_*`);
  - reads back `RETURNING id` **only at `insert/N:1`** — the Storm fixture routes N=1 through the single-row `insert(obj)` path (RETURNING) but N>1 through the bulk `insert(span).execute()` **VOID** path (no RETURNING), so at N>1 both anchors are identical plain bulk inserts.
- Registered both `Storm/INSERT/insert/N:<n>` and `Storm/INSERT/insert_no_return/N:<n>` over the full sweep `{1,10,100,500,1000,5000,10000,50000,100000}` via runtime `RegisterBenchmark`, with `ArgName("N")` + `Complexity(oN)` + `SetComplexityN` so the `(test_name, dataset_size)` keys match Storm's exactly.
- Raw `CREATE TABLE` keeps `AUTOINCREMENT` to stay fair (both sides pay the `sqlite_sequence` bookkeeping). Whether Storm should drop it from its own schema is a separate question, filed as #379.
- Updated the anchor file header comment and `benchmarks/README.md` anchor enumeration.

## Verification

- `storm_anchors` + `storm_bench` build clean (Release); 18 INSERT anchor rows (9 sizes × 2 variants) with keys matching `storm_bench` output exactly.
- Live dashboard (`--baseline raw:last`) shows `% of raw` on the full sweep: **~86–97% of raw** — lower than the general 96–108% because of the AUTOINCREMENT bookkeeping both sides now pay (expected, documented).
- Pre-commit hook green: clang-format, clang-tidy `--diff`, release build. Tests/coverage correctly skipped (benchmark-only diff; no `src/`/`tests/`/`cmake` changes). Sanitizers not applicable — they exercise `src/`+`tests/`, untouched here.

## Out of scope (tracked separately)

- The `_cv`/`_stddev` aggregate rows getting a `% of raw` label → #346 (done).
- A `⚠ DRIFT` false-positive when the baseline is a raw run (the coef-drift flag restates the efficiency gap and always trips yellow against `raw:last`) — minor dashboard-rendering nit, can file if wanted.
- Dropping `AUTOINCREMENT` from Storm's SQLite int PKs by default → #379.

Closes #345

🤖 Generated with [Claude Code](https://claude.com/claude-code)
