### PR TITLE
fix(safety): make 3 latent lifetime invariants explicit (#357)

### DIFF
--- a/benchmarks/base.cppm
+++ b/benchmarks/base.cppm
@@ -35,7 +35,7 @@ export namespace storm::benchmark {
     // get_db: Helper to get raw sqlite3* from default connection
     // ========================================================================
     template <typename Model> auto get_db() -> sqlite3* {
-        auto& conn = storm::QuerySet<Model>::get_default_connection();
+        const auto& conn = storm::QuerySet<Model>::get_default_connection();
         return conn->get();
     }
 

--- a/docs/development/PERFORMANCE_TIPS.md
+++ b/docs/development/PERFORMANCE_TIPS.md
@@ -28,7 +28,7 @@ qs.insert(objects);
 
 ```cpp
 // FAST: ~1.7M ops/sec - single commit at end
-auto& conn = QuerySet<Person>::get_default_connection();
+const auto& conn = QuerySet<Person>::get_default_connection();
 conn->execute("BEGIN TRANSACTION");
 for (auto& obj : objects) {
     qs.insert(obj);
@@ -75,7 +75,7 @@ This optimization is **universal** - it works for PostgreSQL, MySQL, SQLite, and
 ### Error Handling with Manual Transactions
 
 ```cpp
-auto& conn = QuerySet<Person>::get_default_connection();
+const auto& conn = QuerySet<Person>::get_default_connection();
 
 if (auto result = conn->execute("BEGIN TRANSACTION"); !result) {
     // Handle error

--- a/src/db/concept.cppm
+++ b/src/db/concept.cppm
@@ -265,6 +265,16 @@ export namespace storm::db {
     // Hot path: shared_lock find + reset. On a hit, sets the entry's CLOCK ref bit
     // and bumps `hits`; on a miss, bumps `misses`. Returns the cached Statement* on
     // a hit, nullptr on a miss (caller then prepares + inserts).
+    //
+    // LIFETIME INVARIANT (issue #357, finding A): the returned Stmt* outlives the
+    // shared_lock released on return. It is valid ONLY under the single-owner-per-
+    // Connection contract — exactly one thread may touch a given Connection at a
+    // time (per-thread connections, or pool checkout enforced by debug_claim_owner).
+    // Under that contract no other thread can evict (eviction needs the unique_lock)
+    // or reset the same entry concurrently, so the pointee cannot be freed or mutated
+    // out from under the caller. The debug owner assertions are load-bearing: they
+    // catch a violation of this contract in debug/sanitizer builds. Do NOT relax them
+    // or hand this pointer to another thread.
     template <typename Stmt>
     [[nodiscard]] auto cache_find_hit(StatementCacheState<Stmt>& state, std::string_view sql) -> Stmt* {
         std::shared_lock read_lock(state.mutex);

--- a/src/orm/queryset.cppm
+++ b/src/orm/queryset.cppm
@@ -481,7 +481,14 @@ export namespace storm {
             return {};
         }
 
-        [[nodiscard]] static auto get_default_connection() -> const std::shared_ptr<ConnType>& {
+        // Returns a COPY of the thread_local default-connection shared_ptr (issue #357,
+        // finding C). Returning by value — not by reference into the thread_local — means
+        // a held copy keeps the connection alive across a later clear_default_connection()
+        // or set_default_connection() on this thread, so the dangling use-after-reseat
+        // pattern (`const auto& c = get_default_connection(); clear...(); use(c);`) is
+        // impossible by construction. The extra shared_ptr copy is one atomic refcount
+        // bump; benched as no measurable change on the QuerySet construction path.
+        [[nodiscard]] static auto get_default_connection() -> std::shared_ptr<ConnType> {
             assert(detail::get_default_connection_ptr<ConnType>() &&
                    "Default database connection not set. Call QuerySet::set_default_connection() first.");
             return detail::get_default_connection_ptr<ConnType>();

--- a/src/orm/statements/erase.cppm
+++ b/src/orm/statements/erase.cppm
@@ -220,6 +220,12 @@ export namespace storm::orm::statements {
         auto query(const T& obj [[clang::lifetimebound]]) -> SingleQuery {
             return {std::move(*this), obj};
         }
+        // LIFETIME CONTRACT (issue #357, finding B): the returned BulkQuery holds a
+        // std::span<const T> aliasing the caller's container. `[[clang::lifetimebound]]`
+        // catches the inline-temporary case at compile time, but a span built from a
+        // container that dies before .execute()/.to_sql() runs still dangles silently at
+        // runtime. Treat the proxy as single-expression-use: keep the backing container
+        // alive until the terminal call completes.
         auto query(std::span<const T> objects [[clang::lifetimebound]]) -> BulkQuery {
             return {std::move(*this), objects};
         }

--- a/src/orm/statements/insert.cppm
+++ b/src/orm/statements/insert.cppm
@@ -289,6 +289,13 @@ export namespace storm::orm::statements {
                 return VoidQuery{std::move(*this), obj};
             }
         }
+        // LIFETIME CONTRACT (issue #357, finding B): the returned BulkQuery holds a
+        // std::span<const T> aliasing the caller's container. `[[clang::lifetimebound]]`
+        // (+ -Werror=dangling) catches the inline-temporary case at compile time, but a
+        // span built from a container that dies before .execute()/.to_sql() runs still
+        // dangles silently at runtime. Treat the proxy as single-expression-use: keep the
+        // backing container alive until the terminal call completes. Same for the
+        // ReturnId-templated overload below.
         auto
         query(std::span<const T> objects [[clang::lifetimebound]], std::optional<InsertOptions> opts = std::nullopt)
                 -> BulkQuery {

--- a/src/orm/statements/update.cppm
+++ b/src/orm/statements/update.cppm
@@ -161,6 +161,12 @@ export namespace storm::orm::statements {
         auto query(const T& obj [[clang::lifetimebound]]) -> SingleQuery {
             return {{}, std::move(*this), obj};
         }
+        // LIFETIME CONTRACT (issue #357, finding B): the returned BulkQuery holds a
+        // std::span<const T> aliasing the caller's container. `[[clang::lifetimebound]]`
+        // catches the inline-temporary case at compile time, but a span built from a
+        // container that dies before .execute()/.to_sql() runs still dangles silently at
+        // runtime. Treat the proxy as single-expression-use: keep the backing container
+        // alive until the terminal call completes.
         auto query(std::span<const T> objects [[clang::lifetimebound]]) -> BulkQuery {
             return {{}, std::move(*this), objects};
         }

--- a/tests/test_db_helpers.h
+++ b/tests/test_db_helpers.h
@@ -95,7 +95,7 @@ template <typename ConnType> auto pg_schema_init(auto &conn) -> void {
 
 // End test isolation. For PG: drops the per-process schema (instant cleanup).
 // For SQLite: no-op (:memory: is destroyed with the connection).
-template <typename ConnType> auto rollback_test_txn(auto &conn) -> void {
+template <typename ConnType> auto rollback_test_txn(const auto &conn) -> void {
     if constexpr (std::is_same_v<ConnType, storm::db::postgresql::Connection>) {
         if (!detail::current_test_schema.empty()) {
             (void)conn->execute(std::format("DROP SCHEMA IF EXISTS {} CASCADE", detail::current_test_schema));


### PR DESCRIPTION
Closes #357.

Three LOW-severity findings from the `src/` memory-safety review are safe **today** only because of an implicit invariant. None fire in current code. This PR makes each invariant explicit — A/B by comment, C by a small safe change.

## Findings

### A — `concept.cppm` `cache_find_hit`
Returns a `Stmt*` after releasing the `shared_lock`. Documented that the pointer is valid **only** under the single-owner-per-Connection contract (per-thread connections / pool checkout via `debug_claim_owner`), and that the debug owner assertions are load-bearing.

### B — `insert/update/erase` `BulkQuery`
The proxy holds a `std::span<const T>` into the caller's container. `[[clang::lifetimebound]]` catches the inline-temporary case at compile time, but a span built one statement earlier still dangles silently at runtime. Documented the proxy as single-expression-use.

### C — `get_default_connection()` → **return by value**
Previously returned `const std::shared_ptr<ConnType>&` into a `thread_local`. A caller doing `const auto& c = get_default_connection(); clear_default_connection(); use(c);` would dangle. Now returns `std::shared_ptr<ConnType>` by value — a held copy survives a later `clear()`/`set()` on the same thread, so the dangle is **impossible by construction**.

Why not `[[clang::lifetimebound]]`? It's **rejected by the compiler** on a static no-arg function (no object/param to bind), and even where applicable it catches only end-of-full-expression temporaries, not cross-statement invalidation. Verified that `-Wdangling`, clang `--analyze`, `clang-tidy bugprone-dangling-handle`, and `-Wlifetime` all stay silent on this pattern. By-value is the only mechanism that actually prevents it.

Callers that bound the old reference with a non-const `auto&` updated to `const auto&` (`rollback_test_txn`, bench `get_db`, `PERFORMANCE_TIPS` examples).

## Verification
- **Tests**: 1995/1995 pass under ASAN+UBSAN and TSAN
- **Coverage**: 100% (pre-commit gate)
- **Bench (the gate for C)**: `Storm/SELECT` median vs develop — −1.0% / −1.8% / −4.4% / −3.2% across N=100→100k. No regression; the extra atomic refcount bump is within noise (cv 0.7–3%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)