### PR TITLE
docs(cache): correct cache_find_hit lifetime invariant to real contract

### DIFF
--- a/src/db/concept.cppm
+++ b/src/db/concept.cppm
@@ -267,14 +267,15 @@ export namespace storm::db {
     // a hit, nullptr on a miss (caller then prepares + inserts).
     //
     // LIFETIME INVARIANT (issue #357, finding A): the returned Stmt* outlives the
-    // shared_lock released on return. It is valid ONLY under the single-owner-per-
-    // Connection contract — exactly one thread may touch a given Connection at a
-    // time (per-thread connections, or pool checkout enforced by debug_claim_owner).
-    // Under that contract no other thread can evict (eviction needs the unique_lock)
-    // or reset the same entry concurrently, so the pointee cannot be freed or mutated
-    // out from under the caller. The debug owner assertions are load-bearing: they
-    // catch a violation of this contract in debug/sanitizer builds. Do NOT relax them
-    // or hand this pointer to another thread.
+    // shared_lock released on return. Concurrent access to the cache from multiple
+    // threads IS supported and tested — the shared_mutex serialises map structure
+    // (#271; see StatementCacheThreadingTest, which pounds one Connection from 8
+    // threads under TSAN). The actual contract is narrower than single-owner: the
+    // returned Stmt* is valid only WITHIN the iteration that fetched it. A caller
+    // must NOT retain it across a concurrent clear_statement_cache() / eviction,
+    // which destroys the entry's unique_ptr<Stmt> and dangles the pointer. (The
+    // per-thread-connection model trivially satisfies this; the bound is the
+    // dereference window, not the number of threads.)
     template <typename Stmt>
     [[nodiscard]] auto cache_find_hit(StatementCacheState<Stmt>& state, std::string_view sql) -> Stmt* {
         std::shared_lock read_lock(state.mutex);


### PR DESCRIPTION
Follow-up to #357 / PR #381. Closes #382 (already closed as invalid — see its thread).

## Problem

PR #381 (closing #357 finding A) added a comment to `cache_find_hit()` in `src/db/concept.cppm` that **overstated** the lifetime invariant as *"single-owner-per-Connection — exactly one thread may touch a given Connection at a time."*

That is **wrong**. The L3 statement cache is **intentionally multi-thread** (issue #271): `MovableSharedMutex` + shared/unique locks exist precisely so concurrent access is safe, and it is validated on the ninja-tsan matrix by `tests/db/test_statement_cache_threading.cpp` (`StatementCacheThreadingTest.Concurrent*` — 8 threads pounding one Connection's cache).

## How it was found

While prototyping #382 (a debug single-owner tripwire), the assertion fired on those 4 `Concurrent*` tests — proving the premise false. #382 closed as invalid; this PR keeps only the comment correction.

## Fix

Comment-only. The real contract (already documented in that test file's header) is narrower than thread count:

> the returned `Stmt*` is valid only **within the iteration that fetched it**; it must not be retained across a concurrent `clear_statement_cache()` / eviction (which frees the entry's `unique_ptr<Stmt>`).

No behavior change. No code change.

## Verification
- Pre-commit gate passed: clang-format, clang-tidy, tests (SQLite + PG), 100% coverage
- `StatementCacheThreadingTest` (all 5) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)