### PR TITLE
lint: enable clang-analyzer + curated modernize/portability/google categories (#364)

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,8 +2,12 @@
 # Clang-Tidy configuration for Storm ORM
 # Comprehensive checks for C++26 ORM project
 #
-# Categories enabled: bugprone, cert, concurrency, cppcoreguidelines, misc, performance, readability
-# Excluded categories: android, fuchsia, llvm, abseil, google, objc, etc. (platform/library-specific)
+# Categories enabled (full): clang-analyzer, bugprone, cert, concurrency,
+#   cppcoreguidelines, misc, performance, portability, readability
+# Categories enabled (curated subset only): modernize, google (see notes below)
+# Excluded categories: android, fuchsia, llvm, llvmlibc, abseil, boost, darwin,
+#   mpi, objc, openmp, zircon, altera, linuxkernel, hicpp (platform/library-specific
+#   or pure aliases of already-enabled checks).
 #
 # Exclusion policy:
 # - Keep checks that catch real bugs
@@ -42,9 +46,57 @@
 #   constexpr ternary to eliminate the clone.
 # - performance-enum-size: re-enabled 2026-05-25 (issue #313); enums in src/ given explicit small
 #   underlying types (std::uint8_t) since none exceed 256 enumerators.
+#
+# Category additions (issue #364):
+#
+# clang-analyzer-* (path-sensitive analysis — catches resource leak / use-after-free
+#   on error paths the sanitizers never execute, null deref on a specific branch,
+#   uninitialized reads the syntactic checks miss):
+#   - Enabled wholesale. The full-tree sweep found 0 warnings in src/ and 8 in
+#     test/bench code (all idiomatic: gbench `for (auto _ : state)` dead-store on
+#     the iteration token, intentional moved-from assertions, a bounded mock copy);
+#     each fixed at the site (NOLINT or memcpy).
+#   - Runtime: measured ~0 added cost. The analyzer runs during the same single-TU
+#     parse/AST that the already-enabled syntactic categories pay for (24 src TUs:
+#     145s with vs 145s without; analyzer-only is 14s). So it rides the normal
+#     --full / --all sweep and pre-commit --diff — NO special CI-only gating needed.
+#
+# modernize-* (curated allow-list, NOT wholesale — several modernize checks fight
+#   Storm's C++26/consteval style or duplicate SonarCloud rules):
+#   Enabled: use-nullptr, use-override, use-equals-default, use-equals-delete,
+#     make-unique, make-shared, use-emplace, loop-convert.
+#   Excluded with cause (omitted from the allow-list above):
+#   - modernize-use-trailing-return-type: cosmetic; would churn every signature.
+#   - modernize-use-auto: fights Storm's explicit-type-in-consteval style.
+#   - modernize-avoid-c-arrays: consteval code uses C arrays deliberately
+#     (cf. NOSONAR S6188 — std::span is unreliable in consteval).
+#   Also implicitly excluded (the rest of modernize-*, e.g. use-ranges S6197,
+#     use-std-contains-after-find S7034, use-using, concat-nested-namespaces) —
+#     either duplicate SonarCloud rules already in CLAUDE.md or out of scope here.
+#
+# portability-* (enabled wholesale): low-noise insurance for the planned
+#   PostgreSQL/MySQL backends. The only finding was portability-avoid-pragma-once
+#   (4 test/bench headers) — those 4 were converted to include guards so the
+#   category enables clean.
+#
+# google-* (NOT monolithic — enable header-hygiene checks, keep the one conflict off):
+#   Enabled: build-using-namespace, build-namespaces, global-names-in-headers,
+#     readability-casting. The 58 build-using-namespace findings (all in .cpp
+#     test/bench TUs, none in headers) were converted to explicit
+#     using-declarations / namespace aliases.
+#   Excluded with cause:
+#   - google-explicit-constructor: Expr/UUID implicit conversions are intentional
+#     public API (kept off globally; see the GTest block below).
+#   - google-runtime-int, google-readability-{braces-around-statements,function-size,
+#     namespace-comments,todo}, google-objc-*: noisy, cosmetic, aliases of already-
+#     enabled readability-* checks, or N/A. Not added (allow-list above excludes them).
+#
+# hicpp-*: NOT added — pure aliases of cppcoreguidelines/bugprone checks already
+#   enabled; only adds duplicate diagnostics.
 
 Checks: >
   -*,
+  clang-analyzer-*,
   bugprone-*,
   -bugprone-argument-comment,
   -bugprone-easily-swappable-parameters,
@@ -67,9 +119,22 @@ Checks: >
   misc-*,
   -misc-const-correctness,
   -misc-include-cleaner,
+  modernize-use-nullptr,
+  modernize-use-override,
+  modernize-use-equals-default,
+  modernize-use-equals-delete,
+  modernize-make-unique,
+  modernize-make-shared,
+  modernize-use-emplace,
+  modernize-loop-convert,
   performance-*,
+  portability-*,
   readability-*,
   -readability-magic-numbers,
+  google-build-using-namespace,
+  google-build-namespaces,
+  google-global-names-in-headers,
+  google-readability-casting,
   -google-explicit-constructor
 
 # Header filter - apply to project headers, exclude third_party

--- a/benchmarks/anchors_raw.cpp
+++ b/benchmarks/anchors_raw.cpp
@@ -189,6 +189,7 @@ namespace {
         seeder(db, seed_rows);
         sqlite3_stmt* sel = prepare(db, query_sql);
 
+        // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores) -- Google Benchmark loop idiom: `_` is the iteration token, never read
         for (auto _ : state) {
             int const rows = drain_person_select(sel);
             if (assert_full_count && rows != seed_rows) {
@@ -363,6 +364,7 @@ namespace {
         InsertPlan const plan = make_insert_plan(db, n, use_returning);
 
         int counter = 0;
+        // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores) -- Google Benchmark loop idiom: `_` is the iteration token, never read
         for (auto _ : state) {
             run_insert_chunks(db, plan, counter);
         }

--- a/benchmarks/dashboard/reporter.h
+++ b/benchmarks/dashboard/reporter.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef STORM_BENCHMARKS_DASHBOARD_REPORTER_H
+#define STORM_BENCHMARKS_DASHBOARD_REPORTER_H
 
 // install_storm_reporter() — wires a custom Google Benchmark reporter that
 // streams every Run as a one-line NDJSON datagram to the storm_bench_dashboard
@@ -37,3 +38,5 @@ namespace bench_dashboard {
 auto install_storm_reporter(std::string_view socket_path, std::string_view filter) -> ::benchmark::BenchmarkReporter *;
 
 } // namespace bench_dashboard
+
+#endif // STORM_BENCHMARKS_DASHBOARD_REPORTER_H

--- a/benchmarks/dashboard/row_classify.hpp
+++ b/benchmarks/dashboard/row_classify.hpp
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef STORM_BENCHMARKS_DASHBOARD_ROW_CLASSIFY_HPP
+#define STORM_BENCHMARKS_DASHBOARD_ROW_CLASSIFY_HPP
 
 // Pure, Google-Benchmark-free classification of a benchmark Run into a
 // dashboard row_kind (Issue #265).
@@ -64,3 +65,5 @@ namespace bench_dashboard {
     }
 
 } // namespace bench_dashboard
+
+#endif // STORM_BENCHMARKS_DASHBOARD_ROW_CLASSIFY_HPP

--- a/benchmarks/dashboard/wire.hpp
+++ b/benchmarks/dashboard/wire.hpp
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef STORM_BENCHMARKS_DASHBOARD_WIRE_HPP
+#define STORM_BENCHMARKS_DASHBOARD_WIRE_HPP
 
 // Wire format for the storm_bench → storm_bench_dashboard link (Issue #247,
 // Phase 2). NDJSON over AF_UNIX SOCK_DGRAM: one datagram = one JSON line. The
@@ -380,3 +381,5 @@ namespace bench_dashboard::wire {
     }
 
 } // namespace bench_dashboard::wire
+
+#endif // STORM_BENCHMARKS_DASHBOARD_WIRE_HPP

--- a/benchmarks/register.cpp
+++ b/benchmarks/register.cpp
@@ -35,8 +35,6 @@ import storm_benchmark_registry;
 import storm_benchmark_schema;
 import storm_benchmark_sizes;
 
-using namespace storm;
-
 namespace storm::benchmark {
 
     auto registered_benchmarks() -> std::vector<RegisteredBenchmark>& {

--- a/scripts/run_clang_tidy.sh
+++ b/scripts/run_clang_tidy.sh
@@ -148,6 +148,15 @@ echo ""
 #   benchmarks/dashboard/args.hpp, benchmarks/dashboard/backup.hpp,
 #   benchmarks/dashboard/db.hpp, benchmarks/dashboard/events.hpp,
 #   benchmarks/dashboard/tui_render.hpp, benchmarks/dashboard/models.hpp
+#
+#   benchmarks/schema.cppm — parses fine, but ANY ASTMatcher-based check
+#       (every enabled check) SIGSEGVs clang-tidy inside
+#       RecursiveASTVisitor::TraverseTemplateInstantiations on the std-module
+#       VarTemplateDecl `std::__desugars_to_v` (a clang-p2996 ParentMap/AST
+#       traversal bug over `import std;` instantiations). Reproduces with the
+#       pre-#364 7-category config and with a single readability check, so it is
+#       a toolchain crash, not a Storm-code or check-config issue. Tracked with
+#       the other clang-p2996 module crashes under issue #262.
 is_known_unparseable() {
     local file="$1"
     case "$file" in
@@ -169,6 +178,7 @@ is_known_unparseable() {
         benchmarks/dashboard/events.hpp) return 0 ;;
         benchmarks/dashboard/tui_render.hpp) return 0 ;;
         benchmarks/dashboard/models.hpp) return 0 ;;
+        benchmarks/schema.cppm) return 0 ;;
         *) return 1 ;;
     esac
 }

--- a/src/db/postgresql_connection.cppm
+++ b/src/db/postgresql_connection.cppm
@@ -180,9 +180,7 @@ export namespace storm::db::postgresql {
             bool in_single_quote = false;
             bool in_double_quote = false;
 
-            for (std::size_t i = 0; i < sql.size(); ++i) {
-                const char ch = sql[i];
-
+            for (const char ch : sql) {
                 // Track quoted strings to avoid translating ? inside them
                 if (ch == '\'' && !in_double_quote) {
                     in_single_quote = !in_single_quote;

--- a/src/db/postgresql_statement.cppm
+++ b/src/db/postgresql_statement.cppm
@@ -274,8 +274,7 @@ export namespace storm::db::postgresql {
             int  param_idx       = 0;
             bool in_single_quote = false;
             bool in_double_quote = false;
-            for (std::size_t i = 0; i < original_sql_.size(); ++i) {
-                const char ch = original_sql_[i];
+            for (const char ch : original_sql_) {
                 if (ch == '\'' && !in_double_quote) {
                     in_single_quote = !in_single_quote;
                     result += ch;

--- a/tests/.clang-tidy
+++ b/tests/.clang-tidy
@@ -11,6 +11,13 @@
 # - cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers: test data uses literals.
 # - bugprone-unchecked-optional-access: ASSERT_TRUE guards optional access but clang-tidy
 #   cannot see through GTest macros — false positives on valid checked access patterns.
+#
+# GTest-only google-* checks NOT enabled (issue #364):
+# - google-readability-avoid-underscore-in-googletest-name: Storm deliberately uses
+#   `_` to group related test names (IsNull_MethodSyntax, IsNull_NulloptSyntax, ...);
+#   enabling would force renaming dozens of tests for no correctness gain.
+# - google-upgrade-googletest-case: one-time migration check; the suite already uses
+#   the current TYPED_TEST_SUITE / *_SUITE_P spelling, so it has nothing to flag.
 InheritParentConfig: true
 Checks: >
   -bugprone-unchecked-optional-access,

--- a/tests/bench_dashboard/test_dashboard_result_counter.cpp
+++ b/tests/bench_dashboard/test_dashboard_result_counter.cpp
@@ -59,8 +59,9 @@ namespace {
 // data shown in the Complexity footer and must not inflate the session total.
 TEST(DashboardResultCounter, OnlyMeasurements) {
     bench_dashboard::tui::Session sess{};
-    for (int i = 0; i < 9; ++i)
+    for (int i = 0; i < 9; ++i) {
         add(sess, make_measurement("Storm/INSERT/insert/N:1000", "INSERT"));
+    }
 
     EXPECT_EQ(sess.result_count, 9U);
 }
@@ -79,10 +80,12 @@ TEST(DashboardResultCounter, OnlyBigOAndRms) {
 // Counter must show 18, not 22 and not 36.
 TEST(DashboardResultCounter, MixedMeasurementsAndComplexity) {
     bench_dashboard::tui::Session sess{};
-    for (int i = 0; i < 9; ++i)
+    for (int i = 0; i < 9; ++i) {
         add(sess, make_measurement("Storm/INSERT/insert/N:1000", "INSERT"));
-    for (int i = 0; i < 9; ++i)
+    }
+    for (int i = 0; i < 9; ++i) {
         add(sess, make_measurement("Storm/UPDATE_PK/update_pk/N:1000", "UPDATE_PK"));
+    }
     add(sess, make_bigo("Storm/INSERT/insert_BigO", "INSERT"));
     add(sess, make_rms("Storm/INSERT/insert_RMS", "INSERT"));
     add(sess, make_bigo("Storm/UPDATE_PK/update_pk_BigO", "UPDATE_PK"));

--- a/tests/bench_dashboard/test_raw_baseline.cpp
+++ b/tests/bench_dashboard/test_raw_baseline.cpp
@@ -41,7 +41,9 @@ namespace {
 // ---------------------------------------------------------------------------
 
 TEST(WireRunStart, IsRawRoundTrips) {
-    using namespace bench_dashboard::wire;
+    using bench_dashboard::wire::build_run_start;
+    using bench_dashboard::wire::MessageKind;
+    using bench_dashboard::wire::parse;
     const auto json = build_run_start("WHERE.*", /*is_full_run=*/false, /*is_raw=*/true);
     const auto msg  = parse(json);
     ASSERT_TRUE(msg.has_value());
@@ -52,7 +54,7 @@ TEST(WireRunStart, IsRawRoundTrips) {
 }
 
 TEST(WireRunStart, IsRawDefaultsFalseWhenAbsent) {
-    using namespace bench_dashboard::wire;
+    using bench_dashboard::wire::parse;
     // Backward compat: an older producer omits is_raw → parses as false.
     const auto msg = parse(R"({"type":"run_start","filter":"","is_full_run":true})");
     ASSERT_TRUE(msg.has_value());
@@ -61,7 +63,8 @@ TEST(WireRunStart, IsRawDefaultsFalseWhenAbsent) {
 }
 
 TEST(WireRunStart, IsRawFalseRoundTrips) {
-    using namespace bench_dashboard::wire;
+    using bench_dashboard::wire::build_run_start;
+    using bench_dashboard::wire::parse;
     const auto json = build_run_start("", /*is_full_run=*/true, /*is_raw=*/false);
     const auto msg  = parse(json);
     ASSERT_TRUE(msg.has_value());

--- a/tests/crud/test_crud.cpp
+++ b/tests/crud/test_crud.cpp
@@ -42,7 +42,7 @@ template <typename ConnType> class PersonCrudTestBase : public StormTestFixture<
     }
 
     static auto personExists(int person_id) -> bool {
-        using namespace storm::orm::where;
+        using storm::orm::where::field;
         const storm::QuerySet<Person, ConnType> qs;
         auto result = qs.where(field<^^Person::id>() == person_id).select().execute();
         return result.has_value() && !result.value().empty();
@@ -206,7 +206,7 @@ template <typename ConnType> class QuerySetUpdateTest : public PersonCrudTestBas
   protected:
     // Helper function to get person by ID using the ORM
     static auto getPerson(int person_id) -> std::optional<Person> {
-        using namespace storm::orm::where;
+        using storm::orm::where::field;
         const storm::QuerySet<Person, ConnType> qs;
         auto result = qs.where(field<^^Person::id>() == person_id).select().execute();
         if (!result.has_value() || result.value().empty()) {

--- a/tests/crud/test_crud_lifecycle.cpp
+++ b/tests/crud/test_crud_lifecycle.cpp
@@ -50,7 +50,7 @@ template <typename ConnType> class QuerySetCrudLifecycleTest : public StormTestF
 TYPED_TEST_SUITE(QuerySetCrudLifecycleTest, DatabaseTypes);
 
 TYPED_TEST(QuerySetCrudLifecycleTest, FullLifecycle) {
-    using namespace storm::orm::where;
+    using storm::orm::where::field;
     storm::QuerySet<Person, TypeParam> qs;
 
     // 1. Verify empty state
@@ -146,7 +146,7 @@ TYPED_TEST(QuerySetCrudLifecycleTest, BatchLifecycle) {
 
 // All supported field types: int, string, double, bool, optional<int>, optional<string>, blob
 TYPED_TEST(QuerySetCrudLifecycleTest, AllFieldTypesLifecycle) {
-    using namespace storm::orm::where;
+    using storm::orm::where::field;
     storm::QuerySet<Person, TypeParam> qs;
 
     // 1. Insert with all fields populated
@@ -228,7 +228,7 @@ TYPED_TEST(QuerySetCrudLifecycleTest, BoundaryBatchLifecycle) {
 
 // Insert, selectively update and erase via WHERE, verify unaffected rows unchanged
 TYPED_TEST(QuerySetCrudLifecycleTest, FilteredLifecycle) {
-    using namespace storm::orm::where;
+    using storm::orm::where::field;
     storm::QuerySet<Person, TypeParam> qs;
 
     // 1. Insert mixed data
@@ -242,6 +242,7 @@ TYPED_TEST(QuerySetCrudLifecycleTest, FilteredLifecycle) {
     EXPECT_EQ(this->countPersons(), 4);
 
     // 2. Select only active persons
+    // NOLINTNEXTLINE(readability-simplify-boolean-expr) -- `== true` is the WHERE-DSL comparison (generates `is_active = ?`), not a redundant bool op
     auto active = qs.where(field<^^Person::is_active>() == true).select().execute();
     ASSERT_TRUE(active.has_value());
     EXPECT_EQ(static_cast<int>(active.value().size()), 2) << "Should have 2 active persons";

--- a/tests/crud/test_select.cpp
+++ b/tests/crud/test_select.cpp
@@ -4,7 +4,7 @@
 import storm;
 import std;
 
-using namespace storm;
+using storm::QuerySet;
 
 #include "test_models.h" // NOSONAR cpp:S954
 

--- a/tests/crud/test_select_large.cpp
+++ b/tests/crud/test_select_large.cpp
@@ -6,7 +6,7 @@ import std;
 
 #include "test_models.h"
 
-using namespace storm;
+using storm::QuerySet;
 
 // Test fixture for large SELECT operations — templated on database backend
 template <typename ConnType> class SelectLargeTest : public StormTestFixture<SimpleRecord, ConnType> {};

--- a/tests/crud/test_select_one.cpp
+++ b/tests/crud/test_select_one.cpp
@@ -4,8 +4,8 @@
 import storm;
 import std;
 
-using namespace storm;
-using namespace storm::orm::where;
+using storm::QuerySet;
+using storm::orm::where::field;
 
 #include "test_models.h" // NOSONAR cpp:S954
 #include "test_seed_helpers.h"

--- a/tests/db/test_statement_move.cpp
+++ b/tests/db/test_statement_move.cpp
@@ -58,7 +58,9 @@ namespace {
         Statement dst{std::move(src)};
 
         EXPECT_EQ(as_void(dst.handle()), as_void(raw));
-        EXPECT_EQ(as_void(src.handle()), nullptr);
+        // Intentional moved-from read: the test asserts the move nulled the source.
+        const void* moved_src = as_void(src.handle()); // NOLINT(clang-analyzer-cplusplus.Move,bugprone-use-after-move)
+        EXPECT_EQ(moved_src, nullptr);
     }
 
     // Same invariant for move assignment.
@@ -71,7 +73,9 @@ namespace {
         dst = std::move(src);
 
         EXPECT_EQ(as_void(dst.handle()), as_void(raw_src));
-        EXPECT_EQ(as_void(src.handle()), nullptr);
+        // Intentional moved-from read: the test asserts the move nulled the source.
+        const void* moved_src = as_void(src.handle()); // NOLINT(clang-analyzer-cplusplus.Move,bugprone-use-after-move)
+        EXPECT_EQ(moved_src, nullptr);
     }
 
 } // namespace

--- a/tests/errors/test_sqlite_errors.cpp
+++ b/tests/errors/test_sqlite_errors.cpp
@@ -17,7 +17,8 @@ import storm_db_sqlite;
 import storm_orm_statements_insert;
 
 namespace fs = std::filesystem;
-using namespace storm::db::sqlite;
+using storm::db::sqlite::Connection;
+using storm::db::sqlite::Statement;
 
 // ============================================================================
 // Connection Error Tests
@@ -76,12 +77,13 @@ TEST_F(ConnectionErrorTest, ConnectionNotOpenPrepare) {
     auto conn       = std::move(result.value());
     auto moved_conn = std::move(conn);
 
-    // Original conn is now in moved-from state
-    EXPECT_FALSE(conn.is_open()) << "Moved-from connection should not be open"; // NOLINT(bugprone-use-after-move)
+    // Original conn is now in moved-from state. Intentional moved-from reads:
+    // these tests assert the API rejects a moved-from (closed) connection.
+    const bool moved_open = conn.is_open(); // NOLINT(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
+    EXPECT_FALSE(moved_open) << "Moved-from connection should not be open";
 
     // prepare() on closed connection should return error
-    auto prep_result =
-            conn.prepare("SELECT 1"); // NOLINT(bugprone-use-after-move) -- intentional: testing moved-from behavior
+    auto prep_result = conn.prepare("SELECT 1"); // NOLINT(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
     ASSERT_FALSE(prep_result.has_value()) << "prepare() on closed connection should fail";
     EXPECT_EQ(prep_result.error().code(), SQLITE_MISUSE);
 }
@@ -93,8 +95,9 @@ TEST_F(ConnectionErrorTest, ConnectionNotOpenPrepareCached) {
     auto conn       = std::move(result.value());
     auto moved_conn = std::move(conn);
 
-    // prepare_cached() on closed connection should return error
-    auto prep_result = conn.prepare_cached("SELECT 1"); // NOLINT(bugprone-use-after-move)
+    // prepare_cached() on closed connection should return error (intentional moved-from read)
+    // NOLINTNEXTLINE(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
+    auto prep_result = conn.prepare_cached("SELECT 1");
     ASSERT_FALSE(prep_result.has_value()) << "prepare_cached() on closed connection should fail";
     EXPECT_EQ(prep_result.error().code(), SQLITE_MISUSE);
 }
@@ -107,7 +110,7 @@ TEST_F(ConnectionErrorTest, ConnectionNotOpenExecute) {
     auto moved_conn = std::move(conn);
 
     // execute() on closed connection should return error
-    auto exec_result = conn.execute("SELECT 1"); // NOLINT(bugprone-use-after-move)
+    auto exec_result = conn.execute("SELECT 1"); // NOLINT(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
     ASSERT_FALSE(exec_result.has_value()) << "execute() on closed connection should fail";
     EXPECT_EQ(exec_result.error().code(), SQLITE_MISUSE);
 }

--- a/tests/mock_libpq/test_pq_mock.cpp
+++ b/tests/mock_libpq/test_pq_mock.cpp
@@ -18,7 +18,8 @@
 // NOLINTBEGIN(cppcoreguidelines-pro-type-cstyle-cast,misc-const-correctness) // NOSONAR(cpp:S125)
 // NOLINTBEGIN(readability-static-accessed-through-instance) // NOSONAR(cpp:S125)
 
-using namespace storm::test;
+using storm::test::MockPqConfig;
+using storm::test::MockPqGuard;
 
 // ============================================================================
 // Default Behavior Tests

--- a/tests/mock_sqlite/mock_sqlite3.cpp
+++ b/tests/mock_sqlite/mock_sqlite3.cpp
@@ -9,6 +9,7 @@
 // NOLINTBEGIN(bugprone-easily-swappable-parameters) // mock signatures must match real SQLite3 API // NOSONAR(cpp:S125)
 
 #include "mock_sqlite3.h"
+#include <algorithm>
 #include <cstring>
 #include <mutex>
 
@@ -570,10 +571,15 @@ auto sqlite3_expanded_sql(sqlite3_stmt* /*pStmt*/) -> char* {
     if (g_mock_config.expanded_sql_returns_null) {
         return nullptr;
     }
-    // Return a malloc'd copy of a placeholder SQL string (caller must sqlite3_free)
-    const char* placeholder = "SELECT 1";
-    auto*       copy        = static_cast<char*>(malloc(strlen(placeholder) + 1)); // NOSONAR(cpp:S1231)
-    strcpy(copy, placeholder);                                                     // NOSONAR(cpp:S5025)
+    // Return a malloc'd copy of a placeholder SQL string. malloc (not new /
+    // unique_ptr) is mandatory: the caller frees this via sqlite3_free → free(),
+    // matching SQLite's C ABI contract (see sqlite.cppm expanded_sql()).
+    constexpr std::string_view placeholder = "SELECT 1";
+    auto*                      copy        = static_cast<char*>(malloc(placeholder.size() + 1)); // NOSONAR(cpp:S1231)
+    if (copy == nullptr) {
+        return nullptr; // OOM — the real sqlite3_expanded_sql() returns null too
+    }
+    *std::ranges::copy(placeholder, copy).out = '\0'; // bounded, null-terminated
     return copy;
 }
 

--- a/tests/mock_sqlite/test_orm_mock_errors.cpp
+++ b/tests/mock_sqlite/test_orm_mock_errors.cpp
@@ -28,7 +28,9 @@ import std;
 import storm_orm_utilities;
 import storm_orm_transaction;
 
-using namespace storm;
+namespace db  = storm::db;
+namespace orm = storm::orm;
+using storm::QuerySet;
 using storm::test::MockSqlite3Config;
 
 // Struct with indexes — must be at namespace scope for Indexes<> specialization

--- a/tests/mock_sqlite/test_sqlite_mock.cpp
+++ b/tests/mock_sqlite/test_sqlite_mock.cpp
@@ -15,7 +15,8 @@
 
 // NOLINTBEGIN(misc-const-correctness,cppcoreguidelines-pro-type-cstyle-cast,performance-no-int-to-ptr)
 
-using namespace storm::test;
+using storm::test::MockSqlite3Config;
+using storm::test::MockSqlite3Guard;
 
 // ============================================================================
 // Mock Configuration Tests - Verify the mock itself works correctly

--- a/tests/query/test_aggregate.cpp
+++ b/tests/query/test_aggregate.cpp
@@ -4,7 +4,7 @@
 import storm;
 import std;
 
-using namespace storm;
+using storm::QuerySet;
 
 #include "test_models.h" // NOSONAR cpp:S954
 #include "test_seed_helpers.h"

--- a/tests/query/test_aggregate_combined.cpp
+++ b/tests/query/test_aggregate_combined.cpp
@@ -6,7 +6,7 @@
 import storm;
 import std;
 
-using namespace storm;
+using storm::QuerySet;
 
 #include "test_models.h" // NOSONAR cpp:S954
 #include "test_seed_helpers.h"

--- a/tests/query/test_aggregate_groupby.cpp
+++ b/tests/query/test_aggregate_groupby.cpp
@@ -4,7 +4,7 @@
 import storm;
 import std;
 
-using namespace storm;
+using storm::QuerySet;
 
 #include "test_models.h" // NOSONAR cpp:S954
 #include "test_seed_helpers.h"

--- a/tests/query/test_aggregate_having.cpp
+++ b/tests/query/test_aggregate_having.cpp
@@ -6,7 +6,7 @@
 import storm;
 import std;
 
-using namespace storm;
+using storm::QuerySet;
 
 #include "test_models.h" // NOSONAR cpp:S954
 #include "test_seed_helpers.h"

--- a/tests/query/test_aggregate_optional.cpp
+++ b/tests/query/test_aggregate_optional.cpp
@@ -4,7 +4,7 @@
 import storm;
 import std;
 
-using namespace storm;
+using storm::QuerySet;
 
 #include "test_models.h" // NOSONAR cpp:S954
 #include "test_seed_helpers.h"

--- a/tests/query/test_collate.cpp
+++ b/tests/query/test_collate.cpp
@@ -8,9 +8,9 @@ import storm;
 import std;
 
 #include "test_models.h" // NOSONAR cpp:S954
-using namespace storm;
-using namespace storm::orm::where;
+using storm::QuerySet;
 using storm::orm::utilities::Collate;
+using storm::orm::where::field;
 
 // SQLite-only: COLLATE NOCASE/BINARY/RTRIM are SQLite-specific collation sequences.
 // PostgreSQL uses different syntax (COLLATE "C", COLLATE "en_US").

--- a/tests/query/test_distinct.cpp
+++ b/tests/query/test_distinct.cpp
@@ -7,8 +7,8 @@
 import storm;
 import std;
 
-using namespace storm;
-using namespace storm::orm::where;
+using storm::QuerySet;
+using storm::orm::where::field;
 
 #include "test_models.h" // NOSONAR cpp:S954
 

--- a/tests/query/test_expected_transform.cpp
+++ b/tests/query/test_expected_transform.cpp
@@ -10,8 +10,8 @@ import std;
 #include "test_models.h" // NOSONAR cpp:S954
 #include "test_seed_helpers.h"
 
-using namespace storm;
-using namespace storm::orm::where;
+using storm::QuerySet;
+using storm::orm::where::field;
 
 template <typename ConnType> class ExpectedTransformTest : public StormTestFixture<Person, ConnType> {
   protected:

--- a/tests/query/test_join_wide.cpp
+++ b/tests/query/test_join_wide.cpp
@@ -6,8 +6,7 @@
 import storm;
 import std;
 
-using namespace storm;
-using namespace storm::orm::where;
+using storm::QuerySet;
 
 #include "test_models.h" // NOSONAR cpp:S954
 

--- a/tests/query/test_limit_offset.cpp
+++ b/tests/query/test_limit_offset.cpp
@@ -4,8 +4,8 @@
 import storm;
 import std;
 
-using namespace storm;
-using namespace storm::orm::where;
+using storm::QuerySet;
+using storm::orm::where::field;
 
 #include "test_models.h" // NOSONAR cpp:S954
 #include "test_seed_helpers.h"

--- a/tests/query/test_order_by.cpp
+++ b/tests/query/test_order_by.cpp
@@ -10,8 +10,8 @@ import std;
 #include "test_models.h" // NOSONAR cpp:S954
 #include "test_seed_helpers.h"
 #include "test_select_runner.h"
-using namespace storm;
-using namespace storm::orm::where;
+using storm::QuerySet;
+using storm::orm::where::field;
 
 template <typename ConnType> auto insert_test_data(const std::vector<Person>& data) -> void {
     QuerySet<Person, ConnType> qs;

--- a/tests/query/test_rows.cpp
+++ b/tests/query/test_rows.cpp
@@ -9,8 +9,8 @@ import std;
 #include "test_models.h" // NOSONAR cpp:S954
 #include "test_seed_helpers.h"
 
-using namespace storm;
-using namespace storm::orm::where;
+using storm::QuerySet;
+using storm::orm::where::field;
 
 template <typename ConnType> class RowsTest : public StormTestFixture<Person, ConnType> {
   protected:

--- a/tests/query/test_setop.cpp
+++ b/tests/query/test_setop.cpp
@@ -7,8 +7,8 @@
 import storm;
 import std;
 
-using namespace storm;
-using namespace storm::orm::where;
+using storm::QuerySet;
+using storm::orm::where::field;
 
 #include "test_models.h" // NOSONAR cpp:S954
 

--- a/tests/query/test_sql_verify.cpp
+++ b/tests/query/test_sql_verify.cpp
@@ -6,8 +6,8 @@
 import storm;
 import std;
 
-using namespace storm;
-using namespace storm::orm::where;
+using storm::QuerySet;
+using storm::orm::where::field;
 
 #include "test_models.h" // NOSONAR cpp:S954
 

--- a/tests/query/test_values.cpp
+++ b/tests/query/test_values.cpp
@@ -7,8 +7,8 @@
 import storm;
 import std;
 
-using namespace storm;
-using namespace storm::orm::where;
+using storm::QuerySet;
+using storm::orm::where::field;
 
 #include "test_models.h" // NOSONAR cpp:S954
 

--- a/tests/query/test_where.cpp
+++ b/tests/query/test_where.cpp
@@ -10,8 +10,12 @@ import std;
 #include "test_seed_helpers.h"
 #include "test_select_runner.h"
 
-using namespace storm;
-using namespace storm::orm::where;
+using storm::QuerySet;
+using storm::orm::where::ComparisonExpr;
+using storm::orm::where::CompOp;
+using storm::orm::where::Expr;
+using storm::orm::where::ExpressionVariant;
+using storm::orm::where::field;
 
 // Test fixture for WHERE operations — templated on database backend
 template <typename ConnType> class WhereTest : public StormTestFixture<Person, ConnType> {

--- a/tests/query/test_where_complex.cpp
+++ b/tests/query/test_where_complex.cpp
@@ -7,8 +7,7 @@ import std;
 #include "test_models.h" // NOSONAR cpp:S954
 #include "test_seed_helpers.h"
 
-using namespace storm;
-using namespace storm::orm::where;
+using storm::orm::where::field;
 
 template <typename ConnType> class ComplexWhereTest : public PersonSeedFixture<ConnType> {};
 

--- a/tests/query/test_where_lifetime.cpp
+++ b/tests/query/test_where_lifetime.cpp
@@ -9,8 +9,9 @@ import std;
 #include "test_models.h" // NOSONAR cpp:S954
 #include "test_seed_helpers.h"
 
-using namespace storm;
-using namespace storm::orm::where;
+using storm::QuerySet;
+using storm::orm::where::Expr;
+using storm::orm::where::field;
 
 // Lifetime safety for WHERE comparison operands (#352).
 //

--- a/tests/schema/test_bool_default.cpp
+++ b/tests/schema/test_bool_default.cpp
@@ -12,7 +12,7 @@
 import storm;
 import std;
 
-using namespace storm;
+using storm::QuerySet;
 
 #include "test_models.h" // NOSONAR cpp:S954
 

--- a/tests/schema/test_fk_fields.cpp
+++ b/tests/schema/test_fk_fields.cpp
@@ -45,7 +45,7 @@ struct Summary {
     std::string                               report_type;
 };
 
-using namespace storm;
+using storm::QuerySet;
 
 // Test fixture for FK field operations — templated on database backend
 template <typename ConnType> class FKFieldTest : public StormTestFixture<Person, ConnType, Task> {};

--- a/tests/schema/test_orm_schema.cpp
+++ b/tests/schema/test_orm_schema.cpp
@@ -9,7 +9,8 @@
 import storm;
 import std;
 
-using namespace storm;
+namespace orm = storm::orm;
+using storm::QuerySet;
 
 #include "test_models.h" // NOSONAR cpp:S954
 

--- a/tests/schema/test_sql_inspection.cpp
+++ b/tests/schema/test_sql_inspection.cpp
@@ -8,8 +8,8 @@ import std;
 
 #include "test_models.h"
 
-using namespace storm;
-using namespace storm::orm::where;
+using storm::QuerySet;
+using storm::orm::where::field;
 
 // ============================================================================
 // Test fixture

--- a/tests/schema/test_types.cpp
+++ b/tests/schema/test_types.cpp
@@ -10,7 +10,16 @@ import std;
 
 #include "test_models.h"
 
-using namespace storm;
+using std::chrono::day;
+using std::chrono::hours;
+using std::chrono::minutes;
+using std::chrono::month;
+using std::chrono::seconds;
+using std::chrono::sys_days;
+using std::chrono::system_clock;
+using std::chrono::year;
+using std::chrono::year_month_day;
+using storm::QuerySet;
 using storm::orm::where::field;
 
 // ===== INTEGER TYPES TESTS =====
@@ -1247,7 +1256,6 @@ template <typename ConnType> class ChronoDateTest : public StormTestFixture<Exte
 TYPED_TEST_SUITE(ChronoDateTest, DatabaseTypes);
 
 TYPED_TEST(ChronoDateTest, InsertAndSelectDate) {
-    using namespace std::chrono;
     QuerySet<ExtendedTypes, TypeParam> qs;
     auto                               ymd = year_month_day{year{2026}, month{3}, day{21}};
     ExtendedTypes                      obj{.label = "date_test", .date_field = ymd};
@@ -1264,7 +1272,6 @@ TYPED_TEST(ChronoDateTest, InsertAndSelectDate) {
 }
 
 TYPED_TEST(ChronoDateTest, InsertAndSelectDatetime) {
-    using namespace std::chrono;
     QuerySet<ExtendedTypes, TypeParam> qs;
     auto          tp = sys_days{year_month_day{year{2024}, month{12}, day{25}}} + hours{14} + minutes{30} + seconds{45};
     ExtendedTypes obj{.label = "dt_test", .datetime_field = tp};
@@ -1279,7 +1286,6 @@ TYPED_TEST(ChronoDateTest, InsertAndSelectDatetime) {
 }
 
 TYPED_TEST(ChronoDateTest, InsertAndSelectDuration) {
-    using namespace std::chrono;
     QuerySet<ExtendedTypes, TypeParam> qs;
     ExtendedTypes                      obj{.label = "dur_test", .duration_field = seconds{3600}};
 
@@ -1292,7 +1298,6 @@ TYPED_TEST(ChronoDateTest, InsertAndSelectDuration) {
 }
 
 TYPED_TEST(ChronoDateTest, ZeroDuration) {
-    using namespace std::chrono;
     QuerySet<ExtendedTypes, TypeParam> qs;
     ExtendedTypes                      obj{.label = "zero_dur", .duration_field = seconds{0}};
 
@@ -1305,7 +1310,6 @@ TYPED_TEST(ChronoDateTest, ZeroDuration) {
 }
 
 TYPED_TEST(ChronoDateTest, EpochDatetime) {
-    using namespace std::chrono;
     QuerySet<ExtendedTypes, TypeParam> qs;
     auto                               epoch = system_clock::time_point{};
     ExtendedTypes                      obj{.label = "epoch", .datetime_field = epoch};
@@ -1331,7 +1335,6 @@ TYPED_TEST(ChronoDateTest, OptionalTimestampNull) {
 }
 
 TYPED_TEST(ChronoDateTest, OptionalTimestampWithValue) {
-    using namespace std::chrono;
     QuerySet<ExtendedTypes, TypeParam> qs;
     auto                               tp = sys_days{year_month_day{year{2025}, month{6}, day{15}}} + hours{10};
     ExtendedTypes                      obj{.label = "opt_ts_val", .opt_timestamp = tp};
@@ -1346,7 +1349,6 @@ TYPED_TEST(ChronoDateTest, OptionalTimestampWithValue) {
 }
 
 TYPED_TEST(ChronoDateTest, BatchChronoInsert) {
-    using namespace std::chrono;
     QuerySet<ExtendedTypes, TypeParam> qs;
     std::vector<ExtendedTypes>         batch = {
             {.label = "d1", .date_field = year_month_day{year{2024}, month{1}, day{1}}, .duration_field = seconds{60}},
@@ -1621,7 +1623,6 @@ template <typename ConnType> class AllNewTypesRoundtripTest : public StormTestFi
 TYPED_TEST_SUITE(AllNewTypesRoundtripTest, DatabaseTypes);
 
 TYPED_TEST(AllNewTypesRoundtripTest, FullRoundtrip) {
-    using namespace std::chrono;
     QuerySet<ExtendedTypes, TypeParam> qs;
 
     auto date     = year_month_day{year{2025}, month{1}, day{15}};

--- a/tests/test_db_helpers.h
+++ b/tests/test_db_helpers.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef STORM_TESTS_TEST_DB_HELPERS_H
+#define STORM_TESTS_TEST_DB_HELPERS_H
 
 /**
  * @file test_db_helpers.h
@@ -118,3 +119,5 @@ template <typename ConnType> constexpr auto is_sqlite() -> bool {
 }
 
 } // namespace storm::test
+
+#endif // STORM_TESTS_TEST_DB_HELPERS_H

--- a/tests/yaml/test_unified_yaml.cpp
+++ b/tests/yaml/test_unified_yaml.cpp
@@ -4,8 +4,6 @@
 import storm;
 import std;
 
-using namespace storm;
-
 #include "test_models.h" // NOSONAR cpp:S954
 #include "test_seed_helpers.h"
 #include "test_select_runner.h"


### PR DESCRIPTION
## Summary

Adds 4 clang-tidy check categories to the existing 7, fixes every resulting warning, and documents each decision in the `.clang-tidy` comment block.

### Categories added
- **`clang-analyzer-*`** (wholesale) — path-sensitive analysis. 0 findings in `src/`; 8 idiomatic test/bench findings fixed at the site. **Measured ~0 added runtime** (rides the existing single-TU parse: 145s with vs without across 24 src TUs), so it rides the normal `--all` sweep + pre-commit `--diff` with no special CI-only gating.
- **`modernize-*`** (curated allow-list, not wholesale) — `use-nullptr`, `use-override`, `use-equals-default/delete`, `make-unique/shared`, `use-emplace`, `loop-convert`. Fixed 2 `loop-convert` findings in PostgreSQL SQL-rewrite loops. The 3 excluded checks (`use-trailing-return-type`, `use-auto`, `avoid-c-arrays`) are documented.
- **`portability-*`** (wholesale) — converted 4 `#pragma once` headers to include guards so the category enables clean.
- **`google-*`** (header-hygiene subset) — `build-using-namespace`, `build-namespaces`, `global-names-in-headers`, `readability-casting`. Converted 58 `using namespace` sites (all in test/bench `.cpp` TUs, none in headers) to explicit using-declarations / namespace aliases. `google-explicit-constructor` stays off (intentional Expr/UUID API).

### Also
- Modernized the mock `sqlite3_expanded_sql` copy to `std::string_view` + `std::ranges::copy` with a `malloc` null-check (`malloc`/`free` stays — SQLite C ABI contract: caller frees via `sqlite3_free`).
- Skip-listed `benchmarks/schema.cppm`: pre-existing clang-p2996 crash in `RecursiveASTVisitor` over the std-module `std::__desugars_to_v` instantiation (fires on any check, reproduces with the pre-#364 config). Tracked under #262.
- Fixed 4 pre-existing warnings surfaced by the full-tree sweep.

## Verification
- `scripts/run_clang_tidy.sh --all`: **0 warnings / 0 errors / 0 unexpected crashes**
- Full suite: 2000 tests, 100% passed
- ASAN+UBSAN and TSAN: clean
- clang-format: clean
- Pre-commit hook: all 6 stages green

Closes #364

🤖 Generated with [Claude Code](https://claude.com/claude-code)