### PR TITLE
feat(orm): auto_create / auto_update timestamp fields (#209)

### DIFF
--- a/.claude/agents/dev.md
+++ b/.claude/agents/dev.md
@@ -13,7 +13,7 @@ You are an expert C++26 engineer and architect for the Storm ORM project. You ha
 
 When implementing features:
 1. Use compile-time reflection with `std::meta` for automatic struct-to-database mapping
-2. Mark primary keys with `[[=storm::meta::FieldAttr::primary]]` attributes (use `primary_autoincrement` to opt a SQLite int PK into `AUTOINCREMENT`/never-reuse; plain `primary` emits plain `INTEGER PRIMARY KEY` since #379)
+2. Mark primary keys with `[[=storm::meta::FieldAttr::primary]]` attributes (use `primary_autoincrement` to opt a SQLite int PK into `AUTOINCREMENT`/never-reuse; plain `primary` emits plain `INTEGER PRIMARY KEY` since #379). Auto-timestamp fields use `auto_create`/`auto_update` on a `system_clock::time_point` (#209) — bind-time `now()`, no write-back; injected in `bind_field_at_index` via `stamps_now()`/`batch_now()`
 3. Inherit new statement classes from `BaseStatement<T>` to leverage shared utilities
 4. Implement both single-object and batch operations using `std::span<const T>`
 5. Apply adaptive thresholds:

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -19,6 +19,7 @@ You are a senior C++ code reviewer specializing in the Storm ORM project, with d
 ### 2. C++26 Reflection Compliance
 - Verify proper use of `std::meta` for compile-time reflection
 - Ensure primary key fields are marked with `[[=storm::meta::FieldAttr::primary]]` (or `primary_autoincrement` for the SQLite never-reuse opt-in, #379); both are treated as a PK via `meta::is_primary_attr`
+- For auto-timestamps (#209): `auto_create`/`auto_update` must be on `system_clock::time_point` (compile-time `static_assert`); both enums (base.cppm + where.cppm) must stay in sync; the `now()` read must be gated by `has_auto_timestamp_field_` (zero cost on plain models)
 - Check that reflection splice operators (`obj.[:primary_key_:]`) are used appropriately
 - Validate SQL generation leverages reflection for automatic field mapping
 - **NO REFL-CPP usage** — only native C++26 reflection

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -311,6 +311,12 @@ See [docs/development/PERFORMANCE_GUIDELINES.md](docs/development/PERFORMANCE_GU
 
 `int`, `int64_t`, `double`, `float`, `bool`, `std::string`, `std::string_view`, `std::optional<T>`, `std::vector<uint8_t>` (BLOB)
 
+**Auto-timestamps (#209)**: `[[= FieldAttr::auto_create]]` / `[[= FieldAttr::auto_update]]` on a
+`std::chrono::system_clock::time_point` field auto-stamp `now()` — `auto_create` on INSERT only,
+`auto_update` on INSERT and UPDATE. **Bind-time only, no write-back** (the caller's object is never
+mutated; re-SELECT to read the value). UPDATE preserves `created_at` by binding the object's stored
+value, so pass the original `created_at` when updating. Zero cost on models without timestamp fields.
+
 See [docs/reference/FIELD_TYPES.md](docs/reference/FIELD_TYPES.md).
 
 ## Known Compiler Issues

--- a/docs/COOKBOOK.md
+++ b/docs/COOKBOOK.md
@@ -94,6 +94,33 @@ for (auto& p : people) { p.salary *= 1.1; }
 qs.update(people);
 ```
 
+## Automatic Timestamps
+
+```cpp
+struct Article {
+    [[=storm::meta::FieldAttr::primary]] int id;
+    std::string title;
+    [[=storm::meta::FieldAttr::auto_create]] std::chrono::system_clock::time_point created_at;
+    [[=storm::meta::FieldAttr::auto_update]] std::chrono::system_clock::time_point updated_at;
+};
+
+QuerySet<Article> qs;
+
+// INSERT — created_at and updated_at are stamped automatically (any value you set is ignored).
+qs.insert(Article{.title = "Hello"}).execute();
+
+// The object in memory is NOT mutated — re-SELECT to read the stamped values.
+auto saved = *qs.select().execute().value().begin();
+
+// UPDATE — updated_at is re-stamped; created_at is preserved by passing the saved value back.
+saved.title = "Hello (edited)";
+qs.update(saved).execute();
+```
+
+`auto_create` stamps on INSERT only; `auto_update` stamps on INSERT and UPDATE. Both
+fields must be `std::chrono::system_clock::time_point`. See
+[reference/FIELD_TYPES.md](reference/FIELD_TYPES.md#automatic-timestamps-auto_create--auto_update).
+
 ## DELETE
 
 ```cpp

--- a/docs/reference/FIELD_TYPES.md
+++ b/docs/reference/FIELD_TYPES.md
@@ -142,6 +142,52 @@ std::vector<uint8_t> binary_data = {0x89, 0x50, 0x4E, 0x47}; // PNG header
 FileData file{0, "image.png", binary_data};
 ```
 
+## Automatic Timestamps (`auto_create` / `auto_update`)
+
+Two field attributes populate `std::chrono::system_clock::time_point` columns with
+the current time automatically, so you never set them by hand (#209):
+
+| Attribute | INSERT | UPDATE |
+|-----------|--------|--------|
+| `auto_create` | set to `now()` | preserved (bound from the object's stored value) |
+| `auto_update` | set to `now()` | set to `now()` |
+
+```cpp
+struct User {
+    [[=storm::meta::FieldAttr::primary]] int id;
+    std::string name;
+    [[=storm::meta::FieldAttr::auto_create]] std::chrono::system_clock::time_point created_at;
+    [[=storm::meta::FieldAttr::auto_update]] std::chrono::system_clock::time_point updated_at;
+};
+
+// INSERT — both stamped automatically; any value you set is ignored.
+QuerySet<User>().insert(User{.name = "John"}).execute();
+// row: created_at = now, updated_at = now
+
+// UPDATE — only updated_at re-stamped; created_at preserved.
+User u{.id = 1, .name = "Jane", .created_at = original_created_at};
+QuerySet<User>().update(u).execute();
+// row: created_at unchanged, updated_at = now
+```
+
+**Contract and constraints:**
+
+- **Bind-time only, no write-back.** The value is computed in C++ (`system_clock::now()`)
+  and bound as a parameter. The caller's in-memory object is **not** mutated — re-SELECT
+  the row to read the stamped value.
+- **Preserving `created_at` on UPDATE** requires the object to carry its original
+  `created_at` (UPDATE binds it from the object). Load-modify-save, or pass the value
+  you read on INSERT.
+- **One `now()` per batch.** A bulk INSERT/UPDATE reads the clock once and shares it
+  across every row, so all rows in a batch get the same timestamp.
+- **Type-checked at compile time.** An `auto_create`/`auto_update` field that is not a
+  `std::chrono::system_clock::time_point` fails to compile with a clear message.
+- **Zero cost when unused.** Models without any timestamp field do not pay for the
+  clock read — the call compiles away.
+
+The column maps to `TIMESTAMP` (PostgreSQL) / `TEXT` (SQLite) and round-trips via the
+existing `time_point` ↔ `"YYYY-MM-DD HH:MM:SS"` conversion.
+
 ## Type Dispatch Implementation
 
 The binding uses compile-time `if constexpr` type dispatch to select the appropriate SQLite binding function with **zero runtime overhead**.

--- a/docs/superpowers/specs/2026-06-08-209-auto-timestamps-design.md
+++ b/docs/superpowers/specs/2026-06-08-209-auto-timestamps-design.md
@@ -1,0 +1,185 @@
+# Automatic Timestamp Support (`auto_create` / `auto_update`) — Design
+
+**Issue:** #209
+**Date:** 2026-06-08
+**Status:** Design approved, pending spec review
+
+## Summary
+
+Add two field attributes — `auto_create` and `auto_update` — that automatically
+populate `std::chrono::system_clock::time_point` columns with the current time
+during INSERT and UPDATE. The value is computed in C++ (`system_clock::now()`)
+and bound as a parameter; the database row receives the correct timestamp with no
+manual bookkeeping by the user.
+
+## Decisions
+
+These were settled during brainstorming. They are deliberate and should not be
+re-litigated without cause:
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| **Mutation** | Never mutate the caller's object | Preserves the `const T&` / `span<const T>` contract |
+| **Write-back** | None — bind-time only | YAGNI: DB row is correct; re-SELECT to read the value in memory |
+| **Overloads** | None added | Existing signatures unchanged → zero call-site churn |
+| **Value source** | C++ `system_clock::now()` | Backend-uniform (same bound string for SQLite + PG); round-trips via existing `time_point`↔text conversion; makes the per-field UPDATE rule trivial |
+| **Bulk timestamp** | One `now()` per batch, reused for all rows | Matches issue intent ("same `created_at` for all rows"); one clock read |
+| **UPDATE behaviour** | `auto_update` → `now()`; `auto_create` → bound from the object's stored value | "Preserves" created_at without touching UPDATE column generation |
+| **Manual override** | Always auto-set; manual values on auto fields ignored | No sentinel check, no hot-path branch |
+
+### Why C++ clock, not SQL `CURRENT_TIMESTAMP`
+
+- Backend-uniform: SQLite `CURRENT_TIMESTAMP` is second-precision UTC text;
+  PostgreSQL is sub-second `timestamptz`. Binding a C++-formatted string gives the
+  same value/format on both.
+- `auto_update` on UPDATE cannot be expressed as a schema `DEFAULT` (defaults only
+  fire on INSERT), so SQL-side would require literal substitution anyway.
+- Storm already converts `time_point` ↔ `"YYYY-MM-DD HH:MM:SS"` text in both
+  directions (`utilities.cppm:202`), so values round-trip cleanly when selected back.
+
+## Lifetime safety (already in place — no prerequisite)
+
+No prerequisite PR is needed. `-Wdangling` is **on by default** in clang and the
+library target already compiles with `-Werror` (`CMakeLists.txt:85`), so the
+existing `[[clang::lifetimebound]]` annotations on `insert`/`update` are **already
+enforced as hard errors**. Verified empirically: a `lifetimebound` parameter bound
+to a temporary fails the build today with `[-Werror,-Wdangling]`, with no `-Wall`
+and no explicit `-Wdangling` flag.
+
+This catches the same-statement temporary case (`insert(Article{...})`). It does
+**not** catch cross-statement use-after-free (no clang flag does — that is
+borrow-checker territory; verified for #357). Since this design adds no new
+reference-taking signatures (existing `const T&` / `span<const T>` unchanged), the
+lifetime surface is unchanged.
+
+## Architecture
+
+The change has a single behavioural locus: the unified field binder. Everything
+else is attribute plumbing and validation.
+
+### 1. Field attribute extension
+
+Append to `FieldAttr` in **both** `src/orm/statements/base.cppm:24` and
+`src/orm/where.cppm:35` (the two enums must stay byte-identical):
+
+```cpp
+enum class FieldAttr : std::uint8_t {
+    primary, primary_autoincrement, indexed, unique, fk, auto_create, auto_update
+};
+```
+
+> The issue's proposed enum was stale — it dropped `primary_autoincrement` (added
+> in #379). We **append**, not replace.
+
+Add two consteval detectors in `BaseStatement`, mirroring `is_fk_field`
+(`base.cppm:78`):
+
+```cpp
+static consteval auto is_auto_create_field(std::meta::info member) -> bool;
+static consteval auto is_auto_update_field(std::meta::info member) -> bool;
+```
+
+### 2. Compile-time validation
+
+A `requires`-based concept (not `throw`, per CLAUDE.md rule 11) ensures a timestamp
+field has the correct type:
+
+```cpp
+template <auto MemberPtr>
+concept ValidTimestampField =
+    std::same_as<std::remove_cvref_t<typename [:std::meta::type_of(MemberPtr):]>,
+                 std::chrono::system_clock::time_point>;
+```
+
+A wrong-typed timestamp field (e.g. `[[= FieldAttr::auto_create]] int created_at`)
+produces a constraint violation at the call site with a clear message.
+
+### 3. Bind-time substitution (the only runtime change)
+
+Single injection point: `bind_field_at_index` (`base.cppm:265`). This unified
+binder is used by **all four** paths:
+
+- INSERT single — `bind_non_pk_fields_impl` → `bind_field_at_index`
+- INSERT bulk — `bind_non_pk_objects_bulk_impl` → `bind_field_at_index`
+- UPDATE single & bulk — `update.cppm:266` `inline_bind_all_fields` →
+  `Base::bind_field_at_index`
+
+Thread a compile-time `bool IsUpdate` template parameter through the binder. Add an
+`if constexpr` branch **before** the plain-field `else` (currently `base.cppm:302`):
+
+```cpp
+else if constexpr (is_auto_update_field(member)
+                   || (is_auto_create_field(member) && !IsUpdate)) {
+    // auto_update: now() on INSERT and UPDATE
+    // auto_create: now() on INSERT only
+    auto result = bind_value_by_type<ConnType>(*stmt, param_index, /* batch now() */);
+    if (!result) return std::unexpected(result.error());
+    ++param_index;
+    return {};
+}
+// auto_create on UPDATE falls through to the normal obj.[:member:] bind below.
+```
+
+The `now()` value for a batch is read **once** and threaded into the binder so all
+rows in a bulk operation share it. The bound value reuses the existing `time_point`
+text-storage binding (`is_text_stored_v`, `base.cppm:427`) — no schema change.
+
+### 4. Schema
+
+No change. `schema.cppm:82` already maps `system_clock::time_point` to `TEXT`
+(SQLite) / `TIMESTAMP` (PostgreSQL).
+
+## Components and boundaries
+
+| Unit | Responsibility | Depends on |
+|---|---|---|
+| `FieldAttr` enum (base + where) | Declare the two new attributes | — |
+| `is_auto_create_field` / `is_auto_update_field` | Detect annotated members at compile time | `std::meta::annotation_of_type` |
+| `ValidTimestampField` concept | Reject wrong-typed timestamp fields | `std::meta::type_of` |
+| `bind_field_at_index<…, IsUpdate>` | Substitute `now()` for the right fields at bind time | batch `now()`, `bind_value_by_type` |
+
+## Error handling
+
+- Wrong field type → **compile-time** constraint violation (not a runtime error).
+- Binding `now()` reuses the existing `bind_value_by_type` path, which already
+  returns `std::expected<void, Error>`; failures propagate unchanged. No new runtime
+  error modes.
+
+## Testing
+
+Tests are written **first** (must fail before implementation), and run on both
+backends via `TYPED_TEST` with `DatabaseTypes`.
+
+**Detection / validation**
+- `is_auto_create_field` / `is_auto_update_field` return correct results.
+- A model with a wrong-typed timestamp field fails to compile (negative compile
+  test, where feasible).
+
+**INSERT**
+- Single insert stamps both `created_at` and `updated_at`.
+- Bulk insert stamps every row; all rows in a batch share the same value.
+- A model with no timestamp fields is unaffected (no-op).
+- SQL/value verification: the bound value is `now()`, not the object's stale value.
+
+**UPDATE**
+- Single update stamps `updated_at`; `created_at` is bound from the object's stored
+  value (not overwritten with `now()`).
+- Bulk update behaves likewise.
+
+**Cross-cutting**
+- All supported timestamp scenarios run on SQLite and PostgreSQL.
+
+## Documentation
+
+- `docs/reference/FIELD_TYPES.md` — new section on `auto_create` / `auto_update`.
+- `docs/.../COOKBOOK.md` — usage example.
+- `CLAUDE.md` — attribute guideline + the bind-time-only / no-write-back contract.
+
+## Out of scope
+
+- In-memory write-back into the caller's object (explicitly declined — re-SELECT to
+  read the value).
+- `insert`/`update` overloads for write-back.
+- SQL-side `CURRENT_TIMESTAMP` / schema `DEFAULT` population.
+- Soft-delete (`auto_delete`) — mentioned in the issue as a future extension, not
+  built here.

--- a/docs/superpowers/specs/2026-06-08-209-auto-timestamps-design.md
+++ b/docs/superpowers/specs/2026-06-08-209-auto-timestamps-design.md
@@ -2,7 +2,7 @@
 
 **Issue:** #209
 **Date:** 2026-06-08
-**Status:** Design approved, pending spec review
+**Status:** Implemented (feature/209-auto-timestamps)
 
 ## Summary
 
@@ -96,15 +96,26 @@ produces a constraint violation at the call site with a clear message.
 
 ### 3. Bind-time substitution (the only runtime change)
 
-Single injection point: `bind_field_at_index` (`base.cppm:265`). This unified
+Single injection point: `bind_field_at_index` (`base.cppm:267`). This unified
 binder is used by **all four** paths:
 
-- INSERT single — `bind_non_pk_fields_impl` → `bind_field_at_index`
-- INSERT bulk — `bind_non_pk_objects_bulk_impl` → `bind_field_at_index`
+- INSERT single/bulk — `bind_non_pk_fields_impl` (`base.cppm:258`) → `bind_field_at_index`
+- INSERT all-fields — `bind_all_fields_impl` (`base.cppm:247`) → `bind_field_at_index`
 - UPDATE single & bulk — `update.cppm:266` `inline_bind_all_fields` →
   `Base::bind_field_at_index`
 
-Thread a compile-time `bool IsUpdate` template parameter through the binder. Add an
+**The binder already carries a 3rd template parameter** — `bool SkipPK = false`
+(`base.cppm:265`). It is `true` for *both* INSERT-non-PK (`base.cppm:258`) *and*
+UPDATE (`update.cppm:272`), so `SkipPK` **cannot** tell INSERT from UPDATE and must
+not be reused for the timestamp rule. Add `IsUpdate` as a **separate, 4th**
+template parameter:
+
+```cpp
+template <typename ConnType, std::size_t Index, bool SkipPK = false, bool IsUpdate = false>
+```
+
+Only the two UPDATE call sites (`update.cppm:272` and the bulk path) pass
+`IsUpdate = true`; all INSERT call sites keep the default `false`. Then add an
 `if constexpr` branch **before** the plain-field `else` (currently `base.cppm:302`):
 
 ```cpp
@@ -112,7 +123,7 @@ else if constexpr (is_auto_update_field(member)
                    || (is_auto_create_field(member) && !IsUpdate)) {
     // auto_update: now() on INSERT and UPDATE
     // auto_create: now() on INSERT only
-    auto result = bind_value_by_type<ConnType>(*stmt, param_index, /* batch now() */);
+    auto result = bind_value_by_type<ConnType>(*stmt, param_index, now);
     if (!result) return std::unexpected(result.error());
     ++param_index;
     return {};
@@ -120,9 +131,22 @@ else if constexpr (is_auto_update_field(member)
 // auto_create on UPDATE falls through to the normal obj.[:member:] bind below.
 ```
 
-The `now()` value for a batch is read **once** and threaded into the binder so all
-rows in a bulk operation share it. The bound value reuses the existing `time_point`
-text-storage binding (`is_text_stored_v`, `base.cppm:427`) — no schema change.
+**Threading the batch `now()` value.** `bind_field_at_index` currently takes
+`(stmt, obj, param_index)`. To make all rows in a bulk operation share one clock
+read, the per-batch `now()` value must reach the binder as data, not be re-read per
+field. Add a trailing `now` parameter (a `system_clock::time_point`), defaulted so
+non-timestamp call paths need no churn:
+
+```cpp
+// new trailing binder param; default lets non-timestamp paths stay untouched
+std::chrono::system_clock::time_point now = std::chrono::system_clock::now()
+```
+
+The caller reads `now()` **once** per operation (`bind_all_fields_impl`,
+`bind_non_pk_fields_impl`, `inline_bind_all_fields`) and forwards the same value
+into every `bind_field_at_index` invocation in the fold. The bound value reuses the
+existing `time_point` text-storage binding (`is_text_stored_v`, `base.cppm:427`) —
+no schema change.
 
 ### 4. Schema
 
@@ -134,9 +158,9 @@ No change. `schema.cppm:82` already maps `system_clock::time_point` to `TEXT`
 | Unit | Responsibility | Depends on |
 |---|---|---|
 | `FieldAttr` enum (base + where) | Declare the two new attributes | — |
-| `is_auto_create_field` / `is_auto_update_field` | Detect annotated members at compile time | `std::meta::annotation_of_type` |
+| `is_auto_create_field` / `is_auto_update_field` | Detect annotated members at compile time | `annotation_of_type<meta::FieldAttr>` + equality (mirrors `is_fk_field`) |
 | `ValidTimestampField` concept | Reject wrong-typed timestamp fields | `std::meta::type_of` |
-| `bind_field_at_index<…, IsUpdate>` | Substitute `now()` for the right fields at bind time | batch `now()`, `bind_value_by_type` |
+| `bind_field_at_index<…, SkipPK, IsUpdate>` | Substitute `now()` for the right fields at bind time | new 4th template param `IsUpdate`, batch `now()`, `bind_value_by_type` |
 
 ## Error handling
 

--- a/shared/models.h
+++ b/shared/models.h
@@ -90,6 +90,15 @@ struct ExtendedTypes {
     std::optional<std::filesystem::path> opt_path;
 };
 
+// Auto-timestamp model — created_at stamped on INSERT only, updated_at on
+// INSERT and UPDATE. Both are std::chrono::system_clock::time_point (#209).
+struct TimestampedRecord {
+    [[= storm::meta::FieldAttr::primary]] int id{};
+    std::string name;
+    [[= storm::meta::FieldAttr::auto_create]] std::chrono::system_clock::time_point created_at{};
+    [[= storm::meta::FieldAttr::auto_update]] std::chrono::system_clock::time_point updated_at{};
+};
+
 // =============================================================================
 // Section 3: FK-dependent structs (must come after section 1)
 // =============================================================================

--- a/src/orm/statements/base.cppm
+++ b/src/orm/statements/base.cppm
@@ -21,7 +21,15 @@ export namespace storm::orm::statements {
 
     // Mirror of meta::FieldAttr from storm module - must match exactly
     namespace meta {
-        enum class FieldAttr : std::uint8_t { primary, primary_autoincrement, indexed, unique, fk };
+        enum class FieldAttr : std::uint8_t {
+            primary,
+            primary_autoincrement,
+            indexed,
+            unique,
+            fk,
+            auto_create,
+            auto_update
+        };
 
         // A field is "a primary key" for either annotation variant: plain `primary`
         // (plain INTEGER PRIMARY KEY) or `primary_autoincrement` (the SQLite never-reuse
@@ -49,6 +57,13 @@ export namespace storm::orm::statements {
         }
         return false;
     }();
+
+    // A field carrying auto_create/auto_update must be a system_clock::time_point (#209).
+    // Referenced by a static_assert in bind_field_at_index so a wrong-typed timestamp field
+    // fails to compile with a clear message rather than deep inside parameter binding.
+    template <std::meta::info Member>
+    concept ValidTimestampField = std::
+            same_as<std::remove_cvref_t<typename[:std::meta::type_of(Member):]>, std::chrono::system_clock::time_point>;
 
     // Shared reflection utilities for all statement types
     template <typename T>
@@ -90,6 +105,25 @@ export namespace storm::orm::statements {
         static consteval auto is_indexed_field(std::meta::info member) -> bool {
             auto field_attr = std::meta::annotation_of_type<meta::FieldAttr>(member);
             return field_attr.has_value() && field_attr.value() == meta::FieldAttr::indexed;
+        }
+
+        // Auto-timestamp detection (#209): auto_create stamps now() on INSERT only;
+        // auto_update stamps now() on both INSERT and UPDATE.
+        static consteval auto is_auto_create_field(std::meta::info member) -> bool {
+            auto field_attr = std::meta::annotation_of_type<meta::FieldAttr>(member);
+            return field_attr.has_value() && field_attr.value() == meta::FieldAttr::auto_create;
+        }
+
+        static consteval auto is_auto_update_field(std::meta::info member) -> bool {
+            auto field_attr = std::meta::annotation_of_type<meta::FieldAttr>(member);
+            return field_attr.has_value() && field_attr.value() == meta::FieldAttr::auto_update;
+        }
+
+        // True when `member` should be stamped with now() on this operation: auto_update
+        // always; auto_create on INSERT only (IsUpdate=false). auto_create on UPDATE is
+        // false here so it binds the object's stored value (preserving created_at).
+        static consteval auto stamps_now(std::meta::info member, bool is_update) -> bool {
+            return is_auto_update_field(member) || (is_auto_create_field(member) && !is_update);
         }
 
         // Check if a field needs an index (indexed, unique, or fk — but not primary key)
@@ -228,6 +262,28 @@ export namespace storm::orm::statements {
         static constexpr auto           field_names_array_ = build_all_field_names_list();
         static inline const std::string field_names_       = std::string(field_names_array_);
 
+        // True if T has any auto_create/auto_update field (#209). Gates the per-operation
+        // system_clock::now() read so models with no timestamp fields pay zero overhead.
+        static constexpr bool has_auto_timestamp_field_ = []() consteval {
+            for (const auto m : all_members_) {
+                if (is_auto_create_field(m) || is_auto_update_field(m)) {
+                    return true;
+                }
+            }
+            return false;
+        }();
+
+        // One clock read per operation, but only for models that actually have a timestamp
+        // field — otherwise the call compiles away entirely (no regression on plain models).
+        [[nodiscard]] __attribute__((always_inline)) static auto batch_now() noexcept
+                -> std::chrono::system_clock::time_point {
+            if constexpr (has_auto_timestamp_field_) {
+                return std::chrono::system_clock::now();
+            } else {
+                return {};
+            }
+        }
+
         // Reflection data - made public for JOIN statement access
         static constexpr auto primary_key_ = find_primary_key_impl();
         static constexpr auto pk_name_     = std::meta::identifier_of(primary_key_);
@@ -244,7 +300,8 @@ export namespace storm::orm::statements {
                 -> std::expected<void, typename ConnType::Error> {
             int                                           param_index = 1;
             std::expected<void, typename ConnType::Error> result{};
-            ((result = bind_field_at_index<ConnType, Is>(&stmt, obj, param_index), result.has_value()) && ...);
+            const auto now = batch_now(); // shared by all fields of this object (compiles away if none)
+            ((result = bind_field_at_index<ConnType, Is>(&stmt, obj, param_index, now), result.has_value()) && ...);
             return result;
         }
 
@@ -255,58 +312,90 @@ export namespace storm::orm::statements {
                 -> std::expected<void, typename ConnType::Error> {
             int                                           param_index = 1;
             std::expected<void, typename ConnType::Error> result{};
-            ((result = bind_field_at_index<ConnType, Is, true>(&stmt, obj, param_index), result.has_value()) && ...);
+            const auto now = batch_now(); // shared by all fields of this object (compiles away if none)
+            ((result = bind_field_at_index<ConnType, Is, true>(&stmt, obj, param_index, now), result.has_value()) &&
+             ...);
             return result;
         }
 
-        // Unified field binder: binds a single field at compile-time index
-        // SkipPK=true skips primary key fields (for INSERT/UPDATE non-PK binding)
-        // Auto-increments param_index on successful bind
-        template <typename ConnType, std::size_t Index, bool SkipPK = false>
-        [[nodiscard]] __attribute__((always_inline)) static constexpr auto
-        bind_field_at_index(typename ConnType::Statement* stmt, const T& obj, int& param_index) noexcept
-                -> std::expected<void, typename ConnType::Error> {
+        // Unified field binder: binds a single field at compile-time index.
+        // SkipPK=true skips primary key fields (for INSERT/UPDATE non-PK binding).
+        // IsUpdate=true marks the UPDATE path so auto_create fields bind the object's
+        // stored value instead of now() (#209). `now` is read once per operation by the
+        // caller and threaded in so every row in a batch shares the same timestamp.
+        // Auto-increments param_index on successful bind.
+        template <typename ConnType, std::size_t Index, bool SkipPK = false, bool IsUpdate = false>
+        [[nodiscard]] __attribute__((always_inline)) static constexpr auto bind_field_at_index(
+                typename ConnType::Statement*         stmt,
+                const T&                              obj,
+                int&                                  param_index,
+                std::chrono::system_clock::time_point now = {}
+        ) noexcept -> std::expected<void, typename ConnType::Error> {
             constexpr auto member = all_members_[Index];
+
+            // Auto-timestamp fields (#209) must be system_clock::time_point — binding now()
+            // to any other type is a model error. Fires at the call site with a clear message.
+            if constexpr (is_auto_create_field(member) || is_auto_update_field(member)) {
+                static_assert(
+                        ValidTimestampField<member>,
+                        "auto_create / auto_update fields must be std::chrono::system_clock::time_point"
+                );
+            }
 
             // Compile-time PK skip for INSERT/UPDATE non-PK paths
             if constexpr (SkipPK && member == primary_key_) {
                 return {};
             }
+            // Auto-timestamp (#209): stamp now() for auto_update (always) and auto_create
+            // (INSERT only). auto_create on UPDATE is not stamped here and falls through to
+            // the normal bind below, preserving the object's stored created_at.
+            else if constexpr (stamps_now(member, IsUpdate)) {
+                return bind_one<ConnType>(stmt, param_index, now);
+            }
             // FK field - extract and bind the PK value from the foreign object
             else if constexpr (is_fk_field(member)) {
-                using FKType = std::remove_cvref_t<decltype(obj.[:member:])>;
-                if constexpr (utilities::is_optional_v<FKType>) {
-                    // Optional FK: bind NULL when empty, otherwise bind the inner PK value
-                    std::expected<void, typename ConnType::Error> result{};
-                    if (obj.[:member:].has_value()) {
-                        constexpr auto fk_pk_member = find_fk_primary_key<FKType>();
-                        auto           pk_value     = obj.[:member:].value().[:fk_pk_member:];
-                        result                      = bind_value_by_type<ConnType>(*stmt, param_index, pk_value);
-                    } else {
-                        result = stmt->bind_null(param_index);
-                    }
-                    if (!result) {
-                        return std::unexpected(result.error());
-                    }
-                } else {
-                    const auto&    fk_object    = obj.[:member:];
-                    constexpr auto fk_pk_member = find_fk_primary_key<FKType>();
-                    const auto&    pk_value     = fk_object.[:fk_pk_member:];
-                    auto           result       = bind_value_by_type<ConnType>(*stmt, param_index, pk_value);
-                    if (!result) {
-                        return std::unexpected(result.error());
-                    }
-                }
-                ++param_index;
-                return {};
+                return bind_fk_field_at_index<ConnType, Index>(stmt, obj, param_index);
             } else {
-                const auto& field_value = obj.[:member:];
-                auto        result      = bind_value_by_type<ConnType>(*stmt, param_index, field_value);
-                if (!result) {
-                    return std::unexpected(result.error());
+                return bind_one<ConnType>(stmt, param_index, obj.[:member:]);
+            }
+        }
+
+        // Bind one value at param_index and advance it on success. Shared tail used by the
+        // plain-field and auto-timestamp branches of bind_field_at_index.
+        template <typename ConnType>
+        [[nodiscard]] __attribute__((always_inline)) static constexpr auto
+        bind_one(typename ConnType::Statement* stmt, int& param_index, const auto& value) noexcept
+                -> std::expected<void, typename ConnType::Error> {
+            auto result = bind_value_by_type<ConnType>(*stmt, param_index, value);
+            if (!result) {
+                return std::unexpected(result.error());
+            }
+            ++param_index;
+            return {};
+        }
+
+        // Extract and bind the foreign object's PK value (NULL for an empty optional FK).
+        template <typename ConnType, std::size_t Index>
+        [[nodiscard]] __attribute__((always_inline)) static constexpr auto
+        bind_fk_field_at_index(typename ConnType::Statement* stmt, const T& obj, int& param_index) noexcept
+                -> std::expected<void, typename ConnType::Error> {
+            constexpr auto member = all_members_[Index];
+            using FKType          = std::remove_cvref_t<decltype(obj.[:member:])>;
+            if constexpr (utilities::is_optional_v<FKType>) {
+                // Optional FK: bind NULL when empty, otherwise bind the inner PK value
+                if (!obj.[:member:].has_value()) {
+                    auto null_result = stmt->bind_null(param_index);
+                    if (!null_result) {
+                        return std::unexpected(null_result.error());
+                    }
+                    ++param_index;
+                    return {};
                 }
-                ++param_index;
-                return {};
+                constexpr auto fk_pk_member = find_fk_primary_key<FKType>();
+                return bind_one<ConnType>(stmt, param_index, obj.[:member:].value().[:fk_pk_member:]);
+            } else {
+                constexpr auto fk_pk_member = find_fk_primary_key<FKType>();
+                return bind_one<ConnType>(stmt, param_index, obj.[:member:].[:fk_pk_member:]);
             }
         }
 
@@ -319,10 +408,13 @@ export namespace storm::orm::statements {
                 Statement& stmt, const ContainerType& objects, std::index_sequence<Is...> /*unused*/
         ) noexcept -> std::expected<void, typename ConnType::Error> {
             int param_index = 1;
+            // One now() per batch, reused for every row (#209): all rows share the same
+            // created_at/updated_at, matching the issue's batch-timestamp intent.
+            const auto now = batch_now();
 
             for (const auto& obj : objects) {
                 std::expected<void, typename ConnType::Error> result{};
-                ((result = bind_field_at_index<ConnType, Is, SkipPrimaryKey>(&stmt, obj, param_index),
+                ((result = bind_field_at_index<ConnType, Is, SkipPrimaryKey>(&stmt, obj, param_index, now),
                   result.has_value()) &&
                  ...);
                 if (!result) {

--- a/src/orm/statements/update.cppm
+++ b/src/orm/statements/update.cppm
@@ -267,9 +267,12 @@ export namespace storm::orm::statements {
                 -> std::expected<void, Error> {
             int param_index = 1;
 
-            // Bind all non-PK fields at compile time using unified binder
+            // Bind all non-PK fields at compile time using unified binder.
+            // IsUpdate=true: auto_update stamps now(); auto_create binds the object's
+            // stored value (preserving created_at). One now() read shared across fields (#209).
             std::expected<void, Error> result{};
-            ((result = Base::template bind_field_at_index<ConnType, Is, true>(stmt, obj, param_index),
+            const auto                 now = Base::batch_now();
+            ((result = Base::template bind_field_at_index<ConnType, Is, true, true>(stmt, obj, param_index, now),
               result.has_value()) &&
              ...);
 

--- a/src/orm/where.cppm
+++ b/src/orm/where.cppm
@@ -32,7 +32,15 @@ export namespace storm::orm::where {
 
     // Mirror of meta::FieldAttr from storm module - must match exactly
     namespace meta {
-        enum class FieldAttr : std::uint8_t { primary, primary_autoincrement, indexed, unique, fk };
+        enum class FieldAttr : std::uint8_t {
+            primary,
+            primary_autoincrement,
+            indexed,
+            unique,
+            fk,
+            auto_create,
+            auto_update
+        };
     }
 
     // Comparison operators

--- a/tests/crud/test_auto_timestamps.cpp
+++ b/tests/crud/test_auto_timestamps.cpp
@@ -1,0 +1,152 @@
+#include <gtest/gtest.h>
+#include "test_db_helpers.h"
+
+import storm;
+import std;
+
+#include "test_models.h"
+
+// readability-implicit-bool-conversion: false positive from GTest's EXPECT_TRUE(cond) << "msg"
+// macro expansion (the streamed message literal is misattributed); same pattern is used
+// throughout tests/ — see tests/mock_libpq/mock_libpq.cpp for the same file-level suppression.
+// NOLINTBEGIN(misc-const-correctness,readability-implicit-bool-conversion)
+
+using std::chrono::system_clock;
+using storm::QuerySet;
+
+namespace {
+
+    // Seconds-granularity epoch is what the TEXT/TIMESTAMP round-trip preserves
+    // (tp_to_string emits "YYYY-MM-DD HH:MM:SS"). Compare at that resolution.
+    auto to_seconds(system_clock::time_point tp) -> std::int64_t {
+        return std::chrono::duration_cast<std::chrono::seconds>(tp.time_since_epoch()).count();
+    }
+
+    // A timestamp is "stamped" if it lands in a sane window around the test's now()
+    // (not the zero-epoch default the object was constructed with).
+    auto is_recent(system_clock::time_point tp, system_clock::time_point ref) -> bool {
+        auto delta = std::chrono::abs(tp - ref);
+        return delta < std::chrono::seconds{120};
+    }
+
+    // Insert a single record and SELECT the (only) row back. Returns the row by value.
+    // Fails the calling test via fatal assertions if any step errors.
+    template <typename ConnType>
+    auto insert_and_read_one(QuerySet<TimestampedRecord, ConnType>& qs, TimestampedRecord const& obj)
+            -> TimestampedRecord {
+        auto inserted = qs.insert(obj).execute();
+        [&] { ASSERT_TRUE(inserted.has_value()); }();
+        auto selected = qs.select().execute();
+        [&] { ASSERT_TRUE(selected.has_value()); }();
+        [&] { ASSERT_FALSE(selected.value().empty()); }();
+        return *selected.value().begin();
+    }
+
+} // namespace
+
+template <typename ConnType> class AutoTimestampTest : public StormTestFixture<TimestampedRecord, ConnType> {};
+
+TYPED_TEST_SUITE(AutoTimestampTest, DatabaseTypes);
+
+// ===== INSERT =====
+
+TYPED_TEST(AutoTimestampTest, InsertSingleStampsBothFields) {
+    QuerySet<TimestampedRecord, TypeParam> qs;
+    auto                                   before = system_clock::now();
+    // Both timestamp fields left at zero-epoch default — must be overwritten with now().
+    auto row = insert_and_read_one(qs, TimestampedRecord{.id = 0, .name = "alpha"});
+
+    EXPECT_EQ(row.name, "alpha");
+    EXPECT_TRUE(is_recent(row.created_at, before)) << "created_at not stamped on INSERT";
+    EXPECT_TRUE(is_recent(row.updated_at, before)) << "updated_at not stamped on INSERT";
+    // On INSERT both are stamped from the same batch now().
+    EXPECT_EQ(to_seconds(row.created_at), to_seconds(row.updated_at));
+}
+
+TYPED_TEST(AutoTimestampTest, InsertIgnoresManualTimestampValues) {
+    QuerySet<TimestampedRecord, TypeParam> qs;
+    auto                                   before = system_clock::now();
+    // Manually set a clearly-stale 2001 value — design says auto fields always override.
+    auto stale = system_clock::from_time_t(978'307'200); // 2001-01-01 00:00:00 UTC
+    auto row   = insert_and_read_one(
+            qs, TimestampedRecord{.id = 0, .name = "manual", .created_at = stale, .updated_at = stale}
+    );
+
+    EXPECT_TRUE(is_recent(row.created_at, before)) << "manual created_at not overridden";
+    EXPECT_TRUE(is_recent(row.updated_at, before)) << "manual updated_at not overridden";
+}
+
+TYPED_TEST(AutoTimestampTest, InsertBatchSharesOneTimestampPerBatch) {
+    QuerySet<TimestampedRecord, TypeParam> qs;
+    auto                                   before = system_clock::now();
+    std::vector<TimestampedRecord>         batch  = {
+            {.id = 0, .name = "one"},
+            {.id = 0, .name = "two"},
+            {.id = 0, .name = "three"},
+    };
+
+    auto result = qs.insert(batch).execute();
+    ASSERT_TRUE(result.has_value());
+
+    auto selected = qs.select().execute();
+    ASSERT_TRUE(selected.has_value());
+    ASSERT_EQ(selected.value().size(), 3);
+
+    std::int64_t shared = -1;
+    for (auto const& row : selected.value()) {
+        EXPECT_TRUE(is_recent(row.created_at, before)) << "batch created_at not stamped";
+        EXPECT_TRUE(is_recent(row.updated_at, before)) << "batch updated_at not stamped";
+        // All rows in one batch share the same created_at second.
+        if (shared == -1) {
+            shared = to_seconds(row.created_at);
+        }
+        EXPECT_EQ(to_seconds(row.created_at), shared) << "batch rows do not share one now()";
+    }
+}
+
+// ===== UPDATE =====
+
+TYPED_TEST(AutoTimestampTest, UpdateStampsUpdatedAtPreservesCreatedAt) {
+    QuerySet<TimestampedRecord, TypeParam> qs;
+    auto inserted                = insert_and_read_one(qs, TimestampedRecord{.id = 0, .name = "before"});
+    auto created_at_after_insert = inserted.created_at;
+
+    // Wait so the UPDATE's now() is observably later than the INSERT's.
+    std::this_thread::sleep_for(std::chrono::seconds{1});
+
+    // The caller carries the original created_at in the object (no write-back needed):
+    // auto_create on UPDATE binds the object's stored value, not now().
+    TimestampedRecord const updated{
+            .id = inserted.id, .name = "after", .created_at = created_at_after_insert, .updated_at = {}
+    };
+    auto update_result = qs.update(updated).execute();
+    ASSERT_TRUE(update_result.has_value());
+
+    auto selected = qs.select().execute();
+    ASSERT_TRUE(selected.has_value());
+    auto const& row = *selected.value().begin();
+
+    EXPECT_EQ(row.name, "after");
+    EXPECT_EQ(to_seconds(row.created_at), to_seconds(created_at_after_insert))
+            << "created_at must be preserved on UPDATE";
+    EXPECT_GT(to_seconds(row.updated_at), to_seconds(created_at_after_insert)) << "updated_at must advance on UPDATE";
+}
+
+// ===== No-op: a model without timestamp fields is unaffected =====
+
+TYPED_TEST(AutoTimestampTest, ModelWithoutTimestampFieldsUnaffected) {
+    QuerySet<SimpleRecord, TypeParam> qs;
+    ASSERT_TRUE((storm::test::ensure_tables<TypeParam, SimpleRecord>(
+            storm::QuerySet<SimpleRecord, TypeParam>::get_default_connection()
+    )));
+    SimpleRecord const obj{.id = 0, .name = "plain", .value = 42};
+
+    auto result = qs.insert(obj).execute();
+    ASSERT_TRUE(result.has_value());
+
+    auto selected = qs.select().execute();
+    ASSERT_TRUE(selected.has_value());
+    EXPECT_EQ(selected.value().begin()->value, 42);
+}
+
+// NOLINTEND(misc-const-correctness,readability-implicit-bool-conversion)


### PR DESCRIPTION
Closes #209

## Summary

Adds two field attributes that auto-populate `std::chrono::system_clock::time_point` columns at bind time:

- `auto_create` → `now()` on INSERT only (preserved on UPDATE)
- `auto_update` → `now()` on INSERT and UPDATE

**Bind-time only, no write-back** — the caller's object is never mutated (re-SELECT to read the value). UPDATE preserves `created_at` by binding the object's stored value. One `now()` read per batch, shared across all rows.

```cpp
struct User {
    [[= storm::meta::FieldAttr::primary]] int id;
    std::string name;
    [[= storm::meta::FieldAttr::auto_create]] std::chrono::system_clock::time_point created_at;
    [[= storm::meta::FieldAttr::auto_update]] std::chrono::system_clock::time_point updated_at;
};
QuerySet<User>().insert(User{.name = "John"}).execute(); // both stamped automatically
```

## Implementation

- Append `auto_create`/`auto_update` to `FieldAttr` in **both** `base.cppm` + `where.cppm` (kept in sync).
- `is_auto_create_field` / `is_auto_update_field` detectors + `stamps_now()` predicate.
- `ValidTimestampField` concept: a wrong-typed timestamp field fails to compile with a clear message.
- Injected in the unified `bind_field_at_index` via a **new `IsUpdate` template param** — the pre-existing `SkipPK` is `true` for both INSERT-non-PK and UPDATE, so it can't distinguish them.
- `has_auto_timestamp_field_` gate makes `batch_now()` compile away for models with no timestamp field → **zero overhead** (see Benchmarks).
- FK/plain bind extracted into `bind_one` / `bind_fk_field_at_index` to keep `bind_field_at_index` under the complexity limit (behaviour-preserving).
- No schema change — `time_point` already maps to `TIMESTAMP` (PG) / `TEXT` (SQLite).

## Testing

`tests/crud/test_auto_timestamps.cpp` (SQLite + PostgreSQL via `TYPED_TEST`):
single & bulk INSERT stamping, shared-`now` per batch, manual-override-ignored, UPDATE stamps `updated_at` while preserving `created_at`, and a no-op check on a plain model.

- 2010 tests pass (0 failed), 100% coverage (pre-commit gate)
- ASAN+UBSAN and TSAN clean
- Wrong-typed timestamp field verified to fail compilation (`ValidTimestampField`)

## Benchmarks (Release, alternating runs vs `develop`)

The feature adds a `now()` read only for models that use timestamps. On `BenchPerson` (no timestamp fields), there is **no regression**: `insert/N:1` ties, bulk paths within noise, `insert_no_return/N:1` median +0.03% / mean −0.81% (overlapping distributions). An earlier unconditional `now()` showed ~3.9%; the `has_auto_timestamp_field_` compile-time gate eliminated it.

## Docs

`docs/reference/FIELD_TYPES.md`, `docs/COOKBOOK.md`, `CLAUDE.md`, and the dev/reviewer agent files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)