### PR TITLE
refactor(api): migrate join<&T::field>() member pointers to reflection join<^^T::field>() (#388)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -398,8 +398,9 @@ qs.distinct<^^Person::name>().execute();
 qs.values<^^Person::name>().execute();                      // plf::hive<std::string>
 qs.values<^^Person::name, ^^Person::age>().execute();       // plf::hive<std::tuple<std::string, int>>
 
-// JOIN
-qs.join<Message>().where(...).select();
+// JOIN — FK field selectors use reflection NTTPs like every other field selector
+message_qs.join<^^Message::sender>().where(...).select();
+message_qs.left_join<^^Message::sender, ^^Message::receiver>().select();
 ```
 
 **Methods**: `where()`, `join()`, `order_by()`, `limit()`, `offset()`, `group_by()`, `having()`, `distinct()`, `values()`

--- a/benchmarks/query_benchmark.cppm
+++ b/benchmarks/query_benchmark.cppm
@@ -80,7 +80,7 @@ export namespace storm::benchmark {
         using WhereModel = [:where_model_:];
 
         static constexpr auto fk_resolver = [](std::string_view name) consteval {
-            return registry::resolve_fk_ptr(name);
+            return registry::resolve_fk_field(name);
         };
 
         using Builder = storm::orm::query_builder::QueryBuilder<Model, test, fk_resolver>;

--- a/benchmarks/registry.cppm
+++ b/benchmarks/registry.cppm
@@ -2,7 +2,7 @@
 //
 // Compile-time model registry for benchmark schema-driven dispatch. Maps
 // BenchmarkTest.model / .join string fields to concrete C++ types and
-// member pointers, all at compile time.
+// field reflections, all at compile time.
 //
 // The annotated model types (Person / User / FKMessage) live in models.hpp
 // because C++26 reflection-annotated structs are simpler to consume from
@@ -19,6 +19,7 @@ module;
 
 #include "models.hpp"
 
+#include <meta>
 #include <stdexcept>
 
 export module storm_benchmark_registry;
@@ -36,14 +37,14 @@ export namespace storm::benchmark::registry {
 
     // ========================================================================
     // FK field resolution for FKMessage (the only FK model in benchmarks).
-    // Returns User FKMessage::* member pointer by field name.
+    // Returns the FKMessage field reflection by field name (#388).
     // ========================================================================
-    consteval auto resolve_fk_ptr(std::string_view name) {
+    consteval auto resolve_fk_field(std::string_view name) -> std::meta::info {
         if (name == "sender") {
-            return &FKMessage::sender;
+            return ^^FKMessage::sender;
         }
         if (name == "receiver") {
-            return &FKMessage::receiver;
+            return ^^FKMessage::receiver;
         }
         throw std::runtime_error("Unknown FK field"); // NOSONAR(cpp:S112)
     }

--- a/docs/architecture/DESIGN_DECISIONS.md
+++ b/docs/architecture/DESIGN_DECISIONS.md
@@ -176,7 +176,7 @@ class IJoinStatement {
 };
 
 // Unified variadic template (single + multi FK)
-template <typename T, ConnType, auto... FKFieldPtrs>
+template <typename T, ConnType, std::meta::info... FKFields>
 class JoinStatement : public IJoinStatement {
     // Pure SQL builder - no execute(), no caching
     // Generates: " INNER JOIN table t2 ON t2.id = t1.fk_id"
@@ -194,10 +194,10 @@ class JoinStatement : public IJoinStatement {
 **Usage:**
 ```cpp
 // Single FK - populates sender fully
-auto result = message_qs.join<&Message::sender>().select();
+auto result = message_qs.join<^^Message::sender>().select();
 
 // Multi FK - populates both sender and receiver
-auto result = message_qs.join<&Message::sender, &Message::receiver>().select();
+auto result = message_qs.join<^^Message::sender, ^^Message::receiver>().select();
 ```
 
 See [JOIN Performance Analysis](../benchmarks/JOIN_ANALYSIS.md) for detailed performance data.

--- a/docs/development/COMPILER_ISSUES.md
+++ b/docs/development/COMPILER_ISSUES.md
@@ -234,6 +234,40 @@ Folding a pure-library header is only safe per location:
   uses reflection. `fuzz_models.h` dropped its `<string>`; the harness TUs that
   use `std::meta::` keep textual `<meta>` before `import storm; import std;`.
 
+### 10. `annotation_of_type` Segfaults on BMI-Imported Member Reflections
+
+**Problem**: Calling `std::meta::annotation_of_type<X>(member)` on a reflection
+that was **created in another module TU** (e.g. returned by an exported consteval
+function and consumed across the BMI boundary) segfaults the compiler (exit 139,
+crash in `ExprConstant.cpp` metafunction evaluation). In constraint-satisfaction
+contexts the crash can instead surface as a misleading
+`error: cannot take the reflection of an overload set`.
+
+**Structural metafunctions are safe** on the same BMI-crossing reflection:
+`is_nonstatic_data_member`, `parent_of`, `identifier_of`, `has_identifier` all
+work. Only annotation lookup breaks (same family as the annotations-lost-across-BMI
+issue, clang-p2996 [#262](https://github.com/bloomberg/clang-p2996/issues/262)).
+
+**Solution**: Re-derive the member from `^^T` locally before reading annotations —
+match by identifier, then call `annotation_of_type` on the freshly derived info:
+
+```cpp
+// ❌ Crashes when Member crossed a BMI boundary
+auto attr = std::meta::annotation_of_type<meta::FieldAttr>(Member);
+
+// ✅ Safe — annotation read from a locally derived reflection
+for (auto m : std::meta::nonstatic_data_members_of(^^T, std::meta::access_context::unchecked())) {
+    if (std::meta::identifier_of(m) == std::meta::identifier_of(Member)) {
+        auto attr = std::meta::annotation_of_type<meta::FieldAttr>(m);
+        // ...
+    }
+}
+```
+
+Found in #388: the `FKFieldOf<T, Member>` concept (base.cppm) constrains
+`join<^^T::field>()` and must work with FK reflections produced by the benchmark
+registry module (`storm_benchmark_registry::resolve_fk_field`).
+
 ## Debugging Tips
 
 1. **Clean build**: `rm -rf build/ && cmake --preset ninja-debug`

--- a/docs/features/JOIN_OPERATIONS.md
+++ b/docs/features/JOIN_OPERATIONS.md
@@ -31,7 +31,7 @@ struct Message {
 storm::orm::QuerySet<Message> message_qs(conn);
 
 // Populates sender field fully for each message
-auto result = message_qs.join<&Message::sender>().select();
+auto result = message_qs.join<^^Message::sender>().select();
 if (result) {
     for (const auto& msg : result.value()) {
         std::cout << msg.content << " from " << msg.sender.username << std::endl;
@@ -59,7 +59,7 @@ struct Message {
 };
 
 // Populates both sender and receiver fields
-auto result = message_qs.join<&Message::sender, &Message::receiver>().select();
+auto result = message_qs.join<^^Message::sender, ^^Message::receiver>().select();
 if (result) {
     for (const auto& msg : result.value()) {
         std::cout << msg.sender.username << " → "
@@ -90,7 +90,7 @@ Storm ORM supports all standard SQL JOIN types:
 Only returns rows where FK relationship exists:
 
 ```cpp
-auto result = message_qs.join<&Message::sender>().select();
+auto result = message_qs.join<^^Message::sender>().select();
 ```
 
 **Use when**: You only want messages with valid senders
@@ -100,7 +100,7 @@ auto result = message_qs.join<&Message::sender>().select();
 Returns all base table rows, FK fields may be NULL:
 
 ```cpp
-auto result = message_qs.left_join<&Message::sender>().select();
+auto result = message_qs.left_join<^^Message::sender>().select();
 ```
 
 **Use when**: You want all messages, even those without senders
@@ -111,7 +111,7 @@ auto result = message_qs.left_join<&Message::sender>().select();
 Returns all FK table rows, base fields may be NULL:
 
 ```cpp
-auto result = message_qs.right_join<&Message::sender>().select();
+auto result = message_qs.right_join<^^Message::sender>().select();
 ```
 
 **Use when**: You want all users, even those without messages
@@ -131,13 +131,13 @@ class IJoinStatement {
 };
 
 // Unified variadic template (handles single + multi FK)
-template <typename T, ConnType, auto... FKFieldPtrs>
+template <typename T, ConnType, std::meta::info... FKFields>
 class JoinStatement : public IJoinStatement {
     // Pure SQL builder - no execute(), no caching
 
     std::string to_sql() const override {
         // Generate: " INNER JOIN table t2 ON t2.id = t1.fk_id"
-        // Uses fold expressions for variadic FKFieldPtrs
+        // Uses fold expressions for variadic FKFields
     }
 
     void extract_row(void* stmt, void* obj) const override {
@@ -154,9 +154,9 @@ QuerySet stores the JOIN statement using type erasure:
 template <class T> class QuerySet {
     mutable std::unique_ptr<IJoinStatement> join_stmt_;
 
-    template <auto... FKFieldPtrs>
+    template <std::meta::info... FKFields>
     auto&& join(this auto&& self) {
-        self.join_stmt_ = std::make_unique<JoinStatement<T, ConnType, FKFieldPtrs...>>();
+        self.join_stmt_ = std::make_unique<JoinStatement<T, ConnType, FKFields...>>();
         return self;  // Chainable
     }
 
@@ -283,7 +283,7 @@ JOIN operations can be combined with WHERE clauses:
 using namespace storm::orm::where;
 
 // Filter on both base table and joined table
-auto result = message_qs.join<&Message::sender>()
+auto result = message_qs.join<^^Message::sender>()
                         .where(field<^^User::level>() > 5 and
                                field<^^Message::content>().like("%urgent%"))
                         .select();

--- a/docs/features/SELECT_QUERIES.md
+++ b/docs/features/SELECT_QUERIES.md
@@ -61,13 +61,13 @@ See [WHERE Clauses](WHERE_CLAUSES.md) for detailed WHERE syntax.
 
 ```cpp
 // Single FK JOIN
-auto result = message_qs.join<&Message::sender>().select();
+auto result = message_qs.join<^^Message::sender>().select();
 
 // Multi-FK JOIN
-auto result = message_qs.join<&Message::sender, &Message::receiver>().select();
+auto result = message_qs.join<^^Message::sender, ^^Message::receiver>().select();
 
 // JOIN with WHERE
-auto result = message_qs.join<&Message::sender>()
+auto result = message_qs.join<^^Message::sender>()
                         .where(field<^^User::level>() > 5)
                         .select();
 ```

--- a/src/orm/query_builder.hpp
+++ b/src/orm/query_builder.hpp
@@ -73,8 +73,8 @@ namespace storm::orm::query_builder {
     // spec protocol (spec.where, spec.join, spec.order_by[], spec.group_by,
     // spec.distinct, spec.limit, spec.aggregate, spec.setop, spec.operation).
     //
-    // fk_resolver: consteval callable (string_view) -> member-ptr for JOIN
-    // field dispatch. Pass a no-op for tests that don't use JOINs.
+    // fk_resolver: consteval callable (string_view) -> std::meta::info for
+    // JOIN field dispatch. Pass a no-op for tests that don't use JOINs.
     // ========================================================================
     template <typename Model, auto spec, auto fk_resolver, typename ConnType = storm::db::sqlite::Connection>
     class QueryBuilder {

--- a/src/orm/queryset.cppm
+++ b/src/orm/queryset.cppm
@@ -235,28 +235,28 @@ export namespace storm {
         // INNER JOIN support for single or multiple FK fields
         // Immutable: returns a new QuerySet with the join attached (Django-style).
         // Usage:
-        //   Single FK: message_qs.join<&Message::sender>().select()
-        //   Multi FK:  message_qs.join<&Message::sender, &Message::receiver>().select()
-        template <auto... FKFieldPtrs>
-            requires(sizeof...(FKFieldPtrs) >= 1)
+        //   Single FK: message_qs.join<^^Message::sender>().select()
+        //   Multi FK:  message_qs.join<^^Message::sender, ^^Message::receiver>().select()
+        template <std::meta::info... FKFields>
+            requires(sizeof...(FKFields) >= 1 && (orm::statements::FKFieldOf<T, FKFields> && ...))
         [[nodiscard]] auto join() const -> QuerySet {
             auto result = clone_state();
             result.join_stmt_ =
-                    orm::statements::make_join_wrapper<T, ConnType, orm::statements::JoinType::Inner, FKFieldPtrs...>();
+                    orm::statements::make_join_wrapper<T, ConnType, orm::statements::JoinType::Inner, FKFields...>();
             return result;
         }
 
         // LEFT JOIN support for single or multiple FK fields
         // Immutable: returns a new QuerySet with the join attached.
         // Usage:
-        //   Single FK: message_qs.left_join<&Message::sender>().select()
-        //   Multi FK:  message_qs.left_join<&Message::sender, &Message::receiver>().select()
-        template <auto... FKFieldPtrs>
-            requires(sizeof...(FKFieldPtrs) >= 1)
+        //   Single FK: message_qs.left_join<^^Message::sender>().select()
+        //   Multi FK:  message_qs.left_join<^^Message::sender, ^^Message::receiver>().select()
+        template <std::meta::info... FKFields>
+            requires(sizeof...(FKFields) >= 1 && (orm::statements::FKFieldOf<T, FKFields> && ...))
         [[nodiscard]] auto left_join() const -> QuerySet {
             auto result = clone_state();
             result.join_stmt_ =
-                    orm::statements::make_join_wrapper<T, ConnType, orm::statements::JoinType::Left, FKFieldPtrs...>();
+                    orm::statements::make_join_wrapper<T, ConnType, orm::statements::JoinType::Left, FKFields...>();
             return result;
         }
 
@@ -264,14 +264,17 @@ export namespace storm {
         // Immutable: returns a new QuerySet with the join attached.
         // Requires backend support (SQLite 3.39.0+, PostgreSQL always)
         // Usage:
-        //   Single FK: message_qs.right_join<&Message::sender>().select()
-        //   Multi FK:  message_qs.right_join<&Message::sender, &Message::receiver>().select()
-        template <auto... FKFieldPtrs>
-            requires(sizeof...(FKFieldPtrs) >= 1 && ConnType::supports_right_join)
+        //   Single FK: message_qs.right_join<^^Message::sender>().select()
+        //   Multi FK:  message_qs.right_join<^^Message::sender, ^^Message::receiver>().select()
+        template <std::meta::info... FKFields>
+            requires(
+                    sizeof...(FKFields) >= 1 && (orm::statements::FKFieldOf<T, FKFields> && ...) &&
+                    ConnType::supports_right_join
+            )
         [[nodiscard]] auto right_join() const -> QuerySet {
             auto result = clone_state();
             result.join_stmt_ =
-                    orm::statements::make_join_wrapper<T, ConnType, orm::statements::JoinType::Right, FKFieldPtrs...>();
+                    orm::statements::make_join_wrapper<T, ConnType, orm::statements::JoinType::Right, FKFields...>();
             return result;
         }
 

--- a/src/orm/statements/base.cppm
+++ b/src/orm/statements/base.cppm
@@ -65,6 +65,32 @@ export namespace storm::orm::statements {
     concept ValidTimestampField = std::
             same_as<std::remove_cvref_t<typename[:std::meta::type_of(Member):]>, std::chrono::system_clock::time_point>;
 
+    // A JOIN field selector must reflect a non-static data member of T annotated with
+    // FieldAttr::fk (#388). Constrains QuerySet::join/left_join/right_join and
+    // JoinStatement so a non-member or non-FK argument fails at the call site with a
+    // clear constraint violation.
+    //
+    // The annotation is read from the member re-derived out of ^^T (matched by
+    // identifier), NOT from Member itself: annotation_of_type on a reflection that
+    // crossed a BMI boundary segfaults clang-p2996 (#262), while structural queries
+    // (is_nonstatic_data_member / parent_of / identifier_of) are safe on it.
+    template <typename T, std::meta::info Member>
+    concept FKFieldOf = []() consteval {
+        if (!std::meta::is_nonstatic_data_member(Member) || !std::meta::has_identifier(Member)) {
+            return false;
+        }
+        if (std::meta::parent_of(Member) != ^^T) {
+            return false;
+        }
+        for (auto m : std::meta::nonstatic_data_members_of(^^T, std::meta::access_context::unchecked())) {
+            if (std::meta::identifier_of(m) == std::meta::identifier_of(Member)) {
+                auto field_attr = std::meta::annotation_of_type<meta::FieldAttr>(m);
+                return field_attr.has_value() && field_attr.value() == meta::FieldAttr::fk;
+            }
+        }
+        return false;
+    }();
+
     // Shared reflection utilities for all statement types
     template <typename T>
         requires ModelWithPrimaryKey<T>

--- a/src/orm/statements/join.cppm
+++ b/src/orm/statements/join.cppm
@@ -38,29 +38,23 @@ export namespace storm::orm::statements {
         }
     };
 
-    template <typename T, storm::db::DatabaseConnection ConnType, JoinType Type, auto... FKFieldPtrs>
-        requires(sizeof...(FKFieldPtrs) >= 1)
+    template <typename T, storm::db::DatabaseConnection ConnType, JoinType Type, std::meta::info... FKFields>
+        requires(sizeof...(FKFields) >= 1 && (FKFieldOf<T, FKFields> && ...))
     class JoinStatement : private BaseStatement<T> {
         friend class BaseStatement<T>;
         using Base      = BaseStatement<T>;
         using Error     = typename ConnType::Error;
         using Statement = typename ConnType::Statement;
 
-        static constexpr std::size_t fk_count_ = sizeof...(FKFieldPtrs);
+        static constexpr std::size_t fk_count_ = sizeof...(FKFields);
 
         // C++26: Direct pack indexing
         // FK_type unwraps std::optional<FKModel> → FKModel so FKBase_at works correctly
         template <std::size_t Idx>
         using FK_type =
-                utilities::optional_inner_type_t<std::remove_cvref_t<decltype(std::declval<T>().*FKFieldPtrs...[Idx])>>;
+                utilities::optional_inner_type_t<std::remove_cvref_t<typename[:std::meta::type_of(FKFields...[Idx]):]>>;
 
         template <std::size_t Idx> using FKBase_at = BaseStatement<FK_type<Idx>>;
-
-        // Compile-time validation
-        static_assert(
-                (std::is_member_object_pointer_v<decltype(FKFieldPtrs)> && ...),
-                "FK pointers must be member object pointers"
-        );
 
         static consteval auto count_non_fk_fields() -> std::size_t {
             std::size_t count = 0;
@@ -91,20 +85,8 @@ export namespace storm::orm::statements {
 
         static constexpr auto column_offsets_ = calculate_column_offsets();
 
-        static consteval auto build_fk_field_names() {
-            std::array<std::string_view, fk_count_> names{};
-            std::size_t                             fk_idx = 0;
-
-            for (std::size_t member_idx = 0; member_idx < Base::field_count_ && fk_idx < fk_count_; ++member_idx) {
-                auto member = Base::all_members_[member_idx];
-                if (Base::is_fk_field(member)) {
-                    names[fk_idx++] = std::meta::identifier_of(member);
-                }
-            }
-            return names;
-        }
-
-        static constexpr auto fk_field_names_ = build_fk_field_names();
+        // FK names derived per-info — independent of FK declaration order in T (#388)
+        static constexpr std::array<std::string_view, fk_count_> fk_field_names_{std::meta::identifier_of(FKFields)...};
 
         // LCOV_EXCL_START - compile-time only (called from consteval functions)
         static constexpr auto get_join_keyword() -> std::string_view {
@@ -318,24 +300,24 @@ export namespace storm::orm::statements {
 
         template <std::size_t Idx>
         __attribute__((always_inline)) static void extract_fk_at(Statement* stmt, T& obj) noexcept {
-            constexpr auto FKPtr              = FKFieldPtrs...[Idx]; // C++26 pack indexing
-            using RawFKFieldType              = std::remove_cvref_t<decltype(obj.*FKPtr)>;
+            constexpr auto FKField            = FKFields...[Idx]; // C++26 pack indexing
+            using RawFKFieldType              = std::remove_cvref_t<decltype(obj.[:FKField:])>;
             constexpr std::size_t field_count = FKBase_at<Idx>::field_count_;
 
             if constexpr (utilities::is_optional_v<RawFKFieldType>) {
                 // Optional FK: NULL first joined column means no match → set nullopt
                 const auto first_col = static_cast<int>(column_offsets_[Idx]);
                 if (stmt->is_null(first_col)) {
-                    obj.*FKPtr = std::nullopt;
+                    obj.[:FKField:] = std::nullopt;
                 } else {
                     FK_type<Idx> fk_inner{};
                     extract_fk_fields_impl<Idx>(
                             stmt, fk_inner, column_offsets_[Idx], std::make_index_sequence<field_count>{}
                     );
-                    obj.*FKPtr = std::move(fk_inner);
+                    obj.[:FKField:] = std::move(fk_inner);
                 }
             } else {
-                auto& fk_obj = obj.*FKPtr;
+                auto& fk_obj = obj.[:FKField:];
                 extract_fk_fields_impl<Idx>(
                         stmt, fk_obj, column_offsets_[Idx], std::make_index_sequence<field_count>{}
                 );
@@ -379,9 +361,10 @@ export namespace storm::orm::statements {
         }
     };
 
-    template <typename T, storm::db::DatabaseConnection ConnType, JoinType Type, auto... FKFieldPtrs>
+    template <typename T, storm::db::DatabaseConnection ConnType, JoinType Type, std::meta::info... FKFields>
+        requires(sizeof...(FKFields) >= 1 && (FKFieldOf<T, FKFields> && ...))
     [[nodiscard]] auto make_join_wrapper() -> JoinStatementWrapper {
-        using JS = JoinStatement<T, ConnType, Type, FKFieldPtrs...>;
+        using JS = JoinStatement<T, ConnType, Type, FKFields...>;
 
         return JoinStatementWrapper{
                 +[]() -> const std::string& { return JS::get_complete_sql(); },

--- a/tests/mock_sqlite/test_orm_mock_errors.cpp
+++ b/tests/mock_sqlite/test_orm_mock_errors.cpp
@@ -1085,7 +1085,7 @@ namespace {
         MockSqlite3Config::prepare_returns(SQLITE_ERROR);
 
         QuerySet<MockMessage> qs;
-        auto                  result = qs.join<&MockMessage::sender>().select().execute();
+        auto                  result = qs.join<^^MockMessage::sender>().select().execute();
 
         // Verify prepare error is propagated (error code may differ at ORM layer)
         ASSERT_FALSE(result.has_value());
@@ -1096,7 +1096,7 @@ namespace {
         MockSqlite3Config::step_returns(SQLITE_CORRUPT);
 
         QuerySet<MockMessage> qs;
-        auto                  result = qs.join<&MockMessage::sender>().select().execute();
+        auto                  result = qs.join<^^MockMessage::sender>().select().execute();
 
         ASSERT_FALSE(result.has_value());
         EXPECT_EQ(result.error().code(), SQLITE_CORRUPT);
@@ -1107,7 +1107,7 @@ namespace {
 
         QuerySet<MockMessage> qs;
         auto                  id     = storm::orm::where::Field<^^MockMessage::id>{};
-        auto                  result = qs.where(id > 5).join<&MockMessage::sender>().select().execute();
+        auto                  result = qs.where(id > 5).join<^^MockMessage::sender>().select().execute();
 
         if (!result.has_value()) {
             EXPECT_EQ(result.error().code(), SQLITE_NOMEM);
@@ -1118,7 +1118,7 @@ namespace {
         MockSqlite3Config::step_returns(SQLITE_IOERR);
 
         QuerySet<MockMessage> qs;
-        auto                  result = qs.join<&MockMessage::sender>().order_by<^^MockMessage::id>().select().execute();
+        auto result = qs.join<^^MockMessage::sender>().order_by<^^MockMessage::id>().select().execute();
 
         ASSERT_FALSE(result.has_value());
         EXPECT_EQ(result.error().code(), SQLITE_IOERR);
@@ -1762,7 +1762,7 @@ namespace {
         MockSqlite3Config::prepare_returns(SQLITE_ERROR);
 
         QuerySet<MockMessage> qs;
-        auto                  result = qs.join<&MockMessage::sender>().sum<^^MockMessage::id>().execute();
+        auto                  result = qs.join<^^MockMessage::sender>().sum<^^MockMessage::id>().execute();
 
         ASSERT_FALSE(result.has_value()) << "Aggregate with JOIN should fail on prepare error";
         EXPECT_EQ(result.error().code(), SQLITE_ERROR);
@@ -1772,7 +1772,7 @@ namespace {
         MockSqlite3Config::step_returns(SQLITE_CORRUPT);
 
         QuerySet<MockMessage> qs;
-        auto                  result = qs.join<&MockMessage::sender>().count().execute();
+        auto                  result = qs.join<^^MockMessage::sender>().count().execute();
 
         ASSERT_FALSE(result.has_value()) << "Aggregate with JOIN should fail on step error";
         EXPECT_EQ(result.error().code(), SQLITE_CORRUPT);
@@ -1784,7 +1784,7 @@ namespace {
 
         QuerySet<MockMessage> qs;
         auto                  id     = storm::orm::where::Field<^^MockMessage::id>{};
-        auto                  result = qs.where(id > 5).join<&MockMessage::sender>().count().execute();
+        auto                  result = qs.where(id > 5).join<^^MockMessage::sender>().count().execute();
 
         ASSERT_FALSE(result.has_value()) << "Aggregate with WHERE+JOIN should fail on prepare error";
         EXPECT_EQ(result.error().code(), SQLITE_ERROR);
@@ -1795,8 +1795,8 @@ namespace {
         MockSqlite3Config::bind_int_returns(SQLITE_NOMEM);
 
         QuerySet<MockMessage> qs;
-        auto                  id     = storm::orm::where::Field<^^MockMessage::id>{};
-        auto                  result = qs.where(id > 5).join<&MockMessage::sender>().sum<^^MockMessage::id>().execute();
+        auto                  id = storm::orm::where::Field<^^MockMessage::id>{};
+        auto result              = qs.where(id > 5).join<^^MockMessage::sender>().sum<^^MockMessage::id>().execute();
 
         if (!result.has_value()) {
             EXPECT_EQ(result.error().code(), SQLITE_NOMEM);
@@ -2473,7 +2473,7 @@ namespace {
         MockSqlite3Config::prepare_returns(SQLITE_ERROR);
 
         QuerySet<MockMessage> qs;
-        auto                  result = qs.join<&MockMessage::sender>().first().execute();
+        auto                  result = qs.join<^^MockMessage::sender>().first().execute();
 
         ASSERT_FALSE(result.has_value());
     }
@@ -2482,7 +2482,7 @@ namespace {
         MockSqlite3Config::prepare_returns(SQLITE_ERROR);
 
         QuerySet<MockMessage> qs;
-        auto                  result = qs.join<&MockMessage::sender>().get().execute();
+        auto                  result = qs.join<^^MockMessage::sender>().get().execute();
 
         ASSERT_FALSE(result.has_value());
     }
@@ -2491,7 +2491,7 @@ namespace {
         MockSqlite3Config::step_returns(SQLITE_CORRUPT);
 
         QuerySet<MockMessage> qs;
-        auto                  result = qs.join<&MockMessage::sender>().first().execute();
+        auto                  result = qs.join<^^MockMessage::sender>().first().execute();
 
         ASSERT_FALSE(result.has_value());
         EXPECT_EQ(result.error().code(), SQLITE_CORRUPT);
@@ -2502,7 +2502,7 @@ namespace {
         MockSqlite3Config::step_returns_sequence({SQLITE_ROW, SQLITE_DONE});
 
         QuerySet<MockMessage> qs;
-        auto                  result = qs.join<&MockMessage::sender>().first().execute();
+        auto                  result = qs.join<^^MockMessage::sender>().first().execute();
 
         // Mock returns zeroed data, but the path is exercised
         ASSERT_TRUE(result.has_value());
@@ -2513,7 +2513,7 @@ namespace {
         MockSqlite3Config::step_returns(SQLITE_CORRUPT);
 
         QuerySet<MockMessage> qs;
-        auto                  result = qs.join<&MockMessage::sender>().get().execute();
+        auto                  result = qs.join<^^MockMessage::sender>().get().execute();
 
         ASSERT_FALSE(result.has_value());
         EXPECT_EQ(result.error().code(), SQLITE_CORRUPT);
@@ -2524,7 +2524,7 @@ namespace {
         MockSqlite3Config::step_returns_sequence({SQLITE_ROW, SQLITE_DONE});
 
         QuerySet<MockMessage> qs;
-        auto                  result = qs.join<&MockMessage::sender>().get().execute();
+        auto                  result = qs.join<^^MockMessage::sender>().get().execute();
 
         // Mock returns zeroed data, but the path is exercised
         ASSERT_TRUE(result.has_value());
@@ -2855,7 +2855,7 @@ namespace {
 
         QuerySet<MockMessage> qs;
         bool                  got_error = false;
-        for (auto&& result : qs.template join<&MockMessage::sender>().rows()) {
+        for (auto&& result : qs.template join<^^MockMessage::sender>().rows()) {
             if (!result.has_value()) {
                 EXPECT_EQ(result.error().code(), SQLITE_IOERR);
                 got_error = true;

--- a/tests/query/test_aggregate.cpp
+++ b/tests/query/test_aggregate.cpp
@@ -67,7 +67,7 @@ TYPED_TEST(AggregateTest, SingleAggregates_WithWhereAndJoin) {
     this->insert_join_test_data();
 
     auto sum_result = this->msg_qs->where(storm::orm::where::field<^^Message::value>() > 25)
-                              .template join<&Message::sender>()
+                              .template join<^^Message::sender>()
                               .template sum<^^Message::value>()
                               .execute();
     ASSERT_TRUE(sum_result.has_value()) << "SUM with WHERE+JOIN failed: " << sum_result.error().message();
@@ -76,7 +76,7 @@ TYPED_TEST(AggregateTest, SingleAggregates_WithWhereAndJoin) {
     (*this->msg_qs).reset();
 
     auto count_result = this->msg_qs->where(storm::orm::where::field<^^Message::value>() > 25)
-                                .template join<&Message::sender>()
+                                .template join<^^Message::sender>()
                                 .count()
                                 .execute();
     ASSERT_TRUE(count_result.has_value()) << "COUNT with WHERE+JOIN failed: " << count_result.error().message();
@@ -85,7 +85,7 @@ TYPED_TEST(AggregateTest, SingleAggregates_WithWhereAndJoin) {
     (*this->msg_qs).reset();
 
     auto min_result = this->msg_qs->where(storm::orm::where::field<^^Message::value>() > 25)
-                              .template join<&Message::sender>()
+                              .template join<^^Message::sender>()
                               .template min<^^Message::value>()
                               .execute();
     ASSERT_TRUE(min_result.has_value()) << "MIN with WHERE+JOIN failed: " << min_result.error().message();
@@ -325,7 +325,7 @@ TYPED_TEST(AggregateTest, WhereJoinRepeatedQueries) {
 
     for (int i = 0; i < 50; ++i) {
         auto result = this->msg_qs->where(storm::orm::where::field<^^Message::value>() > 20)
-                              .template join<&Message::sender>()
+                              .template join<^^Message::sender>()
                               .count()
                               .execute();
         ASSERT_TRUE(result.has_value()) << "Iteration " << i << " failed: " << result.error().message();

--- a/tests/query/test_aggregate_combined.cpp
+++ b/tests/query/test_aggregate_combined.cpp
@@ -59,7 +59,7 @@ TYPED_TEST(AggregateTest, FullChain_WhereJoinOrderByLimitOffset) {
     // Values >= 20 ordered DESC: 75,70,65,60,55,50,45,40,35,30,25,20
     // After OFFSET 2: 65,60,55,50,45,...  After LIMIT 5: 65,60,55,50,45
     auto result = this->msg_qs->where(storm::orm::where::field<^^Message::value>() >= 20)
-                          .template join<&Message::sender>()
+                          .template join<^^Message::sender>()
                           .template order_by<^^Message::value, false>()
                           .limit(5)
                           .offset(2)
@@ -75,7 +75,7 @@ TYPED_TEST(AggregateTest, FullChain_WhereJoinOrderByAscLimit) {
     insert_full_chain_14_messages<TypeParam>();
 
     auto result = this->msg_qs->where(storm::orm::where::field<^^Message::value>() >= 20)
-                          .template join<&Message::sender>()
+                          .template join<^^Message::sender>()
                           .template order_by<^^Message::value, true>()
                           .limit(3)
                           .offset(0)
@@ -91,7 +91,7 @@ TYPED_TEST(AggregateTest, FullChain_JoinResolvesCorrectSender) {
     insert_full_chain_14_messages<TypeParam>();
 
     auto result = this->msg_qs->where(storm::orm::where::field<^^Message::value>() == 75)
-                          .template join<&Message::sender>()
+                          .template join<^^Message::sender>()
                           .select()
                           .execute();
 

--- a/tests/query/test_aggregate_groupby.cpp
+++ b/tests/query/test_aggregate_groupby.cpp
@@ -100,7 +100,7 @@ TYPED_TEST(AggregateTest, GroupByWithMax) {
 TYPED_TEST(AggregateTest, GroupByWithJoinAndSum) {
     this->insert_join_test_data();
 
-    auto result = this->msg_qs->template join<&Message::sender>()
+    auto result = this->msg_qs->template join<^^Message::sender>()
                           .template group_by<^^Message::content>()
                           .template sum<^^Message::value>()
                           .execute();
@@ -134,7 +134,7 @@ TYPED_TEST(AggregateTest, GroupByFullChain_Count) {
     this->insert_full_chain_data();
 
     auto count_result = this->msg_qs->where(storm::orm::where::field<^^Message::value>() >= 20)
-                                .template join<&Message::sender>()
+                                .template join<^^Message::sender>()
                                 .template group_by<^^Message::value>()
                                 .count()
                                 .execute();
@@ -149,7 +149,7 @@ TYPED_TEST(AggregateTest, GroupByFullChain_SumAndAvg) {
     this->insert_full_chain_data();
 
     auto sum_result = this->msg_qs->where(storm::orm::where::field<^^Message::value>() < 50)
-                              .template join<&Message::sender>()
+                              .template join<^^Message::sender>()
                               .template group_by<^^Message::content>()
                               .template sum<^^Message::value>()
                               .execute();
@@ -161,7 +161,7 @@ TYPED_TEST(AggregateTest, GroupByFullChain_SumAndAvg) {
     auto avg_result = this->msg_qs
                               ->where(storm::orm::where::field<^^Message::value>() >= 10 &&
                                       storm::orm::where::field<^^Message::value>() <= 70)
-                              .template join<&Message::sender>()
+                              .template join<^^Message::sender>()
                               .template group_by<^^Message::value>()
                               .template avg<^^Message::value>()
                               .execute();
@@ -193,7 +193,8 @@ TYPED_TEST(AggregateTest, CountDistinctWithDuplicates) {
 TYPED_TEST(AggregateTest, CountDistinctWithJoin) {
     this->insert_join_test_data();
 
-    auto result = this->msg_qs->template join<&Message::sender>().template count_distinct<^^Message::value>().execute();
+    auto result =
+            this->msg_qs->template join<^^Message::sender>().template count_distinct<^^Message::value>().execute();
     ASSERT_TRUE(result.has_value()) << "COUNT(DISTINCT) with JOIN failed";
     EXPECT_EQ(result.value(), 6);
 }

--- a/tests/query/test_aggregate_having.cpp
+++ b/tests/query/test_aggregate_having.cpp
@@ -66,7 +66,7 @@ TYPED_TEST(AggregateTest, HavingOnAggregateStatement) {
 TYPED_TEST(AggregateTest, HavingWithJoin) {
     this->insert_join_test_data();
 
-    auto result = this->msg_qs->template join<&Message::sender>()
+    auto result = this->msg_qs->template join<^^Message::sender>()
                           .template group_by<^^Message::value>()
                           .having(storm::orm::where::field<^^Message::value>() > 30)
                           .count()
@@ -119,7 +119,7 @@ TYPED_TEST(AggregateTest, HavingWithWhereAndJoin) {
     // WHERE value >= 20 + JOIN + GROUP BY value HAVING value > 25
     // After WHERE: 20,30,50,70 → After HAVING > 25: 30,50,70 → 3 groups
     auto result = this->msg_qs->where(storm::orm::where::field<^^Message::value>() >= 20)
-                          .template join<&Message::sender>()
+                          .template join<^^Message::sender>()
                           .template group_by<^^Message::value>()
                           .having(storm::orm::where::field<^^Message::value>() > 25)
                           .count()

--- a/tests/query/test_distinct.cpp
+++ b/tests/query/test_distinct.cpp
@@ -526,7 +526,7 @@ TYPED_TEST(DistinctTest, DocumentedBehaviorAndLimitations) {
      *
      * 6. **No JOIN Support**:
      *    - DISTINCT operates only on the base table
-     *    - Cannot do: queryset.template join<&FK>().template distinct<&JoinedTable::field>()
+     *    - Cannot do: queryset.template join<^^FK>().template distinct<&JoinedTable::field>()
      *    - Would require significant refactoring to support
      *
      * Recommendations for future improvement:
@@ -607,22 +607,22 @@ TYPED_TEST(DistinctTest, DesiredSQLForDistinctWithJoin) {
      * Current Storm ORM API doesn't support this because:
      * 1. DISTINCT operates independently of JOIN
      * 2. No way to specify fields from joined tables
-     * 3. QuerySet<Message>.template join<&sender>().template distinct<???>() - what goes in distinct?
+     * 3. QuerySet<Message>.template join<^^sender>().template distinct<???>() - what goes in distinct?
      *
      * Possible API designs:
      *
      * Option A: Chaining
-     *   msg_qs.template join<&Message::sender>()
+     *   msg_qs.template join<^^Message::sender>()
      *         .template distinct<&Person::name>()  // PROBLEM: &Person::name won't match Message fields
      *         .execute()
      *
      * Option B: Separate DISTINCT type for JOINs
-     *   msg_qs.template join<&Message::sender>()
+     *   msg_qs.template join<^^Message::sender>()
      *         .distinct_joined<&Message::sender, &Person::name>()
      *         .execute()
      *
      * Option C: SQL-style field selection
-     *   msg_qs.template join<&Message::sender>()
+     *   msg_qs.template join<^^Message::sender>()
      *         .select_distinct(
      *             field<&Message::content>(),
      *             field<&Message::sender, &Person::name>()  // Joined field
@@ -686,7 +686,7 @@ TYPED_TEST(DistinctTest, CurrentLimitations) {
      *    - They don't integrate
      *
      * 2. **No Chaining Support**:
-     *    - Cannot do: queryset.template join<&FK>().template distinct<&Field>()
+     *    - Cannot do: queryset.template join<^^FK>().template distinct<&Field>()
      *    - join() returns QuerySet&&, but DISTINCT expects to operate independently
      *
      * 3. **Field Specification Limitation**:
@@ -724,7 +724,7 @@ TYPED_TEST(DistinctTest, AlternativeApproaches) {
      *   - Loss of type safety and ORM convenience
      *
      * Approach 2: Application-level filtering
-     *   - Fetch all data with JOIN: msg_qs.template join<&sender>().select()
+     *   - Fetch all data with JOIN: msg_qs.template join<^^sender>().select()
      *   - Filter unique values in application code (std::set, std::unique)
      *   - May load more data than necessary
      *
@@ -874,7 +874,7 @@ TYPED_TEST(DistinctTest, DistinctWithJoinSingleField) {
     // SELECT DISTINCT sender.name (via JOIN)
     // Note: We need to select from Message and distinct on Message fields
     // The JOIN should expand the result set
-    auto result = msg_qs.template join<&Message::sender>().template distinct<^^Message::content>().execute();
+    auto result = msg_qs.template join<^^Message::sender>().template distinct<^^Message::content>().execute();
     ASSERT_TRUE(result.has_value()) << "DISTINCT with JOIN failed: " << result.error().message();
 
     const auto& contents = result.value();
@@ -895,7 +895,7 @@ TYPED_TEST(DistinctTest, ChainingOrderWhereJoinDistinct) {
     // Test that WHERE -> JOIN -> DISTINCT works
     // Using content field to avoid ambiguous column names
     auto result = msg_qs.where(field<^^Message::content>().like("%e%"))
-                          .template join<&Message::sender>()
+                          .template join<^^Message::sender>()
                           .template distinct<^^Message::content>()
                           .execute();
     ASSERT_TRUE(result.has_value()) << "WHERE -> JOIN -> DISTINCT failed: " << result.error().message();
@@ -909,7 +909,7 @@ TYPED_TEST(DistinctTest, ChainingOrderJoinWhereDistinct) {
 
     // Test that JOIN -> WHERE -> DISTINCT works
     // Using content field to avoid ambiguous column names
-    auto result = msg_qs.template join<&Message::sender>()
+    auto result = msg_qs.template join<^^Message::sender>()
                           .where(field<^^Message::content>().like("%e%"))
                           .template distinct<^^Message::content>()
                           .execute();
@@ -991,7 +991,7 @@ TYPED_TEST(DistinctTest, DistinctKeywordInjectionInJoinQueries) {
     QuerySet<Message, TypeParam> msg_qs;
 
     // Test 1: Verify JOIN + DISTINCT works (implicit validation of SELECT clause injection)
-    auto result = msg_qs.template join<&Message::sender>().template distinct<^^Message::content>().execute();
+    auto result = msg_qs.template join<^^Message::sender>().template distinct<^^Message::content>().execute();
     ASSERT_TRUE(result.has_value()) << "JOIN + DISTINCT failed: " << result.error().message();
 
     const auto& contents = result.value();
@@ -1644,14 +1644,14 @@ TYPED_TEST(DistinctTest, SqlVerifyDistinctWithWhere) {
 // Test: DISTINCT + JOIN generates projected fields with t1 prefix (the bug fix)
 TYPED_TEST(DistinctTest, SqlVerifyDistinctWithJoin) {
     QuerySet<Message, TypeParam> msg_qs;
-    auto sql = msg_qs.template join<&Message::sender>().template distinct<^^Message::content>().sql();
+    auto sql = msg_qs.template join<^^Message::sender>().template distinct<^^Message::content>().sql();
     EXPECT_EQ(sql, "SELECT DISTINCT t1.content FROM Message t1 INNER JOIN Person t2 ON t2.id = t1.sender_id");
 }
 
 // Test: DISTINCT + JOIN + WHERE
 TYPED_TEST(DistinctTest, SqlVerifyDistinctWithJoinAndWhere) {
     QuerySet<Message, TypeParam> msg_qs;
-    auto                         sql = msg_qs.template join<&Message::sender>()
+    auto                         sql = msg_qs.template join<^^Message::sender>()
                        .where(field<^^Message::content>().like("%test%"))
                        .template distinct<^^Message::content>()
                        .sql();
@@ -1666,7 +1666,7 @@ TYPED_TEST(DistinctTest, SqlVerifyDistinctWithJoinAndWhere) {
 TYPED_TEST(DistinctTest, SqlVerifyDistinctJoinMultiFieldWithFK) {
     QuerySet<Message, TypeParam> msg_qs;
     auto                         sql =
-            msg_qs.template join<&Message::sender>().template distinct<^^Message::content, ^^Message::sender>().sql();
+            msg_qs.template join<^^Message::sender>().template distinct<^^Message::content, ^^Message::sender>().sql();
     EXPECT_EQ(
             sql,
             "SELECT DISTINCT t1.content, t1.sender_id"
@@ -1677,7 +1677,7 @@ TYPED_TEST(DistinctTest, SqlVerifyDistinctJoinMultiFieldWithFK) {
 // Test: VALUES (no DISTINCT keyword) + JOIN
 TYPED_TEST(DistinctTest, SqlVerifyValuesWithJoin) {
     QuerySet<Message, TypeParam> msg_qs;
-    auto sql = msg_qs.template join<&Message::sender>().template values<^^Message::content>().sql();
+    auto sql = msg_qs.template join<^^Message::sender>().template values<^^Message::content>().sql();
     EXPECT_EQ(sql, "SELECT t1.content FROM Message t1 INNER JOIN Person t2 ON t2.id = t1.sender_id");
 }
 
@@ -1705,7 +1705,7 @@ TYPED_TEST(DistinctTest, SqlVerifyDistinctWithLimitOffset) {
 // Test: DISTINCT + JOIN + WHERE + ORDER BY + LIMIT (full combo)
 TYPED_TEST(DistinctTest, SqlVerifyDistinctFullCombo) {
     QuerySet<Message, TypeParam> msg_qs;
-    auto                         sql = msg_qs.template join<&Message::sender>()
+    auto                         sql = msg_qs.template join<^^Message::sender>()
                        .where(field<^^Message::value>() > 10)
                        .template order_by<^^Message::content>()
                        .limit(5)

--- a/tests/query/test_join_wide.cpp
+++ b/tests/query/test_join_wide.cpp
@@ -37,15 +37,15 @@ TYPED_TEST_SUITE(WideJoinTest, DatabaseTypes);
 // Attaches all 9 FK joins to a WideJoin QuerySet (single source for the FK pack).
 template <typename ConnType> auto join_all_nine(const QuerySet<WideJoin, ConnType>& qs) {
     return qs.template join<
-            &WideJoin::fk1,
-            &WideJoin::fk2,
-            &WideJoin::fk3,
-            &WideJoin::fk4,
-            &WideJoin::fk5,
-            &WideJoin::fk6,
-            &WideJoin::fk7,
-            &WideJoin::fk8,
-            &WideJoin::fk9>();
+            ^^WideJoin::fk1,
+            ^^WideJoin::fk2,
+            ^^WideJoin::fk3,
+            ^^WideJoin::fk4,
+            ^^WideJoin::fk5,
+            ^^WideJoin::fk6,
+            ^^WideJoin::fk7,
+            ^^WideJoin::fk8,
+            ^^WideJoin::fk9>();
 }
 
 // SQL structural check: the 9th FK alias must render as t10 (not bare "t").

--- a/tests/query/test_rows.cpp
+++ b/tests/query/test_rows.cpp
@@ -271,7 +271,7 @@ TYPED_TEST_SUITE(RowsJoinTest, DatabaseTypes);
 TYPED_TEST(RowsJoinTest, WithJoin) {
     QuerySet<Message, TypeParam> qs;
     int                          count = 0;
-    for (auto&& result : qs.template join<&Message::sender>().rows()) {
+    for (auto&& result : qs.template join<^^Message::sender>().rows()) {
         ASSERT_TRUE(result.has_value());
         ++count;
     }
@@ -281,7 +281,7 @@ TYPED_TEST(RowsJoinTest, WithJoin) {
 TYPED_TEST(RowsJoinTest, WithJoinAndWhere) {
     QuerySet<Message, TypeParam> qs;
     int                          count = 0;
-    for (auto&& result : qs.template join<&Message::sender>().where(field<^^Message::value>() > 30).rows()) {
+    for (auto&& result : qs.template join<^^Message::sender>().where(field<^^Message::value>() > 30).rows()) {
         ASSERT_TRUE(result.has_value());
         EXPECT_GT(result.value().value, 30);
         ++count;

--- a/tests/query/test_sql_verify.cpp
+++ b/tests/query/test_sql_verify.cpp
@@ -74,7 +74,7 @@ TYPED_TEST(SqlVerifyTest, SelectWithWhere) {
 
 TYPED_TEST(SqlVerifyTest, SelectWithJoin) {
     QuerySet<Message, TypeParam> qs;
-    auto                         sql = qs.template join<&Message::sender>().select().sql();
+    auto                         sql = qs.template join<^^Message::sender>().select().sql();
     EXPECT_EQ(
             sql,
             "SELECT t1.id, t1.content, t1.value, t2.id, t2.name, t2.age, t2.salary,"
@@ -85,7 +85,7 @@ TYPED_TEST(SqlVerifyTest, SelectWithJoin) {
 
 TYPED_TEST(SqlVerifyTest, SelectWithJoinAndWhere) {
     QuerySet<Message, TypeParam> qs;
-    auto sql = qs.template join<&Message::sender>().where(field<^^Message::value>() > 10).select().sql();
+    auto sql = qs.template join<^^Message::sender>().where(field<^^Message::value>() > 10).select().sql();
     EXPECT_EQ(
             sql,
             "SELECT t1.id, t1.content, t1.value, t2.id, t2.name, t2.age, t2.salary,"
@@ -145,7 +145,7 @@ TYPED_TEST(SqlVerifyTest, SelectWithOffsetOnly) {
 
 TYPED_TEST(SqlVerifyTest, SelectFullCombo) {
     QuerySet<Message, TypeParam> qs;
-    auto                         sql = qs.template join<&Message::sender>()
+    auto                         sql = qs.template join<^^Message::sender>()
                        .where(field<^^Message::value>() > 10)
                        .template order_by<^^Message::content>()
                        .limit(5)
@@ -394,13 +394,13 @@ TYPED_TEST(SqlVerifyTest, AggregateChainedOps) {
 
 TYPED_TEST(SqlVerifyTest, AggregateCountWithJoin) {
     QuerySet<Message, TypeParam> qs;
-    auto                         sql = qs.template join<&Message::sender>().count().sql();
+    auto                         sql = qs.template join<^^Message::sender>().count().sql();
     EXPECT_EQ(sql, "SELECT COUNT(*) FROM Message t1 INNER JOIN Person t2 ON t2.id = t1.sender_id");
 }
 
 TYPED_TEST(SqlVerifyTest, AggregateCountWithJoinAndWhere) {
     QuerySet<Message, TypeParam> qs;
-    auto sql = qs.template join<&Message::sender>().where(field<^^Message::value>() > 10).count().sql();
+    auto sql = qs.template join<^^Message::sender>().where(field<^^Message::value>() > 10).count().sql();
     EXPECT_EQ(sql, "SELECT COUNT(*) FROM Message t1 INNER JOIN Person t2 ON t2.id = t1.sender_id WHERE value > ?");
 }
 
@@ -477,7 +477,7 @@ TYPED_TEST(SqlVerifyTest, GroupByMultiField) {
 
 TYPED_TEST(SqlVerifyTest, GroupByWithJoin) {
     QuerySet<Message, TypeParam> qs;
-    auto sql = qs.template join<&Message::sender>().template group_by<^^Message::content>().template count<>().sql();
+    auto sql = qs.template join<^^Message::sender>().template group_by<^^Message::content>().template count<>().sql();
     EXPECT_EQ(
             sql,
             "SELECT content, COUNT(*) FROM Message t1 INNER JOIN Person t2 ON t2.id = t1.sender_id"

--- a/tests/query/test_values.cpp
+++ b/tests/query/test_values.cpp
@@ -275,7 +275,7 @@ TYPED_TEST(ValuesTest, WithJoinSingleField) {
     QuerySet<Message, TypeParam> msg_qs;
 
     // SELECT content FROM Message JOIN Person (values replaces field list)
-    auto result = msg_qs.template join<&Message::sender>().template values<^^Message::content>().execute();
+    auto result = msg_qs.template join<^^Message::sender>().template values<^^Message::content>().execute();
     ASSERT_TRUE(result.has_value()) << "values with JOIN failed: " << result.error().message();
 
     const auto& contents = result.value();
@@ -289,7 +289,7 @@ TYPED_TEST(ValuesTest, WithJoinAndWhere) {
 
     QuerySet<Message, TypeParam> msg_qs;
 
-    auto result = msg_qs.template join<&Message::sender>()
+    auto result = msg_qs.template join<^^Message::sender>()
                           .where(field<^^Message::content>().like("%o%")) // Hello, World, Goodbye
                           .template values<^^Message::content>()
                           .execute();

--- a/tests/query/test_where.cpp
+++ b/tests/query/test_where.cpp
@@ -139,7 +139,7 @@ TYPED_TEST(WhereJoinTest, WhereWithJoin) {
     QuerySet<Message, TypeParam> queryset;
 
     // SELECT with JOIN and WHERE filtering by Person.age
-    auto result = queryset.template join<&Message::sender>().where(field<^^Person::age>() >= 10).select().execute();
+    auto result = queryset.template join<^^Message::sender>().where(field<^^Person::age>() >= 10).select().execute();
     ASSERT_TRUE(result.has_value()) << "WHERE + JOIN failed: " << result.error().message();
 
     const auto& messages = result.value();
@@ -164,7 +164,7 @@ TYPED_TEST(WhereJoinTest, WhereWithJoinMultipleConditions) {
 
     auto expr1  = field<^^Person::age>() > 5;
     auto expr2  = field<^^Message::content>().like("%from%");
-    auto result = queryset.template join<&Message::sender>().where(expr1 && expr2).select().execute();
+    auto result = queryset.template join<^^Message::sender>().where(expr1 && expr2).select().execute();
     ASSERT_TRUE(result.has_value()) << "WHERE + JOIN failed: " << result.error().message();
 
     const auto& messages = result.value();
@@ -176,7 +176,7 @@ TYPED_TEST(WhereJoinTest, WhereWithNaturalOperators) {
     QuerySet<Message, TypeParam> queryset;
 
     // Using natural 'and' operator (also works with &&)
-    auto result = queryset.template join<&Message::sender>()
+    auto result = queryset.template join<^^Message::sender>()
                           .where(field<^^Person::age>() > 5 and field<^^Message::content>().like("%from%"))
                           .select()
                           .execute();
@@ -550,7 +550,7 @@ TYPED_TEST(WhereJoinTest, IsNull_WithJoin) {
     // In WhereJoinTest fixture, Person rows are inserted without score → all NULL
     // So IS NULL on score matches all 4 messages
     auto result =
-            queryset.template join<&Message::sender>().where(field<^^Person::score>().is_null()).select().execute();
+            queryset.template join<^^Message::sender>().where(field<^^Person::score>().is_null()).select().execute();
     ASSERT_TRUE(result.has_value()) << "IS NULL with JOIN failed: " << result.error().message();
     EXPECT_EQ(result.value().size(), 4) << "Expected 4 messages (all senders have NULL score in this fixture)";
 }

--- a/tests/schema/test_fk_fields.cpp
+++ b/tests/schema/test_fk_fields.cpp
@@ -47,6 +47,23 @@ struct Summary {
 
 using storm::QuerySet;
 
+// ── Compile-time API contract (#388) ─────────────────────────────────────────
+// join/left_join/right_join take ^^T::field reflection NTTPs. Member-pointer
+// syntax, non-member reflections, non-FK fields, and other models' fields are
+// all rejected by the FKFieldOf constraint. The template parameter makes the
+// call dependent so a rejected argument is a substitution failure (= false),
+// not a hard error.
+template <auto... FKs> constexpr bool join_accepts = requires(QuerySet<Task> qs) { qs.template join<FKs...>(); };
+
+static_assert(join_accepts<^^Task::assignee>);
+static_assert(join_accepts<^^Task::assignee, ^^Task::reviewer>);
+static_assert(requires(QuerySet<Task> qs) { qs.template left_join<^^Task::assignee>(); });
+static_assert(requires(QuerySet<Task> qs) { qs.template right_join<^^Task::assignee>(); });
+static_assert(!join_accepts<&Task::assignee>);     // old pointer syntax removed
+static_assert(!join_accepts<^^Task::description>); // non-FK field
+static_assert(!join_accepts<^^Task>);              // not a data member
+static_assert(!join_accepts<^^Person::name>);      // member of another model
+
 // Test fixture for FK field operations — templated on database backend
 template <typename ConnType> class FKFieldTest : public StormTestFixture<Person, ConnType, Task> {};
 
@@ -389,7 +406,7 @@ TYPED_TEST(FKFieldTest, JoinFullyPopulatesFKObject) {
     ASSERT_TRUE(msg_result.has_value());
 
     // Phase 2: JOIN to get fully populated assignee
-    auto join_result = message_qs.template join<&Task::assignee>().select().execute();
+    auto join_result = message_qs.template join<^^Task::assignee>().select().execute();
     ASSERT_TRUE(join_result.has_value()) << "JOIN failed: " << join_result.error().message();
 
     const auto& messages = join_result.value();
@@ -436,7 +453,7 @@ TYPED_TEST(FKFieldTest, JoinMultipleFKFields) {
     ASSERT_TRUE(msg_result.has_value());
 
     // Phase 3: Multi-JOIN to get BOTH assignee and reviewer fully populated
-    auto join_result = message_qs.template join<&Task::assignee, &Task::reviewer>().select().execute();
+    auto join_result = message_qs.template join<^^Task::assignee, ^^Task::reviewer>().select().execute();
     ASSERT_TRUE(join_result.has_value()) << "Multi-JOIN failed: " << join_result.error().message();
 
     const auto& messages = join_result.value();
@@ -483,7 +500,7 @@ TYPED_TEST(FKFieldTest, LeftJoinReturnsAllMessages) {
     ASSERT_EQ(step_result, decltype(stmt)::NO_MORE_ROWS) << "Direct INSERT failed";
 
     // LEFT JOIN on assignee - should return task even though reviewer doesn't exist
-    auto join_result = message_qs.template left_join<&Task::assignee>().select().execute();
+    auto join_result = message_qs.template left_join<^^Task::assignee>().select().execute();
     ASSERT_TRUE(join_result.has_value()) << "LEFT JOIN failed: " << join_result.error().message();
 
     const auto& messages = join_result.value();
@@ -528,7 +545,7 @@ TYPED_TEST(FKFieldTest, LeftJoinMultipleFKFields) {
     ASSERT_TRUE(msg_result.has_value());
 
     // LEFT JOIN on both assignee and reviewer
-    auto join_result = message_qs.template left_join<&Task::assignee, &Task::reviewer>().select().execute();
+    auto join_result = message_qs.template left_join<^^Task::assignee, ^^Task::reviewer>().select().execute();
     ASSERT_TRUE(join_result.has_value()) << "Multi LEFT JOIN failed: " << join_result.error().message();
 
     const auto& messages = join_result.value();
@@ -579,7 +596,7 @@ TYPED_TEST(FKFieldTest, RightJoinBehavior) {
 
     // RIGHT JOIN on assignee - should return all users in Person table as assignees
     // This includes Charlie even though no task references him
-    auto join_result = message_qs.template right_join<&Task::assignee>().select().execute();
+    auto join_result = message_qs.template right_join<^^Task::assignee>().select().execute();
     ASSERT_TRUE(join_result.has_value()) << "RIGHT JOIN failed: " << join_result.error().message();
 
     const auto& messages = join_result.value();
@@ -629,7 +646,7 @@ TYPED_TEST(FKFieldTest, RightJoinMultipleFKFields) {
     ASSERT_TRUE(msg_result.has_value());
 
     // RIGHT JOIN on both assignee and reviewer
-    auto join_result = message_qs.template right_join<&Task::assignee, &Task::reviewer>().select().execute();
+    auto join_result = message_qs.template right_join<^^Task::assignee, ^^Task::reviewer>().select().execute();
     ASSERT_TRUE(join_result.has_value()) << "Multi RIGHT JOIN failed: " << join_result.error().message();
 
     const auto& messages = join_result.value();
@@ -732,7 +749,7 @@ TYPED_TEST(NullableFKTest, LeftJoinWithNullFKField) {
     ASSERT_TRUE(insert_result.has_value());
 
     // LEFT JOIN on sender - should return message even with NULL sender_id
-    auto join_result = message_qs.template left_join<&NullableFKMessage::sender>().select().execute();
+    auto join_result = message_qs.template left_join<^^NullableFKMessage::sender>().select().execute();
     ASSERT_TRUE(join_result.has_value()) << "LEFT JOIN with NULL FK failed: " << join_result.error().message();
 
     const auto& messages = join_result.value();
@@ -767,7 +784,7 @@ TYPED_TEST(NullableFKTest, LeftJoinWithMixedNullAndValidFKs) {
     ASSERT_TRUE(message_qs.insert(msg2).execute().has_value());
 
     // LEFT JOIN should return both messages
-    auto join_result = message_qs.template left_join<&NullableFKMessage::sender>().select().execute();
+    auto join_result = message_qs.template left_join<^^NullableFKMessage::sender>().select().execute();
     ASSERT_TRUE(join_result.has_value());
 
     const auto& messages = join_result.value();
@@ -845,7 +862,7 @@ TYPED_TEST(ExtendedTypesJoinTest, JoinWithExtendedTypes) {
     ASSERT_TRUE(proj2_result.has_value()) << "Failed to insert project 2: " << proj2_result.error().message();
 
     // JOIN to get projects with fully populated manager (Person) objects
-    auto join_result = project_qs.template join<&Project::manager>().select().execute();
+    auto join_result = project_qs.template join<^^Project::manager>().select().execute();
     ASSERT_TRUE(join_result.has_value()) << "JOIN failed: " << join_result.error().message();
 
     const auto& projects = join_result.value();
@@ -946,7 +963,7 @@ TYPED_TEST(ExtendedTypesJoinTest, MultiJoinWithExtendedTypes) {
 
     // Multi-JOIN to populate both assignee and reviewer
     // NOLINTNEXTLINE(readability-isolate-declaration) - false positive with template
-    auto join_result = task_qs.template join<&Task::assignee, &Task::reviewer>().select().execute();
+    auto join_result = task_qs.template join<^^Task::assignee, ^^Task::reviewer>().select().execute();
     ASSERT_TRUE(join_result.has_value()) << "Multi-JOIN failed: " << join_result.error().message();
 
     const auto& tasks = join_result.value();
@@ -1014,7 +1031,7 @@ TYPED_TEST(ExtendedTypesJoinTest, JoinWithFloatAndLongLongTypes) {
     ASSERT_TRUE(reading_result.has_value()) << "Failed to insert reading: " << reading_result.error().message();
 
     // JOIN to get readings with fully populated measurement
-    auto join_result = reading_qs.template join<&Reading::measurement>().select().execute();
+    auto join_result = reading_qs.template join<^^Reading::measurement>().select().execute();
     ASSERT_TRUE(join_result.has_value()) << "JOIN failed: " << join_result.error().message();
 
     const auto& readings = join_result.value();
@@ -1067,7 +1084,7 @@ TYPED_TEST(ExtendedTypesJoinTest, JoinWithLongType) {
     ASSERT_TRUE(sum_result.has_value()) << "Failed to insert summary: " << sum_result.error().message();
 
     // JOIN to get summaries with fully populated counter
-    auto join_result = summary_qs.template join<&Summary::counter>().select().execute();
+    auto join_result = summary_qs.template join<^^Summary::counter>().select().execute();
     ASSERT_TRUE(join_result.has_value()) << "JOIN failed: " << join_result.error().message();
 
     const auto& summaries = join_result.value();
@@ -1125,7 +1142,7 @@ template <typename ConnType> class JoinTypeExtractionTest : public StormTestFixt
 TYPED_TEST_SUITE(JoinTypeExtractionTest, DatabaseTypes);
 
 TYPED_TEST(JoinTypeExtractionTest, JoinExtractsFloatField) {
-    auto result = this->msg_qs->template join<&Message::sender>().select().execute();
+    auto result = this->msg_qs->template join<^^Message::sender>().select().execute();
 
     ASSERT_TRUE(result.has_value()) << "JOIN with float field should succeed";
     ASSERT_FALSE(result.value().empty());
@@ -1142,7 +1159,7 @@ TYPED_TEST(JoinTypeExtractionTest, JoinExtractsFloatField) {
 }
 
 TYPED_TEST(JoinTypeExtractionTest, JoinExtractsBoolField) {
-    auto result = this->msg_qs->template join<&Message::sender>().select().execute();
+    auto result = this->msg_qs->template join<^^Message::sender>().select().execute();
 
     ASSERT_TRUE(result.has_value()) << "JOIN with bool field should succeed";
     ASSERT_FALSE(result.value().empty());
@@ -1159,7 +1176,7 @@ TYPED_TEST(JoinTypeExtractionTest, JoinExtractsBoolField) {
 }
 
 TYPED_TEST(JoinTypeExtractionTest, JoinExtractsOptionalIntWithValue) {
-    auto result = this->msg_qs->template join<&Message::sender>().select().execute();
+    auto result = this->msg_qs->template join<^^Message::sender>().select().execute();
 
     ASSERT_TRUE(result.has_value()) << "JOIN with optional int should succeed";
     ASSERT_FALSE(result.value().empty());
@@ -1176,7 +1193,7 @@ TYPED_TEST(JoinTypeExtractionTest, JoinExtractsOptionalIntWithValue) {
 }
 
 TYPED_TEST(JoinTypeExtractionTest, JoinExtractsOptionalIntNull) {
-    auto result = this->msg_qs->template join<&Message::sender>().select().execute();
+    auto result = this->msg_qs->template join<^^Message::sender>().select().execute();
 
     ASSERT_TRUE(result.has_value()) << "JOIN with NULL optional should succeed";
     ASSERT_FALSE(result.value().empty());
@@ -1189,7 +1206,7 @@ TYPED_TEST(JoinTypeExtractionTest, JoinExtractsOptionalIntNull) {
 }
 
 TYPED_TEST(JoinTypeExtractionTest, JoinExtractsOptionalStringWithValue) {
-    auto result = this->msg_qs->template join<&Message::sender>().select().execute();
+    auto result = this->msg_qs->template join<^^Message::sender>().select().execute();
 
     ASSERT_TRUE(result.has_value()) << "JOIN with optional string should succeed";
     ASSERT_FALSE(result.value().empty());
@@ -1203,7 +1220,7 @@ TYPED_TEST(JoinTypeExtractionTest, JoinExtractsOptionalStringWithValue) {
 }
 
 TYPED_TEST(JoinTypeExtractionTest, JoinExtractsOptionalStringNull) {
-    auto result = this->msg_qs->template join<&Message::sender>().select().execute();
+    auto result = this->msg_qs->template join<^^Message::sender>().select().execute();
 
     ASSERT_TRUE(result.has_value()) << "JOIN with NULL optional string should succeed";
     ASSERT_FALSE(result.value().empty());
@@ -1217,7 +1234,7 @@ TYPED_TEST(JoinTypeExtractionTest, JoinExtractsOptionalStringNull) {
 
 TYPED_TEST(JoinTypeExtractionTest, JoinWithOrderBy) {
     auto result =
-            this->msg_qs->template join<&Message::sender>().template order_by<^^Message::value>().select().execute();
+            this->msg_qs->template join<^^Message::sender>().template order_by<^^Message::value>().select().execute();
 
     ASSERT_TRUE(result.has_value()) << "JOIN with ORDER BY should succeed";
     EXPECT_EQ(result.value().size(), 4);

--- a/tests/test_select_runner.h
+++ b/tests/test_select_runner.h
@@ -52,9 +52,9 @@ constexpr auto build_where_expr(std::string_view op, ValueType value) {
 
 // FK resolver for test models (Message::sender → Person).
 struct TestFkResolver {
-    consteval auto operator()(std::string_view name) const {
+    consteval auto operator()(std::string_view name) const -> std::meta::info {
         if (name == "sender")
-            return &Message::sender;
+            return ^^Message::sender;
         std::unreachable();
     }
 };


### PR DESCRIPTION
## Summary

Migrates `join()` / `left_join()` / `right_join()` from member-pointer NTTPs to C++26 reflection NTTPs, matching every other field selector (`order_by`/`sum`/`distinct`/`values`/`group_by`). Hard migration — the `&`-pointer overload is removed, not aliased.

```cpp
// Before                                  // After
qs.join<&Message::sender>()               qs.join<^^Message::sender>()
qs.left_join<&Task::assignee,             qs.left_join<^^Task::assignee,
             &Task::reviewer>()                        ^^Task::reviewer>()
```

## Implementation

- **New `FKFieldOf<T, Member>` concept** (base.cppm) constrains all three QuerySet methods + `JoinStatement`/`make_join_wrapper`: non-members, non-FK fields, and other models' fields fail at the call site with a clear constraint violation (`requires`, not `throw`).
- **FK SQL names** come from `identifier_of(FKFields...[Idx])` per-info. The positional `build_fk_field_names()` scan is removed — it had a latent bug where joining only a later-declared FK (e.g. `join<&Message::receiver>` alone) emitted the *first* FK's column name.
- **Extraction** switches `obj.*ptr` → `obj.[:info:]`; `FK_type` derives via `type_of` (keeps the `optional_inner_type_t` unwrap).

## Compiler finding (new, documented)

`annotation_of_type` on a reflection that crossed a BMI boundary **segfaults clang-p2996** (surfacing as `cannot take the reflection of an overload set` during constraint checks). Structural metafunctions (`is_nonstatic_data_member`/`parent_of`/`identifier_of`) are safe. `FKFieldOf` therefore re-derives the member from `^^T` by identifier before reading the annotation. Documented in COMPILER_ISSUES.md §10. This was hit via the benchmark registry's exported `resolve_fk_field` infos.

## Beyond the issue's affected-files list

Also required migration (discovered during build): `src/orm/query_builder.hpp` (fk_resolver contract comment), `tests/test_select_runner.h` (TestFkResolver), `tests/query/test_join_wide.cpp`, `benchmarks/registry.cppm` (`resolve_fk_ptr` → `resolve_fk_field`) + `benchmarks/query_benchmark.cppm`. `right_join` (not named in the issue title) migrated alongside.

## Verification

- 2010/2010 tests pass (SQLite + PostgreSQL), debug + release
- Compile-time contract tests in test_fk_fields.cpp: `static_assert(!join_accepts<&Task::assignee>)` proves old syntax is gone; non-FK / non-member / wrong-model reflections rejected
- Join SQL byte-identical (test_sql_verify.cpp)
- ASAN+UBSAN clean (2010/2010), TSAN clean (2010/2010)
- Join benchmarks: cv < 1%, throughput in line with dashboard history (compile-time-only change)
- Pre-commit: format, tidy --diff, release build, tests, 100% coverage — all green

Closes #388

🤖 Generated with [Claude Code](https://claude.com/claude-code)