### PR TITLE
feat(orm): many-to-many relationship support (#203)

### DIFF
--- a/.claude/agents/dev.md
+++ b/.claude/agents/dev.md
@@ -13,7 +13,7 @@ You are an expert C++26 engineer and architect for the Storm ORM project. You ha
 
 When implementing features:
 1. Use compile-time reflection with `std::meta` for automatic struct-to-database mapping
-2. Mark primary keys with `[[=storm::meta::FieldAttr::primary]]` attributes (use `primary_autoincrement` to opt a SQLite int PK into `AUTOINCREMENT`/never-reuse; plain `primary` emits plain `INTEGER PRIMARY KEY` since #379). Auto-timestamp fields use `auto_create`/`auto_update` on a `system_clock::time_point` (#209) — bind-time `now()`, no write-back; injected in `bind_field_at_index` via `stamps_now()`/`batch_now()`
+2. Mark primary keys with `[[=storm::meta::FieldAttr::primary]]` attributes (use `primary_autoincrement` to opt a SQLite int PK into `AUTOINCREMENT`/never-reuse; plain `primary` emits plain `INTEGER PRIMARY KEY` since #379). Auto-timestamp fields use `auto_create`/`auto_update` on a `system_clock::time_point` (#209) — bind-time `now()`, no write-back; injected in `bind_field_at_index` via `stamps_now()`/`batch_now()`. Many-to-many container fields use `[[=storm::meta::many_to_many]]` (auto junction table) or `many_to_many_through<Model>` (#203) — class-template annotations, NOT FieldAttr values; m2m members are filtered out of `all_members_`/`field_count_` (not columns) and eager-loaded via `join<^^T::field>()` (M2MJoinStatement: base-table subquery + outer `ORDER BY …, t1.<pk>` row adjacency)
 3. Inherit new statement classes from `BaseStatement<T>` to leverage shared utilities
 4. Implement both single-object and batch operations using `std::span<const T>`
 5. Apply adaptive thresholds:

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -20,6 +20,7 @@ You are a senior C++ code reviewer specializing in the Storm ORM project, with d
 - Verify proper use of `std::meta` for compile-time reflection
 - Ensure primary key fields are marked with `[[=storm::meta::FieldAttr::primary]]` (or `primary_autoincrement` for the SQLite never-reuse opt-in, #379); both are treated as a PK via `meta::is_primary_attr`
 - For auto-timestamps (#209): `auto_create`/`auto_update` must be on `system_clock::time_point` (compile-time `static_assert`); both enums (base.cppm + where.cppm) must stay in sync; the `now()` read must be gated by `has_auto_timestamp_field_` (zero cost on plain models)
+- For many-to-many (#203): `many_to_many`/`many_to_many_through<T>` are `ManyToMany<>` class-template annotations, not FieldAttr values; m2m container members must stay filtered out of `all_members_`/`field_count_`; m2m WHERE/ORDER/LIMIT must stay INSIDE the base-table subquery and the outer ORDER BY must end in `t1.<pk>` (the aggregation loops rely on same-entity row adjacency)
 - Check that reflection splice operators (`obj.[:primary_key_:]`) are used appropriately
 - Validate SQL generation leverages reflection for automatic field mapping
 - **NO REFL-CPP usage** — only native C++26 reflection

--- a/.claude/agents/test.md
+++ b/.claude/agents/test.md
@@ -85,6 +85,7 @@ When tests fail, systematically check:
 
 ### 3. Reflection-Related Issues
 - Primary key field annotations: `[[=storm::meta::FieldAttr::primary]]`
+- Many-to-many annotations (#203): `[[=storm::meta::many_to_many]]` / `many_to_many_through<Model>` — m2m test models live in `tests/query/test_m2m_models.h` (textual header, include after `import storm;` + `plf_hive` before the imports)
 - Splice operator usage: `obj.[:primary_key_:]`
 - Meta functionality in struct definitions
 - Module import hierarchy problems

--- a/.lint-skip
+++ b/.lint-skip
@@ -6,6 +6,7 @@
 src/orm/statements/insert.cppm:    file-size
 src/orm/statements/select.cppm:    file-size
 src/orm/statements/base.cppm:      file-size, duplicate
+src/orm/statements/join.cppm:      file-size
 src/orm/statements/aggregate.cppm: file-size
 src/orm/queryset.cppm:             file-size
 src/orm/schema.cppm:               file-size

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -311,6 +311,12 @@ See [docs/development/PERFORMANCE_GUIDELINES.md](docs/development/PERFORMANCE_GU
 
 `int`, `int64_t`, `double`, `float`, `bool`, `std::string`, `std::string_view`, `std::optional<T>`, `std::vector<uint8_t>` (BLOB)
 
+**Many-to-many (#203)**: `[[= storm::meta::many_to_many]]` (auto junction `<Owner>_<Related>`)
+or `[[= storm::meta::many_to_many_through<Model>]]` on a container member
+(`std::vector<T>`, `plf::hive<T>`, `vector<shared_ptr<T>>`). Not a column — invisible to
+CRUD/schema; eager-loaded via `join<^^T::field>()`. See
+[docs/features/JOIN_OPERATIONS.md](docs/features/JOIN_OPERATIONS.md).
+
 **Auto-timestamps (#209)**: `[[= FieldAttr::auto_create]]` / `[[= FieldAttr::auto_update]]` on a
 `std::chrono::system_clock::time_point` field auto-stamp `now()` — `auto_create` on INSERT only,
 `auto_update` on INSERT and UPDATE. **Bind-time only, no write-back** (the caller's object is never
@@ -401,6 +407,12 @@ qs.values<^^Person::name, ^^Person::age>().execute();       // plf::hive<std::tu
 // JOIN — FK field selectors use reflection NTTPs like every other field selector
 message_qs.join<^^Message::sender>().where(...).select();
 message_qs.left_join<^^Message::sender, ^^Message::receiver>().select();
+
+// Many-to-many (#203) — container field annotated [[= storm::meta::many_to_many]]
+// (auto junction table) or many_to_many_through<Enrollment> (explicit junction model).
+// Single-query eager load; WHERE/ORDER BY/LIMIT apply to BASE entities (subquery).
+student_qs.join<^^Student::courses>().select();      // students with courses aggregated
+student_qs.left_join<^^Student::courses>().select(); // + students with no courses
 ```
 
 **Methods**: `where()`, `join()`, `order_by()`, `limit()`, `offset()`, `group_by()`, `having()`, `distinct()`, `values()`

--- a/docs/features/JOIN_OPERATIONS.md
+++ b/docs/features/JOIN_OPERATIONS.md
@@ -116,6 +116,103 @@ auto result = message_qs.right_join<^^Message::sender>().select();
 
 **Use when**: You want all users, even those without messages
 
+## Many-to-Many Joins (#203)
+
+Many-to-many relationships use a container field annotated with `many_to_many`
+(auto-generated junction table) or `many_to_many_through<Model>` (explicit
+junction model). The same `join<^^Field>()` API eager-loads the relationship in
+a **single query** — no N+1 problem.
+
+### Phase 1: Auto-Generated Junction Table
+
+```cpp
+struct Course {
+    [[= storm::meta::FieldAttr::primary]] int id{};
+    std::string title;
+};
+
+struct Student {
+    [[= storm::meta::FieldAttr::primary]] int id{};
+    std::string name;
+    int age{};
+    [[= storm::meta::many_to_many]] std::vector<Course> courses;
+};
+
+// One query: students deduplicated, courses collected into each student
+auto students = QuerySet<Student>().join<^^Student::courses>().select().execute();
+for (const auto& s : *students) {
+    // s.courses holds ALL of the student's courses
+}
+```
+
+- The related type (`Course`) is extracted from the container via C++26 `std::meta`
+  — `std::vector<T>`, `plf::hive<T>`, `std::deque<T>`, and
+  `std::vector<std::shared_ptr<T>>` / `unique_ptr` elements all work.
+- `create_table_if_not_exists<Student>` also creates the junction table
+  `Student_Course (Student_id, Course_id, PRIMARY KEY(both))` — naming is
+  `<OwnerTable>_<RelatedTable>` with `<Table>_id` columns.
+- The m2m container member is **not a column**: plain `select()`, `insert()`,
+  `update()` ignore it entirely (zero cost for models without m2m fields).
+
+**SQL Generated**:
+```sql
+SELECT t1.id, t1.name, t1.age, t3.id, t3.title
+FROM (SELECT id, name, age FROM Student) t1
+INNER JOIN Student_Course t2 ON t1.id = t2.Student_id
+INNER JOIN Course t3 ON t2.Course_id = t3.id
+ORDER BY t1.id
+```
+
+### Phase 2: Explicit Junction Model (metadata)
+
+```cpp
+struct Enrollment {
+    [[= storm::meta::FieldAttr::primary]] int id{};
+    [[= storm::meta::FieldAttr::fk]] Pupil pupil;
+    [[= storm::meta::FieldAttr::fk]] Course course;
+    std::string grade;  // relationship metadata
+};
+
+struct Pupil {
+    [[= storm::meta::FieldAttr::primary]] int id{};
+    std::string name;
+    [[= storm::meta::many_to_many_through<Enrollment>]] std::vector<Course> courses;
+};
+
+// Simple access — metadata ignored, same single-query eager load
+auto pupils = QuerySet<Pupil>().join<^^Pupil::courses>().select().execute();
+
+// Metadata access — query the junction model directly (regular FK joins)
+auto enrollments = QuerySet<Enrollment>()
+        .join<^^Enrollment::pupil, ^^Enrollment::course>()
+        .where(field<^^Enrollment::grade>() == "A")
+        .select().execute();
+```
+
+The junction table is the through model's own table; FK columns come from its
+field names (`pupil_id`, `course_id`). The through model must have exactly one
+`FieldAttr::fk` field per side (enforced at compile time).
+
+### Semantics
+
+| Aspect | Behavior |
+|---|---|
+| `WHERE` / `ORDER BY` / `LIMIT` / `OFFSET` | Apply to **base entities** (inside a base-table subquery) — `limit(1)` returns one student with ALL courses |
+| `first()` / `get()` | Entity-level: `get()` errors only on 0 or >1 *entities*, never on multiple relations |
+| `rows()` | Yields one aggregated entity at a time (lazy) |
+| `join` (INNER) | Drops base entities with no relations |
+| `left_join` | Keeps them with an empty container |
+| Aggregates (`count()` …) | Count (base, related) **pairs** over the flat 3-table join |
+| Result order | Deterministic: user `order_by` (t1-qualified) + pk tiebreak |
+
+### Limitations
+
+- One m2m field per model; self-referential m2m rejected at compile time.
+- Write-side helpers (`add()`/`remove()`) are not provided — insert junction
+  rows via the through model (`QuerySet<Enrollment>`) or raw SQL for Phase 1.
+- The annotation spelling differs from issue #203's sketch
+  (`FieldAttr::many_to_many<T>` is impossible — `FieldAttr` is an enum).
+
 ## Architecture
 
 ### Type-Erased SQL Builder Pattern

--- a/docs/reference/FIELD_TYPES.md
+++ b/docs/reference/FIELD_TYPES.md
@@ -188,6 +188,28 @@ QuerySet<User>().update(u).execute();
 The column maps to `TIMESTAMP` (PostgreSQL) / `TEXT` (SQLite) and round-trips via the
 existing `time_point` ↔ `"YYYY-MM-DD HH:MM:SS"` conversion.
 
+## Many-to-Many Container Fields (`many_to_many` / `many_to_many_through`)
+
+A container member annotated with `[[= storm::meta::many_to_many]]` (or
+`many_to_many_through<JunctionModel>`) declares a many-to-many relationship (#203):
+
+```cpp
+struct Student {
+    [[= storm::meta::FieldAttr::primary]] int id{};
+    std::string name;
+    [[= storm::meta::many_to_many]] std::vector<Course> courses;
+};
+```
+
+- **Not a column.** The member maps to a junction table, not to a column —
+  `INSERT`/`SELECT`/`UPDATE`/schema generation skip it entirely. Plain `select()`
+  leaves it empty; `join<^^Student::courses>()` eager-loads it.
+- **Supported containers:** `std::vector<T>`, `plf::hive<T>`, `std::deque<T>`,
+  and smart-pointer elements (`std::vector<std::shared_ptr<T>>`); the related
+  model type is extracted via C++26 `std::meta`.
+- **Junction DDL** is auto-generated for the `many_to_many` form (see
+  [JOIN_OPERATIONS.md](../features/JOIN_OPERATIONS.md#many-to-many-joins-203)).
+
 ## Type Dispatch Implementation
 
 The binding uses compile-time `if constexpr` type dispatch to select the appropriate SQLite binding function with **zero runtime overhead**.

--- a/docs/superpowers/plans/2026-06-10-203-many-to-many.md
+++ b/docs/superpowers/plans/2026-06-10-203-many-to-many.md
@@ -1,0 +1,903 @@
+# Many-to-Many Relationship Support (#203) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Attribute-based many-to-many relationships with single-query eager loading: `[[= storm::meta::many_to_many]]` (auto junction table, Phase 1) and `[[= storm::meta::many_to_many_through<Enrollment>]]` (explicit junction model, Phase 2), consumed through the existing `join<^^T::field>()` API.
+
+**Architecture:** A `ManyToMany<Through>` class-template annotation (the issue's `FieldAttr::many_to_many<X>` syntax is impossible — `FieldAttr` is an enum; enum values can't be templated). M2M container fields are filtered out of `BaseStatement::all_members_`, so all existing CRUD/schema code ignores them at zero cost. A new `M2MJoinStatement` generates a 3-table JOIN over a base-table subquery (WHERE/ORDER BY/LIMIT/OFFSET apply to *base entities*, not joined rows) with a deterministic outer `ORDER BY …, t1.<pk>` so rows for one base entity are always adjacent. The existing type-erased `JoinStatementWrapper` is extended with three nullable fn pointers (`build_m2m_sql_fn`, `extract_base_pk_fn`, `append_related_fn`); `SelectStatement` grows an adjacency-based aggregation loop (no map needed) that deduplicates base rows and appends related objects into the container member.
+
+**Tech Stack:** C++26 reflection (P2996: `annotations_of`, `template_of`, `template_arguments_of`, `dealias` — all verified present in `../clang-p2996/libcxx/include/meta`), existing Storm module structure, GoogleTest TYPED_TEST over SQLite+PostgreSQL.
+
+**Key design decisions (deviations from issue text, to report in the PR):**
+1. `FieldAttr::many_to_many<Enrollment>` is not valid C++ (enum). API is `storm::meta::many_to_many` (value of `ManyToMany<void>`) and `storm::meta::many_to_many_through<Enrollment>` (variable template).
+2. Junction table naming: `<OwnerTable>_<RelatedTable>` verbatim (`Student_Course`), matching Storm's existing convention (table name == struct identifier, e.g. `Person`). The issue's prose says "alphabetical" but every SQL example uses owner-first; owner-first wins. FK columns: `<OwnerTable>_id`, `<RelatedTable>_id`.
+3. LIMIT/OFFSET/first()/get() apply to base entities via subquery — `LIMIT 1` returns one student with ALL their courses (a flat outer LIMIT would truncate the related collection).
+4. Single m2m field per model (issue Phase 1 scope); self-referential m2m rejected at compile time.
+5. m2m joins are supported by `select()/first()/get()/rows()`. Aggregates (`count()` etc.) over an m2m join count (base, related) *pairs* — documented behavior. Write-side junction API (`add()`/`remove()`) is out of scope (issue covers querying only); tests populate junction tables with raw SQL / `QuerySet<Enrollment>`.
+6. INNER join drops base rows with no related records (SQL semantics, same as existing FK joins); `left_join` yields them with an empty container.
+
+**Files:**
+- Modify: `src/orm/statements/base.cppm` — `ManyToMany`, m2m meta helpers, `M2MFieldOf`/`ThroughWithFKTo` concepts, `all_members_` filtering
+- Modify: `src/orm/statements/join.cppm` — extended `JoinStatementWrapper`, `M2MJoinStatement`, `make_m2m_join_wrapper`
+- Modify: `src/orm/statements/select.cppm` — m2m branches in `build_sql`/`execute`/`execute_one`/`execute_get`/`rows_generator` + aggregation loops
+- Modify: `src/orm/queryset.cppm` — `join()/left_join()` dispatch on `M2MFieldOf`
+- Modify: `src/orm/schema.cppm` — auto-junction DDL + creation
+- Modify: `src/storm.cppm` — export `many_to_many`, `many_to_many_through`, `ManyToMany`
+- Create: `tests/query/test_m2m_models.h` — shared m2m test models (textual header, include after `import storm;`)
+- Create: `tests/query/test_many_to_many.cpp` — Phase 1 CT + runtime tests
+- Create: `tests/query/test_many_to_many_modifiers.cpp` — WHERE/ORDER/LIMIT/first/get/rows/caching
+- Create: `tests/query/test_many_to_many_through.cpp` — Phase 2 tests
+- Modify: `docs/features/JOIN_OPERATIONS.md`, `docs/reference/FIELD_TYPES.md`, `CLAUDE.md`, agent files mentioning join/FieldAttr patterns
+
+No CMake changes needed (GLOB auto-discovery for tests; `.h` needs no registration).
+
+---
+
+### Task 1: Branch setup
+
+- [ ] **Step 1.1:** `gh issue develop 203 --name feature/203-many-to-many --base develop --checkout`
+- [ ] **Step 1.2:** Verify base is develop tip (memory: `gh issue develop` can branch one commit behind): `git fetch origin develop && git log HEAD..origin/develop --oneline` — must be empty; if not, `git reset --hard origin/develop`.
+- [ ] **Step 1.3:** Baseline build green: `cmake --preset ninja-debug && cmake --build --preset ninja-debug && ctest --preset ninja-debug` (run build twice if module cache corruption appears).
+
+### Task 2: Annotation + meta infrastructure + member filtering (base.cppm, storm.cppm)
+
+**Files:** Modify `src/orm/statements/base.cppm` (meta namespace + BaseStatement), `src/storm.cppm`. Test: `tests/query/test_m2m_models.h`, `tests/query/test_many_to_many.cpp`.
+
+- [ ] **Step 2.1: Write the failing test.** Create `tests/query/test_m2m_models.h`:
+
+```cpp
+#pragma once
+
+// Many-to-many test models (#203). Include AFTER `import storm;` (annotation
+// attributes need the storm module; clang-p2996 #262 keeps models textual).
+
+#include <memory>
+#include <plf_hive/plf_hive.h>
+#include <vector>
+
+struct Course {
+    [[= storm::meta::FieldAttr::primary]] int id{};
+    std::string title;
+};
+
+// Phase 1: auto-generated junction table Student_Course (Student_id, Course_id)
+struct Student {
+    [[= storm::meta::FieldAttr::primary]] int id{};
+    std::string name;
+    int age{};
+    [[= storm::meta::many_to_many]] std::vector<Course> courses;
+};
+
+// Phase 2: explicit junction model with metadata
+struct Enrollment;
+struct CourseStudent;  // not needed — through models reference concrete types
+
+struct Pupil {
+    [[= storm::meta::FieldAttr::primary]] int id{};
+    std::string name;
+    [[= storm::meta::many_to_many_through<Enrollment>]] std::vector<Course> courses;
+};
+
+struct Enrollment {
+    [[= storm::meta::FieldAttr::primary]] int id{};
+    [[= storm::meta::FieldAttr::fk]] Pupil pupil;
+    [[= storm::meta::FieldAttr::fk]] Course course;
+    std::string grade;
+};
+
+// Container-coverage models (Phase 1 edge cases)
+struct Track {
+    [[= storm::meta::FieldAttr::primary]] int id{};
+    std::string title;
+};
+struct Playlist {
+    [[= storm::meta::FieldAttr::primary]] int id{};
+    std::string name;
+    [[= storm::meta::many_to_many]] plf::hive<Track> tracks;
+};
+struct Album {
+    [[= storm::meta::FieldAttr::primary]] int id{};
+    std::string name;
+    [[= storm::meta::many_to_many]] std::vector<std::shared_ptr<Track>> tracks;
+};
+```
+
+NOTE: `Pupil`/`Enrollment` are mutually referential — `many_to_many_through<Enrollment>` only needs `Enrollment` complete at annotation evaluation; if forward declaration fails to compile, fall back to declaring Enrollment fully before Pupil with `[[= FieldAttr::fk]] int pupil_id` style — verify during execution and adjust (the annotation value `ManyToMany<Enrollment>{}` requires only an empty-struct instantiation, which works with incomplete `Enrollment`? No — instantiating `ManyToMany<Enrollment>` does NOT require `Enrollment` complete since the template only names it. Forward-declare `struct Enrollment;` before `Pupil` as shown.)
+
+Create `tests/query/test_many_to_many.cpp` with compile-time assertions first:
+
+```cpp
+#include <gtest/gtest.h>
+#include "test_db_helpers.h"
+
+// NOLINTBEGIN(misc-const-correctness)
+
+import storm;
+import std;
+
+using storm::QuerySet;
+
+#include "test_models.h"     // NOSONAR cpp:S954
+#include "test_m2m_models.h" // NOSONAR cpp:S954
+
+// ---- Compile-time: m2m fields are excluded from persisted members ----
+static_assert(storm::orm::statements::BaseStatement<Student>::field_count_ == 3,
+              "courses (m2m) must not count as a persisted column");
+
+// ---- Compile-time: M2MFieldOf concept ----
+static_assert(storm::orm::statements::M2MFieldOf<Student, ^^Student::courses>);
+static_assert(!storm::orm::statements::M2MFieldOf<Student, ^^Student::name>);
+static_assert(!storm::orm::statements::FKFieldOf<Student, ^^Student::courses>);
+
+// ---- Compile-time: related-type extraction from containers ----
+static_assert(std::same_as<storm::orm::statements::meta::m2m_related_t<std::vector<Course>>, Course>);
+static_assert(std::same_as<storm::orm::statements::meta::m2m_related_t<plf::hive<Track>>, Track>);
+static_assert(std::same_as<storm::orm::statements::meta::m2m_related_t<std::vector<std::shared_ptr<Track>>>, Track>);
+static_assert(std::same_as<storm::orm::statements::meta::m2m_related_t<std::deque<Course>>, Course>);
+static_assert(std::same_as<storm::orm::statements::meta::m2m_related_t<std::vector<std::unique_ptr<Course>>>, Course>);
+
+// ---- CRUD on a model WITH an m2m field ignores the container ----
+template <typename ConnType> class M2MBaseTest : public StormTestFixture<Student, ConnType, Course> {};
+TYPED_TEST_SUITE(M2MBaseTest, DatabaseTypes);
+
+TYPED_TEST(M2MBaseTest, PlainCrudIgnoresM2MField) {
+    QuerySet<Student, TypeParam> qs;
+    Student const s{.name = "Alice", .age = 20, .courses = {{.id = 99, .title = "ghost"}}};
+    auto ins = qs.insert(s).execute();
+    ASSERT_TRUE(ins.has_value()) << ins.error().message();
+
+    auto rows = qs.select().execute();
+    ASSERT_TRUE(rows.has_value()) << rows.error().message();
+    ASSERT_EQ(rows->size(), 1U);
+    EXPECT_EQ(rows->begin()->name, "Alice");
+    EXPECT_TRUE(rows->begin()->courses.empty()); // plain select never populates m2m
+}
+// NOLINTEND(misc-const-correctness)
+```
+
+- [ ] **Step 2.2:** Build → MUST fail (no `many_to_many`, no `M2MFieldOf`, `field_count_ == 4`).
+- [ ] **Step 2.3: Implement in `base.cppm`** — add to `namespace meta` (after `is_primary_attr`):
+
+```cpp
+// Many-to-many annotation (#203). Phase 1 (auto junction table):
+//   [[= storm::meta::many_to_many]] std::vector<Course> courses;
+// Phase 2 (explicit junction model):
+//   [[= storm::meta::many_to_many_through<Enrollment>]] std::vector<Course> courses;
+// FieldAttr is an enum, so the issue's FieldAttr::many_to_many<X> spelling is
+// impossible — a class-template annotation carries the optional through-model.
+template <typename Through = void> struct ManyToMany {
+    using through_type = Through;
+};
+inline constexpr ManyToMany<> many_to_many{};
+template <typename Through> inline constexpr ManyToMany<Through> many_to_many_through{};
+
+// Reflection of the ManyToMany<...> annotation TYPE on `member`, if any.
+consteval auto m2m_annotation_type_of(std::meta::info member) -> std::optional<std::meta::info> {
+    for (const auto annotation : std::meta::annotations_of(member)) {
+        const auto type = std::meta::type_of(annotation);
+        if (std::meta::has_template_arguments(type) && std::meta::template_of(type) == ^^ManyToMany) {
+            return type;
+        }
+    }
+    return std::nullopt;
+}
+
+consteval auto is_m2m_field(std::meta::info member) -> bool {
+    return m2m_annotation_type_of(member).has_value();
+}
+
+// Through model of an m2m member (void = auto junction table).
+template <std::meta::info Member>
+using m2m_through_t = typename[:std::meta::template_arguments_of(m2m_annotation_type_of(Member).value())[0]:];
+
+consteval auto is_m2m_auto(std::meta::info member) -> bool {
+    auto type = m2m_annotation_type_of(member);
+    return type.has_value() && std::meta::dealias(std::meta::template_arguments_of(type.value())[0]) == ^^void;
+}
+
+// Related model type from a container field type via C++26 std::meta (#203):
+// vector<Course> → Course, plf::hive<Track> → Track,
+// vector<shared_ptr<Course>> / vector<unique_ptr<Course>> → Course.
+consteval auto related_type_from_container(std::meta::info container_type) -> std::meta::info {
+    const auto first = std::meta::dealias(std::meta::template_arguments_of(std::meta::dealias(container_type))[0]);
+    if (std::meta::has_template_arguments(first)) {
+        const auto tmpl = std::meta::template_of(first);
+        if (tmpl == ^^std::shared_ptr || tmpl == ^^std::unique_ptr) {
+            return std::meta::dealias(std::meta::template_arguments_of(first)[0]);
+        }
+    }
+    return first;
+}
+
+template <typename Container>
+using m2m_related_t = typename[:related_type_from_container(^^Container):];
+```
+
+After `FKFieldOf`, add (BMI-safe: re-derive from `^^T` by identifier, same as `FKFieldOf` — annotation reads on a reflection that crossed a BMI boundary segfault clang-p2996 #262):
+
+```cpp
+// A many-to-many JOIN field selector must reflect a non-static data member of T
+// carrying a ManyToMany annotation (#203). Same BMI-boundary discipline as FKFieldOf.
+template <typename T, std::meta::info Member>
+concept M2MFieldOf = []() consteval {
+    if (!std::meta::is_nonstatic_data_member(Member) || !std::meta::has_identifier(Member)) {
+        return false;
+    }
+    if (std::meta::parent_of(Member) != ^^T) {
+        return false;
+    }
+    for (auto m : std::meta::nonstatic_data_members_of(^^T, std::meta::access_context::unchecked())) {
+        if (std::meta::identifier_of(m) == std::meta::identifier_of(Member)) {
+            return meta::is_m2m_field(m);
+        }
+    }
+    return false;
+}();
+
+// Through must carry exactly one FieldAttr::fk member of type Side (#203 Phase 2).
+template <typename Through, typename Side>
+concept ThroughWithFKTo = []() consteval {
+    std::size_t count = 0;
+    for (auto m : std::meta::nonstatic_data_members_of(^^Through, std::meta::access_context::unchecked())) {
+        auto attr = std::meta::annotation_of_type<meta::FieldAttr>(m);
+        if (attr.has_value() && attr.value() == meta::FieldAttr::fk &&
+            std::meta::dealias(std::meta::type_of(m)) == std::meta::dealias(^^Side)) {
+            ++count;
+        }
+    }
+    return count == 1;
+}();
+```
+
+Filter m2m members out of persisted fields — replace `get_field_count()` / `get_all_field_members()` bodies:
+
+```cpp
+// Number of PERSISTED fields — m2m container members map to a junction table,
+// not to a column, so they are invisible to INSERT/SELECT/UPDATE/SCHEMA (#203).
+static consteval auto get_field_count() -> std::size_t {
+    std::size_t count = 0;
+    for (const auto member : std::meta::nonstatic_data_members_of(^^T, std::meta::access_context::unchecked())) {
+        if (!meta::is_m2m_field(member)) {
+            ++count;
+        }
+    }
+    return count;
+}
+
+template <std::size_t N> static consteval auto get_all_field_members() -> std::array<std::meta::info, N> {
+    std::array<std::meta::info, N> result{};
+    std::size_t                    idx = 0;
+    for (const auto member : std::meta::nonstatic_data_members_of(^^T, std::meta::access_context::unchecked())) {
+        if (!meta::is_m2m_field(member) && idx < N) {
+            result[idx++] = member;
+        }
+    }
+    return result;
+}
+```
+
+In `src/storm.cppm`, inside `namespace meta`:
+
+```cpp
+using orm::statements::meta::ManyToMany;
+using orm::statements::meta::many_to_many;
+using orm::statements::meta::many_to_many_through;
+```
+
+- [ ] **Step 2.4:** Build + run `./build/debug/tests/storm_tests --gtest_filter="M2MBaseTest*"` → PASS; full `ctest --preset ninja-debug` → no regressions.
+- [ ] **Step 2.5:** Commit `feat(orm): ManyToMany annotation, m2m meta helpers, persisted-member filtering (#203)`.
+
+### Task 3: Auto-junction schema DDL (schema.cppm)
+
+- [ ] **Step 3.1: Failing tests** (append to `test_many_to_many.cpp`):
+
+```cpp
+TEST(M2MSchemaTest, JunctionTableSqlSQLite) {
+    const auto& sql = storm::orm::schema::SchemaStatement<Student>::junction_table_sql<storm::orm::schema::Dialect::SQLite>();
+    EXPECT_TRUE(sql.contains("CREATE TABLE Student_Course"));
+    EXPECT_TRUE(sql.contains("Student_id INTEGER NOT NULL"));
+    EXPECT_TRUE(sql.contains("Course_id INTEGER NOT NULL"));
+    EXPECT_TRUE(sql.contains("PRIMARY KEY (Student_id, Course_id)"));
+}
+TEST(M2MSchemaTest, JunctionTableSqlPostgreSQL) {
+    const auto& sql = storm::orm::schema::SchemaStatement<Student>::junction_table_sql<storm::orm::schema::Dialect::PostgreSQL>();
+    EXPECT_TRUE(sql.contains("Student_id BIGINT NOT NULL"));
+    EXPECT_TRUE(sql.contains("Course_id BIGINT NOT NULL"));
+}
+TYPED_TEST(M2MBaseTest, JunctionTableIsCreatedAndWritable) {
+    auto conn = QuerySet<Student, TypeParam>::get_default_connection();
+    // fixture already ran create_table_if_not_exists<Student> — junction must exist
+    auto ins = conn->execute("INSERT INTO Student_Course (Student_id, Course_id) VALUES (1, 1)");
+    ASSERT_TRUE(ins.has_value()) << ins.error().message();
+}
+```
+
+- [ ] **Step 3.2:** Build → fails (`junction_table_sql` missing).
+- [ ] **Step 3.3: Implement in `schema.cppm`:**
+
+```cpp
+// ---- Auto-junction table for ManyToMany fields without a through model (#203) ----
+// Scans RAW members (all_members_ excludes m2m fields by design).
+static consteval auto find_m2m_auto_member() -> std::optional<std::meta::info> {
+    for (auto m : std::meta::nonstatic_data_members_of(^^T, std::meta::access_context::unchecked())) {
+        if (statements::meta::is_m2m_auto(m)) {
+            return m;
+        }
+    }
+    return std::nullopt;
+}
+
+public:
+static constexpr bool has_m2m_junction_ = find_m2m_auto_member().has_value();
+
+private:
+template <Dialect D> static consteval auto build_junction_sql() {
+    constexpr auto member  = find_m2m_auto_member().value();
+    constexpr auto related = statements::meta::related_type_from_container(std::meta::type_of(member));
+    constexpr auto owner_name   = std::meta::identifier_of(^^T);
+    constexpr auto related_name = std::meta::identifier_of(related);
+    constexpr std::string_view id_type = (D == Dialect::PostgreSQL) ? "_id BIGINT NOT NULL" : "_id INTEGER NOT NULL";
+    ConstexprString<(owner_name.size() + related_name.size()) * 3 + 128> sql;
+    sql.append("CREATE TABLE ");
+    sql.append(owner_name); sql.append("_"); sql.append(related_name);
+    sql.append(" (\n    ");
+    sql.append(owner_name); sql.append(id_type);
+    sql.append(",\n    ");
+    sql.append(related_name); sql.append(id_type);
+    sql.append(",\n    PRIMARY KEY (");
+    sql.append(owner_name); sql.append("_id, ");
+    sql.append(related_name); sql.append("_id)\n)");
+    return sql;
+}
+```
+
+Pre-compute (guarded — only when junction exists, mirror existing per-dialect statics):
+
+```cpp
+// Junction SQL statics must be guarded: build_junction_sql() calls .value() on the
+// optional. Use if constexpr inside an immediately-invoked lambda OR specialize via
+// a requires-guarded accessor:
+public:
+template <Dialect D> static auto junction_table_sql() -> const std::string&
+    requires(has_m2m_junction_)
+{
+    if constexpr (D == Dialect::PostgreSQL) {
+        static const std::string str{std::string(build_junction_sql<Dialect::PostgreSQL>())};
+        return str;
+    } else {
+        static const std::string str{std::string(build_junction_sql<Dialect::SQLite>())};
+        return str;
+    }
+}
+```
+
+Extract the `IF NOT EXISTS` injection from `create_table_if_not_exists` into a shared helper (avoids Sonar duplication):
+
+```cpp
+// Rewrites "CREATE TABLE " → "CREATE TABLE IF NOT EXISTS " (idempotent DDL).
+static auto with_if_not_exists(std::string sql) -> std::string {
+    const std::string create_prefix = "CREATE TABLE ";
+    if (sql.starts_with(create_prefix)) {
+        sql.insert(create_prefix.size(), "IF NOT EXISTS ");
+    }
+    return sql;
+}
+```
+
+…and in `create_table_if_not_exists`, after the base-table execute succeeds:
+
+```cpp
+auto result = conn->execute(with_if_not_exists(std::move(sql)));
+if constexpr (has_m2m_junction_) {
+    if (!result) {
+        return result;
+    }
+    std::string jsql;
+    if constexpr (requires { ConnType::uses_pg_dialect; }) {
+        jsql = junction_table_sql<Dialect::PostgreSQL>();
+    } else {
+        jsql = junction_table_sql<Dialect::SQLite>();
+    }
+    return conn->execute(with_if_not_exists(std::move(jsql)));
+}
+return result;
+```
+
+- [ ] **Step 3.4:** Build, run `M2MSchemaTest*` + `M2MBaseTest*` → PASS. Full ctest → green.
+- [ ] **Step 3.5:** Commit `feat(schema): auto-generated junction table DDL for many_to_many fields (#203)`.
+
+### Task 4: M2MJoinStatement + wrapper extension + QuerySet dispatch (SQL only)
+
+- [ ] **Step 4.1: Failing SQL-shape tests** (append to `test_many_to_many.cpp`):
+
+```cpp
+TYPED_TEST(M2MBaseTest, M2MJoinSqlShape) {
+    QuerySet<Student, TypeParam> qs;
+    auto sql = qs.template join<^^Student::courses>().select().sql();
+    EXPECT_TRUE(sql.contains("FROM (SELECT id, name, age FROM Student) t1")) << sql;
+    EXPECT_TRUE(sql.contains("INNER JOIN Student_Course t2 ON t1.id = t2.Student_id")) << sql;
+    EXPECT_TRUE(sql.contains("INNER JOIN Course t3 ON t2.Course_id = t3.id")) << sql;
+    EXPECT_TRUE(sql.contains("t3.id, t3.title")) << sql;
+    EXPECT_TRUE(sql.ends_with(" ORDER BY t1.id")) << sql;
+}
+TYPED_TEST(M2MBaseTest, M2MJoinSqlModifiersGoInsideSubquery) {
+    QuerySet<Student, TypeParam> qs;
+    auto sql = qs.template join<^^Student::courses>()
+                       .where(storm::orm::where::field<^^Student::age>() > 18)
+                       .template order_by<^^Student::name, false>()
+                       .limit(2)
+                       .select()
+                       .sql();
+    EXPECT_TRUE(sql.contains("FROM Student WHERE age > ? ORDER BY name DESC LIMIT 2) t1")) << sql;
+    EXPECT_TRUE(sql.contains("ORDER BY t1.name DESC, t1.id")) << sql;
+}
+TYPED_TEST(M2MBaseTest, M2MLeftJoinSqlShape) {
+    QuerySet<Student, TypeParam> qs;
+    auto sql = qs.template left_join<^^Student::courses>().select().sql();
+    EXPECT_TRUE(sql.contains("LEFT JOIN Student_Course t2")) << sql;
+    EXPECT_TRUE(sql.contains("LEFT JOIN Course t3")) << sql;
+}
+```
+
+(Adjust the exact `where`-field include path to how other tests spell `field<...>()` — check `test_where.cpp` for the helper import.)
+
+- [ ] **Step 4.2:** Build → fails (constraint rejects m2m field selector).
+- [ ] **Step 4.3: Implement.**
+
+`join.cppm` — imports: add `import storm_orm_where;` and `import storm_orm_statements_orderby;`. Extend the wrapper:
+
+```cpp
+struct JoinStatementWrapper {
+    auto (*get_complete_sql_fn)() -> const std::string&;
+    auto (*extract_row_fn)(ErasedStatementPtr, ErasedObjectPtr) -> void;
+
+    // Many-to-many extension (#203) — nullptr for plain FK joins.
+    // M2M SQL depends on runtime WHERE/ORDER/LIMIT (they live INSIDE the base-table
+    // subquery), so the wrapper builds it per call instead of returning a static string.
+    auto (*build_m2m_sql_fn)(
+            const orm::where::ExpressionVariantPtr&,
+            const std::optional<OrderByWrapper>&,
+            const std::optional<int>&,
+            const std::optional<int>&) -> std::string                = nullptr;
+    auto (*extract_base_pk_fn)(ErasedStatementPtr) -> std::int64_t   = nullptr;
+    auto (*append_related_fn)(ErasedStatementPtr, ErasedObjectPtr) -> void = nullptr;
+
+    [[nodiscard]] auto is_m2m() const -> bool { return build_m2m_sql_fn != nullptr; }
+    // existing get_complete_sql / extract_row unchanged
+};
+```
+
+`M2MJoinStatement` (same file, after `JoinStatement`):
+
+```cpp
+template <typename T, storm::db::DatabaseConnection ConnType, JoinType Type, std::meta::info M2MField>
+    requires M2MFieldOf<T, M2MField> && (Type == JoinType::Inner || Type == JoinType::Left)
+class M2MJoinStatement : private BaseStatement<T> {
+    friend class BaseStatement<T>;
+    using Base      = BaseStatement<T>;
+    using Statement = typename ConnType::Statement;
+
+    // Re-derive the member from ^^T by identifier — annotation reads on a reflection
+    // that crossed a BMI boundary segfault clang-p2996 (#262), same as FKFieldOf.
+    static constexpr auto m2m_member_ = []() consteval {
+        for (auto m : std::meta::nonstatic_data_members_of(^^T, std::meta::access_context::unchecked())) {
+            if (std::meta::identifier_of(m) == std::meta::identifier_of(M2MField)) {
+                return m;
+            }
+        }
+        std::unreachable(); // M2MFieldOf<T, M2MField> guarantees a match
+    }();
+
+    using ContainerType = std::remove_cvref_t<typename[:std::meta::type_of(m2m_member_):]>;
+    using Related       = meta::m2m_related_t<ContainerType>;
+    using Through       = meta::m2m_through_t<m2m_member_>;
+    using RelatedBase   = BaseStatement<Related>;
+
+    static_assert(!std::same_as<Related, T>, "self-referential many-to-many is not supported (#203)");
+    static_assert(std::same_as<Through, void> || (ThroughWithFKTo<Through, T> && ThroughWithFKTo<Through, Related>),
+                  "through model must have exactly one FieldAttr::fk field for each side (#203)");
+
+    // ---- Junction descriptor -------------------------------------------------
+    template <typename Side> static consteval auto find_through_fk() -> std::meta::info {
+        for (auto m : std::meta::nonstatic_data_members_of(^^Through, std::meta::access_context::unchecked())) {
+            auto attr = std::meta::annotation_of_type<meta::FieldAttr>(m);
+            if (attr.has_value() && attr.value() == meta::FieldAttr::fk &&
+                std::meta::dealias(std::meta::type_of(m)) == std::meta::dealias(^^Side)) {
+                return m;
+            }
+        }
+        std::unreachable(); // ThroughWithFKTo guarantees a match
+    }
+
+    static consteval auto junction_table() -> std::string_view {
+        if constexpr (std::same_as<Through, void>) { /* build "<T>_<Related>" ConstexprString — see below */ }
+        else { return std::meta::identifier_of(^^Through); }
+    }
+    // For Through==void the name must live in static storage:
+    static constexpr auto junction_table_arr_ = []() consteval {
+        ConstexprString<Base::table_name_.size() + RelatedBase::table_name_.size() + 2> s;
+        s.append(Base::table_name_); s.append("_"); s.append(RelatedBase::table_name_);
+        return s;
+    }();
+    static constexpr std::string_view junction_table_v_ =
+        std::same_as<Through, void> ? junction_table_arr_.view() : std::meta::identifier_of(^^Through);
+
+    static constexpr auto owner_col_arr_ = []() consteval {
+        // auto:    "<T>_id";      through: "<fk-field>_id"
+        ... append name + "_id" into ConstexprString sized name+4 ...
+    }();
+    static constexpr auto related_col_arr_ = ...same for Related side...;
+```
+
+(For the two `_col_arr_` builders: when `Through == void` the name is `Base::table_name_` / `RelatedBase::table_name_`; otherwise `std::meta::identifier_of(find_through_fk<T>())` / `<Related>()`. `if constexpr` inside the consteval lambda; size the buffer with the max of both candidates or just `64 + table_name_.size()`.)
+
+```cpp
+    // ---- Pre-computed SQL fragments -------------------------------------------
+    // select_prefix_: "SELECT t1.<c1>, …, t3.<r1>, … FROM (SELECT <cols> FROM <T>"
+    // join_suffix_:   ") t1 <KW> <junction> t2 ON t1.<pk> = t2.<owner_col> <KW> <Related> t3 ON t2.<related_col> = t3.<rpk>"
+    // Sizes: reuse the calculate-then-build pattern from JoinStatement with
+    // utilities::sql_len::SMALL_BUFFER slack. t1 list = for each Base::all_members_
+    // entry: "t1." + identifier (+ "_id" if Base::is_fk_field). t3 list likewise over
+    // RelatedBase::all_members_ with Base::is_fk_field (static, works on any member).
+    static constexpr auto select_prefix_arr_ = build_select_prefix();
+    static constexpr auto join_suffix_arr_   = build_join_suffix();
+
+    static consteval auto pk_index_in(/* members array, pk */) -> int; // position of pk column
+    static constexpr int base_pk_col_    = /* index of Base::primary_key_ in Base::all_members_ */;
+    static constexpr int related_pk_col_ = /* offset = Base::field_count_ + index of RelatedBase pk */;
+
+  public:
+    static auto get_complete_sql() -> const std::string& {
+        static const std::string str =
+                std::string(select_prefix_arr_.view()) + std::string(join_suffix_arr_.view());
+        return str;
+    }
+
+    // Build the full query. WHERE / inner ORDER BY / LIMIT / OFFSET apply to BASE
+    // entities (inside the subquery). The outer ORDER BY repeats the user's ordering
+    // qualified with t1. and appends t1.<pk> so one entity's rows are always adjacent
+    // (the aggregation loop in select.cppm relies on this).
+    static auto build_m2m_sql(
+            const orm::where::ExpressionVariantPtr& where_expr,
+            const std::optional<OrderByWrapper>&    order_by,
+            const std::optional<int>&               limit,
+            const std::optional<int>&               offset) -> std::string {
+        std::string sql{select_prefix_arr_.view()};
+        if (where_expr) {
+            sql += " WHERE ";
+            sql += orm::where::to_sql(*where_expr);
+        }
+        Base::template append_order_by<ConnType>(sql, order_by);
+        Base::template append_limit_offset<ConnType>(sql, limit, offset);
+        sql += join_suffix_arr_.view();
+        append_outer_order_by(sql, order_by);
+        return sql;
+    }
+
+  private:
+    static auto append_outer_order_by(std::string& sql, const std::optional<OrderByWrapper>& order_by) -> void {
+        sql += " ORDER BY ";
+        if (order_by.has_value() && !order_by->empty()) {
+            // wrapper format is exactly " ORDER BY <f> [COLLATE …] ASC|DESC, …"
+            std::string fields = order_by->get_order_by_sql().substr(10); // strip " ORDER BY "
+            std::string qualified = "t1." + fields;
+            std::size_t pos = 0;
+            while ((pos = qualified.find(", ", pos)) != std::string::npos) {
+                qualified.insert(pos + 2, "t1.");
+                pos += 5;
+            }
+            if constexpr (requires { ConnType::uses_pg_dialect; }) {
+                Base::adapt_order_by_for_pg(qualified);
+            }
+            sql += qualified;
+            sql += ", ";
+        }
+        sql += "t1.";
+        sql += Base::pk_name_;
+    }
+
+  public:
+    // Row 1 of an entity: base columns + first related row (if any).
+    static auto extract_joined_row(Statement* stmt, T& obj) noexcept -> void {
+        Base::template extract_all_columns(stmt, obj);
+        append_related(stmt, obj);
+    }
+
+    static auto extract_base_pk(Statement* stmt) noexcept -> std::int64_t {
+        return stmt->extract_int64(base_pk_col_);
+    }
+
+    // Append the current row's related object into obj's container member.
+    // LEFT JOIN emits NULL related columns for entities with no relations — skip.
+    static auto append_related(Statement* stmt, T& obj) noexcept -> void {
+        if constexpr (Type == JoinType::Left) {
+            if (stmt->is_null(related_pk_col_)) {
+                return;
+            }
+        }
+        Related rel{};
+        extract_related(stmt, rel, std::make_index_sequence<RelatedBase::field_count_>{});
+        using Elem = typename ContainerType::value_type;
+        if constexpr (utilities::is_shared_ptr_v<Elem>) {
+            insert_into(obj.[:m2m_member_:], std::make_shared<Related>(std::move(rel)));
+        } else {
+            insert_into(obj.[:m2m_member_:], std::move(rel));
+        }
+    }
+
+  private:
+    template <typename C, typename V> static auto insert_into(C& container, V&& value) -> void {
+        if constexpr (requires { container.push_back(std::forward<V>(value)); }) {
+            container.push_back(std::forward<V>(value));
+        } else {
+            container.insert(std::forward<V>(value)); // plf::hive, std::set
+        }
+    }
+
+    template <std::size_t... Is>
+    static auto extract_related(Statement* stmt, Related& rel, std::index_sequence<Is...>) noexcept -> void {
+        ((extract_related_at<Is>(stmt, rel)), ...);
+    }
+    template <std::size_t I> static auto extract_related_at(Statement* stmt, Related& rel) noexcept -> void {
+        constexpr auto member  = RelatedBase::all_members_[I];
+        constexpr int  col     = static_cast<int>(Base::field_count_ + I);
+        using FieldType        = std::remove_cvref_t<decltype(rel.[:member:])>;
+        if constexpr (Base::is_fk_field(member)) {
+            // FK column of the related model holds only the foreign pk (same as plain SELECT)
+            ...mirror Base::extract_column_fast's fk branch with explicit col...
+        } else {
+            rel.[:member:] = Base::template extract_column_value<FieldType>(stmt, col);
+        }
+    }
+};
+
+template <typename T, storm::db::DatabaseConnection ConnType, JoinType Type, std::meta::info M2MField>
+    requires M2MFieldOf<T, M2MField>
+[[nodiscard]] auto make_m2m_join_wrapper() -> JoinStatementWrapper {
+    using JS = M2MJoinStatement<T, ConnType, Type, M2MField>;
+    return JoinStatementWrapper{
+            +[]() -> const std::string& { return JS::get_complete_sql(); },
+            +[](ErasedStatementPtr stmt, ErasedObjectPtr obj) -> void {
+                JS::extract_joined_row(static_cast<typename ConnType::Statement*>(stmt), *static_cast<T*>(obj));
+            },
+            +[](const orm::where::ExpressionVariantPtr& we, const std::optional<OrderByWrapper>& ob,
+                const std::optional<int>& limit, const std::optional<int>& offset) -> std::string {
+                return JS::build_m2m_sql(we, ob, limit, offset);
+            },
+            +[](ErasedStatementPtr stmt) -> std::int64_t {
+                return JS::extract_base_pk(static_cast<typename ConnType::Statement*>(stmt));
+            },
+            +[](ErasedStatementPtr stmt, ErasedObjectPtr obj) -> void {
+                JS::append_related(static_cast<typename ConnType::Statement*>(stmt), *static_cast<T*>(obj));
+            }
+    };
+}
+```
+
+Add `is_shared_ptr_v` to `utilities.cppm` next to `is_optional_v`:
+
+```cpp
+template <typename T> struct is_shared_ptr : std::false_type {};
+template <typename U> struct is_shared_ptr<std::shared_ptr<U>> : std::true_type {};
+template <typename T> constexpr bool is_shared_ptr_v = is_shared_ptr<T>::value;
+```
+
+`queryset.cppm` — relax `join()`/`left_join()` (right_join stays FK-only):
+
+```cpp
+template <std::meta::info... FKFields>
+    requires(sizeof...(FKFields) >= 1 &&
+             ((orm::statements::FKFieldOf<T, FKFields> && ...) ||
+              (sizeof...(FKFields) == 1 && (orm::statements::M2MFieldOf<T, FKFields> && ...))))
+[[nodiscard]] auto join() const -> QuerySet {
+    auto result = clone_state();
+    if constexpr ((orm::statements::M2MFieldOf<T, FKFields> && ...)) {
+        result.join_stmt_ = orm::statements::
+                make_m2m_join_wrapper<T, ConnType, orm::statements::JoinType::Inner, FKFields...[0]>();
+    } else {
+        result.join_stmt_ =
+                orm::statements::make_join_wrapper<T, ConnType, orm::statements::JoinType::Inner, FKFields...>();
+    }
+    return result;
+}
+```
+
+(same for `left_join` with `JoinType::Left`).
+
+`select.cppm` — `build_sql` m2m branch (this makes `.sql()` produce the right string before the runtime loop exists):
+
+```cpp
+std::string sql;
+if (join_wrapper && join_wrapper->is_m2m()) {
+    return join_wrapper->build_m2m_sql_fn(where_expr, order_by_wrapper, limit, offset);
+}
+sql = join_wrapper ? join_wrapper->get_complete_sql() : std::string(get_select_sql());
+// …existing tail unchanged
+```
+
+- [ ] **Step 4.4:** Build, run `M2MBaseTest*` SQL tests → PASS. Full ctest → green (regular joins unaffected — `make_join_wrapper` leaves new pointers defaulted to nullptr).
+- [ ] **Step 4.5:** Commit `feat(orm): M2MJoinStatement — 3-table join SQL over base subquery (#203)`.
+
+### Task 5: select() aggregation loop
+
+- [ ] **Step 5.1: Failing runtime tests** (append; add a seeding helper in `test_m2m_models.h`):
+
+```cpp
+// Seeds: Alice(20)→[Math,Physics], Bob(22)→[Math], Carol(25)→[] (no courses)
+template <typename ConnType> inline auto seed_students() -> void {
+    storm::QuerySet<Student, ConnType> sqs;
+    std::vector<Student> const students = {{.name = "Alice", .age = 20}, {.name = "Bob", .age = 22},
+                                           {.name = "Carol", .age = 25}};
+    ASSERT_TRUE(sqs.insert(std::span<const Student>(students)).execute().has_value());
+    storm::QuerySet<Course, ConnType> cqs;
+    std::vector<Course> const courses = {{.title = "Math"}, {.title = "Physics"}};
+    ASSERT_TRUE(cqs.insert(std::span<const Course>(courses)).execute().has_value());
+    auto conn = storm::QuerySet<Student, ConnType>::get_default_connection();
+    for (const auto* pair : {"(1, 1)", "(1, 2)", "(2, 1)"}) {
+        ASSERT_TRUE(conn->execute(std::format("INSERT INTO Student_Course (Student_id, Course_id) VALUES {}", pair))
+                            .has_value());
+    }
+}
+```
+
+Tests: `EagerLoadAggregatesCourses` (2 students returned, Alice has 2 courses [Math, Physics], Bob 1, Carol absent — INNER), `LeftJoinKeepsStudentsWithoutCourses` (3 students, Carol's container empty), `EmptyResultSet` (where age > 99 → 0 rows), `NoRelatedRecordsInnerDrops` (already covered by Carol), duplicate-base-dedup (`rows->size() == 2`, not 3 joined rows).
+
+- [ ] **Step 5.2:** Run → FAIL (execute uses per-row extract; returns 3 Student rows with 1 course each).
+- [ ] **Step 5.3: Implement in `select.cppm`:** in `execute()`:
+
+```cpp
+if (join_wrapper) {
+    if (join_wrapper->is_m2m()) {
+        return execute_m2m_loop(stmt_ptr, *join_wrapper);
+    }
+    return execute_query_loop(...existing...);
+}
+```
+
+New private loop (rows for one entity are adjacent thanks to the outer `ORDER BY …, t1.<pk>`):
+
+```cpp
+// M2M aggregation loop (#203): deduplicate base rows, append related objects.
+// Relies on M2MJoinStatement's outer ORDER BY making same-entity rows adjacent.
+[[nodiscard]] auto execute_m2m_loop(Statement* stmt, const JoinStatementWrapper& jw) noexcept
+        -> std::expected<plf::hive<T>, Error> {
+    plf::hive<T> results;
+    T*           current     = nullptr;
+    std::int64_t current_pk  = 0;
+    int          step_result = 0;
+    while ((step_result = stmt->step_raw()) == Statement::ROW_AVAILABLE) {
+        const std::int64_t pk = jw.extract_base_pk_fn(stmt);
+        if (current == nullptr || pk != current_pk) {
+            T obj;
+            jw.extract_row(stmt, &obj);
+            current    = &*results.insert(std::move(obj)); // plf::hive: stable pointers
+            current_pk = pk;
+        } else {
+            jw.append_related_fn(stmt, current);
+        }
+    }
+    if (step_result != Statement::NO_MORE_ROWS) {
+        stmt->reset();
+        return std::unexpected(Error{step_result, stmt->get_error_message()});
+    }
+    stmt->reset();
+    return results;
+}
+```
+
+- [ ] **Step 5.4:** Tests PASS; full ctest green.
+- [ ] **Step 5.5:** Commit `feat(orm): m2m eager-load aggregation in select() (#203)`.
+
+### Task 6: Modifiers + first()/get()/rows() (new file `tests/query/test_many_to_many_modifiers.cpp`)
+
+- [ ] **Step 6.1: Failing tests** (same fixture/seed include):
+  - `WhereFiltersBaseEntities`: `where(age >= 22)` + join → only Bob (INNER); Bob has Math.
+  - `WhereAllSixOperators`: `==, !=, >, >=, <, <=` on age — assert returned student sets (checklist).
+  - `WhereInBetweenLike`: `field.in(20,25)`, `field.between(19,21)`, `name.like("A%")`, plus `(A && B) || C` combo.
+  - `OrderByOrdersStudents`: `order_by<^^Student::name, false>()` → first element Bob, second Alice; each with full courses.
+  - `LimitLimitsStudentsNotRows`: `limit(1)` + join → exactly 1 student (Alice) with BOTH courses.
+  - `OffsetSkipsStudents`: `limit(1).offset(1)` (with order_by name ASC) → Bob with Math.
+  - `FirstReturnsCompleteEntity`: `.first().execute()` → Alice with 2 courses.
+  - `FirstOnEmpty`: where age>99 → nullopt.
+  - `GetExactlyOne`: `where(name == "Bob")` + join + `.get().execute()` → Bob, 1 course.
+  - `GetZeroRowsIsError` / `GetMultipleRowsIsError` (no where → 2 students).
+  - `RowsGeneratorYieldsAggregated`: iterate `qs.join<...>().rows()` → 2 yielded students, Alice 2 courses, Bob 1.
+  - `RepeatedQueryUsesCache`: run the same join select twice, second result identical (statement caching).
+  - `DifferentQueriesSameQuerySet`: plain select after m2m join select on same base QuerySet (immutability — base unaffected).
+- [ ] **Step 6.2:** Run → first/get/rows FAIL (single-row extraction truncates; rows yields per-joined-row).
+- [ ] **Step 6.3: Implement in `select.cppm`:**
+  - `execute_one` m2m branch: run `execute_m2m_loop`, then `results.empty() ? nullopt : std::move(*results.begin())` (limit 1 already applied inside subquery by build_sql).
+  - `execute_get` m2m branch: loop with limit 2 in SQL; `size()==0` → `Error{-1, "No row found matching query"}`; `>1` → `Error{-1, "Multiple rows found matching query"}`; else value.
+  - `rows_generator` m2m branch: adjacency grouping:
+
+```cpp
+if (join_wrapper && join_wrapper->is_m2m()) {
+    std::optional<T> current;
+    std::int64_t     current_pk  = 0;
+    int              step_result = 0;
+    while ((step_result = stmt.step_raw()) == Statement::ROW_AVAILABLE) {
+        const std::int64_t pk = join_wrapper->extract_base_pk_fn(&stmt);
+        if (!current.has_value()) {
+            current.emplace();
+            join_wrapper->extract_row(&stmt, &*current);
+        } else if (pk != current_pk) {
+            co_yield std::move(*current);
+            current.emplace();
+            join_wrapper->extract_row(&stmt, &*current);
+        } else {
+            join_wrapper->append_related_fn(&stmt, &*current);
+        }
+        current_pk = pk;
+    }
+    if (step_result != Statement::NO_MORE_ROWS) {
+        co_yield std::unexpected(Error{step_result, stmt.get_error_message()});
+        co_return;
+    }
+    if (current.has_value()) {
+        co_yield std::move(*current);
+    }
+    co_return;
+}
+```
+
+  (Keep the coroutine body flat — `co_yield` can't live in a lambda. If the existing single coroutine grows too complex for lizard/tidy thresholds, split the m2m variant into a separate private generator function called from `rows_generator`.)
+  - first()/get() in `queryset.cppm`: the `fast` flag already excludes joins; no change needed.
+- [ ] **Step 6.4:** PASS + full ctest green.
+- [ ] **Step 6.5:** Commit `feat(orm): m2m support for first/get/rows + modifier integration (#203)`.
+
+### Task 7: Container coverage (hive, shared_ptr)
+
+- [ ] **Step 7.1: Failing tests** (in `test_many_to_many.cpp`): fixtures for `Playlist`/`Track` and `Album`/`Track`; seed via junction inserts (`Playlist_Track`, `Album_Track`); assert eager load fills `plf::hive<Track>` (covers `insert_into`'s `insert` branch) and `vector<shared_ptr<Track>>` (covers `make_shared` branch; assert `(*tracks[0]).title`). SQLite-only is fine if PG fixtures get heavy — but TYPED_TEST costs nothing extra; keep typed.
+- [ ] **Step 7.2:** Run → FAIL (tables missing → fixture creates them; if code from Task 5 is complete these may pass immediately — that's acceptable; they're coverage tests for the two append branches).
+- [ ] **Step 7.3:** Fix anything that falls out; run; commit `test(orm): m2m container coverage — plf::hive + shared_ptr elements (#203)`.
+
+### Task 8: Phase 2 — explicit through model (`tests/query/test_many_to_many_through.cpp`)
+
+- [ ] **Step 8.1: Failing tests:**
+
+```cpp
+TYPED_TEST(M2MThroughTest, ThroughSqlUsesJunctionModel) {
+    QuerySet<Pupil, TypeParam> qs;
+    auto sql = qs.template join<^^Pupil::courses>().select().sql();
+    EXPECT_TRUE(sql.contains("INNER JOIN Enrollment t2 ON t1.id = t2.pupil_id")) << sql;
+    EXPECT_TRUE(sql.contains("INNER JOIN Course t3 ON t2.course_id = t3.id")) << sql;
+}
+```
+
+  - `ThroughEagerLoadIgnoresMetadata`: seed pupils/courses + `QuerySet<Enrollment>` inserts (with grade strings); join → courses aggregated, metadata invisible.
+  - `ThroughJunctionQueriedDirectlyForMetadata`: `QuerySet<Enrollment>().join<^^Enrollment::pupil, ^^Enrollment::course>().select()` → existing FK join machinery returns enrollments with embedded Pupil + Course and the `grade` field (this also proves a through model whose FK target has an m2m field compiles — `BaseStatement<Pupil>` filtering).
+  - `ThroughWithWhereAndOrderAndLimit`: one combined modifier test (subquery placement identical to Phase 1).
+  - Fixture: `StormTestFixture<Pupil, ConnType, Course, Enrollment>`. NOTE: `Pupil` has a through-m2m field — `has_m2m_junction_` is false (no AUTO junction) so no junction DDL; Enrollment's table comes from `ensure_tables`.
+- [ ] **Step 8.2:** Run → FAIL if any through-path bug exists (`find_through_fk`, table name). All `if constexpr (std::same_as<Through, void>)` branches get their `else` exercised here.
+- [ ] **Step 8.3:** Fix; PASS; full ctest. Commit `feat(orm): Phase 2 explicit through-model m2m joins (#203)`.
+
+### Task 9: Quality gates (run in this order)
+
+- [ ] **Step 9.1:** Coverage: `cmake --build --preset ninja-debug-coverage --target coverage` — new code at 100% (project standard). Mark consteval-only lines `LCOV_EXCL` per existing conventions if llvm-cov misattributes.
+- [ ] **Step 9.2:** Release build + full test: `cmake --preset ninja-release && cmake --build --preset ninja-release && ctest --preset ninja-release` (release exposes template bugs debug hides — memory: spike under-tested at debug-only).
+- [ ] **Step 9.3:** Benchmarks (Release): `./build/release/benchmarks/storm_bench --benchmark_filter='Storm/SELECT/.*'` vs develop — wrapper gained 3 nullptr fn pointers and execute() one `is_m2m()` branch per query (not per row). If delta <2% treat as noise only with interleaved A/B runs (dev,feat alternating ×5, median-of-medians — memory lesson). Revert approach if ANY real slowdown: move m2m fns out of `JoinStatementWrapper` into a separate optional member.
+- [ ] **Step 9.4:** Sanitizers: `cmake --preset ninja-asan-ubsan && cmake --build --preset ninja-asan-ubsan && ctest --preset ninja-asan-ubsan` (timeout 900+, ASAN is 4-5× slower) and same for `ninja-tsan`.
+- [ ] **Step 9.5:** clang-tidy: `bash scripts/run_clang_tidy.sh --diff 2>&1 | tee /tmp/tidy_203.txt` — fix all new warnings.
+- [ ] **Step 9.6:** Re-glob before commit if needed: `cmake --preset ninja-debug` (new test files added).
+
+### Task 10: Documentation + agent files
+
+- [ ] **Step 10.1:** `docs/features/JOIN_OPERATIONS.md` — new "Many-to-Many Joins" section: both annotations, junction naming convention, subquery semantics for WHERE/ORDER/LIMIT (base entities), INNER vs LEFT empty-relation behavior, aggregate-counts-pairs note, write-side out of scope.
+- [ ] **Step 10.2:** `docs/reference/FIELD_TYPES.md` — m2m container field types (vector/hive/deque/shared_ptr elements), "not a column" semantics.
+- [ ] **Step 10.3:** `CLAUDE.md` — QuerySet API section: add m2m join example; Supported Field Types note.
+- [ ] **Step 10.4:** Grep `.claude/agents/*.md` for join/FieldAttr descriptions; update any that enumerate FieldAttr values or join capabilities (Critical Safety Rule 8).
+- [ ] **Step 10.5:** No new `.md` files (convention: ASK first — everything fits existing docs). Commit docs together with any remaining code tweaks.
+
+### Task 11: Ship
+
+- [ ] **Step 11.1:** `git status --short`, review file list (never `git add -A` — add explicitly).
+- [ ] **Step 11.2:** Final commit; push; `gh pr create --base develop` with `Closes #203`, documenting the API deviations (decision list above).
+- [ ] **Step 11.3:** Check off issue #203 subtask checkboxes that were genuinely delivered (`gh issue edit 203 --body ...`) BEFORE merging; explicitly note out-of-scope items (write-side API; `std::list` runtime; circular m2m) in a PR/issue comment.
+- [ ] **Step 11.4:** Wait 30s → `/sonarcloud-status`; fix until clean; `gh pr checks --watch`; merge `--squash`; `gh issue close 203`; `git checkout develop && git pull`.
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** Phase 1 attribute ✓ (T2), type extraction incl. hive/smart-ptr ✓ (T2/T7), junction naming ✓ (T4), FK column auto-detection ✓ (T4), 3-table JOIN ✓ (T4), aggregation ✓ (T5), single m2m per model ✓ (design), Phase 2 through model ✓ (T8), metadata ignored ✓ (T8), WHERE/ORDER/LIMIT/first/get/rows ✓ (T6), empty results + no-related ✓ (T5), caching ✓ (T6), both backends ✓ (TYPED_TEST), benchmark ✓ (T9), docs ✓ (T10). Out of scope (reported, not silently dropped): self-referential m2m (compile-error), multiple m2m fields per model (Phase 1 plan line says single), `std::deque`/`std::list` runtime path (deque covered at CT; push_back branch covered by vector), circular relationships.
+- **Risk register:** (1) annotation on member with template-value `many_to_many_through<Enrollment>` + incomplete type — validated in T2 or adjust model ordering; (2) `substr(10)` magic for ORDER BY qualification — wrapper format is fixed, add a comment + assert in tests; (3) coverage of `if constexpr` Inner/Left branches — both join types tested; (4) PG identifier folding (`Student_Course` → `student_course`) — harmless, all references unquoted.

--- a/scripts/run_clang_tidy.sh
+++ b/scripts/run_clang_tidy.sh
@@ -136,8 +136,8 @@ echo ""
 #   them standalone and hits missing storm symbols:
 #   tests/test_models.h, tests/test_seed_helpers.h, tests/test_select_runner.h,
 #   tests/test_write_runner.h, tests/test_yaml_register.h,
-#   tests/query/test_aggregate_fixture.h, tests/test_parser.hpp,
-#   tests/tools/storm_schema/models.h
+#   tests/query/test_aggregate_fixture.h, tests/query/test_m2m_models.h,
+#   tests/test_parser.hpp, tests/tools/storm_schema/models.h
 #
 #   benchmarks/bench_register.h — includes benchmark/benchmark.h which
 #   clang-tidy cannot parse (gbench macro / linkage issue).
@@ -167,6 +167,7 @@ is_known_unparseable() {
         tests/test_write_runner.h) return 0 ;;
         tests/test_yaml_register.h) return 0 ;;
         tests/query/test_aggregate_fixture.h) return 0 ;;
+        tests/query/test_m2m_models.h) return 0 ;;
         tests/test_parser.hpp) return 0 ;;
         tests/tools/storm_schema/models.h) return 0 ;;
         benchmarks/bench_register.h) return 0 ;;

--- a/src/orm/queryset.cppm
+++ b/src/orm/queryset.cppm
@@ -232,31 +232,52 @@ export namespace storm {
             return StmtType{conn_, where_expr_, join_stmt_, limit_value_, offset_value_, order_by_wrapper_};
         }
 
-        // INNER JOIN support for single or multiple FK fields
+        // INNER JOIN support for FK fields or a single many-to-many field (#203)
         // Immutable: returns a new QuerySet with the join attached (Django-style).
         // Usage:
         //   Single FK: message_qs.join<^^Message::sender>().select()
         //   Multi FK:  message_qs.join<^^Message::sender, ^^Message::receiver>().select()
+        //   M2M:       student_qs.join<^^Student::courses>().select()
         template <std::meta::info... FKFields>
-            requires(sizeof...(FKFields) >= 1 && (orm::statements::FKFieldOf<T, FKFields> && ...))
+            requires(
+                    sizeof...(FKFields) >= 1 &&
+                    ((orm::statements::FKFieldOf<T, FKFields> && ...) ||
+                     (sizeof...(FKFields) == 1 && (orm::statements::M2MFieldOf<T, FKFields> && ...)))
+            )
         [[nodiscard]] auto join() const -> QuerySet {
             auto result = clone_state();
-            result.join_stmt_ =
-                    orm::statements::make_join_wrapper<T, ConnType, orm::statements::JoinType::Inner, FKFields...>();
+            if constexpr ((orm::statements::M2MFieldOf<T, FKFields> && ...)) {
+                result.join_stmt_ = orm::statements::
+                        make_m2m_join_wrapper<T, ConnType, orm::statements::JoinType::Inner, FKFields...[0]>();
+            } else {
+                result.join_stmt_ = orm::statements::
+                        make_join_wrapper<T, ConnType, orm::statements::JoinType::Inner, FKFields...>();
+            }
             return result;
         }
 
-        // LEFT JOIN support for single or multiple FK fields
+        // LEFT JOIN support for FK fields or a single many-to-many field (#203).
+        // For m2m, LEFT JOIN keeps base entities with no relations (empty container).
         // Immutable: returns a new QuerySet with the join attached.
         // Usage:
         //   Single FK: message_qs.left_join<^^Message::sender>().select()
         //   Multi FK:  message_qs.left_join<^^Message::sender, ^^Message::receiver>().select()
+        //   M2M:       student_qs.left_join<^^Student::courses>().select()
         template <std::meta::info... FKFields>
-            requires(sizeof...(FKFields) >= 1 && (orm::statements::FKFieldOf<T, FKFields> && ...))
+            requires(
+                    sizeof...(FKFields) >= 1 &&
+                    ((orm::statements::FKFieldOf<T, FKFields> && ...) ||
+                     (sizeof...(FKFields) == 1 && (orm::statements::M2MFieldOf<T, FKFields> && ...)))
+            )
         [[nodiscard]] auto left_join() const -> QuerySet {
             auto result = clone_state();
-            result.join_stmt_ =
-                    orm::statements::make_join_wrapper<T, ConnType, orm::statements::JoinType::Left, FKFields...>();
+            if constexpr ((orm::statements::M2MFieldOf<T, FKFields> && ...)) {
+                result.join_stmt_ = orm::statements::
+                        make_m2m_join_wrapper<T, ConnType, orm::statements::JoinType::Left, FKFields...[0]>();
+            } else {
+                result.join_stmt_ =
+                        orm::statements::make_join_wrapper<T, ConnType, orm::statements::JoinType::Left, FKFields...>();
+            }
             return result;
         }
 

--- a/src/orm/schema.cppm
+++ b/src/orm/schema.cppm
@@ -612,7 +612,7 @@ export namespace storm::orm::schema {
         // Pre-computed junction CREATE TABLE SQL for the given dialect (#203).
         template <Dialect D = Dialect::SQLite>
         static auto junction_table_sql() -> const std::string&
-            requires(has_m2m_junction_)
+            requires has_m2m_junction_
         {
             if constexpr (D == Dialect::PostgreSQL) {
                 static const std::string str{std::string(build_junction_sql<Dialect::PostgreSQL>())};

--- a/src/orm/schema.cppm
+++ b/src/orm/schema.cppm
@@ -554,7 +554,74 @@ export namespace storm::orm::schema {
         // Pre-computed index SQL strings
         static inline const std::vector<std::string> index_sql_strings_ = build_all_index_sql();
 
+        // =====================================================================
+        // AUTO-JUNCTION TABLE for many_to_many fields without a through model (#203)
+        // =====================================================================
+
+        // Scans RAW members — all_members_ excludes m2m fields by design.
+        static consteval auto find_m2m_auto_member() -> std::optional<std::meta::info> {
+            for (auto member : std::meta::nonstatic_data_members_of(^^T, std::meta::access_context::unchecked())) {
+                if (statements::meta::is_m2m_auto(member)) {
+                    return member;
+                }
+            }
+            return std::nullopt;
+        }
+
+        // Junction DDL: <T>_<Related> (<T>_id, <Related>_id, PRIMARY KEY (both)).
+        // The composite PK rejects duplicate relation pairs and doubles as the index.
+        template <Dialect D> static consteval auto build_junction_sql() {
+            constexpr auto member       = find_m2m_auto_member().value();
+            constexpr auto related      = statements::meta::related_type_from_container(std::meta::type_of(member));
+            constexpr auto owner_name   = std::meta::identifier_of(^^T);
+            constexpr auto related_name = std::meta::identifier_of(related);
+            constexpr std::string_view id_type =
+                    (D == Dialect::PostgreSQL) ? "_id BIGINT NOT NULL" : "_id INTEGER NOT NULL";
+            ConstexprString<((owner_name.size() + related_name.size()) * 3) + 128> sql;
+            sql.append("CREATE TABLE ");
+            sql.append(owner_name);
+            sql.append("_");
+            sql.append(related_name);
+            sql.append(" (\n    ");
+            sql.append(owner_name);
+            sql.append(id_type);
+            sql.append(",\n    ");
+            sql.append(related_name);
+            sql.append(id_type);
+            sql.append(",\n    PRIMARY KEY (");
+            sql.append(owner_name);
+            sql.append("_id, ");
+            sql.append(related_name);
+            sql.append("_id)\n)");
+            return sql;
+        }
+
+        // Rewrites "CREATE TABLE " → "CREATE TABLE IF NOT EXISTS " (idempotent DDL).
+        static auto with_if_not_exists(std::string sql) -> std::string {
+            const std::string create_prefix = "CREATE TABLE ";
+            if (sql.starts_with(create_prefix)) {
+                sql.insert(create_prefix.size(), "IF NOT EXISTS ");
+            }
+            return sql;
+        }
+
       public:
+        // True when T has a many_to_many field with an auto-generated junction table.
+        static constexpr bool has_m2m_junction_ = find_m2m_auto_member().has_value();
+
+        // Pre-computed junction CREATE TABLE SQL for the given dialect (#203).
+        template <Dialect D = Dialect::SQLite>
+        static auto junction_table_sql() -> const std::string&
+            requires(has_m2m_junction_)
+        {
+            if constexpr (D == Dialect::PostgreSQL) {
+                static const std::string str{std::string(build_junction_sql<Dialect::PostgreSQL>())};
+                return str;
+            } else {
+                static const std::string str{std::string(build_junction_sql<Dialect::SQLite>())};
+                return str;
+            }
+        }
         // Return the pre-computed CREATE TABLE SQL for the given dialect.
         template <Dialect D = Dialect::SQLite> static auto create_table_sql() -> const std::string& {
             if constexpr (D == Dialect::PostgreSQL) {
@@ -587,21 +654,17 @@ export namespace storm::orm::schema {
         template <db::DatabaseConnection ConnType>
         static auto create_table_if_not_exists(std::shared_ptr<ConnType> conn)
                 -> std::expected<void, typename ConnType::Error> {
-            std::string sql;
-            if constexpr (requires { ConnType::uses_pg_dialect; }) {
-                sql = create_table_sql<Dialect::PostgreSQL>();
-            } else {
-                sql = create_table_sql<Dialect::SQLite>();
-            }
+            constexpr Dialect dialect = requires { ConnType::uses_pg_dialect; } ? Dialect::PostgreSQL : Dialect::SQLite;
 
-            // Inject IF NOT EXISTS
-            const std::string create_prefix = "CREATE TABLE ";
-            const std::string if_not_exists = "CREATE TABLE IF NOT EXISTS ";
-            if (sql.substr(0, create_prefix.size()) == create_prefix) {
-                sql = if_not_exists + sql.substr(create_prefix.size());
-            }
+            auto result = conn->execute(with_if_not_exists(create_table_sql<dialect>()));
 
-            return conn->execute(sql);
+            // Auto-generated junction table for many_to_many fields (#203 Phase 1).
+            if constexpr (has_m2m_junction_) {
+                result = result.and_then([&conn] {
+                    return conn->execute(with_if_not_exists(junction_table_sql<dialect>()));
+                });
+            }
+            return result;
         }
     };
 

--- a/src/orm/statements/base.cppm
+++ b/src/orm/statements/base.cppm
@@ -39,6 +39,65 @@ export namespace storm::orm::statements {
             using enum FieldAttr;
             return attr == primary || attr == primary_autoincrement;
         }
+
+        // Many-to-many annotation (#203). Phase 1 (auto-generated junction table):
+        //   [[= storm::meta::many_to_many]] std::vector<Course> courses;
+        // Phase 2 (explicit junction model):
+        //   [[= storm::meta::many_to_many_through<Enrollment>]] std::vector<Course> courses;
+        // FieldAttr is an enum, so a templated enumerator is impossible — a class-template
+        // annotation carries the optional through-model type instead.
+        template <typename Through = void> struct ManyToMany {
+            using through_type = Through;
+        };
+        inline constexpr ManyToMany<>                                    many_to_many{};
+        template <typename Through> inline constexpr ManyToMany<Through> many_to_many_through{};
+
+        // Reflection of the ManyToMany<...> annotation TYPE carried by `member`, if any.
+        consteval auto m2m_annotation_type_of(std::meta::info member) -> std::optional<std::meta::info> {
+            for (const auto annotation : std::meta::annotations_of(member)) {
+                const auto type = std::meta::type_of(annotation);
+                if (std::meta::has_template_arguments(type) && std::meta::template_of(type) == ^^ManyToMany) {
+                    return type;
+                }
+            }
+            return std::nullopt;
+        }
+
+        consteval auto is_m2m_field(std::meta::info member) -> bool {
+            return m2m_annotation_type_of(member).has_value();
+        }
+
+        // True for m2m members WITHOUT a through model (auto-generated junction table).
+        consteval auto is_m2m_auto(std::meta::info member) -> bool {
+            auto type = m2m_annotation_type_of(member);
+            return type.has_value() && std::meta::dealias(std::meta::template_arguments_of(type.value())[0]) == ^^void;
+        }
+
+        // Through model of an m2m member (void = auto-generated junction table).
+        template <std::meta::info Member>
+        using m2m_through_t = typename[:std::meta::template_arguments_of(m2m_annotation_type_of(Member).value())[0]:];
+
+        // Related model type extracted from a container field type via C++26 std::meta (#203):
+        // vector<Course> → Course, plf::hive<Track> → Track,
+        // vector<shared_ptr<Course>> / vector<unique_ptr<Course>> → Course.
+        consteval auto related_type_from_container(std::meta::info container_type) -> std::meta::info {
+            const auto first =
+                    std::meta::dealias(std::meta::template_arguments_of(std::meta::dealias(container_type))[0]);
+            if (std::meta::has_template_arguments(first)) {
+                // ^^std::shared_ptr names a using-declarator under `import std;` and can't
+                // be reflected directly — derive the canonical template from a concrete
+                // specialization instead.
+                const auto tmpl            = std::meta::template_of(first);
+                const auto shared_ptr_tmpl = std::meta::template_of(std::meta::dealias(^^std::shared_ptr<int>));
+                const auto unique_ptr_tmpl = std::meta::template_of(std::meta::dealias(^^std::unique_ptr<int>));
+                if (tmpl == shared_ptr_tmpl || tmpl == unique_ptr_tmpl) {
+                    return std::meta::dealias(std::meta::template_arguments_of(first)[0]);
+                }
+            }
+            return first;
+        }
+
+        template <typename Container> using m2m_related_t = typename[:related_type_from_container(^^Container):];
     } // namespace meta
 
     // Concept: T must have at least one field annotated with FieldAttr::primary.
@@ -89,6 +148,40 @@ export namespace storm::orm::statements {
             }
         }
         return false;
+    }();
+
+    // A many-to-many JOIN field selector must reflect a non-static data member of T
+    // carrying a ManyToMany annotation (#203). Same BMI-boundary discipline as
+    // FKFieldOf: the annotation is read from the member re-derived out of ^^T.
+    template <typename T, std::meta::info Member>
+    concept M2MFieldOf = []() consteval {
+        if (!std::meta::is_nonstatic_data_member(Member) || !std::meta::has_identifier(Member)) {
+            return false;
+        }
+        if (std::meta::parent_of(Member) != ^^T) {
+            return false;
+        }
+        for (auto m : std::meta::nonstatic_data_members_of(^^T, std::meta::access_context::unchecked())) {
+            if (std::meta::identifier_of(m) == std::meta::identifier_of(Member)) {
+                return meta::is_m2m_field(m);
+            }
+        }
+        return false;
+    }();
+
+    // A through model must carry exactly one FieldAttr::fk member of type Side
+    // (#203 Phase 2) — that member names the junction FK column (<identifier>_id).
+    template <typename Through, typename Side>
+    concept ThroughWithFKTo = []() consteval {
+        std::size_t count = 0;
+        for (auto m : std::meta::nonstatic_data_members_of(^^Through, std::meta::access_context::unchecked())) {
+            auto attr = std::meta::annotation_of_type<meta::FieldAttr>(m);
+            if (attr.has_value() && attr.value() == meta::FieldAttr::fk &&
+                std::meta::dealias(std::meta::type_of(m)) == std::meta::dealias(^^Side)) {
+                ++count;
+            }
+        }
+        return count == 1;
     }();
 
     // Shared reflection utilities for all statement types
@@ -187,18 +280,28 @@ export namespace storm::orm::statements {
             std::unreachable(); // never reached: requires ModelWithPrimaryKey<...> guarantees a primary key exists
         }
 
-        // Helper to get the number of fields
+        // Number of PERSISTED fields. Many-to-many container members map to a junction
+        // table, not to a column, so they are invisible to INSERT/SELECT/UPDATE/SCHEMA (#203).
         static consteval auto get_field_count() -> std::size_t {
-            return std::meta::nonstatic_data_members_of(^^T, std::meta::access_context::unchecked()).size();
+            std::size_t count = 0;
+            for (const auto member :
+                 std::meta::nonstatic_data_members_of(^^T, std::meta::access_context::unchecked())) {
+                if (!meta::is_m2m_field(member)) {
+                    ++count;
+                }
+            }
+            return count;
         }
 
-        // Pre-compute all field members at compile-time
+        // Pre-compute all persisted field members at compile-time (m2m members filtered, #203)
         template <std::size_t N> static consteval auto get_all_field_members() -> std::array<std::meta::info, N> {
             std::array<std::meta::info, N> result{};
-            auto members = std::meta::nonstatic_data_members_of(^^T, std::meta::access_context::unchecked());
-
-            for (std::size_t i = 0; i < N && i < members.size(); ++i) {
-                result[i] = members[i];
+            std::size_t                    idx = 0;
+            for (const auto member :
+                 std::meta::nonstatic_data_members_of(^^T, std::meta::access_context::unchecked())) {
+                if (!meta::is_m2m_field(member) && idx < N) {
+                    result[idx++] = member;
+                }
             }
             return result;
         }

--- a/src/orm/statements/base.cppm
+++ b/src/orm/statements/base.cppm
@@ -98,6 +98,12 @@ export namespace storm::orm::statements {
         }
 
         template <typename Container> using m2m_related_t = typename[:related_type_from_container(^^Container):];
+
+        // Detect std::shared_ptr container elements (m2m append path wraps the
+        // extracted related object in make_shared, #203).
+        template <typename T> struct is_shared_ptr : std::false_type {};
+        template <typename TValue> struct is_shared_ptr<std::shared_ptr<TValue>> : std::true_type {};
+        template <typename TValue> constexpr bool is_shared_ptr_v = is_shared_ptr<TValue>::value;
     } // namespace meta
 
     // Concept: T must have at least one field annotated with FieldAttr::primary.

--- a/src/orm/statements/join.cppm
+++ b/src/orm/statements/join.cppm
@@ -475,7 +475,8 @@ export namespace storm::orm::statements {
             if constexpr (std::same_as<Through, void>) {
                 return junction_table_arr_.view();
             } else {
-                return std::meta::identifier_of(^^Through);
+                // ^^Through names the local alias — dealias to the model's own name
+                return std::meta::identifier_of(std::meta::dealias(^^Through));
             }
         }
 

--- a/src/orm/statements/join.cppm
+++ b/src/orm/statements/join.cppm
@@ -644,6 +644,8 @@ export namespace storm::orm::statements {
         }
 
       private:
+        using Base::adapt_order_by_for_pg; // unqualified call below (Sonar S1117 false-positive on Base::)
+
         // The user's ordering, t1-qualified, then the pk tiebreak that guarantees
         // same-entity row adjacency. Wrapper SQL is exactly " ORDER BY <f> […] ASC|DESC, …".
         static auto append_outer_order_by(std::string& sql, const std::optional<OrderByWrapper>& order_by) -> void {
@@ -656,7 +658,7 @@ export namespace storm::orm::statements {
                     pos += 5;
                 }
                 if constexpr (requires { ConnType::uses_pg_dialect; }) {
-                    Base::adapt_order_by_for_pg(qualified); // LCOV_EXCL_LINE — PG-only
+                    adapt_order_by_for_pg(qualified); // LCOV_EXCL_LINE — PG-only
                 }
                 sql += qualified;
                 sql += ", ";

--- a/src/orm/statements/join.cppm
+++ b/src/orm/statements/join.cppm
@@ -8,7 +8,9 @@ export module storm_orm_statements_join;
 import std;
 
 import storm_orm_statements_base;
+import storm_orm_statements_orderby;
 import storm_orm_utilities;
+import storm_orm_where;
 import storm_db_concept;
 
 export namespace storm::orm::statements {
@@ -27,6 +29,24 @@ export namespace storm::orm::statements {
     struct JoinStatementWrapper {
         auto (*get_complete_sql_fn)() -> const std::string&;
         auto (*extract_row_fn)(ErasedStatementPtr, ErasedObjectPtr) -> void;
+
+        // Many-to-many extension (#203) — nullptr for plain FK joins. M2M SQL depends
+        // on the runtime WHERE/ORDER BY/LIMIT/OFFSET (they live INSIDE the base-table
+        // subquery), so the wrapper builds it per call instead of returning a static
+        // string. extract_base_pk_fn/append_related_fn drive the aggregation loop in
+        // SelectStatement (deduplicate base rows, append related objects).
+        auto (*build_m2m_sql_fn)(
+                const orm::where::ExpressionVariantPtr&,
+                const std::optional<OrderByWrapper>&,
+                const std::optional<int>&,
+                const std::optional<int>&
+        ) -> std::string                                                       = nullptr;
+        auto (*extract_base_pk_fn)(ErasedStatementPtr) -> std::int64_t         = nullptr;
+        auto (*append_related_fn)(ErasedStatementPtr, ErasedObjectPtr) -> void = nullptr;
+
+        [[nodiscard]] auto is_m2m() const -> bool {
+            return build_m2m_sql_fn != nullptr;
+        }
 
         // Get complete pre-computed SELECT...JOIN SQL
         [[nodiscard]] auto get_complete_sql() const -> const std::string& {
@@ -370,6 +390,344 @@ export namespace storm::orm::statements {
                 +[]() -> const std::string& { return JS::get_complete_sql(); },
                 +[](ErasedStatementPtr stmt, ErasedObjectPtr obj) -> void {
                     JS::extract_joined_row(static_cast<typename ConnType::Statement*>(stmt), *static_cast<T*>(obj));
+                }
+        };
+    }
+
+    // =========================================================================
+    // MANY-TO-MANY JOIN (#203) — 3-table join over a base-table subquery:
+    //
+    //   SELECT t1.<cols>, t3.<cols>
+    //   FROM (SELECT <cols> FROM <Base> [WHERE …] [ORDER BY …] [LIMIT/OFFSET]) t1
+    //   <KW> JOIN <junction> t2 ON t1.<pk> = t2.<owner_col>
+    //   <KW> JOIN <Related>  t3 ON t2.<related_col> = t3.<rpk>
+    //   ORDER BY [t1.<user order>, ]t1.<pk>
+    //
+    // WHERE/ORDER BY/LIMIT/OFFSET select WHICH base entities load (inside the
+    // subquery) — a flat outer LIMIT would truncate the related collection. The
+    // outer ORDER BY ends with t1.<pk> so one entity's rows are always adjacent;
+    // the aggregation loops in SelectStatement rely on that.
+    //
+    // Junction descriptor: auto mode (Through = void) uses <Base>_<Related> with
+    // <Base>_id / <Related>_id columns; through mode uses the through model's
+    // table with its FK field names (<field>_id).
+    // =========================================================================
+    template <typename T, storm::db::DatabaseConnection ConnType, JoinType Type, std::meta::info M2MField>
+        requires M2MFieldOf<T, M2MField> && (Type == JoinType::Inner || Type == JoinType::Left)
+    class M2MJoinStatement : private BaseStatement<T> {
+        friend class BaseStatement<T>;
+        using Base      = BaseStatement<T>;
+        using Statement = typename ConnType::Statement;
+
+        // Re-derive the member from ^^T by identifier — annotation reads on a
+        // reflection that crossed a BMI boundary segfault clang-p2996 (#262).
+        static constexpr auto m2m_member_ = []() consteval {
+            for (auto m : std::meta::nonstatic_data_members_of(^^T, std::meta::access_context::unchecked())) {
+                if (std::meta::identifier_of(m) == std::meta::identifier_of(M2MField)) {
+                    return m;
+                }
+            }
+            std::unreachable(); // M2MFieldOf<T, M2MField> guarantees a match
+        }();
+
+        using ContainerType = std::remove_cvref_t<typename[:std::meta::type_of(m2m_member_):]>;
+        using Related       = meta::m2m_related_t<ContainerType>;
+        using Through       = meta::m2m_through_t<m2m_member_>;
+        using RelatedBase   = BaseStatement<Related>;
+
+        static_assert(!std::same_as<Related, T>, "self-referential many-to-many is not supported (#203)");
+
+        // if constexpr keeps the concept from being checked with Through = void
+        // (nonstatic_data_members_of(^^void) is not a constant expression).
+        static consteval auto through_is_valid() -> bool {
+            if constexpr (std::same_as<Through, void>) {
+                return true;
+            } else {
+                return ThroughWithFKTo<Through, T> && ThroughWithFKTo<Through, Related>;
+            }
+        }
+        static_assert(
+                through_is_valid(), "through model must have exactly one FieldAttr::fk field for each side (#203)"
+        );
+
+        // ---- Junction descriptor ---------------------------------------------
+        template <typename Side> static consteval auto find_through_fk() -> std::meta::info {
+            for (auto m : std::meta::nonstatic_data_members_of(^^Through, std::meta::access_context::unchecked())) {
+                auto attr = std::meta::annotation_of_type<meta::FieldAttr>(m);
+                if (attr.has_value() && attr.value() == meta::FieldAttr::fk &&
+                    std::meta::dealias(std::meta::type_of(m)) == std::meta::dealias(^^Side)) {
+                    return m;
+                }
+            }
+            std::unreachable(); // ThroughWithFKTo guarantees a match
+        }
+
+        // Auto-junction table name "<Base>_<Related>" needs static storage.
+        static constexpr auto junction_table_arr_ = []() consteval {
+            ConstexprString<Base::table_name_.size() + RelatedBase::table_name_.size() + 2> name;
+            name.append(Base::table_name_);
+            name.append("_");
+            name.append(RelatedBase::table_name_);
+            return name;
+        }();
+
+        static consteval auto junction_table_name() -> std::string_view {
+            if constexpr (std::same_as<Through, void>) {
+                return junction_table_arr_.view();
+            } else {
+                return std::meta::identifier_of(^^Through);
+            }
+        }
+
+        // Junction column base names (the "_id" suffix is appended in the builder).
+        static consteval auto owner_col_name() -> std::string_view {
+            if constexpr (std::same_as<Through, void>) {
+                return Base::table_name_;
+            } else {
+                return std::meta::identifier_of(find_through_fk<T>());
+            }
+        }
+        static consteval auto related_col_name() -> std::string_view {
+            if constexpr (std::same_as<Through, void>) {
+                return RelatedBase::table_name_;
+            } else {
+                return std::meta::identifier_of(find_through_fk<Related>());
+            }
+        }
+
+        static consteval auto join_keyword() -> std::string_view {
+            return Type == JoinType::Inner ? " INNER JOIN " : " LEFT JOIN ";
+        }
+
+        // ---- Pre-computed SQL fragments --------------------------------------
+        // select_prefix_: "SELECT t1.<c…>, t3.<r…> FROM (SELECT <cols> FROM <Base>"
+        static consteval auto calculate_select_prefix_size() -> std::size_t {
+            std::size_t total = 7; // "SELECT "
+            for (std::size_t i = 0; i < Base::field_count_; ++i) {
+                total += 2 + 3 + std::meta::identifier_of(Base::all_members_[i]).size() + 3;
+            }
+            for (std::size_t i = 0; i < RelatedBase::field_count_; ++i) {
+                total += 2 + 3 + std::meta::identifier_of(RelatedBase::all_members_[i]).size() + 3;
+            }
+            total += 14 + Base::field_names_array_.len + 6 + Base::table_name_.size();
+            return total + utilities::sql_len::SMALL_BUFFER;
+        }
+
+        static consteval auto build_select_prefix() {
+            ConstexprString<calculate_select_prefix_size()> result;
+            result.append("SELECT ");
+            bool first = true;
+            for (std::size_t i = 0; i < Base::field_count_; ++i) {
+                if (!first) {
+                    result.append(", ");
+                }
+                result.append("t1.");
+                result.append(std::meta::identifier_of(Base::all_members_[i]));
+                if (Base::is_fk_field(Base::all_members_[i])) {
+                    result.append("_id");
+                }
+                first = false;
+            }
+            for (std::size_t i = 0; i < RelatedBase::field_count_; ++i) {
+                result.append(", t3.");
+                result.append(std::meta::identifier_of(RelatedBase::all_members_[i]));
+                if (Base::is_fk_field(RelatedBase::all_members_[i])) {
+                    result.append("_id");
+                }
+            }
+            result.append(" FROM (SELECT ");
+            result.append(Base::field_names_array_);
+            result.append(" FROM ");
+            result.append(Base::table_name_);
+            return result;
+        }
+
+        // join_suffix_: ") t1 <KW> <junction> t2 ON t1.<pk> = t2.<owner>_id <KW> <Related> t3 ON t2.<related>_id =
+        // t3.<rpk>"
+        static consteval auto calculate_join_suffix_size() -> std::size_t {
+            return 4 + (2 * join_keyword().size()) + junction_table_name().size() + 10 + Base::pk_name_.size() + 6 +
+                   owner_col_name().size() + 3 + RelatedBase::table_name_.size() + 10 + related_col_name().size() + 9 +
+                   RelatedBase::pk_name_.size() + utilities::sql_len::SMALL_BUFFER;
+        }
+
+        static consteval auto build_join_suffix() {
+            ConstexprString<calculate_join_suffix_size()> result;
+            result.append(") t1");
+            result.append(join_keyword());
+            result.append(junction_table_name());
+            result.append(" t2 ON t1.");
+            result.append(Base::pk_name_);
+            result.append(" = t2.");
+            result.append(owner_col_name());
+            result.append("_id");
+            result.append(join_keyword());
+            result.append(RelatedBase::table_name_);
+            result.append(" t3 ON t2.");
+            result.append(related_col_name());
+            result.append("_id = t3.");
+            result.append(RelatedBase::pk_name_);
+            return result;
+        }
+
+        static constexpr auto select_prefix_arr_ = build_select_prefix();
+        static constexpr auto join_suffix_arr_   = build_join_suffix();
+
+        // Column index of a model's pk within its own column block.
+        static consteval auto pk_index_of(const auto& members, std::meta::info pk_member) -> int {
+            for (std::size_t i = 0; i < members.size(); ++i) {
+                if (members[i] == pk_member) {
+                    return static_cast<int>(i);
+                }
+            }
+            std::unreachable(); // ModelWithPrimaryKey guarantees the pk is a member
+        }
+
+        static constexpr int base_pk_col_    = pk_index_of(Base::all_members_, Base::primary_key_);
+        static constexpr int related_pk_col_ = static_cast<int>(Base::field_count_) +
+                                               pk_index_of(RelatedBase::all_members_, RelatedBase::primary_key_);
+
+      public:
+        // Modifier-free complete SQL — consumed by aggregates/set-ops via the
+        // wrapper's get_complete_sql_fn (a COUNT over it counts (base, related) pairs).
+        static auto get_complete_sql() -> const std::string& {
+            static const std::string str =
+                    std::string(select_prefix_arr_.view()) + std::string(join_suffix_arr_.view());
+            return str;
+        }
+
+        // Build the full query — see the class comment for clause placement.
+        static auto build_m2m_sql(
+                const orm::where::ExpressionVariantPtr& where_expr,
+                const std::optional<OrderByWrapper>&    order_by,
+                const std::optional<int>&               limit,
+                const std::optional<int>&               offset
+        ) -> std::string {
+            std::string sql{select_prefix_arr_.view()};
+            if (where_expr) {
+                sql += " WHERE ";
+                sql += orm::where::to_sql(*where_expr);
+            }
+            Base::template append_order_by<ConnType>(sql, order_by);
+            Base::template append_limit_offset<ConnType>(sql, limit, offset);
+            sql += join_suffix_arr_.view();
+            append_outer_order_by(sql, order_by);
+            return sql;
+        }
+
+        // Row 1 of an entity: base columns + first related row (if any).
+        static auto extract_joined_row(Statement* stmt, T& obj) noexcept -> void {
+            Base::extract_all_columns(stmt, obj);
+            append_related(stmt, obj);
+        }
+
+        static auto extract_base_pk(Statement* stmt) noexcept -> std::int64_t {
+            return stmt->extract_int64(base_pk_col_);
+        }
+
+        // Append the current row's related object into obj's container member.
+        // LEFT JOIN emits NULL related columns for entities with no relations — skip.
+        static auto append_related(Statement* stmt, T& obj) noexcept -> void {
+            if constexpr (Type == JoinType::Left) {
+                if (stmt->is_null(related_pk_col_)) {
+                    return;
+                }
+            }
+            Related rel{};
+            extract_related(stmt, rel, std::make_index_sequence<RelatedBase::field_count_>{});
+            using Elem = typename ContainerType::value_type;
+            if constexpr (meta::is_shared_ptr_v<Elem>) {
+                insert_into(obj.[:m2m_member_:], std::make_shared<Related>(std::move(rel)));
+            } else {
+                insert_into(obj.[:m2m_member_:], std::move(rel));
+            }
+        }
+
+      private:
+        // The user's ordering, t1-qualified, then the pk tiebreak that guarantees
+        // same-entity row adjacency. Wrapper SQL is exactly " ORDER BY <f> […] ASC|DESC, …".
+        static auto append_outer_order_by(std::string& sql, const std::optional<OrderByWrapper>& order_by) -> void {
+            sql += " ORDER BY ";
+            if (order_by.has_value() && !order_by->empty()) {
+                std::string qualified = "t1." + order_by->get_order_by_sql().substr(10); // strip " ORDER BY "
+                std::size_t pos       = 0;
+                while ((pos = qualified.find(", ", pos)) != std::string::npos) {
+                    qualified.insert(pos + 2, "t1.");
+                    pos += 5;
+                }
+                if constexpr (requires { ConnType::uses_pg_dialect; }) {
+                    Base::adapt_order_by_for_pg(qualified); // LCOV_EXCL_LINE — PG-only
+                }
+                sql += qualified;
+                sql += ", ";
+            }
+            sql += "t1.";
+            sql += Base::pk_name_;
+        }
+
+        template <typename C, typename V> static auto insert_into(C& container, V&& value) -> void {
+            if constexpr (requires { container.push_back(std::forward<V>(value)); }) {
+                container.push_back(std::forward<V>(value));
+            } else {
+                container.insert(std::forward<V>(value)); // plf::hive
+            }
+        }
+
+        template <std::size_t... Is>
+        static auto extract_related(Statement* stmt, Related& rel, std::index_sequence<Is...> /*unused*/) noexcept
+                -> void {
+            ((extract_related_at<Is>(stmt, rel)), ...);
+        }
+
+        // Mirrors plain-SELECT semantics per related member: regular columns extract
+        // by value; FK columns hold only the foreign pk (pk-only FK object).
+        template <std::size_t I> static auto extract_related_at(Statement* stmt, Related& rel) noexcept -> void {
+            constexpr auto member = RelatedBase::all_members_[I];
+            constexpr int  col    = static_cast<int>(Base::field_count_) + static_cast<int>(I);
+            using FieldType       = std::remove_cvref_t<decltype(rel.[:member:])>;
+            if constexpr (Base::is_fk_field(member)) {
+                extract_related_fk<FieldType, member>(stmt, rel, col);
+            } else {
+                rel.[:member:] = Base::template extract_column_value<FieldType>(stmt, col);
+            }
+        }
+
+        template <typename FieldType, std::meta::info Member>
+        static auto extract_related_fk(Statement* stmt, Related& rel, int col) noexcept -> void {
+            using InnerFK        = utilities::optional_inner_type_t<FieldType>;
+            constexpr auto fk_pk = Base::template find_fk_primary_key<FieldType>();
+            using PKType         = std::remove_cvref_t<decltype(std::declval<InnerFK>().[:fk_pk:])>;
+            if constexpr (utilities::is_optional_v<FieldType>) {
+                if (stmt->is_null(col)) {
+                    rel.[:Member:] = std::nullopt;
+                    return;
+                }
+            }
+            InnerFK inner{};
+            inner.[:fk_pk:] = Base::template extract_column_value<PKType>(stmt, col);
+            rel.[:Member:]  = std::move(inner);
+        }
+    };
+
+    template <typename T, storm::db::DatabaseConnection ConnType, JoinType Type, std::meta::info M2MField>
+        requires M2MFieldOf<T, M2MField>
+    [[nodiscard]] auto make_m2m_join_wrapper() -> JoinStatementWrapper {
+        using JS = M2MJoinStatement<T, ConnType, Type, M2MField>;
+        return JoinStatementWrapper{
+                +[]() -> const std::string& { return JS::get_complete_sql(); },
+                +[](ErasedStatementPtr stmt, ErasedObjectPtr obj) -> void {
+                    JS::extract_joined_row(static_cast<typename ConnType::Statement*>(stmt), *static_cast<T*>(obj));
+                },
+                +[](const orm::where::ExpressionVariantPtr& where_expr,
+                    const std::optional<OrderByWrapper>&    order_by,
+                    const std::optional<int>&               limit,
+                    const std::optional<int>&               offset) -> std::string {
+                    return JS::build_m2m_sql(where_expr, order_by, limit, offset);
+                },
+                +[](ErasedStatementPtr stmt) -> std::int64_t {
+                    return JS::extract_base_pk(static_cast<typename ConnType::Statement*>(stmt));
+                },
+                +[](ErasedStatementPtr stmt, ErasedObjectPtr obj) -> void {
+                    JS::append_related(static_cast<typename ConnType::Statement*>(stmt), *static_cast<T*>(obj));
                 }
         };
     }

--- a/src/orm/statements/select.cppm
+++ b/src/orm/statements/select.cppm
@@ -86,6 +86,11 @@ export namespace storm::orm::statements {
                 const std::optional<int>&                  offset,
                 const std::optional<OrderByWrapper>&       order_by_wrapper
         ) -> std::string {
+            // M2M joins (#203): WHERE/ORDER BY/LIMIT/OFFSET live inside the base-table
+            // subquery — the wrapper owns the whole layout.
+            if (join_wrapper && join_wrapper->is_m2m()) {
+                return join_wrapper->build_m2m_sql_fn(where_expr, order_by_wrapper, limit, offset);
+            }
             std::string sql = join_wrapper ? join_wrapper->get_complete_sql() : std::string(get_select_sql());
             if (where_expr) {
                 sql += " WHERE ";
@@ -257,17 +262,11 @@ export namespace storm::orm::statements {
                 const std::optional<int>&               offset           = std::nullopt,
                 const std::optional<OrderByWrapper>&    order_by_wrapper = std::nullopt)
                 -> std::expected<plf::hive<T>, Error> {
-            auto prepare_result = prepare_statement(join_wrapper, where_expr, limit, offset, order_by_wrapper);
-            if (!prepare_result) [[unlikely]] {
-                return std::unexpected(prepare_result.error());
-            }
-            Statement* stmt_ptr = *prepare_result;
-            if (join_wrapper) {
-                return execute_query_loop(stmt_ptr, [&join_wrapper](Statement* stmt, T& obj) {
-                    join_wrapper->extract_row(stmt, &obj);
-                });
-            }
-            return execute_query_loop(stmt_ptr, [](Statement* stmt, T& obj) { Base::extract_all_columns(stmt, obj); });
+            return prepare_and_dispatch(
+                    QueryClauses{join_wrapper, where_expr, limit, offset, order_by_wrapper},
+                    [this](Statement* stmt, const JoinStatementWrapper& jw) { return execute_m2m_loop(stmt, jw); },
+                    [this](Statement* stmt, const auto& extractor) { return execute_query_loop(stmt, extractor); }
+            );
         }
 
         // Zero-parameter fast path for first() — no checks, no parameter passing overhead
@@ -293,18 +292,7 @@ export namespace storm::orm::statements {
                 const std::optional<int>&                  offset           = std::nullopt,
                 const std::optional<OrderByWrapper>&       order_by_wrapper = std::nullopt
         ) -> std::expected<std::optional<T>, Error> {
-            std::optional<int> const limit_one = 1;
-            auto prepare_result = prepare_statement(join_wrapper, where_expr, limit_one, offset, order_by_wrapper);
-            if (!prepare_result) [[unlikely]] {
-                return std::unexpected(prepare_result.error());
-            }
-            Statement* stmt_ptr = *prepare_result;
-            if (join_wrapper) {
-                return execute_single_row(stmt_ptr, [&join_wrapper](Statement* stmt, T& obj) {
-                    join_wrapper->extract_row(stmt, &obj);
-                });
-            }
-            return execute_single_row(stmt_ptr, [](Statement* stmt, T& obj) { Base::extract_all_columns(stmt, obj); });
+            return execute_one_or_get<false>(join_wrapper, where_expr, offset, order_by_wrapper);
         }
 
         // Zero-parameter fast path for get() — no checks, no parameter passing overhead
@@ -327,18 +315,7 @@ export namespace storm::orm::statements {
                 const std::optional<int>&                  offset           = std::nullopt,
                 const std::optional<OrderByWrapper>&       order_by_wrapper = std::nullopt
         ) -> std::expected<T, Error> {
-            std::optional<int> const limit_two = 2;
-            auto prepare_result = prepare_statement(join_wrapper, where_expr, limit_two, offset, order_by_wrapper);
-            if (!prepare_result) [[unlikely]] {
-                return std::unexpected(prepare_result.error());
-            }
-            Statement* stmt_ptr = *prepare_result;
-            if (join_wrapper) {
-                return execute_exact_one(stmt_ptr, [&join_wrapper](Statement* stmt, T& obj) {
-                    join_wrapper->extract_row(stmt, &obj);
-                });
-            }
-            return execute_exact_one(stmt_ptr, [](Statement* stmt, T& obj) { Base::extract_all_columns(stmt, obj); });
+            return execute_one_or_get<true>(join_wrapper, where_expr, offset, order_by_wrapper);
         }
 
         // Lazy row-by-row iteration via coroutine — yields std::expected<T, Error> per row
@@ -356,22 +333,37 @@ export namespace storm::orm::statements {
 
             auto stmt_result = conn->prepare(sql);
             if (!stmt_result) {
-                co_yield std::unexpected(stmt_result.error());
-                co_return;
+                return yield_error(stmt_result.error());
             }
-            auto& stmt = stmt_result.value();
+            auto stmt = std::move(stmt_result.value());
 
             if (where_expr) {
                 auto bind_result = Base::template bind_where_params<Statement, Error>(&stmt, where_expr);
                 if (!bind_result) {
-                    co_yield std::unexpected(bind_result.error());
-                    co_return;
+                    return yield_error(bind_result.error());
                 }
             }
 
-            // Single step/yield loop — extraction differs only in one line between
-            // the join and non-join cases. co_yield must stay in the coroutine
-            // body (not in a lambda), so we branch only on the per-row extract.
+            // conn and stmt move into the selected coroutine's frame — the statement
+            // (and the connection it needs) live until generator destruction.
+            if (join_wrapper && join_wrapper->is_m2m()) {
+                return rows_m2m_loop(std::move(conn), std::move(stmt), std::move(*join_wrapper));
+            }
+            return rows_plain_loop(std::move(conn), std::move(stmt), std::move(join_wrapper));
+        }
+
+      private:
+        // Single-error generator for prepare/bind failures in rows_generator.
+        static auto yield_error(Error error) -> storm::generator<std::expected<T, Error>&&> {
+            co_yield std::unexpected(std::move(error));
+        }
+
+        // Single step/yield loop — extraction differs only in one line between
+        // the join and non-join cases. co_yield must stay in the coroutine
+        // body (not in a lambda), so we branch only on the per-row extract.
+        static auto rows_plain_loop(
+                std::shared_ptr<ConnType> /*conn*/, Statement stmt, std::optional<JoinStatementWrapper> join_wrapper
+        ) -> storm::generator<std::expected<T, Error>&&> {
             int step_result = 0;
             while ((step_result = stmt.step_raw()) == Statement::ROW_AVAILABLE) {
                 T obj;
@@ -387,6 +379,36 @@ export namespace storm::orm::statements {
             }
         }
 
+        // M2M joins (#203): rows for one entity are adjacent (the outer ORDER BY ends
+        // in t1.<pk>) — group them and yield one aggregated entity per pk change.
+        static auto rows_m2m_loop(std::shared_ptr<ConnType> /*conn*/, Statement stmt, JoinStatementWrapper join_wrapper)
+                -> storm::generator<std::expected<T, Error>&&> {
+            std::optional<T> current;
+            std::int64_t     current_pk  = 0;
+            int              step_result = 0;
+            while ((step_result = stmt.step_raw()) == Statement::ROW_AVAILABLE) {
+                const std::int64_t pk = join_wrapper.extract_base_pk_fn(&stmt);
+                if (current.has_value() && pk == current_pk) {
+                    join_wrapper.append_related_fn(&stmt, &*current);
+                    continue;
+                }
+                if (current.has_value()) {
+                    co_yield std::move(*current);
+                }
+                current.emplace();
+                join_wrapper.extract_row(&stmt, &*current);
+                current_pk = pk;
+            }
+            if (step_result != Statement::NO_MORE_ROWS) {
+                co_yield std::unexpected(Error{step_result, stmt.get_error_message()});
+                co_return;
+            }
+            if (current.has_value()) {
+                co_yield std::move(*current);
+            }
+        }
+
+      public:
       private:
         // =====================================================================
         // STATEMENT PREPARATION - Unified caching for all query types
@@ -482,13 +504,144 @@ export namespace storm::orm::statements {
                 results.insert(std::move(obj));
             }
 
+            return finish_query_loop(stmt, step_result, std::move(results));
+        }
+
+        // Shared loop tail: classify the final step result, reset, return rows or error.
+        // Used by execute_query_loop and execute_m2m_loop.
+        [[nodiscard]] __attribute__((always_inline)) static auto
+        finish_query_loop(Statement* stmt, int step_result, plf::hive<T>&& results) noexcept
+                -> std::expected<plf::hive<T>, Error> {
             if (step_result != Statement::NO_MORE_ROWS) {
                 stmt->reset();
                 return std::unexpected(Error{step_result, stmt->get_error_message()});
             }
-
             stmt->reset();
-            return results;
+            return std::move(results);
+        }
+
+        // Bundles the five query clauses threaded from QuerySet through the proxies
+        // (reference semantics — call-scoped only).
+        struct QueryClauses {
+            const std::optional<JoinStatementWrapper>& join_wrapper;
+            const orm::where::ExpressionVariantPtr&    where_expr;
+            const std::optional<int>&                  limit;
+            const std::optional<int>&                  offset;
+            const std::optional<OrderByWrapper>&       order_by_wrapper;
+        };
+
+        // Prepare the statement (cached, WHERE bound), then dispatch to the m2m
+        // aggregation path, the FK-join extraction path, or the plain-columns path.
+        // Shared by execute / execute_one / execute_get (#203).
+        template <typename M2MFn, typename LoopFn>
+        [[nodiscard]] __attribute__((always_inline)) auto
+        prepare_and_dispatch(const QueryClauses& clauses, const M2MFn& m2m_fn, const LoopFn& loop_fn)
+                -> decltype(m2m_fn(std::declval<Statement*>(), *clauses.join_wrapper)) {
+            auto prepare_result = prepare_statement(
+                    clauses.join_wrapper, clauses.where_expr, clauses.limit, clauses.offset, clauses.order_by_wrapper
+            );
+            if (!prepare_result) [[unlikely]] {
+                return std::unexpected(prepare_result.error());
+            }
+            const auto& join_wrapper = clauses.join_wrapper;
+            if (join_wrapper) {
+                if (join_wrapper->is_m2m()) {
+                    return m2m_fn(*prepare_result, *join_wrapper);
+                }
+                return loop_fn(*prepare_result, [&join_wrapper](Statement* stmt, T& obj) {
+                    join_wrapper->extract_row(stmt, &obj);
+                });
+            }
+            return loop_fn(*prepare_result, [](Statement* stmt, T& obj) { Base::extract_all_columns(stmt, obj); });
+        }
+
+        // Shared body of execute_one (ExactOne=false, LIMIT 1 → optional<T>) and
+        // execute_get (ExactOne=true, LIMIT 2 → T or 0/>1-row error). The LIMIT is
+        // applied here; for m2m joins it lands INSIDE the base-table subquery, so it
+        // bounds base entities, never the related collection (#203).
+        template <bool ExactOne>
+        [[nodiscard]] auto execute_one_or_get(
+                const std::optional<JoinStatementWrapper>& join_wrapper,
+                const orm::where::ExpressionVariantPtr&    where_expr,
+                const std::optional<int>&                  offset,
+                const std::optional<OrderByWrapper>&       order_by_wrapper
+        ) -> std::expected<std::conditional_t<ExactOne, T, std::optional<T>>, Error> {
+            std::optional<int> const limit_value = ExactOne ? 2 : 1;
+            return prepare_and_dispatch(
+                    QueryClauses{join_wrapper, where_expr, limit_value, offset, order_by_wrapper},
+                    [this](Statement* stmt, const JoinStatementWrapper& jw) {
+                        if constexpr (ExactOne) {
+                            return execute_m2m_exact_one(stmt, jw);
+                        } else {
+                            return execute_m2m_one(stmt, jw);
+                        }
+                    },
+                    [this](Statement* stmt, const auto& extractor) {
+                        if constexpr (ExactOne) {
+                            return execute_exact_one(stmt, extractor);
+                        } else {
+                            return execute_single_row(stmt, extractor);
+                        }
+                    }
+            );
+        }
+
+        // m2m first() (#203): LIMIT 1 inside the subquery already restricted the query
+        // to one base entity — aggregate its rows and return it (or nullopt).
+        [[nodiscard]] auto execute_m2m_one(Statement* stmt, const JoinStatementWrapper& join_wrapper) noexcept
+                -> std::expected<std::optional<T>, Error> {
+            auto rows = execute_m2m_loop(stmt, join_wrapper);
+            if (!rows) {
+                return std::unexpected(rows.error());
+            }
+            if (rows->empty()) {
+                return std::optional<T>{std::nullopt};
+            }
+            return std::optional<T>{std::move(*rows->begin())};
+        }
+
+        // m2m get() (#203): LIMIT 2 inside the subquery → 0/1/2 base entities after
+        // aggregation. Multiple RELATED rows for one entity are one result, not a
+        // uniqueness violation.
+        [[nodiscard]] auto execute_m2m_exact_one(Statement* stmt, const JoinStatementWrapper& join_wrapper) noexcept
+                -> std::expected<T, Error> {
+            auto rows = execute_m2m_loop(stmt, join_wrapper);
+            if (!rows) {
+                return std::unexpected(rows.error());
+            }
+            if (rows->empty()) {
+                return std::unexpected(Error{-1, "No row found matching query"});
+            }
+            if (rows->size() > 1) {
+                return std::unexpected(Error{-1, "Multiple rows found matching query"});
+            }
+            return std::move(*rows->begin());
+        }
+
+        // M2M aggregation loop (#203): deduplicate base rows, append related objects.
+        // Relies on M2MJoinStatement's outer ORDER BY ending in t1.<pk>, which makes
+        // one entity's rows adjacent — a pk change starts a new entity, so no map is
+        // needed. plf::hive guarantees stable pointers on insert.
+        [[nodiscard]] auto execute_m2m_loop(Statement* stmt, const JoinStatementWrapper& join_wrapper) noexcept
+                -> std::expected<plf::hive<T>, Error> {
+            plf::hive<T> results;
+            T*           current     = nullptr;
+            std::int64_t current_pk  = 0;
+            int          step_result = 0;
+
+            while ((step_result = stmt->step_raw()) == Statement::ROW_AVAILABLE) {
+                const std::int64_t pk = join_wrapper.extract_base_pk_fn(stmt);
+                if (current == nullptr || pk != current_pk) {
+                    T obj;
+                    join_wrapper.extract_row(stmt, &obj);
+                    current    = &*results.insert(std::move(obj));
+                    current_pk = pk;
+                } else {
+                    join_wrapper.append_related_fn(stmt, current);
+                }
+            }
+
+            return finish_query_loop(stmt, step_result, std::move(results));
         }
 
         // =====================================================================

--- a/src/storm.cppm
+++ b/src/storm.cppm
@@ -37,6 +37,13 @@ export namespace storm {
         // and re-exported here through the import chain
         using FieldAttr = orm::statements::meta::FieldAttr;
 
+        // Many-to-many annotations (#203): many_to_many (auto junction table) and
+        // many_to_many_through<Through> (explicit junction model). These re-exports
+        // are consumed by user model declarations, never inside this module.
+        using orm::statements::meta::many_to_many;         // NOLINT(misc-unused-using-decls)
+        using orm::statements::meta::many_to_many_through; // NOLINT(misc-unused-using-decls)
+        using orm::statements::meta::ManyToMany;           // NOLINT(misc-unused-using-decls)
+
         // Check if member has primary attribute
         consteval auto has_primary_attr(std::meta::info member) -> bool {
             auto field_attr = std::meta::annotation_of_type<FieldAttr>(member);

--- a/tests/mock_sqlite/test_orm_mock_errors.cpp
+++ b/tests/mock_sqlite/test_orm_mock_errors.cpp
@@ -3224,6 +3224,66 @@ namespace {
         EXPECT_NE(raw, nullptr);
     }
 
+    // ============================================================================
+    // Many-to-many (#203) — m2m aggregation error paths (select / first / get / rows)
+    // ============================================================================
+
+    struct MockCourse {
+        [[= storm::meta::FieldAttr::primary]] std::int64_t id{};
+        std::string                                        title;
+    };
+
+    struct MockStudent {
+        [[= storm::meta::FieldAttr::primary]] std::int64_t      id{};
+        std::string                                             name;
+        [[= storm::meta::many_to_many]] std::vector<MockCourse> courses;
+    };
+
+    TEST_F(ORMMockErrorTest, M2MSelectFailsOnStepError) {
+        MockSqlite3Config::step_returns(SQLITE_IOERR);
+
+        QuerySet<MockStudent> qs;
+        auto                  rows = qs.join<^^MockStudent::courses>().select().execute();
+
+        ASSERT_FALSE(rows.has_value());
+        EXPECT_EQ(rows.error().code(), SQLITE_IOERR);
+    }
+
+    TEST_F(ORMMockErrorTest, M2MFirstFailsOnStepError) {
+        MockSqlite3Config::step_returns(SQLITE_IOERR);
+
+        QuerySet<MockStudent> qs;
+        auto                  first = qs.join<^^MockStudent::courses>().first().execute();
+
+        ASSERT_FALSE(first.has_value());
+        EXPECT_EQ(first.error().code(), SQLITE_IOERR);
+    }
+
+    TEST_F(ORMMockErrorTest, M2MGetFailsOnStepError) {
+        MockSqlite3Config::step_returns(SQLITE_IOERR);
+
+        QuerySet<MockStudent> qs;
+        auto                  got = qs.join<^^MockStudent::courses>().get().execute();
+
+        ASSERT_FALSE(got.has_value());
+        EXPECT_EQ(got.error().code(), SQLITE_IOERR);
+    }
+
+    TEST_F(ORMMockErrorTest, M2MRowsGeneratorYieldsStepError) {
+        MockSqlite3Config::step_returns(SQLITE_CORRUPT);
+
+        QuerySet<MockStudent> qs;
+        auto                  joined    = qs.join<^^MockStudent::courses>();
+        bool                  saw_error = false;
+        for (auto&& row : joined.rows()) {
+            ASSERT_FALSE(row.has_value());
+            EXPECT_EQ(row.error().code(), SQLITE_CORRUPT);
+            saw_error = true;
+            break;
+        }
+        EXPECT_TRUE(saw_error);
+    }
+
 } // namespace
 
 // NOLINTEND(misc-const-correctness,bugprone-unused-return-value,performance-inefficient-vector-operation) // NOSONAR(cpp:S125)

--- a/tests/query/test_m2m_models.h
+++ b/tests/query/test_m2m_models.h
@@ -1,0 +1,67 @@
+#ifndef TESTS_QUERY_TEST_M2M_MODELS_H
+#define TESTS_QUERY_TEST_M2M_MODELS_H
+
+// Many-to-many test models (#203). Include AFTER `import storm;` — the
+// [[= storm::meta::many_to_many*]] annotations need the storm module, and
+// model structs stay textual because clang-p2996 loses annotations across
+// BMI boundaries (#262).
+//
+// IMPORTANT: the including .cpp must `#include "plf_hive/plf_hive.h"` BEFORE
+// `import std;` (fresh textual libc++ headers after the import clash with the
+// std module — see COMPILER_ISSUES.md). The includes below are then no-ops.
+
+#include <memory>
+#include <plf_hive/plf_hive.h>
+#include <string>
+#include <vector>
+
+struct Course {
+    [[= storm::meta::FieldAttr::primary]] int id{};
+    std::string title;
+};
+
+// Phase 1: auto-generated junction table Student_Course (Student_id, Course_id).
+struct Student {
+    [[= storm::meta::FieldAttr::primary]] int id{};
+    std::string name;
+    int age{};
+    [[= storm::meta::many_to_many]] std::vector<Course> courses;
+};
+
+// Phase 2: explicit junction model with metadata. ManyToMany<Enrollment> only
+// names the through model, so a forward declaration is enough here.
+struct Enrollment;
+
+struct Pupil {
+    [[= storm::meta::FieldAttr::primary]] int id{};
+    std::string name;
+    int age{};
+    [[= storm::meta::many_to_many_through<Enrollment>]] std::vector<Course> courses;
+};
+
+struct Enrollment {
+    [[= storm::meta::FieldAttr::primary]] int id{};
+    [[= storm::meta::FieldAttr::fk]] Pupil pupil;
+    [[= storm::meta::FieldAttr::fk]] Course course;
+    std::string grade;
+};
+
+// Container-coverage models (Phase 1 edge cases: plf::hive and shared_ptr elements).
+struct Track {
+    [[= storm::meta::FieldAttr::primary]] int id{};
+    std::string title;
+};
+
+struct Playlist {
+    [[= storm::meta::FieldAttr::primary]] int id{};
+    std::string name;
+    [[= storm::meta::many_to_many]] plf::hive<Track> tracks;
+};
+
+struct Album {
+    [[= storm::meta::FieldAttr::primary]] int id{};
+    std::string name;
+    [[= storm::meta::many_to_many]] std::vector<std::shared_ptr<Track>> tracks;
+};
+
+#endif // TESTS_QUERY_TEST_M2M_MODELS_H

--- a/tests/query/test_m2m_models.h
+++ b/tests/query/test_m2m_models.h
@@ -64,4 +64,27 @@ struct Album {
     [[= storm::meta::many_to_many]] std::vector<std::shared_ptr<Track>> tracks;
 };
 
+namespace storm::test {
+
+// Seeds: Alice(20)→[Math, Physics], Bob(22)→[Math], Carol(25)→[] (no courses).
+// Junction rows go through raw SQL — Phase 1 has no model for the auto junction.
+template <typename ConnType> inline auto seed_students() -> void {
+    storm::QuerySet<Student, ConnType> sqs;
+    std::vector<Student> const students = {
+        {.name = "Alice", .age = 20}, {.name = "Bob", .age = 22}, {.name = "Carol", .age = 25}};
+    ASSERT_TRUE(sqs.insert(std::span<const Student>(students)).execute().has_value());
+
+    storm::QuerySet<Course, ConnType> cqs;
+    std::vector<Course> const courses = {{.title = "Math"}, {.title = "Physics"}};
+    ASSERT_TRUE(cqs.insert(std::span<const Course>(courses)).execute().has_value());
+
+    auto conn = storm::QuerySet<Student, ConnType>::get_default_connection();
+    for (const auto *pair : {"(1, 1)", "(1, 2)", "(2, 1)"}) {
+        ASSERT_TRUE(conn->execute(std::format("INSERT INTO Student_Course (Student_id, Course_id) VALUES {}", pair))
+                        .has_value());
+    }
+}
+
+} // namespace storm::test
+
 #endif // TESTS_QUERY_TEST_M2M_MODELS_H

--- a/tests/query/test_many_to_many.cpp
+++ b/tests/query/test_many_to_many.cpp
@@ -1,0 +1,66 @@
+#include <gtest/gtest.h>
+#include "test_db_helpers.h"
+#include "plf_hive/plf_hive.h"
+
+// NOLINTBEGIN(misc-const-correctness)
+
+import storm;
+import std;
+
+using storm::QuerySet;
+
+#include "test_models.h"     // NOSONAR cpp:S954
+#include "test_m2m_models.h" // NOSONAR cpp:S954
+
+// ============================================================================
+// Compile-time: m2m fields are excluded from persisted members (#203)
+// ============================================================================
+
+static_assert(
+        storm::orm::statements::BaseStatement<Student>::field_count_ == 3,
+        "courses (m2m) must not count as a persisted column"
+);
+static_assert(storm::orm::statements::BaseStatement<Course>::field_count_ == 2);
+
+// ============================================================================
+// Compile-time: M2MFieldOf concept
+// ============================================================================
+
+static_assert(storm::orm::statements::M2MFieldOf<Student, ^^Student::courses>);
+static_assert(!storm::orm::statements::M2MFieldOf<Student, ^^Student::name>);
+static_assert(!storm::orm::statements::FKFieldOf<Student, ^^Student::courses>);
+static_assert(storm::orm::statements::M2MFieldOf<Pupil, ^^Pupil::courses>);
+
+// ============================================================================
+// Compile-time: related-type extraction from containers via std::meta
+// ============================================================================
+
+static_assert(std::same_as<storm::orm::statements::meta::m2m_related_t<std::vector<Course>>, Course>);
+static_assert(std::same_as<storm::orm::statements::meta::m2m_related_t<plf::hive<Track>>, Track>);
+static_assert(std::same_as<storm::orm::statements::meta::m2m_related_t<std::vector<std::shared_ptr<Track>>>, Track>);
+static_assert(std::same_as<storm::orm::statements::meta::m2m_related_t<std::deque<Course>>, Course>);
+static_assert(std::same_as<storm::orm::statements::meta::m2m_related_t<std::vector<std::unique_ptr<Course>>>, Course>);
+
+// ============================================================================
+// Runtime: CRUD on a model WITH an m2m field ignores the container member
+// ============================================================================
+
+template <typename ConnType> class M2MBaseTest : public StormTestFixture<Student, ConnType, Course> {};
+
+TYPED_TEST_SUITE(M2MBaseTest, DatabaseTypes);
+
+TYPED_TEST(M2MBaseTest, PlainCrudIgnoresM2MField) {
+    QuerySet<Student, TypeParam> qs;
+    Student const                s{.name = "Alice", .age = 20, .courses = {{.id = 99, .title = "ghost"}}};
+    auto                         ins = qs.insert(s).execute();
+    ASSERT_TRUE(ins.has_value()) << ins.error().message();
+
+    auto rows = qs.select().execute();
+    ASSERT_TRUE(rows.has_value()) << rows.error().message();
+    ASSERT_EQ(rows->size(), 1U);
+    EXPECT_EQ(rows->begin()->name, "Alice");
+    EXPECT_EQ(rows->begin()->age, 20);
+    EXPECT_TRUE(rows->begin()->courses.empty()); // plain select never populates m2m
+}
+
+// NOLINTEND(misc-const-correctness)

--- a/tests/query/test_many_to_many.cpp
+++ b/tests/query/test_many_to_many.cpp
@@ -227,4 +227,49 @@ TYPED_TEST(M2MSeededTest, CountOverM2MJoinCountsPairs) {
     EXPECT_EQ(count.value(), 3);
 }
 
+// ============================================================================
+// Container coverage (#203 Phase 1 edge cases): plf::hive and shared_ptr elements
+// ============================================================================
+
+template <typename ConnType> class M2MContainerTest : public StormTestFixture<Playlist, ConnType, Track, Album> {
+  public:
+    auto on_after_setup(const std::shared_ptr<ConnType>& conn) -> void override {
+        QuerySet<Playlist, ConnType> pqs;
+        ASSERT_TRUE(pqs.insert(Playlist{.name = "Road trip"}).execute().has_value());
+        QuerySet<Album, ConnType> aqs;
+        ASSERT_TRUE(aqs.insert(Album{.name = "Greatest hits"}).execute().has_value());
+        QuerySet<Track, ConnType> tqs;
+        std::vector<Track> const  tracks = {{.title = "Intro"}, {.title = "Outro"}};
+        ASSERT_TRUE(tqs.insert(std::span<const Track>(tracks)).execute().has_value());
+        for (const auto* sql :
+             {"INSERT INTO Playlist_Track (Playlist_id, Track_id) VALUES (1, 1)",
+              "INSERT INTO Playlist_Track (Playlist_id, Track_id) VALUES (1, 2)",
+              "INSERT INTO Album_Track (Album_id, Track_id) VALUES (1, 2)"}) {
+            ASSERT_TRUE(conn->execute(sql).has_value());
+        }
+    }
+};
+
+TYPED_TEST_SUITE(M2MContainerTest, DatabaseTypes);
+
+TYPED_TEST(M2MContainerTest, HiveContainerEagerLoad) {
+    QuerySet<Playlist, TypeParam> qs;
+    auto                          rows = qs.template join<^^Playlist::tracks>().select().execute();
+    ASSERT_TRUE(rows.has_value()) << rows.error().message();
+    ASSERT_EQ(rows->size(), 1U);
+    ASSERT_EQ(rows->begin()->tracks.size(), 2U); // appended via hive insert()
+    auto track_it = rows->begin()->tracks.begin();
+    EXPECT_EQ(track_it->title, "Intro");
+}
+
+TYPED_TEST(M2MContainerTest, SharedPtrElementsEagerLoad) {
+    QuerySet<Album, TypeParam> qs;
+    auto                       rows = qs.template join<^^Album::tracks>().select().execute();
+    ASSERT_TRUE(rows.has_value()) << rows.error().message();
+    ASSERT_EQ(rows->size(), 1U);
+    ASSERT_EQ(rows->begin()->tracks.size(), 1U);
+    ASSERT_NE(rows->begin()->tracks[0], nullptr); // wrapped via make_shared
+    EXPECT_EQ(rows->begin()->tracks[0]->title, "Outro");
+}
+
 // NOLINTEND(misc-const-correctness)

--- a/tests/query/test_many_to_many.cpp
+++ b/tests/query/test_many_to_many.cpp
@@ -63,4 +63,39 @@ TYPED_TEST(M2MBaseTest, PlainCrudIgnoresM2MField) {
     EXPECT_TRUE(rows->begin()->courses.empty()); // plain select never populates m2m
 }
 
+// ============================================================================
+// Schema: auto-generated junction table DDL (#203 Phase 1)
+// ============================================================================
+
+TEST(M2MSchemaTest, JunctionTableSqlSQLite) {
+    const auto& sql =
+            storm::orm::schema::SchemaStatement<Student>::junction_table_sql<storm::orm::schema::Dialect::SQLite>();
+    EXPECT_TRUE(sql.contains("CREATE TABLE Student_Course")) << sql;
+    EXPECT_TRUE(sql.contains("Student_id INTEGER NOT NULL")) << sql;
+    EXPECT_TRUE(sql.contains("Course_id INTEGER NOT NULL")) << sql;
+    EXPECT_TRUE(sql.contains("PRIMARY KEY (Student_id, Course_id)")) << sql;
+}
+
+TEST(M2MSchemaTest, JunctionTableSqlPostgreSQL) {
+    const auto& sql =
+            storm::orm::schema::SchemaStatement<Student>::junction_table_sql<storm::orm::schema::Dialect::PostgreSQL>();
+    EXPECT_TRUE(sql.contains("CREATE TABLE Student_Course")) << sql;
+    EXPECT_TRUE(sql.contains("Student_id BIGINT NOT NULL")) << sql;
+    EXPECT_TRUE(sql.contains("Course_id BIGINT NOT NULL")) << sql;
+}
+
+// A through-model m2m field must NOT produce an auto junction table.
+static_assert(!storm::orm::schema::SchemaStatement<Pupil>::has_m2m_junction_);
+static_assert(storm::orm::schema::SchemaStatement<Student>::has_m2m_junction_);
+
+TYPED_TEST(M2MBaseTest, JunctionTableIsCreatedAndWritable) {
+    auto conn = QuerySet<Student, TypeParam>::get_default_connection();
+    // The fixture ran create_table_if_not_exists<Student> — the junction must exist.
+    auto ins = conn->execute("INSERT INTO Student_Course (Student_id, Course_id) VALUES (1, 1)");
+    ASSERT_TRUE(ins.has_value()) << ins.error().message();
+    // Composite PK rejects duplicate pairs.
+    auto dup = conn->execute("INSERT INTO Student_Course (Student_id, Course_id) VALUES (1, 1)");
+    EXPECT_FALSE(dup.has_value());
+}
+
 // NOLINTEND(misc-const-correctness)

--- a/tests/query/test_many_to_many.cpp
+++ b/tests/query/test_many_to_many.cpp
@@ -98,4 +98,133 @@ TYPED_TEST(M2MBaseTest, JunctionTableIsCreatedAndWritable) {
     EXPECT_FALSE(dup.has_value());
 }
 
+// ============================================================================
+// SQL shape: 3-table join over a base-table subquery (#203 Phase 1)
+// ============================================================================
+
+TYPED_TEST(M2MBaseTest, M2MJoinSqlShape) {
+    QuerySet<Student, TypeParam> qs;
+    auto                         sql = qs.template join<^^Student::courses>().select().sql();
+    EXPECT_TRUE(sql.contains("SELECT t1.id, t1.name, t1.age, t3.id, t3.title")) << sql;
+    EXPECT_TRUE(sql.contains("FROM (SELECT id, name, age FROM Student) t1")) << sql;
+    EXPECT_TRUE(sql.contains("INNER JOIN Student_Course t2 ON t1.id = t2.Student_id")) << sql;
+    EXPECT_TRUE(sql.contains("INNER JOIN Course t3 ON t2.Course_id = t3.id")) << sql;
+    EXPECT_TRUE(sql.ends_with(" ORDER BY t1.id")) << sql;
+}
+
+TYPED_TEST(M2MBaseTest, M2MJoinSqlModifiersGoInsideSubquery) {
+    QuerySet<Student, TypeParam> qs;
+    auto                         sql = qs.template join<^^Student::courses>()
+                       .where(storm::orm::where::field<^^Student::age>() > 18)
+                       .template order_by<^^Student::name, false>()
+                       .limit(2)
+                       .select()
+                       .sql();
+    // WHERE / ORDER BY / LIMIT select WHICH base entities load — inside the subquery.
+    // Outer ORDER BY repeats the user's ordering (t1-qualified) + pk tiebreak.
+    // PG dialect adds NULLS LAST after DESC (matches SQLite NULL ordering).
+    if constexpr (storm::test::is_postgresql<TypeParam>()) {
+        EXPECT_TRUE(sql.contains("FROM Student WHERE age > ? ORDER BY name DESC NULLS LAST LIMIT 2) t1")) << sql;
+        EXPECT_TRUE(sql.ends_with(" ORDER BY t1.name DESC NULLS LAST, t1.id")) << sql;
+    } else {
+        EXPECT_TRUE(sql.contains("FROM Student WHERE age > ? ORDER BY name DESC LIMIT 2) t1")) << sql;
+        EXPECT_TRUE(sql.ends_with(" ORDER BY t1.name DESC, t1.id")) << sql;
+    }
+}
+
+TYPED_TEST(M2MBaseTest, M2MJoinSqlMultiFieldOrderByQualifiesAllFields) {
+    QuerySet<Student, TypeParam> qs;
+    auto                         sql =
+            qs.template join<^^Student::courses>().template order_by<^^Student::age, ^^Student::name>().select().sql();
+    // every user order field gets the t1. prefix, then the pk tiebreak
+    if constexpr (storm::test::is_postgresql<TypeParam>()) {
+        EXPECT_TRUE(sql.ends_with(" ORDER BY t1.age ASC NULLS FIRST, t1.name ASC NULLS FIRST, t1.id")) << sql;
+    } else {
+        EXPECT_TRUE(sql.ends_with(" ORDER BY t1.age ASC, t1.name ASC, t1.id")) << sql;
+    }
+}
+
+TYPED_TEST(M2MBaseTest, M2MLeftJoinSqlShape) {
+    QuerySet<Student, TypeParam> qs;
+    auto                         sql = qs.template left_join<^^Student::courses>().select().sql();
+    EXPECT_TRUE(sql.contains("LEFT JOIN Student_Course t2")) << sql;
+    EXPECT_TRUE(sql.contains("LEFT JOIN Course t3")) << sql;
+}
+
+// ============================================================================
+// Runtime: eager loading aggregates related objects (#203 Phase 1)
+// ============================================================================
+
+// Fixture with seeded data: Alice→[Math, Physics], Bob→[Math], Carol→[].
+template <typename ConnType> class M2MSeededTest : public StormTestFixture<Student, ConnType, Course> {
+  public:
+    auto on_after_setup(const std::shared_ptr<ConnType>& /*conn*/) -> void override {
+        storm::test::seed_students<ConnType>();
+    }
+};
+
+TYPED_TEST_SUITE(M2MSeededTest, DatabaseTypes);
+
+// Finds the student with the given name; fails the test if absent.
+template <typename Hive> auto find_student(Hive& rows, std::string_view name) -> Student* {
+    for (auto& s : rows) {
+        if (s.name == name) {
+            return &s;
+        }
+    }
+    return nullptr;
+}
+
+TYPED_TEST(M2MSeededTest, EagerLoadAggregatesCourses) {
+    QuerySet<Student, TypeParam> qs;
+    auto                         rows = qs.template join<^^Student::courses>().select().execute();
+    ASSERT_TRUE(rows.has_value()) << rows.error().message();
+    // INNER join drops Carol (no courses); 3 joined rows aggregate into 2 students
+    ASSERT_EQ(rows->size(), 2U);
+
+    auto* alice = find_student(*rows, "Alice");
+    ASSERT_NE(alice, nullptr);
+    ASSERT_EQ(alice->courses.size(), 2U);
+    EXPECT_EQ(alice->courses[0].title, "Math");
+    EXPECT_EQ(alice->courses[1].title, "Physics");
+    EXPECT_EQ(alice->age, 20);
+
+    auto* bob = find_student(*rows, "Bob");
+    ASSERT_NE(bob, nullptr);
+    ASSERT_EQ(bob->courses.size(), 1U);
+    EXPECT_EQ(bob->courses[0].title, "Math");
+}
+
+TYPED_TEST(M2MSeededTest, LeftJoinKeepsStudentsWithoutCourses) {
+    QuerySet<Student, TypeParam> qs;
+    auto                         rows = qs.template left_join<^^Student::courses>().select().execute();
+    ASSERT_TRUE(rows.has_value()) << rows.error().message();
+    ASSERT_EQ(rows->size(), 3U);
+
+    auto* carol = find_student(*rows, "Carol");
+    ASSERT_NE(carol, nullptr);
+    EXPECT_TRUE(carol->courses.empty());
+    auto* alice = find_student(*rows, "Alice");
+    ASSERT_NE(alice, nullptr);
+    EXPECT_EQ(alice->courses.size(), 2U);
+}
+
+TYPED_TEST(M2MSeededTest, EmptyResultSet) {
+    QuerySet<Student, TypeParam> qs;
+    auto                         rows = qs.template join<^^Student::courses>()
+                        .where(storm::orm::where::field<^^Student::age>() > 99)
+                        .select()
+                        .execute();
+    ASSERT_TRUE(rows.has_value()) << rows.error().message();
+    EXPECT_TRUE(rows->empty());
+}
+
+// Aggregates over an m2m join count (student, course) PAIRS — documented behavior.
+TYPED_TEST(M2MSeededTest, CountOverM2MJoinCountsPairs) {
+    QuerySet<Student, TypeParam> qs;
+    auto                         count = qs.template join<^^Student::courses>().count().execute();
+    ASSERT_TRUE(count.has_value()) << count.error().message();
+    EXPECT_EQ(count.value(), 3);
+}
+
 // NOLINTEND(misc-const-correctness)

--- a/tests/query/test_many_to_many_modifiers.cpp
+++ b/tests/query/test_many_to_many_modifiers.cpp
@@ -1,0 +1,227 @@
+#include <gtest/gtest.h>
+#include "test_db_helpers.h"
+#include "plf_hive/plf_hive.h"
+
+// NOLINTBEGIN(misc-const-correctness)
+
+import storm;
+import std;
+
+using storm::QuerySet;
+using storm::orm::where::field;
+
+#include "test_models.h"     // NOSONAR cpp:S954
+#include "test_m2m_models.h" // NOSONAR cpp:S954
+
+// ============================================================================
+// M2M joins with WHERE / ORDER BY / LIMIT / OFFSET / first / get / rows (#203)
+// Seed: Alice(20)→[Math, Physics], Bob(22)→[Math], Carol(25)→[].
+// ============================================================================
+
+template <typename ConnType> class M2MModifierTest : public StormTestFixture<Student, ConnType, Course> {
+  public:
+    auto on_after_setup(const std::shared_ptr<ConnType>& /*conn*/) -> void override {
+        storm::test::seed_students<ConnType>();
+    }
+
+    // Joined SELECT with a WHERE expression — shared by the operator tests.
+    auto names_matching(storm::orm::where::ExpressionVariantPtr expr) -> std::vector<std::string> {
+        QuerySet<Student, ConnType> qs;
+        auto rows = qs.template join<^^Student::courses>().where(std::move(expr)).select().execute();
+        EXPECT_TRUE(rows.has_value());
+        std::vector<std::string> names;
+        for (const auto& s : *rows) {
+            names.push_back(s.name);
+        }
+        std::ranges::sort(names);
+        return names;
+    }
+};
+
+TYPED_TEST_SUITE(M2MModifierTest, DatabaseTypes);
+
+using Names = std::vector<std::string>;
+
+TYPED_TEST(M2MModifierTest, WhereFiltersBaseEntities) {
+    QuerySet<Student, TypeParam> qs;
+    auto rows = qs.template join<^^Student::courses>().where(field<^^Student::age>() >= 22).select().execute();
+    ASSERT_TRUE(rows.has_value()) << rows.error().message();
+    // Carol matches the WHERE but has no courses → dropped by INNER join
+    ASSERT_EQ(rows->size(), 1U);
+    EXPECT_EQ(rows->begin()->name, "Bob");
+    ASSERT_EQ(rows->begin()->courses.size(), 1U);
+    EXPECT_EQ(rows->begin()->courses[0].title, "Math");
+}
+
+TYPED_TEST(M2MModifierTest, WhereAllSixComparisonOperators) {
+    EXPECT_EQ(this->names_matching(field<^^Student::age>() == 20), (Names{"Alice"}));
+    EXPECT_EQ(this->names_matching(field<^^Student::age>() != 20), (Names{"Bob"}));
+    EXPECT_EQ(this->names_matching(field<^^Student::age>() > 20), (Names{"Bob"}));
+    EXPECT_EQ(this->names_matching(field<^^Student::age>() >= 20), (Names{"Alice", "Bob"}));
+    EXPECT_EQ(this->names_matching(field<^^Student::age>() < 22), (Names{"Alice"}));
+    EXPECT_EQ(this->names_matching(field<^^Student::age>() <= 22), (Names{"Alice", "Bob"}));
+}
+
+TYPED_TEST(M2MModifierTest, WhereSpecialExpressionsAndLogic) {
+    EXPECT_EQ(this->names_matching(field<^^Student::age>().in(20, 25)), (Names{"Alice"}));
+    EXPECT_EQ(this->names_matching(field<^^Student::age>().between(19, 21)), (Names{"Alice"}));
+    EXPECT_EQ(this->names_matching(field<^^Student::name>().like("B%")), (Names{"Bob"}));
+    EXPECT_EQ(
+            this->names_matching(field<^^Student::name>().like("A%") || field<^^Student::age>() == 22),
+            (Names{"Alice", "Bob"})
+    );
+    EXPECT_EQ(
+            this->names_matching(
+                    (field<^^Student::age>() >= 20 && field<^^Student::age>() < 22) || field<^^Student::name>() == "Bob"
+            ),
+            (Names{"Alice", "Bob"})
+    );
+}
+
+TYPED_TEST(M2MModifierTest, OrderByOrdersStudents) {
+    QuerySet<Student, TypeParam> qs;
+    auto rows = qs.template join<^^Student::courses>().template order_by<^^Student::name, false>().select().execute();
+    ASSERT_TRUE(rows.has_value()) << rows.error().message();
+    ASSERT_EQ(rows->size(), 2U);
+    auto it = rows->begin();
+    EXPECT_EQ(it->name, "Bob"); // DESC: Bob before Alice
+    ++it;
+    EXPECT_EQ(it->name, "Alice");
+    EXPECT_EQ(it->courses.size(), 2U); // full collection survives ordering
+}
+
+TYPED_TEST(M2MModifierTest, LimitLimitsStudentsNotJoinedRows) {
+    QuerySet<Student, TypeParam> qs;
+    auto rows = qs.template join<^^Student::courses>().template order_by<^^Student::name>().limit(1).select().execute();
+    ASSERT_TRUE(rows.has_value()) << rows.error().message();
+    // LIMIT 1 = one STUDENT (a flat outer LIMIT would have cut Alice's courses)
+    ASSERT_EQ(rows->size(), 1U);
+    EXPECT_EQ(rows->begin()->name, "Alice");
+    EXPECT_EQ(rows->begin()->courses.size(), 2U);
+}
+
+TYPED_TEST(M2MModifierTest, OffsetSkipsStudents) {
+    QuerySet<Student, TypeParam> qs;
+    auto                         rows = qs.template join<^^Student::courses>()
+                        .template order_by<^^Student::name>()
+                        .limit(1)
+                        .offset(1)
+                        .select()
+                        .execute();
+    ASSERT_TRUE(rows.has_value()) << rows.error().message();
+    ASSERT_EQ(rows->size(), 1U);
+    EXPECT_EQ(rows->begin()->name, "Bob");
+    EXPECT_EQ(rows->begin()->courses.size(), 1U);
+}
+
+TYPED_TEST(M2MModifierTest, FirstReturnsCompleteEntity) {
+    QuerySet<Student, TypeParam> qs;
+    auto first = qs.template join<^^Student::courses>().template order_by<^^Student::name>().first().execute();
+    ASSERT_TRUE(first.has_value()) << first.error().message();
+    ASSERT_TRUE(first->has_value());
+    EXPECT_EQ((*first)->name, "Alice");
+    EXPECT_EQ((*first)->courses.size(), 2U); // LIMIT 1 applies to students, not rows
+}
+
+TYPED_TEST(M2MModifierTest, FirstOnEmptyReturnsNullopt) {
+    QuerySet<Student, TypeParam> qs;
+    auto first = qs.template join<^^Student::courses>().where(field<^^Student::age>() > 99).first().execute();
+    ASSERT_TRUE(first.has_value()) << first.error().message();
+    EXPECT_FALSE(first->has_value());
+}
+
+TYPED_TEST(M2MModifierTest, GetReturnsExactlyOne) {
+    QuerySet<Student, TypeParam> qs;
+    auto got = qs.template join<^^Student::courses>().where(field<^^Student::name>() == "Bob").get().execute();
+    ASSERT_TRUE(got.has_value()) << got.error().message();
+    EXPECT_EQ(got->name, "Bob");
+    ASSERT_EQ(got->courses.size(), 1U);
+    EXPECT_EQ(got->courses[0].title, "Math");
+}
+
+TYPED_TEST(M2MModifierTest, GetAggregatesMultipleRelationsIntoOneEntity) {
+    QuerySet<Student, TypeParam> qs;
+    // Alice has TWO courses — two joined rows must aggregate into ONE entity,
+    // not trip the "multiple rows" uniqueness check.
+    auto got = qs.template join<^^Student::courses>().where(field<^^Student::name>() == "Alice").get().execute();
+    ASSERT_TRUE(got.has_value()) << got.error().message();
+    EXPECT_EQ(got->name, "Alice");
+    EXPECT_EQ(got->courses.size(), 2U);
+}
+
+TYPED_TEST(M2MModifierTest, GetZeroRowsIsError) {
+    QuerySet<Student, TypeParam> qs;
+    auto got = qs.template join<^^Student::courses>().where(field<^^Student::name>() == "Zed").get().execute();
+    ASSERT_FALSE(got.has_value());
+    EXPECT_TRUE(got.error().message().contains("No row found"));
+}
+
+TYPED_TEST(M2MModifierTest, GetMultipleRowsIsError) {
+    QuerySet<Student, TypeParam> qs;
+    auto                         got = qs.template join<^^Student::courses>().get().execute();
+    ASSERT_FALSE(got.has_value());
+    EXPECT_TRUE(got.error().message().contains("Multiple rows found"));
+}
+
+TYPED_TEST(M2MModifierTest, RowsGeneratorYieldsAggregatedEntities) {
+    QuerySet<Student, TypeParam> qs;
+    auto                         joined = qs.template join<^^Student::courses>().template order_by<^^Student::name>();
+
+    std::vector<Student> yielded;
+    for (auto&& row : joined.rows()) {
+        ASSERT_TRUE(row.has_value()) << row.error().message();
+        yielded.push_back(std::move(*row));
+    }
+    ASSERT_EQ(yielded.size(), 2U);
+    EXPECT_EQ(yielded[0].name, "Alice");
+    EXPECT_EQ(yielded[0].courses.size(), 2U);
+    EXPECT_EQ(yielded[1].name, "Bob");
+    EXPECT_EQ(yielded[1].courses.size(), 1U);
+}
+
+TYPED_TEST(M2MModifierTest, RowsGeneratorOnEmptyYieldsNothing) {
+    QuerySet<Student, TypeParam> qs;
+    auto                         joined = qs.template join<^^Student::courses>().where(field<^^Student::age>() > 99);
+
+    std::size_t count = 0;
+    for (auto&& row : joined.rows()) {
+        ASSERT_TRUE(row.has_value());
+        ++count;
+    }
+    EXPECT_EQ(count, 0U);
+}
+
+TYPED_TEST(M2MModifierTest, RepeatedQueryUsesStatementCache) {
+    QuerySet<Student, TypeParam> qs;
+    auto                         joined    = qs.template join<^^Student::courses>();
+    auto                         first_run = joined.select().execute();
+    ASSERT_TRUE(first_run.has_value()) << first_run.error().message();
+    auto second_run = joined.select().execute(); // same SQL → cached statement
+    ASSERT_TRUE(second_run.has_value()) << second_run.error().message();
+    EXPECT_EQ(first_run->size(), second_run->size());
+    auto* alice = [&]() -> Student* {
+        for (auto& s : *second_run) {
+            if (s.name == "Alice") {
+                return &s;
+            }
+        }
+        return nullptr;
+    }();
+    ASSERT_NE(alice, nullptr);
+    EXPECT_EQ(alice->courses.size(), 2U); // re-extraction appends into a FRESH object
+}
+
+TYPED_TEST(M2MModifierTest, JoinIsImmutableOnBaseQuerySet) {
+    QuerySet<Student, TypeParam> qs;
+    auto                         joined = qs.template join<^^Student::courses>();
+    (void)joined;
+    // base QuerySet is unaffected by the join (Django-style immutability)
+    auto plain = qs.select().execute();
+    ASSERT_TRUE(plain.has_value()) << plain.error().message();
+    EXPECT_EQ(plain->size(), 3U); // Carol included; no aggregation
+    for (const auto& s : *plain) {
+        EXPECT_TRUE(s.courses.empty());
+    }
+}
+
+// NOLINTEND(misc-const-correctness)

--- a/tests/query/test_many_to_many_through.cpp
+++ b/tests/query/test_many_to_many_through.cpp
@@ -1,0 +1,101 @@
+#include <gtest/gtest.h>
+#include "test_db_helpers.h"
+#include "plf_hive/plf_hive.h"
+
+// NOLINTBEGIN(misc-const-correctness)
+
+import storm;
+import std;
+
+using storm::QuerySet;
+using storm::orm::where::field;
+
+#include "test_models.h"     // NOSONAR cpp:S954
+#include "test_m2m_models.h" // NOSONAR cpp:S954
+
+// ============================================================================
+// Phase 2 (#203): explicit junction model — many_to_many_through<Enrollment>
+// Pupil ⟷ Course through Enrollment (with `grade` metadata).
+// ============================================================================
+
+template <typename ConnType> class M2MThroughTest : public StormTestFixture<Pupil, ConnType, Course, Enrollment> {
+  public:
+    auto on_after_setup(const std::shared_ptr<ConnType>& /*conn*/) -> void override {
+        QuerySet<Pupil, ConnType> pqs;
+        std::vector<Pupil> const  pupils = {{.name = "Dora", .age = 11}, {.name = "Eli", .age = 12}};
+        ASSERT_TRUE(pqs.insert(std::span<const Pupil>(pupils)).execute().has_value());
+
+        QuerySet<Course, ConnType> cqs;
+        std::vector<Course> const  courses = {{.title = "Math"}, {.title = "Art"}};
+        ASSERT_TRUE(cqs.insert(std::span<const Course>(courses)).execute().has_value());
+
+        // Junction rows are plain Enrollment inserts — the through model is a model.
+        QuerySet<Enrollment, ConnType> eqs;
+        std::vector<Enrollment> const  enrollments = {
+                {.pupil = {.id = 1}, .course = {.id = 1}, .grade = "A"},
+                {.pupil = {.id = 1}, .course = {.id = 2}, .grade = "B"},
+                {.pupil = {.id = 2}, .course = {.id = 1}, .grade = "C"},
+        };
+        ASSERT_TRUE(eqs.insert(std::span<const Enrollment>(enrollments)).execute().has_value());
+    }
+};
+
+TYPED_TEST_SUITE(M2MThroughTest, DatabaseTypes);
+
+TYPED_TEST(M2MThroughTest, ThroughSqlUsesJunctionModel) {
+    QuerySet<Pupil, TypeParam> qs;
+    auto                       sql = qs.template join<^^Pupil::courses>().select().sql();
+    // junction = the through model's table; FK columns come from its field names
+    EXPECT_TRUE(sql.contains("INNER JOIN Enrollment t2 ON t1.id = t2.pupil_id")) << sql;
+    EXPECT_TRUE(sql.contains("INNER JOIN Course t3 ON t2.course_id = t3.id")) << sql;
+    EXPECT_TRUE(sql.contains("FROM (SELECT id, name, age FROM Pupil) t1")) << sql;
+}
+
+TYPED_TEST(M2MThroughTest, ThroughEagerLoadIgnoresMetadata) {
+    QuerySet<Pupil, TypeParam> qs;
+    auto                       rows = qs.template join<^^Pupil::courses>().select().execute();
+    ASSERT_TRUE(rows.has_value()) << rows.error().message();
+    ASSERT_EQ(rows->size(), 2U);
+
+    for (const auto& pupil : *rows) {
+        if (pupil.name == "Dora") {
+            ASSERT_EQ(pupil.courses.size(), 2U);
+            EXPECT_EQ(pupil.courses[0].title, "Math");
+            EXPECT_EQ(pupil.courses[1].title, "Art");
+        } else {
+            EXPECT_EQ(pupil.name, "Eli");
+            ASSERT_EQ(pupil.courses.size(), 1U);
+            EXPECT_EQ(pupil.courses[0].title, "Math");
+        }
+    }
+}
+
+TYPED_TEST(M2MThroughTest, ThroughWithWhereOrderAndLimit) {
+    QuerySet<Pupil, TypeParam> qs;
+    auto                       rows = qs.template join<^^Pupil::courses>()
+                        .where(field<^^Pupil::age>() >= 11)
+                        .template order_by<^^Pupil::name, false>()
+                        .limit(1)
+                        .select()
+                        .execute();
+    ASSERT_TRUE(rows.has_value()) << rows.error().message();
+    ASSERT_EQ(rows->size(), 1U);
+    EXPECT_EQ(rows->begin()->name, "Eli"); // DESC → Eli first
+    EXPECT_EQ(rows->begin()->courses.size(), 1U);
+}
+
+// Metadata access: query the junction model directly with the existing FK join API.
+TYPED_TEST(M2MThroughTest, JunctionModelQueriedDirectlyForMetadata) {
+    QuerySet<Enrollment, TypeParam> qs;
+    auto                            rows = qs.template join<^^Enrollment::pupil, ^^Enrollment::course>()
+                        .where(field<^^Enrollment::grade>() == "B")
+                        .select()
+                        .execute();
+    ASSERT_TRUE(rows.has_value()) << rows.error().message();
+    ASSERT_EQ(rows->size(), 1U);
+    EXPECT_EQ(rows->begin()->grade, "B");
+    EXPECT_EQ(rows->begin()->pupil.name, "Dora");
+    EXPECT_EQ(rows->begin()->course.title, "Art");
+}
+
+// NOLINTEND(misc-const-correctness)


### PR DESCRIPTION
Closes #203

Attribute-based many-to-many relationships with **single-query eager loading**, consumed through the existing `join<^^T::field>()` API.

## Phase 1 — auto-generated junction table
```cpp
struct Student {
    [[= storm::meta::FieldAttr::primary]] int id{};
    std::string name;
    [[= storm::meta::many_to_many]] std::vector<Course> courses;
};
auto students = QuerySet<Student>().join<^^Student::courses>().select().execute();
```
- Junction DDL auto-generated: `Student_Course (Student_id, Course_id, PRIMARY KEY(both))`, created by `create_table_if_not_exists`.
- Related type extracted from the container via C++26 `std::meta` (`vector`, `plf::hive`, `deque`, `shared_ptr`/`unique_ptr` elements).

## Phase 2 — explicit junction model
```cpp
[[= storm::meta::many_to_many_through<Enrollment>]] std::vector<Course> courses;
```
Junction = the through model's table; FK columns from its `FieldAttr::fk` field names. Metadata is queried directly via `QuerySet<Enrollment>` FK joins.

## Design
- **m2m members are not columns**: filtered out of `BaseStatement::all_members_`/`field_count_` — CRUD/schema ignore them at zero cost.
- **SQL layout**: 3-table join over a base-table subquery; WHERE/ORDER BY/LIMIT/OFFSET apply to *base entities* (`limit(1)` = one student with ALL courses). Outer `ORDER BY …, t1.<pk>` guarantees same-entity row adjacency, so aggregation needs no map.
- **Type-erased wrapper extension**: `JoinStatementWrapper` gains 3 nullable fn pointers; plain FK joins unaffected.
- `first()`/`get()` are entity-level (`get()` errors on 0/>1 *entities*, not relations); `rows()` lazily yields aggregated entities; aggregates over an m2m join count (base, related) pairs (documented).

## Deviations from the issue sketch (reported, not silent)
1. `FieldAttr::many_to_many<T>` is impossible — `FieldAttr` is an enum; enum values can't be templated. API: `storm::meta::many_to_many` + `storm::meta::many_to_many_through<T>` (`ManyToMany<Through>` class-template annotation).
2. Junction naming is `<OwnerTable>_<RelatedTable>` verbatim (`Student_Course`) per Storm's table-name convention and all SQL examples in the issue (the prose said "alphabetical" but every example was owner-first).
3. Out of scope (per Phase 1 plan / not in acceptance criteria): multiple m2m fields per model, self-referential m2m (rejected at compile time), write-side `add()`/`remove()` helpers, `std::list` runtime path.

## Verification
- 2076/2076 tests (SQLite + PostgreSQL, debug + release), 100 % coverage, clang-tidy clean
- ASAN+UBSAN and TSAN: 2076/2076, zero reports
- Benchmarks (interleaved A/B vs develop ×5, median-of-medians): SELECT/JOIN deltas −2.8 %…+0.6 % — no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)