### PR TITLE
refactor(orm): extract FieldAttr into a leaf module to remove the manual enum mirror (#387)

### DIFF
--- a/.claude/agents/dev.md
+++ b/.claude/agents/dev.md
@@ -57,7 +57,7 @@ When adding or modifying modules:
 2. **Prevent circular dependencies**: identify shared dependencies that should be extracted to a base module
 3. **Enforce naming**: module names use underscores (e.g., `storm_db_sqlite`, not `storm.db.sqlite`)
 4. **Minimize coupling**: modules should have minimal import surface area
-5. **Duplicate where needed**: `FieldAttr` enum is intentionally duplicated to avoid circular deps
+5. **Extract shared leaves**: dependency-free shared declarations live in leaf modules (e.g. `storm_orm_field_attr` for `FieldAttr`/`is_primary_attr`, `storm_db_concept`) — never duplicate definitions to break a cycle (#387)
 
 When documenting module structure, provide ASCII dependency graphs showing import relationships and build order.
 

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -64,7 +64,7 @@ You are a senior C++ code reviewer specializing in the Storm ORM project, with d
 ### 9. Compiler-Specific Constraints
 - Code works with the experimental Clang fork at `../clang-p2996/`
 - No constexpr SQL generation (runtime `std::format` only)
-- `FieldAttr` enum duplication where needed to avoid circular dependencies
+- `FieldAttr` has a single definition in the `storm_orm_field_attr` leaf module (#387) — flag any re-declared copy of it
 
 ### 10. C++ Core Guidelines
 - Apply rules from `.claude/agents/rule-standards.md` as a secondary checklist

--- a/.claude/agents/test.md
+++ b/.claude/agents/test.md
@@ -163,7 +163,7 @@ Before declaring tests successful:
 - **In-memory database**: Tests use `:memory:` SQLite database
 - **Fresh tables**: Each test creates new tables and data
 - **Module naming**: Uses underscores (storm_db_sqlite) not dots
-- **Circular dependencies**: Watch for duplicated FieldAttr definitions
+- **Circular dependencies**: Shared declarations belong in leaf modules (`storm_orm_field_attr`), never duplicated (#387)
 - **Compiler crashes**: Be aware of std::mutex module limitations
 
 Always provide actionable insights from test results and suggest specific fixes for any failures encountered. If tests pass, confirm the code meets Storm ORM's quality standards and performance expectations.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -261,6 +261,7 @@ src/
 │   └── sqlite.cppm             # SQLite implementation
 └── orm/
     ├── queryset.cppm           # QuerySet ORM interface
+    ├── field_attr.cppm         # FieldAttr annotation enum + is_primary_attr (leaf module)
     ├── utilities.cppm          # ConstexprString, SQLCache
     ├── indexes.cppm            # Index, UniqueIndex, Indexes<T> trait (namespace storm)
     └── statements/             # INSERT, SELECT, UPDATE, DELETE, DISTINCT, JOIN

--- a/docs/architecture/DESIGN_DECISIONS.md
+++ b/docs/architecture/DESIGN_DECISIONS.md
@@ -229,7 +229,7 @@ See [DISTINCT Analysis](../benchmarks/DISTINCT_ANALYSIS.md) for detailed impleme
 - **Index Sequence Optimization**: Uses `std::index_sequence` and fold expressions
 - **Pre-computed Metadata**: Field information cached in static constexpr variables
 - **Module Naming**: Uses underscores (`storm_db_sqlite`) due to compiler limitations
-- **Circular Dependencies**: Avoided by duplicating `FieldAttr` enum
+- **Circular Dependencies**: Avoided by extracting shared declarations into dependency-free leaf modules (`storm_orm_field_attr` for `FieldAttr`/`is_primary_attr`, #387)
 - **Compiler Crashes**: std::mutex in modules causes segfaults
 - **std::function Linker Errors**: Avoid `std::function` with custom libc++ - use abstract base classes instead (see JOIN architecture)
 - **Primary Key Access**: Uses reflection splice operator `obj.[:primary_key_:]`

--- a/docs/architecture/OVERVIEW.md
+++ b/docs/architecture/OVERVIEW.md
@@ -79,6 +79,7 @@ src/
 │   └── sqlite.cppm                 # SQLite implementation
 └── orm/
     ├── queryset.cppm               # QuerySet interface
+    ├── field_attr.cppm             # FieldAttr annotation enum (leaf module, #387)
     ├── utilities.cppm              # ConstexprString, SQLCache
     └── statements/
         ├── base.cppm               # BaseStatement utilities
@@ -95,6 +96,7 @@ src/
 storm (main module)
 ├── storm_db_concept
 ├── storm_db_sqlite
+├── storm_orm_field_attr
 ├── storm_orm_statements_base
 ├── storm_orm_utilities
 ├── storm_orm_statements_{insert,update,erase,select,join}

--- a/src/orm/field_attr.cppm
+++ b/src/orm/field_attr.cppm
@@ -1,0 +1,34 @@
+module;
+
+export module storm_orm_field_attr;
+
+import std;
+
+// Dependency-free leaf module (#387): single source of truth for the FieldAttr
+// annotation enum, shared by statement modules and the public storm module.
+// Same pattern as storm_db_concept — no Storm imports, so any module may use it
+// without creating a cycle.
+export namespace storm::meta {
+
+    // Field annotation attributes read via C++26 reflection, e.g.
+    //   [[= storm::meta::FieldAttr::primary]] int id;
+    enum class FieldAttr : std::uint8_t {
+        primary,
+        primary_autoincrement,
+        indexed,
+        unique,
+        fk,
+        auto_create,
+        auto_update
+    };
+
+    // A field is "a primary key" for either annotation variant: plain `primary`
+    // (plain INTEGER PRIMARY KEY) or `primary_autoincrement` (the SQLite never-reuse
+    // opt-in, #379). Every PK-detection site routes through here so the two variants
+    // can never drift apart.
+    consteval auto is_primary_attr(FieldAttr attr) -> bool {
+        using enum FieldAttr;
+        return attr == primary || attr == primary_autoincrement;
+    }
+
+} // namespace storm::meta

--- a/src/orm/statements/base.cppm
+++ b/src/orm/statements/base.cppm
@@ -10,6 +10,7 @@ export module storm_orm_statements_base;
 import std;
 
 import storm_db_concept;
+import storm_orm_field_attr;
 import storm_orm_utilities;
 import storm_orm_statements_orderby;
 import storm_orm_where;
@@ -19,26 +20,12 @@ export namespace storm::orm::statements {
     // Import utilities for compile-time string building
     using storm::orm::utilities::ConstexprString;
 
-    // Mirror of meta::FieldAttr from storm module - must match exactly
     namespace meta {
-        enum class FieldAttr : std::uint8_t {
-            primary,
-            primary_autoincrement,
-            indexed,
-            unique,
-            fk,
-            auto_create,
-            auto_update
-        };
-
-        // A field is "a primary key" for either annotation variant: plain `primary`
-        // (plain INTEGER PRIMARY KEY) or `primary_autoincrement` (the SQLite never-reuse
-        // opt-in, #379). Every PK-detection site routes through here so the two variants
-        // can never drift apart.
-        consteval auto is_primary_attr(FieldAttr attr) -> bool {
-            using enum FieldAttr;
-            return attr == primary || attr == primary_autoincrement;
-        }
+        // Canonical FieldAttr + is_primary_attr live in the dependency-free
+        // storm_orm_field_attr leaf module (#387); re-exposed here so statement
+        // modules keep using the meta:: qualifier.
+        using storm::meta::FieldAttr;
+        using storm::meta::is_primary_attr;
 
         // Many-to-many annotation (#203). Phase 1 (auto-generated junction table):
         //   [[= storm::meta::many_to_many]] std::vector<Course> courses;

--- a/src/orm/where.cppm
+++ b/src/orm/where.cppm
@@ -30,19 +30,6 @@ export namespace storm::orm::where {
     // type at compile time. The actual Statement* conversion happens in bind_params_direct().
     using ErasedStatementPtr = void*; // NOSONAR(cpp:S5008) - type erasure requires void*
 
-    // Mirror of meta::FieldAttr from storm module - must match exactly
-    namespace meta {
-        enum class FieldAttr : std::uint8_t {
-            primary,
-            primary_autoincrement,
-            indexed,
-            unique,
-            fk,
-            auto_create,
-            auto_update
-        };
-    }
-
     // Comparison operators
     enum class CompOp : std::uint8_t { Equal, NotEqual, Greater, GreaterEqual, Less, LessEqual };
 

--- a/src/storm.cppm
+++ b/src/storm.cppm
@@ -7,6 +7,7 @@ export module storm;
 import std;
 
 // Import and re-export all Storm ORM modules
+export import storm_orm_field_attr;
 export import storm_orm_generator;
 export import storm_orm_utilities;
 export import storm_db_concept;
@@ -31,12 +32,10 @@ export namespace storm {
     // Re-export UUID type for convenient access as storm::UUID
     using UUID = orm::utilities::UUID;
 
-    // Meta functionality for ORM field attributes and reflection
+    // Meta functionality for ORM field attributes and reflection.
+    // FieldAttr + is_primary_attr come from the storm_orm_field_attr leaf module
+    // (re-exported above), which already declares them in storm::meta (#387).
     namespace meta {
-        // Note: FieldAttr enum is defined in storm_orm_statements_base module
-        // and re-exported here through the import chain
-        using FieldAttr = orm::statements::meta::FieldAttr;
-
         // Many-to-many annotations (#203): many_to_many (auto junction table) and
         // many_to_many_through<Through> (explicit junction model). These re-exports
         // are consumed by user model declarations, never inside this module.
@@ -47,7 +46,7 @@ export namespace storm {
         // Check if member has primary attribute
         consteval auto has_primary_attr(std::meta::info member) -> bool {
             auto field_attr = std::meta::annotation_of_type<FieldAttr>(member);
-            return field_attr.has_value() && orm::statements::meta::is_primary_attr(field_attr.value());
+            return field_attr.has_value() && is_primary_attr(field_attr.value());
         }
 
         // Find primary key member — T must satisfy ModelWithPrimaryKey<T>


### PR DESCRIPTION
Closes #387

## What

`meta::FieldAttr` was physically duplicated in `base.cppm` and `where.cppm`, kept in sync only by a "must match exactly" comment. This extracts it into a dependency-free leaf module — single source of truth, no drift risk.

- **New leaf module** `storm_orm_field_attr` (`src/orm/field_attr.cppm`) exports `storm::meta::FieldAttr` + `is_primary_attr` (same pattern as `storm_db_concept`)
- **`base.cppm`** imports it; `statements::meta` re-exposes both via using-declarations so every existing `meta::FieldAttr` reference site (base/update/distinct/schema/join) compiles unchanged
- **`where.cppm`**: the mirror turned out to be **dead code** — nothing anywhere references `storm::orm::where::meta::FieldAttr` — so it is deleted outright; no import needed (small deviation from the issue's DoD wording, noted on the issue)
- **`storm.cppm`**: the `using FieldAttr = orm::statements::meta::FieldAttr;` alias is replaced by `export import storm_orm_field_attr` — the leaf module already declares the enum in its canonical public namespace `storm::meta`
- Duplication notes updated in `.claude/agents/{dev,reviewer,test}.md`, `CLAUDE.md`, `docs/architecture/{DESIGN_DECISIONS,OVERVIEW}.md`

## Verification

- Debug + release builds clean (first pass, no PCM issues); no circular module dependency
- 2101/2101 tests pass (SQLite + PostgreSQL)
- ASAN+UBSAN clean (2101/2101), TSAN clean (2101/2101)
- Coverage 100% (7192/7192 lines)
- Release benchmark spot check in normal range (consteval-only change, zero runtime cost)
- clang-tidy diff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)