### PR TITLE
refactor(orm): rename where::field<> to where::f<> for terser WHERE syntax

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -405,8 +405,8 @@ qs.avg<^^Person::salary>().execute();          // double
 qs.group_by<^^Person::department>().count().execute();
 
 // HAVING (only with GROUP BY) — filters groups after aggregation
-qs.group_by<^^Person::age>().having(field<^^Person::age>() > 30).count().execute();
-qs.group_by<^^Person::dept>().count().having(field<^^Person::dept>() == "Eng").execute();
+qs.group_by<^^Person::age>().having(f<^^Person::age>() > 30).count().execute();
+qs.group_by<^^Person::dept>().count().having(f<^^Person::dept>() == "Eng").execute();
 
 // DISTINCT
 qs.distinct<^^Person::name>().execute();

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1440,7 +1440,7 @@ class QueryBenchmark : public DataBenchmarkBase<QueryBenchmark<Model, test>, Mod
 - `where_or_simple` - OR combination (age < 25 OR age > 60)
 
 **What's tested:**
-- **Storm ORM**: Uses `field<>().like()`, `field<>().between()`, `field<>().in()`, and `&&`/`||` operators
+- **Storm ORM**: Uses `f<>().like()`, `f<>().between()`, `f<>().in()`, and `&&`/`||` operators
 - **Raw SQLite**: Manual SQL with LIKE, BETWEEN, IN clauses
 - **Fair comparison**: Both versions use prepared statement caching
 
@@ -1821,7 +1821,7 @@ This provides an **apples-to-apples comparison** to measure the actual overhead 
 ```cpp
 // Storm ORM version (automatic statement caching)
 for (int i = 0; i < iterations; i++) {
-    auto results = qs.where(field<age>() > 30).select();
+    auto results = qs.where(f<age>() > 30).select();
 }
 
 // Raw SQLite version (manual statement reuse)

--- a/benchmarks/dashboard/db.hpp
+++ b/benchmarks/dashboard/db.hpp
@@ -93,10 +93,10 @@ namespace {
     auto newest_flagged_run(std::string_view current_branch, std::string_view current_host) -> ResolvedBaseline {
         return newest_run(
                 storm::QuerySet<bench_dashboard::BenchRun>()
-                        .where(storm::orm::where::field<Flag>() == true)
-                        .where(storm::orm::where::field<^^bench_dashboard::BenchRun::branch>() ==
+                        .where(storm::orm::where::f<Flag>() == true)
+                        .where(storm::orm::where::f<^^bench_dashboard::BenchRun::branch>() ==
                                std::string{current_branch})
-                        .where(storm::orm::where::field<^^bench_dashboard::BenchRun::hostname>() ==
+                        .where(storm::orm::where::f<^^bench_dashboard::BenchRun::hostname>() ==
                                std::string{current_host})
         );
     }
@@ -105,7 +105,7 @@ namespace {
     auto run_by_id(std::int64_t id) -> ResolvedBaseline {
         return newest_run(
                 storm::QuerySet<bench_dashboard::BenchRun>().where(
-                        storm::orm::where::field<^^bench_dashboard::BenchRun::id>() == static_cast<int>(id)
+                        storm::orm::where::f<^^bench_dashboard::BenchRun::id>() == static_cast<int>(id)
                 )
         );
     }
@@ -123,8 +123,8 @@ namespace {
         if (const auto* b = std::get_if<BaselineBranch>(&sel))
             return newest_run(
                     storm::QuerySet<bench_dashboard::BenchRun>()
-                            .where(storm::orm::where::field<^^bench_dashboard::BenchRun::is_full_run>() == true)
-                            .where(storm::orm::where::field<^^bench_dashboard::BenchRun::branch>() == b->name)
+                            .where(storm::orm::where::f<^^bench_dashboard::BenchRun::is_full_run>() == true)
+                            .where(storm::orm::where::f<^^bench_dashboard::BenchRun::branch>() == b->name)
             );
 
         if (const auto* rw = std::get_if<BaselineRaw>(&sel)) {
@@ -142,10 +142,10 @@ namespace {
             -> std::optional<double> {
         auto rows = fetch_first_result_row(
                 storm::QuerySet<bench_dashboard::BenchResult>()
-                        .where(storm::orm::where::field<^^bench_dashboard::BenchResult::run_id>() ==
+                        .where(storm::orm::where::f<^^bench_dashboard::BenchResult::run_id>() ==
                                static_cast<int>(baseline_run_id))
-                        .where(storm::orm::where::field<^^bench_dashboard::BenchResult::test_name>() == test_name)
-                        .where(storm::orm::where::field<^^bench_dashboard::BenchResult::dataset_size>() ==
+                        .where(storm::orm::where::f<^^bench_dashboard::BenchResult::test_name>() == test_name)
+                        .where(storm::orm::where::f<^^bench_dashboard::BenchResult::dataset_size>() ==
                                static_cast<int>(dataset_size))
         );
         if (rows.empty())
@@ -169,10 +169,10 @@ namespace {
             -> std::optional<BaselineComplexity> {
         auto rows = fetch_first_result_row(
                 storm::QuerySet<bench_dashboard::BenchResult>()
-                        .where(storm::orm::where::field<^^bench_dashboard::BenchResult::run_id>() ==
+                        .where(storm::orm::where::f<^^bench_dashboard::BenchResult::run_id>() ==
                                static_cast<int>(baseline_run_id))
-                        .where(storm::orm::where::field<^^bench_dashboard::BenchResult::test_name>() == test_name)
-                        .where(storm::orm::where::field<^^bench_dashboard::BenchResult::row_kind>() ==
+                        .where(storm::orm::where::f<^^bench_dashboard::BenchResult::test_name>() == test_name)
+                        .where(storm::orm::where::f<^^bench_dashboard::BenchResult::row_kind>() ==
                                std::string{bench_dashboard::wire::kRowKindBigO})
         );
         if (rows.empty())

--- a/benchmarks/dashboard/events.hpp
+++ b/benchmarks/dashboard/events.hpp
@@ -183,7 +183,7 @@ namespace {
     auto load_results_for_run(int run_id) -> std::vector<bench_dashboard::BenchResult> {
         return materialise_select<bench_dashboard::BenchResult>(
                 storm::QuerySet<bench_dashboard::BenchResult>()
-                        .where(storm::orm::where::field<^^bench_dashboard::BenchResult::run_id>() == run_id)
+                        .where(storm::orm::where::f<^^bench_dashboard::BenchResult::run_id>() == run_id)
                         .order_by<^^bench_dashboard::BenchResult::id>()
         );
     }

--- a/docs/COOKBOOK.md
+++ b/docs/COOKBOOK.md
@@ -44,11 +44,11 @@ qs.insert(people);
 auto all = qs.select();
 
 // With WHERE
-auto seniors = qs.where(field<^^Person::age>() > 30).select();
+auto seniors = qs.where(f<^^Person::age>() > 30).select();
 
 // With ORDER BY + LIMIT + OFFSET
 auto page = qs
-    .where(field<^^Person::is_active>() == true)
+    .where(f<^^Person::is_active>() == true)
     .order_by<^^Person::name>()
     .limit(10)
     .offset(20)
@@ -59,25 +59,25 @@ auto page = qs
 
 ```cpp
 // Comparison operators
-qs.where(field<^^Person::age>() == 30).select();
-qs.where(field<^^Person::age>() != 30).select();
-qs.where(field<^^Person::age>() > 30).select();
-qs.where(field<^^Person::age>() >= 30).select();
-qs.where(field<^^Person::age>() < 30).select();
-qs.where(field<^^Person::age>() <= 30).select();
+qs.where(f<^^Person::age>() == 30).select();
+qs.where(f<^^Person::age>() != 30).select();
+qs.where(f<^^Person::age>() > 30).select();
+qs.where(f<^^Person::age>() >= 30).select();
+qs.where(f<^^Person::age>() < 30).select();
+qs.where(f<^^Person::age>() <= 30).select();
 
 // LIKE
-qs.where(field<^^Person::name>().like("A%")).select();
+qs.where(f<^^Person::name>().like("A%")).select();
 
 // IN
-qs.where(field<^^Person::age>().in(25, 30, 35)).select();
+qs.where(f<^^Person::age>().in(25, 30, 35)).select();
 
 // BETWEEN
-qs.where(field<^^Person::age>().between(25, 35)).select();
+qs.where(f<^^Person::age>().between(25, 35)).select();
 
 // AND / OR
-qs.where(field<^^Person::age>() > 30 && field<^^Person::is_active>() == true).select();
-qs.where(field<^^Person::age>() < 25 || field<^^Person::age>() > 40).select();
+qs.where(f<^^Person::age>() > 30 && f<^^Person::is_active>() == true).select();
+qs.where(f<^^Person::age>() < 25 || f<^^Person::age>() > 40).select();
 ```
 
 ## UPDATE
@@ -128,7 +128,7 @@ fields must be `std::chrono::system_clock::time_point`. See
 qs.erase(p);
 
 // Erase all matching
-auto inactive = qs.where(field<^^Person::is_active>() == false).select();
+auto inactive = qs.where(f<^^Person::is_active>() == false).select();
 qs.erase(inactive);
 
 // Erase all
@@ -146,7 +146,7 @@ auto lo    = qs.min<^^Person::age>().execute();              // int64_t
 auto hi    = qs.max<^^Person::age>().execute();              // int64_t
 
 // With WHERE
-auto active_count = qs.where(field<^^Person::is_active>() == true).count().execute();
+auto active_count = qs.where(f<^^Person::is_active>() == true).count().execute();
 ```
 
 ## GROUP BY + HAVING
@@ -158,7 +158,7 @@ auto groups = qs.group_by<^^Person::is_active>().count().execute();
 // GROUP BY with HAVING
 auto large_groups = qs
     .group_by<^^Person::age>()
-    .having(field<^^Person::age>() > 30)
+    .having(f<^^Person::age>() > 30)
     .count()
     .execute();
 ```
@@ -203,8 +203,8 @@ auto results = msg_qs.join<Message>().where(...).select();
 QuerySet<Person> qs1, qs2;
 
 // UNION (deduplicated)
-auto combined = qs1.where(field<^^Person::age>() > 30)
-    .union_with(qs2.where(field<^^Person::is_active>() == true))
+auto combined = qs1.where(f<^^Person::age>() > 30)
+    .union_with(qs2.where(f<^^Person::is_active>() == true))
     .select();
 
 // UNION ALL (keeps duplicates)
@@ -222,7 +222,7 @@ auto diff   = qs1.where(...).except_with(qs2.where(...)).select();
 void worker() {
     QuerySet<Person>::set_default_connection(":memory:");
     QuerySet<Person> qs;
-    qs.where(field<^^Person::age>() > 30).select();
+    qs.where(f<^^Person::age>() > 30).select();
 }
 
 std::jthread t1(worker), t2(worker);

--- a/docs/architecture/COMPILE_TIME_VS_RUNTIME.md
+++ b/docs/architecture/COMPILE_TIME_VS_RUNTIME.md
@@ -28,7 +28,7 @@ class QuerySet<T> {
 
 // Usage - QuerySet type never changes
 QuerySet<Person> qs;
-auto result = qs.where(field<^^Person::age>() > 30).select();
+auto result = qs.where(f<^^Person::age>() > 30).select();
 ```
 
 ### Characteristics
@@ -113,10 +113,10 @@ struct ComparisonExpr {
 // Type changes with EVERY operation
 QuerySet<Person> qs;
 
-auto qs1 = qs.where(field<^^Person::age>() > 30);
+auto qs1 = qs.where(f<^^Person::age>() > 30);
 // qs1 type: QuerySet<Person, Connection, ComparisonExpr<Person::age, Greater, int>>
 
-auto qs2 = qs1.where(field<^^Person::name>() == "Alice");
+auto qs2 = qs1.where(f<^^Person::name>() == "Alice");
 // qs2 type: QuerySet<Person, Connection,
 //                    AndExpr<ComparisonExpr<Person::age, Greater, int>,
 //                            ComparisonExpr<Person::name, Equal, std::string>>>
@@ -218,7 +218,7 @@ We considered a **hybrid approach** with two APIs:
 
 ```cpp
 // Runtime (default) - clean API
-queryset.where(field<^^Person::age>() > 30).select();
+queryset.where(f<^^Person::age>() > 30).select();
 
 // Compile-time (opt-in) - maximum performance
 queryset.where_ct(field_ct<^^Person::age>() > 30);
@@ -252,7 +252,7 @@ while (stmt.step() == SQLITE_ROW) {
 
 Storm ORM (runtime):
 ```cpp
-queryset.where(field<^^Person::age>() > 30).select();
+queryset.where(f<^^Person::age>() > 30).select();
 ```
 
 ---

--- a/docs/architecture/REFLECTION.md
+++ b/docs/architecture/REFLECTION.md
@@ -76,7 +76,7 @@ auto field() {
     };
 }
 
-// Usage: field<^^Person::age>() > 30
+// Usage: f<^^Person::age>() > 30
 ```
 
 **No macros needed** - fully module-compatible!

--- a/docs/development/PERFORMANCE_TESTING.md
+++ b/docs/development/PERFORMANCE_TESTING.md
@@ -137,7 +137,7 @@ void benchmark_raw_select() {
 void benchmark_storm_where() {
     QuerySet<Person> qs(conn);
     for (int i = 0; i < iterations; ++i) {
-        auto result = qs.where(field<^^Person::age>() > 25).select();
+        auto result = qs.where(f<^^Person::age>() > 25).select();
     }
 }
 ```

--- a/docs/features/JOIN_OPERATIONS.md
+++ b/docs/features/JOIN_OPERATIONS.md
@@ -187,7 +187,7 @@ auto pupils = QuerySet<Pupil>().join<^^Pupil::courses>().select().execute();
 // Metadata access — query the junction model directly (regular FK joins)
 auto enrollments = QuerySet<Enrollment>()
         .join<^^Enrollment::pupil, ^^Enrollment::course>()
-        .where(field<^^Enrollment::grade>() == "A")
+        .where(f<^^Enrollment::grade>() == "A")
         .select().execute();
 ```
 
@@ -535,8 +535,8 @@ using namespace storm::orm::where;
 
 // Filter on both base table and joined table
 auto result = message_qs.join<^^Message::sender>()
-                        .where(field<^^User::level>() > 5 and
-                               field<^^Message::content>().like("%urgent%"))
+                        .where(f<^^User::level>() > 5 and
+                               f<^^Message::content>().like("%urgent%"))
                         .select();
 ```
 

--- a/docs/features/SELECT_QUERIES.md
+++ b/docs/features/SELECT_QUERIES.md
@@ -48,11 +48,11 @@ SELECT id, name, age FROM Person
 using namespace storm::orm::where;
 
 // Filter results
-auto result = queryset.where(field<^^Person::age>() > 25).select();
+auto result = queryset.where(f<^^Person::age>() > 25).select();
 
 // Complex conditions
-auto result = queryset.where(field<^^Person::age>() > 25 and
-                              field<^^Person::age>() < 50).select();
+auto result = queryset.where(f<^^Person::age>() > 25 and
+                              f<^^Person::age>() < 50).select();
 ```
 
 See [WHERE Clauses](WHERE_CLAUSES.md) for detailed WHERE syntax.
@@ -68,7 +68,7 @@ auto result = message_qs.join<^^Message::sender, ^^Message::receiver>().select()
 
 // JOIN with WHERE
 auto result = message_qs.join<^^Message::sender>()
-                        .where(field<^^User::level>() > 5)
+                        .where(f<^^User::level>() > 5)
                         .select();
 ```
 

--- a/docs/features/WHERE_CLAUSES.md
+++ b/docs/features/WHERE_CLAUSES.md
@@ -8,11 +8,11 @@ WHERE expressions use field access via reflection with compile-time operators.
 
 ```cpp
 auto results = QuerySet<Person>()
-    .where(field<^^Person::age>() > 30)
+    .where(f<^^Person::age>() > 30)
     .select();
 ```
 
-The `field<^^Member>()` function creates a field expression for type-safe comparisons at compile time.
+The `f<^^Member>()` function creates a field expression for type-safe comparisons at compile time.
 
 ## Comparison Operators
 
@@ -21,21 +21,21 @@ All 6 comparison operators are supported.
 ```cpp
 // Equals
 auto results = QuerySet<Person>()
-    .where(field<^^Person::age>() == 30)
+    .where(f<^^Person::age>() == 30)
     .select();
 
 // Not equals
 auto results = QuerySet<Person>()
-    .where(field<^^Person::age>() != 30)
+    .where(f<^^Person::age>() != 30)
     .select();
 
 // Greater/Less than
 auto results = QuerySet<Person>()
-    .where(field<^^Person::age>() > 30)
+    .where(f<^^Person::age>() > 30)
     .select();
 
 auto results = QuerySet<Person>()
-    .where(field<^^Person::age>() <= 65)
+    .where(f<^^Person::age>() <= 65)
     .select();
 ```
 
@@ -58,7 +58,7 @@ construction. This means an expression survives the buffer it was built from:
 ```cpp
 auto make_filter() {
     std::string name = load_name();           // local buffer
-    return field<^^Person::name>() == name;    // operand is COPIED, not viewed
+    return f<^^Person::name>() == name;    // operand is COPIED, not viewed
 }                                              // `name` is destroyed here — safe
 
 auto results = QuerySet<Person>().where(make_filter()).select();  // no dangling bind
@@ -73,7 +73,7 @@ The `%` wildcard matches any sequence of characters.
 ```cpp
 // WHERE name LIKE 'Al%'
 auto results = QuerySet<Person>()
-    .where(field<^^Person::name>().like("Al%"))
+    .where(f<^^Person::name>().like("Al%"))
     .select();
 ```
 
@@ -84,7 +84,7 @@ The `between()` method creates a range check.
 ```cpp
 // WHERE age BETWEEN 25 AND 65
 auto results = QuerySet<Person>()
-    .where(field<^^Person::age>().between(25, 65))
+    .where(f<^^Person::age>().between(25, 65))
     .select();
 ```
 
@@ -94,7 +94,7 @@ Collation for string comparisons (case-insensitive, etc).
 
 ```cpp
 auto results = QuerySet<Person>()
-    .where(field<^^Person::name>().collate(Collate::NoCase) == "alice")
+    .where(f<^^Person::name>().collate(Collate::NoCase) == "alice")
     .select();
 ```
 
@@ -117,7 +117,7 @@ Generate an `IS NULL` check.
 ```cpp
 // SELECT * FROM person WHERE score IS NULL
 auto nulls = QuerySet<Person>()
-    .where(field<^^Person::score>().is_null())
+    .where(f<^^Person::score>().is_null())
     .select();
 ```
 
@@ -128,7 +128,7 @@ Generate an `IS NOT NULL` check.
 ```cpp
 // SELECT * FROM person WHERE score IS NOT NULL
 auto non_nulls = QuerySet<Person>()
-    .where(field<^^Person::score>().is_not_null())
+    .where(f<^^Person::score>().is_not_null())
     .select();
 ```
 
@@ -138,12 +138,12 @@ Comparison with `std::nullopt` generates the same SQL.
 
 ```cpp
 // These are equivalent:
-.where(field<^^Person::score>().is_null())
-.where(field<^^Person::score>() == std::nullopt)
+.where(f<^^Person::score>().is_null())
+.where(f<^^Person::score>() == std::nullopt)
 
 // These are equivalent:
-.where(field<^^Person::score>().is_not_null())
-.where(field<^^Person::score>() != std::nullopt)
+.where(f<^^Person::score>().is_not_null())
+.where(f<^^Person::score>() != std::nullopt)
 ```
 
 ### NULL checks with COLLATE
@@ -153,7 +153,7 @@ COLLATE can be combined with NULL checks on optional string fields.
 ```cpp
 // SELECT * FROM person WHERE nickname COLLATE NOCASE IS NULL
 auto results = QuerySet<Person>()
-    .where(field<^^Person::nickname>().collate(Collate::NoCase).is_null())
+    .where(f<^^Person::nickname>().collate(Collate::NoCase).is_null())
     .select();
 ```
 
@@ -164,7 +164,7 @@ NULL checks compose with AND/OR like any other expression.
 ```cpp
 // SELECT * FROM person WHERE score IS NULL AND age > 30
 auto results = QuerySet<Person>()
-    .where(field<^^Person::score>().is_null() && field<^^Person::age>() > 30)
+    .where(f<^^Person::score>().is_null() && f<^^Person::age>() > 30)
     .select();
 ```
 
@@ -175,19 +175,19 @@ Expressions can be combined with `&&` (AND) and `||` (OR).
 ```cpp
 // WHERE (age > 30) AND (name == "Alice")
 auto results = QuerySet<Person>()
-    .where((field<^^Person::age>() > 30) && (field<^^Person::name>() == "Alice"))
+    .where((f<^^Person::age>() > 30) && (f<^^Person::name>() == "Alice"))
     .select();
 
 // WHERE (age < 25) OR (salary > 100000)
 auto results = QuerySet<Person>()
-    .where((field<^^Person::age>() < 25) || (field<^^Person::salary>() > 100000))
+    .where((f<^^Person::age>() < 25) || (f<^^Person::salary>() > 100000))
     .select();
 
 // Complex nesting
 auto results = QuerySet<Person>()
     .where(
-        (field<^^Person::age>() > 30 && field<^^Person::salary>() > 50000) ||
-        (field<^^Person::years_experience>() >= 10)
+        (f<^^Person::age>() > 30 && f<^^Person::salary>() > 50000) ||
+        (f<^^Person::years_experience>() >= 10)
     )
     .select();
 ```

--- a/src/orm/query_builder.hpp
+++ b/src/orm/query_builder.hpp
@@ -11,7 +11,7 @@
 
 namespace storm::orm::query_builder {
 
-    using storm::orm::where::field;
+    using storm::orm::where::f;
 
     // ========================================================================
     // Field dispatcher — compile-time field lookup by name
@@ -134,9 +134,9 @@ namespace storm::orm::query_builder {
         }
 
         template <auto fi, auto op_str, typename... Ts>
-            requires ValidOperator<op_str, typename std::remove_cvref_t<decltype(field<fi>())>::FieldType>
+            requires ValidOperator<op_str, typename std::remove_cvref_t<decltype(f<fi>())>::FieldType>
         static consteval auto resolve_operator() -> std::meta::info {
-            using FE                      = std::remove_cvref_t<decltype(field<fi>())>;
+            using FE                      = std::remove_cvref_t<decltype(f<fi>())>;
             using FieldType               = typename FE::FieldType;
             constexpr std::string_view op = op_str.view();
 
@@ -149,10 +149,10 @@ namespace storm::orm::query_builder {
         }
 
         template <auto fi, auto op_str, typename... Ts>
-            requires ValidOperator<op_str, typename std::remove_cvref_t<decltype(field<fi>())>::FieldType>
+            requires ValidOperator<op_str, typename std::remove_cvref_t<decltype(f<fi>())>::FieldType>
         static auto build_compare_expr(Ts&&... vs) {
             constexpr auto method = resolve_operator<fi, op_str, std::remove_cvref_t<Ts>...>();
-            return (field<fi>().[:method:](std::forward<Ts>(vs)...));
+            return (f<fi>().[:method:](std::forward<Ts>(vs)...));
         }
 
         // ----------------------------------------------------------------
@@ -384,10 +384,10 @@ namespace storm::orm::query_builder {
         static auto build_setop(auto& /*qs*/) {
             constexpr auto            thr = setop_thresholds();
             QuerySet<Model, ConnType> qs_left_base;
-            auto                      qs_left = qs_left_base.where(field<^^Model::age>() < thr.left);
+            auto                      qs_left = qs_left_base.where(f<^^Model::age>() < thr.left);
             QuerySet<Model, ConnType> qs_right_base;
-            auto                      qs_right = thr.overlap ? qs_right_base.where(field<^^Model::age>() > thr.right)
-                                                             : qs_right_base.where(field<^^Model::age>() >= thr.right);
+            auto                      qs_right = thr.overlap ? qs_right_base.where(f<^^Model::age>() > thr.right)
+                                                             : qs_right_base.where(f<^^Model::age>() >= thr.right);
             constexpr auto            method   = resolve_setop();
             auto                      builder  = qs_left.[:method:](qs_right);
             builder                            = apply_order_by(std::move(builder));

--- a/src/orm/queryset.cppm
+++ b/src/orm/queryset.cppm
@@ -98,19 +98,19 @@ export namespace storm {
         // WHERE clause support - builder pattern with method chaining using type-safe expressions
         //
         // Usage examples:
-        //   queryset.where(field<^^Person::age>() > 25).select()
-        //   queryset.where(field<^^Person::id>().in(1, 2, 3)).select()
-        //   queryset.where(field<^^Person::name>().like("A%")).select()
-        //   queryset.where(field<^^Person::age>().between(25, 50)).select()
+        //   queryset.where(f<^^Person::age>() > 25).select()
+        //   queryset.where(f<^^Person::id>().in(1, 2, 3)).select()
+        //   queryset.where(f<^^Person::name>().like("A%")).select()
+        //   queryset.where(f<^^Person::age>().between(25, 50)).select()
         //
         // Chaining with AND composition:
-        //   queryset.where(field<^^Person::age>() > 25)
-        //           .where(field<^^Person::name>() == "Alice")
+        //   queryset.where(f<^^Person::age>() > 25)
+        //           .where(f<^^Person::name>() == "Alice")
         //           .select()
         //
         // Complex expressions with AND/OR:
-        //   queryset.where(field<^^Person::age>() > 25 and field<^^Person::is_active>() == true).select()
-        //   queryset.where((field<^^Person::age>() > 25) or (field<^^Person::name>().like("A%"))).select()
+        //   queryset.where(f<^^Person::age>() > 25 and f<^^Person::is_active>() == true).select()
+        //   queryset.where((f<^^Person::age>() > 25) or (f<^^Person::name>().like("A%"))).select()
         //
         [[nodiscard]] auto where(orm::where::ExpressionVariantPtr expr) const -> QuerySet {
             auto result = clone_state();

--- a/src/orm/where.cppm
+++ b/src/orm/where.cppm
@@ -340,7 +340,7 @@ export namespace storm::orm::where {
     }
 
     // CollatedField proxy - wraps field name with COLLATE clause
-    // Created via field<^^Person::name>().collate(Collate::NoCase)
+    // Created via f<^^Person::name>().collate(Collate::NoCase)
     // All comparison operators produce SQL like: "name COLLATE NOCASE = ?"
     template <std::meta::info MemberInfo>
         requires(std::meta::is_nonstatic_data_member(MemberInfo))
@@ -436,7 +436,7 @@ export namespace storm::orm::where {
         }
 
         // IN: Returns Expr wrapping VARIANT (no heap allocation for expression itself!)
-        // Usage: field<^^Person::id>().in(100, 200, 300)
+        // Usage: f<^^Person::id>().in(100, 200, 300)
         // For enum types, converts to underlying int automatically
         template <typename... Values>
             requires(std::constructible_from<FieldType, Values> && ...)
@@ -528,7 +528,7 @@ export namespace storm::orm::where {
     };
 
     // Pure C++26 Reflection-Based Field Helper (No Macro Needed!)
-    // Usage: field<^^Person::id>().in(100, 200, 300)
+    // Usage: f<^^Person::id>().in(100, 200, 300)
     //
     // Returns Field which provides:
     // - in() -> Expr (runtime expression, composable with AND/OR)
@@ -542,11 +542,11 @@ export namespace storm::orm::where {
         requires(
                 std::meta::is_nonstatic_data_member(MemberInfo) && std::meta::has_identifier(MemberInfo)
         ) // Ensures field has a name
-    constexpr auto field() {
+    constexpr auto f() {
         // Additional compile-time validation: field must be accessible
         static_assert(
                 std::meta::is_nonstatic_data_member(MemberInfo),
-                "field<> requires a non-static data member reflection (use ^^Type::member syntax)"
+                "f<> requires a non-static data member reflection (use ^^Type::member syntax)"
         );
         return Field<MemberInfo>();
     }

--- a/tests/crud/test_crud.cpp
+++ b/tests/crud/test_crud.cpp
@@ -42,9 +42,9 @@ template <typename ConnType> class PersonCrudTestBase : public StormTestFixture<
     }
 
     static auto personExists(int person_id) -> bool {
-        using storm::orm::where::field;
+        using storm::orm::where::f;
         const storm::QuerySet<Person, ConnType> qs;
-        auto result = qs.where(field<^^Person::id>() == person_id).select().execute();
+        auto                                    result = qs.where(f<^^Person::id>() == person_id).select().execute();
         return result.has_value() && !result.value().empty();
     }
 };
@@ -206,9 +206,9 @@ template <typename ConnType> class QuerySetUpdateTest : public PersonCrudTestBas
   protected:
     // Helper function to get person by ID using the ORM
     static auto getPerson(int person_id) -> std::optional<Person> {
-        using storm::orm::where::field;
+        using storm::orm::where::f;
         const storm::QuerySet<Person, ConnType> qs;
-        auto result = qs.where(field<^^Person::id>() == person_id).select().execute();
+        auto                                    result = qs.where(f<^^Person::id>() == person_id).select().execute();
         if (!result.has_value() || result.value().empty()) {
             return std::nullopt;
         }
@@ -400,7 +400,7 @@ template <typename ConnType> class QueryResetTest : public StormTestFixture<Pers
 TYPED_TEST_SUITE(QueryResetTest, DatabaseTypes);
 
 TYPED_TEST(QueryResetTest, ResetClearsAllState) {
-    auto filtered = this->qs->where(storm::orm::where::field<^^Person::age>() > 25);
+    auto filtered = this->qs->where(storm::orm::where::f<^^Person::age>() > 25);
 
     auto result1 = filtered.template order_by<^^Person::name>().limit(2).offset(1).select().execute();
     ASSERT_TRUE(result1.has_value());
@@ -413,7 +413,7 @@ TYPED_TEST(QueryResetTest, ResetClearsAllState) {
 }
 
 TYPED_TEST(QueryResetTest, ReuseSameQuerySetMultipleTimes) {
-    auto result1 = this->qs->where(storm::orm::where::field<^^Person::age>() > 35).select().execute();
+    auto result1 = this->qs->where(storm::orm::where::f<^^Person::age>() > 35).select().execute();
     ASSERT_TRUE(result1.has_value());
     EXPECT_EQ(result1.value().size(), 9);
 
@@ -423,7 +423,7 @@ TYPED_TEST(QueryResetTest, ReuseSameQuerySetMultipleTimes) {
     EXPECT_EQ(result2.value().size(), 25);
 
     // Can create a different filter without reset
-    auto result3 = this->qs->where(storm::orm::where::field<^^Person::age>() < 35).select().execute();
+    auto result3 = this->qs->where(storm::orm::where::f<^^Person::age>() < 35).select().execute();
     ASSERT_TRUE(result3.has_value());
     EXPECT_EQ(result3.value().size(), 14);
 }
@@ -459,13 +459,13 @@ TYPED_TEST(QueryResetTest, ResetBetweenDifferentOperations) {
 }
 
 TYPED_TEST(QueryResetTest, AggregatesWithWhere) {
-    auto count = this->qs->where(storm::orm::where::field<^^Person::age>() >= 35).count().execute();
+    auto count = this->qs->where(storm::orm::where::f<^^Person::age>() >= 35).count().execute();
     ASSERT_TRUE(count.has_value());
     EXPECT_EQ(count.value(), 11);
 
     (*this->qs).reset();
 
-    auto sum = this->qs->where(storm::orm::where::field<^^Person::age>() >= 35).template sum<^^Person::age>().execute();
+    auto sum = this->qs->where(storm::orm::where::f<^^Person::age>() >= 35).template sum<^^Person::age>().execute();
     ASSERT_TRUE(sum.has_value());
     EXPECT_EQ(sum.value(), 442);
 }

--- a/tests/crud/test_crud_lifecycle.cpp
+++ b/tests/crud/test_crud_lifecycle.cpp
@@ -50,7 +50,7 @@ template <typename ConnType> class QuerySetCrudLifecycleTest : public StormTestF
 TYPED_TEST_SUITE(QuerySetCrudLifecycleTest, DatabaseTypes);
 
 TYPED_TEST(QuerySetCrudLifecycleTest, FullLifecycle) {
-    using storm::orm::where::field;
+    using storm::orm::where::f;
     storm::QuerySet<Person, TypeParam> qs;
 
     // 1. Verify empty state
@@ -85,7 +85,7 @@ TYPED_TEST(QuerySetCrudLifecycleTest, FullLifecycle) {
     auto         update_result = qs.update(updated_alice).execute();
     ASSERT_TRUE(update_result.has_value()) << "Update should succeed";
 
-    auto alice_result = qs.where(field<^^Person::id>() == static_cast<int>(id_alice.value())).select().execute();
+    auto alice_result = qs.where(f<^^Person::id>() == static_cast<int>(id_alice.value())).select().execute();
     ASSERT_TRUE(alice_result.has_value());
     ASSERT_FALSE(alice_result.value().empty());
     EXPECT_EQ(alice_result.value().begin()->name, "Alice Updated") << "Name should be updated";
@@ -146,7 +146,7 @@ TYPED_TEST(QuerySetCrudLifecycleTest, BatchLifecycle) {
 
 // All supported field types: int, string, double, bool, optional<int>, optional<string>, blob
 TYPED_TEST(QuerySetCrudLifecycleTest, AllFieldTypesLifecycle) {
-    using storm::orm::where::field;
+    using storm::orm::where::f;
     storm::QuerySet<Person, TypeParam> qs;
 
     // 1. Insert with all fields populated
@@ -164,7 +164,7 @@ TYPED_TEST(QuerySetCrudLifecycleTest, AllFieldTypesLifecycle) {
     ASSERT_TRUE(id.has_value()) << "Insert with all fields should succeed";
 
     // 2. Verify all fields round-trip correctly
-    auto rows = qs.where(field<^^Person::id>() == static_cast<int>(id.value())).select().execute();
+    auto rows = qs.where(f<^^Person::id>() == static_cast<int>(id.value())).select().execute();
     ASSERT_TRUE(rows.has_value());
     ASSERT_EQ(rows.value().size(), 1U);
     this->verifyFullPersonInserted(*rows.value().begin());
@@ -183,7 +183,7 @@ TYPED_TEST(QuerySetCrudLifecycleTest, AllFieldTypesLifecycle) {
     };
     ASSERT_TRUE(qs.update(updated).execute().has_value()) << "Update with all fields should succeed";
 
-    auto updated_rows = qs.where(field<^^Person::id>() == static_cast<int>(id.value())).select().execute();
+    auto updated_rows = qs.where(f<^^Person::id>() == static_cast<int>(id.value())).select().execute();
     ASSERT_TRUE(updated_rows.has_value());
     ASSERT_EQ(updated_rows.value().size(), 1U);
     this->verifyFullPersonUpdated(*updated_rows.value().begin());
@@ -228,7 +228,7 @@ TYPED_TEST(QuerySetCrudLifecycleTest, BoundaryBatchLifecycle) {
 
 // Insert, selectively update and erase via WHERE, verify unaffected rows unchanged
 TYPED_TEST(QuerySetCrudLifecycleTest, FilteredLifecycle) {
-    using storm::orm::where::field;
+    using storm::orm::where::f;
     storm::QuerySet<Person, TypeParam> qs;
 
     // 1. Insert mixed data
@@ -243,12 +243,12 @@ TYPED_TEST(QuerySetCrudLifecycleTest, FilteredLifecycle) {
 
     // 2. Select only active persons
     // NOLINTNEXTLINE(readability-simplify-boolean-expr) -- `== true` is the WHERE-DSL comparison (generates `is_active = ?`), not a redundant bool op
-    auto active = qs.where(field<^^Person::is_active>() == true).select().execute();
+    auto active = qs.where(f<^^Person::is_active>() == true).select().execute();
     ASSERT_TRUE(active.has_value());
     EXPECT_EQ(static_cast<int>(active.value().size()), 2) << "Should have 2 active persons";
 
     // 3. Erase only persons aged < 21
-    auto young = qs.where(field<^^Person::age>() < 21).select().execute();
+    auto young = qs.where(f<^^Person::age>() < 21).select().execute();
     ASSERT_TRUE(young.has_value());
     std::vector<Person> young_vec(young.value().begin(), young.value().end());
     ASSERT_EQ(young_vec.size(), 2U) << "Bob and Dave should be under 21";

--- a/tests/crud/test_insert_returning.cpp
+++ b/tests/crud/test_insert_returning.cpp
@@ -57,7 +57,7 @@ TYPED_TEST(BatchInsertReturningTest, ReturnedIdsMatchInsertedRows) {
 
     // SELECT back each row by ID and verify data
     for (std::size_t i = 0; i < records.size(); ++i) {
-        auto row = qs.where(storm::orm::where::field<^^SimpleRecord::id>() == static_cast<int>(result.value()[i]))
+        auto row = qs.where(storm::orm::where::f<^^SimpleRecord::id>() == static_cast<int>(result.value()[i]))
                            .select()
                            .execute();
         ASSERT_TRUE(row.has_value()) << "Should find row with ID " << result.value()[i];

--- a/tests/crud/test_select_one.cpp
+++ b/tests/crud/test_select_one.cpp
@@ -5,7 +5,7 @@ import storm;
 import std;
 
 using storm::QuerySet;
-using storm::orm::where::field;
+using storm::orm::where::f;
 
 #include "test_models.h" // NOSONAR cpp:S954
 #include "test_seed_helpers.h"
@@ -70,7 +70,7 @@ TYPED_TEST(SelectOneTest, GetWhereMultipleMatch) {
     ASSERT_TRUE((storm::test::batch_insert<Person, TypeParam>(people)));
 
     // Two people have age 30
-    auto result = queryset.where(field<^^Person::age>() == 30).get().execute();
+    auto result = queryset.where(f<^^Person::age>() == 30).get().execute();
     ASSERT_FALSE(result.has_value()) << "get() should return error when WHERE matches multiple rows";
     EXPECT_EQ(result.error().code(), -1);
     EXPECT_EQ(result.error().message(), "Multiple rows found matching query");
@@ -87,7 +87,7 @@ TYPED_TEST(SelectOneTest, FirstWithWhereNoJoin) {
     ASSERT_TRUE(r1.has_value());
     ASSERT_TRUE(r2.has_value());
 
-    auto result = queryset.where(field<^^Person::age>() == 30).first().execute();
+    auto result = queryset.where(f<^^Person::age>() == 30).first().execute();
     ASSERT_TRUE(result.has_value()) << "first() with WHERE failed: " << result.error().message();
     ASSERT_TRUE(result.value().has_value()) << "Expected a row";
     EXPECT_EQ(result.value().value().name, "Alice");
@@ -100,7 +100,7 @@ TYPED_TEST(SelectOneTest, FirstWithWhereNoMatch) {
     Person const alice{.id = 0, .name = "Alice", .age = 30};
     ASSERT_TRUE(queryset.insert(alice).execute().has_value());
 
-    auto result = queryset.where(field<^^Person::age>() == 999).first().execute();
+    auto result = queryset.where(f<^^Person::age>() == 999).first().execute();
     ASSERT_TRUE(result.has_value()) << "first() should succeed even with no match";
     EXPECT_FALSE(result.value().has_value()) << "Expected nullopt when no rows match";
 }

--- a/tests/errors/test_sqlite_errors.cpp
+++ b/tests/errors/test_sqlite_errors.cpp
@@ -947,7 +947,7 @@ TEST_F(ORMErrorTest, SelectWithWhereNoMatch) {
     ASSERT_TRUE(insert_result.has_value());
 
     // Select with WHERE that matches nothing
-    auto result = qs.where(storm::orm::where::field<^^Person::age>() > 100).select().execute();
+    auto result = qs.where(storm::orm::where::f<^^Person::age>() > 100).select().execute();
     ASSERT_TRUE(result.has_value()) << "Select with no matches should succeed";
     EXPECT_TRUE(result.value().empty()) << "Result should be empty";
 }
@@ -991,7 +991,7 @@ TEST_F(ORMErrorTest, AggregateWithWhereNoMatch) {
     ASSERT_TRUE(insert_result.has_value());
 
     // COUNT with WHERE that matches nothing
-    auto count_result = qs.where(storm::orm::where::field<^^Person::age>() > 100).count().execute();
+    auto count_result = qs.where(storm::orm::where::f<^^Person::age>() > 100).count().execute();
     ASSERT_TRUE(count_result.has_value()) << "COUNT with no matches should succeed";
     EXPECT_EQ(count_result.value(), 0);
 }

--- a/tests/mock_sqlite/test_orm_mock_errors.cpp
+++ b/tests/mock_sqlite/test_orm_mock_errors.cpp
@@ -2747,8 +2747,8 @@ namespace {
 
         QuerySet<MockPerson> qs1;
         QuerySet<MockPerson> qs2;
-        auto                 result = qs1.where(storm::orm::where::field<^^MockPerson::age>() > 30)
-                              .union_(qs2.where(storm::orm::where::field<^^MockPerson::age>() < 10))
+        auto                 result = qs1.where(storm::orm::where::f<^^MockPerson::age>() > 30)
+                              .union_(qs2.where(storm::orm::where::f<^^MockPerson::age>() < 10))
                               .execute();
 
         ASSERT_FALSE(result.has_value());
@@ -2760,8 +2760,8 @@ namespace {
 
         QuerySet<MockPerson> qs1;
         QuerySet<MockPerson> qs2;
-        auto                 result = qs1.where(storm::orm::where::field<^^MockPerson::age>() > 30)
-                              .union_(qs2.where(storm::orm::where::field<^^MockPerson::age>() < 10))
+        auto                 result = qs1.where(storm::orm::where::f<^^MockPerson::age>() > 30)
+                              .union_(qs2.where(storm::orm::where::f<^^MockPerson::age>() < 10))
                               .execute();
 
         ASSERT_FALSE(result.has_value());
@@ -2773,8 +2773,8 @@ namespace {
 
         QuerySet<MockPerson> qs1;
         QuerySet<MockPerson> qs2;
-        auto                 result = qs1.where(storm::orm::where::field<^^MockPerson::age>() > 30)
-                              .union_(qs2.where(storm::orm::where::field<^^MockPerson::age>() < 10))
+        auto                 result = qs1.where(storm::orm::where::f<^^MockPerson::age>() > 30)
+                              .union_(qs2.where(storm::orm::where::f<^^MockPerson::age>() < 10))
                               .execute();
 
         ASSERT_FALSE(result.has_value());
@@ -2786,8 +2786,8 @@ namespace {
 
         QuerySet<MockPerson> qs1;
         QuerySet<MockPerson> qs2;
-        auto                 result = qs1.where(storm::orm::where::field<^^MockPerson::age>() > 30)
-                              .union_(qs2.where(storm::orm::where::field<^^MockPerson::age>() < 10))
+        auto                 result = qs1.where(storm::orm::where::f<^^MockPerson::age>() > 30)
+                              .union_(qs2.where(storm::orm::where::f<^^MockPerson::age>() < 10))
                               .to_sql();
 
         ASSERT_FALSE(result.has_value());
@@ -2799,8 +2799,8 @@ namespace {
 
         QuerySet<MockPerson> qs1;
         QuerySet<MockPerson> qs2;
-        auto                 result = qs1.where(storm::orm::where::field<^^MockPerson::age>() > 30)
-                              .union_(qs2.where(storm::orm::where::field<^^MockPerson::age>() < 10))
+        auto                 result = qs1.where(storm::orm::where::f<^^MockPerson::age>() > 30)
+                              .union_(qs2.where(storm::orm::where::f<^^MockPerson::age>() < 10))
                               .to_sql();
 
         ASSERT_FALSE(result.has_value());
@@ -2825,7 +2825,7 @@ namespace {
         MockSqlite3Config::bind_int_returns(SQLITE_NOMEM);
 
         QuerySet<MockPerson> qs;
-        auto                 age       = storm::orm::where::field<^^MockPerson::age>();
+        auto                 age       = storm::orm::where::f<^^MockPerson::age>();
         bool                 got_error = false;
         for (auto&& result : qs.where(age > 25).rows()) {
             if (!result.has_value()) {
@@ -3355,7 +3355,7 @@ namespace {
 
         QuerySet<MockStudent> qs;
         auto                  rows = qs.join<^^MockStudent::courses>()
-                            .where(storm::orm::where::field<^^MockStudent::id>() > 0)
+                            .where(storm::orm::where::f<^^MockStudent::id>() > 0)
                             .select()
                             .execute();
 

--- a/tests/query/test_aggregate.cpp
+++ b/tests/query/test_aggregate.cpp
@@ -66,7 +66,7 @@ TYPED_TEST(AggregateTest, DirectChain_TypeSafety) {
 TYPED_TEST(AggregateTest, SingleAggregates_WithWhereAndJoin) {
     this->insert_join_test_data();
 
-    auto sum_result = this->msg_qs->where(storm::orm::where::field<^^Message::value>() > 25)
+    auto sum_result = this->msg_qs->where(storm::orm::where::f<^^Message::value>() > 25)
                               .template join<^^Message::sender>()
                               .template sum<^^Message::value>()
                               .execute();
@@ -75,7 +75,7 @@ TYPED_TEST(AggregateTest, SingleAggregates_WithWhereAndJoin) {
 
     (*this->msg_qs).reset();
 
-    auto count_result = this->msg_qs->where(storm::orm::where::field<^^Message::value>() > 25)
+    auto count_result = this->msg_qs->where(storm::orm::where::f<^^Message::value>() > 25)
                                 .template join<^^Message::sender>()
                                 .count()
                                 .execute();
@@ -84,7 +84,7 @@ TYPED_TEST(AggregateTest, SingleAggregates_WithWhereAndJoin) {
 
     (*this->msg_qs).reset();
 
-    auto min_result = this->msg_qs->where(storm::orm::where::field<^^Message::value>() > 25)
+    auto min_result = this->msg_qs->where(storm::orm::where::f<^^Message::value>() > 25)
                               .template join<^^Message::sender>()
                               .template min<^^Message::value>()
                               .execute();
@@ -279,7 +279,7 @@ TYPED_TEST(AggregateTest, Integration_AfterDelete) {
 TYPED_TEST(AggregateTest, WhereWithMultiFieldSum) {
     this->insert_test_data();
 
-    auto result = this->qs->where(storm::orm::where::field<^^Person::age>() >= 35)
+    auto result = this->qs->where(storm::orm::where::f<^^Person::age>() >= 35)
                           .template sum<^^Person::age, ^^Person::years_experience>()
                           .execute();
     ASSERT_TRUE(result.has_value()) << "WHERE + SUM(multi-field) failed: " << result.error().message();
@@ -290,7 +290,7 @@ TYPED_TEST(AggregateTest, WhereRepeatedQueries) {
     this->insert_test_data();
 
     for (int i = 0; i < 100; ++i) {
-        auto result = this->qs->where(storm::orm::where::field<^^Person::age>() > 30).count().execute();
+        auto result = this->qs->where(storm::orm::where::f<^^Person::age>() > 30).count().execute();
         ASSERT_TRUE(result.has_value()) << "Iteration " << i << " failed: " << result.error().message();
         EXPECT_EQ(result.value(), 13);
     }
@@ -299,19 +299,19 @@ TYPED_TEST(AggregateTest, WhereRepeatedQueries) {
 TYPED_TEST(AggregateTest, WhereDifferentConditions) {
     this->insert_test_data();
 
-    auto result1 = this->qs->where(storm::orm::where::field<^^Person::age>() > 30).count().execute();
+    auto result1 = this->qs->where(storm::orm::where::f<^^Person::age>() > 30).count().execute();
     ASSERT_TRUE(result1.has_value());
     EXPECT_EQ(result1.value(), 13);
 
     (*this->qs).reset();
 
-    auto result2 = this->qs->where(storm::orm::where::field<^^Person::age>() < 30).count().execute();
+    auto result2 = this->qs->where(storm::orm::where::f<^^Person::age>() < 30).count().execute();
     ASSERT_TRUE(result2.has_value());
     EXPECT_EQ(result2.value(), 9);
 
     (*this->qs).reset();
 
-    auto result3 = this->qs->where(storm::orm::where::field<^^Person::age>() == 30).count().execute();
+    auto result3 = this->qs->where(storm::orm::where::f<^^Person::age>() == 30).count().execute();
     ASSERT_TRUE(result3.has_value());
     EXPECT_EQ(result3.value(), 3);
 }
@@ -324,7 +324,7 @@ TYPED_TEST(AggregateTest, WhereJoinRepeatedQueries) {
     this->insert_join_test_data();
 
     for (int i = 0; i < 50; ++i) {
-        auto result = this->msg_qs->where(storm::orm::where::field<^^Message::value>() > 20)
+        auto result = this->msg_qs->where(storm::orm::where::f<^^Message::value>() > 20)
                               .template join<^^Message::sender>()
                               .count()
                               .execute();

--- a/tests/query/test_aggregate_combined.cpp
+++ b/tests/query/test_aggregate_combined.cpp
@@ -58,7 +58,7 @@ TYPED_TEST(AggregateTest, FullChain_WhereJoinOrderByLimitOffset) {
     // WHERE + JOIN + ORDER BY DESC + LIMIT 5 + OFFSET 2
     // Values >= 20 ordered DESC: 75,70,65,60,55,50,45,40,35,30,25,20
     // After OFFSET 2: 65,60,55,50,45,...  After LIMIT 5: 65,60,55,50,45
-    auto result = this->msg_qs->where(storm::orm::where::field<^^Message::value>() >= 20)
+    auto result = this->msg_qs->where(storm::orm::where::f<^^Message::value>() >= 20)
                           .template join<^^Message::sender>()
                           .template order_by<^^Message::value, false>()
                           .limit(5)
@@ -74,7 +74,7 @@ TYPED_TEST(AggregateTest, FullChain_WhereJoinOrderByLimitOffset) {
 TYPED_TEST(AggregateTest, FullChain_WhereJoinOrderByAscLimit) {
     insert_full_chain_14_messages<TypeParam>();
 
-    auto result = this->msg_qs->where(storm::orm::where::field<^^Message::value>() >= 20)
+    auto result = this->msg_qs->where(storm::orm::where::f<^^Message::value>() >= 20)
                           .template join<^^Message::sender>()
                           .template order_by<^^Message::value, true>()
                           .limit(3)
@@ -90,7 +90,7 @@ TYPED_TEST(AggregateTest, FullChain_WhereJoinOrderByAscLimit) {
 TYPED_TEST(AggregateTest, FullChain_JoinResolvesCorrectSender) {
     insert_full_chain_14_messages<TypeParam>();
 
-    auto result = this->msg_qs->where(storm::orm::where::field<^^Message::value>() == 75)
+    auto result = this->msg_qs->where(storm::orm::where::f<^^Message::value>() == 75)
                           .template join<^^Message::sender>()
                           .select()
                           .execute();
@@ -161,7 +161,7 @@ TYPED_TEST(AggregateTest, GroupByWithAllAggregateTypes) {
     verify_group_by_sum_avg_min_max<TypeParam>(*this->qs);
 
     (*this->qs).reset();
-    auto filtered_sum = this->qs->where(storm::orm::where::field<^^Person::years_experience>() == 5)
+    auto filtered_sum = this->qs->where(storm::orm::where::f<^^Person::years_experience>() == 5)
                                 .template group_by<^^Person::years_experience>()
                                 .template sum<^^Person::age>()
                                 .execute();

--- a/tests/query/test_aggregate_groupby.cpp
+++ b/tests/query/test_aggregate_groupby.cpp
@@ -133,7 +133,7 @@ TYPED_TEST(AggregateTest, GroupByEmptyTable) {
 TYPED_TEST(AggregateTest, GroupByFullChain_Count) {
     this->insert_full_chain_data();
 
-    auto count_result = this->msg_qs->where(storm::orm::where::field<^^Message::value>() >= 20)
+    auto count_result = this->msg_qs->where(storm::orm::where::f<^^Message::value>() >= 20)
                                 .template join<^^Message::sender>()
                                 .template group_by<^^Message::value>()
                                 .count()
@@ -148,7 +148,7 @@ TYPED_TEST(AggregateTest, GroupByFullChain_Count) {
 TYPED_TEST(AggregateTest, GroupByFullChain_SumAndAvg) {
     this->insert_full_chain_data();
 
-    auto sum_result = this->msg_qs->where(storm::orm::where::field<^^Message::value>() < 50)
+    auto sum_result = this->msg_qs->where(storm::orm::where::f<^^Message::value>() < 50)
                               .template join<^^Message::sender>()
                               .template group_by<^^Message::content>()
                               .template sum<^^Message::value>()
@@ -159,8 +159,8 @@ TYPED_TEST(AggregateTest, GroupByFullChain_SumAndAvg) {
     (*this->msg_qs).reset();
 
     auto avg_result = this->msg_qs
-                              ->where(storm::orm::where::field<^^Message::value>() >= 10 &&
-                                      storm::orm::where::field<^^Message::value>() <= 70)
+                              ->where(storm::orm::where::f<^^Message::value>() >= 10 &&
+                                      storm::orm::where::f<^^Message::value>() <= 70)
                               .template join<^^Message::sender>()
                               .template group_by<^^Message::value>()
                               .template avg<^^Message::value>()

--- a/tests/query/test_aggregate_having.cpp
+++ b/tests/query/test_aggregate_having.cpp
@@ -47,7 +47,7 @@ TYPED_TEST(AggregateTest, HavingOnGroupByBuilder) {
     insert_5_people_ye<TypeParam>();
 
     auto result = this->qs->template group_by<^^Person::years_experience>()
-                          .having(storm::orm::where::field<^^Person::years_experience>() > 5)
+                          .having(storm::orm::where::f<^^Person::years_experience>() > 5)
                           .count()
                           .execute();
     check_ye10_count3(result);
@@ -58,7 +58,7 @@ TYPED_TEST(AggregateTest, HavingOnAggregateStatement) {
 
     auto result = this->qs->template group_by<^^Person::years_experience>()
                           .count()
-                          .having(storm::orm::where::field<^^Person::years_experience>() > 5)
+                          .having(storm::orm::where::f<^^Person::years_experience>() > 5)
                           .execute();
     check_ye10_count3(result);
 }
@@ -68,7 +68,7 @@ TYPED_TEST(AggregateTest, HavingWithJoin) {
 
     auto result = this->msg_qs->template join<^^Message::sender>()
                           .template group_by<^^Message::value>()
-                          .having(storm::orm::where::field<^^Message::value>() > 30)
+                          .having(storm::orm::where::f<^^Message::value>() > 30)
                           .count()
                           .execute();
     ASSERT_TRUE(result.has_value()) << "HAVING + JOIN failed: " << result.error().message();
@@ -80,7 +80,7 @@ TYPED_TEST(AggregateTest, HavingRepeatedQueries) {
 
     for (int i = 0; i < 50; ++i) {
         auto result = this->qs->template group_by<^^Person::age>()
-                              .having(storm::orm::where::field<^^Person::age>() > 30)
+                              .having(storm::orm::where::f<^^Person::age>() > 30)
                               .count()
                               .execute();
         ASSERT_TRUE(result.has_value()) << "Iteration " << i << " failed";
@@ -92,7 +92,7 @@ TYPED_TEST(AggregateTest, HavingWithSum) {
     this->insert_test_data();
 
     auto result = this->qs->template group_by<^^Person::years_experience>()
-                          .having(storm::orm::where::field<^^Person::years_experience>() == 5)
+                          .having(storm::orm::where::f<^^Person::years_experience>() == 5)
                           .template sum<^^Person::age>()
                           .execute();
     ASSERT_TRUE(result.has_value()) << "HAVING + SUM failed: " << result.error().message();
@@ -118,10 +118,10 @@ TYPED_TEST(AggregateTest, HavingWithWhereAndJoin) {
 
     // WHERE value >= 20 + JOIN + GROUP BY value HAVING value > 25
     // After WHERE: 20,30,50,70 → After HAVING > 25: 30,50,70 → 3 groups
-    auto result = this->msg_qs->where(storm::orm::where::field<^^Message::value>() >= 20)
+    auto result = this->msg_qs->where(storm::orm::where::f<^^Message::value>() >= 20)
                           .template join<^^Message::sender>()
                           .template group_by<^^Message::value>()
-                          .having(storm::orm::where::field<^^Message::value>() > 25)
+                          .having(storm::orm::where::f<^^Message::value>() > 25)
                           .count()
                           .execute();
     ASSERT_TRUE(result.has_value()) << "HAVING + WHERE + JOIN failed: " << result.error().message();
@@ -132,7 +132,7 @@ TYPED_TEST(AggregateTest, HavingWithWhereAndJoin) {
 
 TYPED_TEST(AggregateTest, HavingWithNotEqual) {
     auto result = this->qs->template group_by<^^Person::age>()
-                          .having(storm::orm::where::field<^^Person::age>() != 30)
+                          .having(storm::orm::where::f<^^Person::age>() != 30)
                           .count()
                           .execute();
     ASSERT_TRUE(result.has_value()) << "HAVING != failed: " << result.error().message();
@@ -143,7 +143,7 @@ TYPED_TEST(AggregateTest, HavingWithNotEqual) {
 
 TYPED_TEST(AggregateTest, HavingWithLessThan) {
     auto result = this->qs->template group_by<^^Person::age>()
-                          .having(storm::orm::where::field<^^Person::age>() < 30)
+                          .having(storm::orm::where::f<^^Person::age>() < 30)
                           .count()
                           .execute();
     ASSERT_TRUE(result.has_value()) << "HAVING < failed: " << result.error().message();
@@ -154,7 +154,7 @@ TYPED_TEST(AggregateTest, HavingWithLessThan) {
 
 TYPED_TEST(AggregateTest, HavingWithLessEqual) {
     auto result = this->qs->template group_by<^^Person::age>()
-                          .having(storm::orm::where::field<^^Person::age>() <= 30)
+                          .having(storm::orm::where::f<^^Person::age>() <= 30)
                           .count()
                           .execute();
     ASSERT_TRUE(result.has_value()) << "HAVING <= failed: " << result.error().message();
@@ -165,7 +165,7 @@ TYPED_TEST(AggregateTest, HavingWithLessEqual) {
 
 TYPED_TEST(AggregateTest, HavingWithGreaterEqual) {
     auto result = this->qs->template group_by<^^Person::age>()
-                          .having(storm::orm::where::field<^^Person::age>() >= 30)
+                          .having(storm::orm::where::f<^^Person::age>() >= 30)
                           .count()
                           .execute();
     ASSERT_TRUE(result.has_value()) << "HAVING >= failed: " << result.error().message();
@@ -176,7 +176,7 @@ TYPED_TEST(AggregateTest, HavingWithGreaterEqual) {
 
 TYPED_TEST(AggregateTest, HavingWithIn) {
     auto result = this->qs->template group_by<^^Person::age>()
-                          .having(storm::orm::where::field<^^Person::age>().in(25, 30, 35))
+                          .having(storm::orm::where::f<^^Person::age>().in(25, 30, 35))
                           .count()
                           .execute();
     ASSERT_TRUE(result.has_value()) << "HAVING IN failed: " << result.error().message();
@@ -187,7 +187,7 @@ TYPED_TEST(AggregateTest, HavingWithIn) {
 
 TYPED_TEST(AggregateTest, HavingWithBetween) {
     auto result = this->qs->template group_by<^^Person::age>()
-                          .having(storm::orm::where::field<^^Person::age>().between(25, 35))
+                          .having(storm::orm::where::f<^^Person::age>().between(25, 35))
                           .count()
                           .execute();
     ASSERT_TRUE(result.has_value()) << "HAVING BETWEEN failed: " << result.error().message();
@@ -199,7 +199,7 @@ TYPED_TEST(AggregateTest, HavingWithBetween) {
 
 TYPED_TEST(AggregateTest, HavingWithLike) {
     auto result = this->qs->template group_by<^^Person::name>()
-                          .having(storm::orm::where::field<^^Person::name>().like("A%"))
+                          .having(storm::orm::where::f<^^Person::name>().like("A%"))
                           .count()
                           .execute();
     ASSERT_TRUE(result.has_value()) << "HAVING LIKE failed: " << result.error().message();
@@ -209,21 +209,21 @@ TYPED_TEST(AggregateTest, HavingWithLike) {
 }
 
 TYPED_TEST(AggregateTest, HavingWithLogicalAnd) {
-    auto result = this->qs->template group_by<^^Person::age>()
-                          .having(storm::orm::where::field<^^Person::age>() > 20 &&
-                                  storm::orm::where::field<^^Person::age>() < 40)
-                          .count()
-                          .execute();
+    auto result =
+            this->qs->template group_by<^^Person::age>()
+                    .having(storm::orm::where::f<^^Person::age>() > 20 && storm::orm::where::f<^^Person::age>() < 40)
+                    .count()
+                    .execute();
     ASSERT_TRUE(result.has_value()) << "HAVING AND failed: " << result.error().message();
     check_age_between_20_40(result.value());
 }
 
 TYPED_TEST(AggregateTest, HavingWithLogicalOr) {
-    auto result = this->qs->template group_by<^^Person::age>()
-                          .having(storm::orm::where::field<^^Person::age>() < 25 ||
-                                  storm::orm::where::field<^^Person::age>() > 35)
-                          .count()
-                          .execute();
+    auto result =
+            this->qs->template group_by<^^Person::age>()
+                    .having(storm::orm::where::f<^^Person::age>() < 25 || storm::orm::where::f<^^Person::age>() > 35)
+                    .count()
+                    .execute();
     ASSERT_TRUE(result.has_value()) << "HAVING OR failed: " << result.error().message();
     for (const auto& [age, count] : result.value()) {
         EXPECT_TRUE(age < 25 || age > 35) << "HAVING OR: unexpected age " << age;
@@ -232,9 +232,9 @@ TYPED_TEST(AggregateTest, HavingWithLogicalOr) {
 
 TYPED_TEST(AggregateTest, HavingWithComplexLogical) {
     auto result = this->qs->template group_by<^^Person::age>()
-                          .having((storm::orm::where::field<^^Person::age>() >= 25 &&
-                                   storm::orm::where::field<^^Person::age>() <= 35) ||
-                                  storm::orm::where::field<^^Person::age>() == 50)
+                          .having((storm::orm::where::f<^^Person::age>() >= 25 &&
+                                   storm::orm::where::f<^^Person::age>() <= 35) ||
+                                  storm::orm::where::f<^^Person::age>() == 50)
                           .count()
                           .execute();
     ASSERT_TRUE(result.has_value()) << "HAVING complex logical failed: " << result.error().message();
@@ -244,9 +244,9 @@ TYPED_TEST(AggregateTest, HavingWithComplexLogical) {
 }
 
 TYPED_TEST(AggregateTest, HavingWithWhereAndIn) {
-    auto result = this->qs->where(storm::orm::where::field<^^Person::salary>() > 50000.0)
+    auto result = this->qs->where(storm::orm::where::f<^^Person::salary>() > 50000.0)
                           .template group_by<^^Person::age>()
-                          .having(storm::orm::where::field<^^Person::age>().in(25, 30, 35))
+                          .having(storm::orm::where::f<^^Person::age>().in(25, 30, 35))
                           .count()
                           .execute();
     ASSERT_TRUE(result.has_value()) << "WHERE + HAVING IN failed: " << result.error().message();
@@ -256,9 +256,9 @@ TYPED_TEST(AggregateTest, HavingWithWhereAndIn) {
 }
 
 TYPED_TEST(AggregateTest, HavingWithWhereAndBetween) {
-    auto result = this->qs->where(storm::orm::where::field<^^Person::salary>() > 30000.0)
+    auto result = this->qs->where(storm::orm::where::f<^^Person::salary>() > 30000.0)
                           .template group_by<^^Person::years_experience>()
-                          .having(storm::orm::where::field<^^Person::years_experience>().between(3, 8))
+                          .having(storm::orm::where::f<^^Person::years_experience>().between(3, 8))
                           .count()
                           .execute();
     ASSERT_TRUE(result.has_value()) << "WHERE + HAVING BETWEEN failed: " << result.error().message();
@@ -269,12 +269,12 @@ TYPED_TEST(AggregateTest, HavingWithWhereAndBetween) {
 }
 
 TYPED_TEST(AggregateTest, HavingWithWhereAndLogicalAnd) {
-    auto result = this->qs->where(storm::orm::where::field<^^Person::salary>() > 30000.0)
-                          .template group_by<^^Person::age>()
-                          .having(storm::orm::where::field<^^Person::age>() > 20 &&
-                                  storm::orm::where::field<^^Person::age>() < 40)
-                          .count()
-                          .execute();
+    auto result =
+            this->qs->where(storm::orm::where::f<^^Person::salary>() > 30000.0)
+                    .template group_by<^^Person::age>()
+                    .having(storm::orm::where::f<^^Person::age>() > 20 && storm::orm::where::f<^^Person::age>() < 40)
+                    .count()
+                    .execute();
     ASSERT_TRUE(result.has_value()) << "WHERE + HAVING AND failed: " << result.error().message();
     check_age_between_20_40(result.value());
 }
@@ -282,7 +282,7 @@ TYPED_TEST(AggregateTest, HavingWithWhereAndLogicalAnd) {
 TYPED_TEST(AggregateTest, HavingInOnAggregateStatement) {
     auto result = this->qs->template group_by<^^Person::age>()
                           .count()
-                          .having(storm::orm::where::field<^^Person::age>().in(25, 30))
+                          .having(storm::orm::where::f<^^Person::age>().in(25, 30))
                           .execute();
     ASSERT_TRUE(result.has_value()) << "HAVING IN on AggregateStatement failed: " << result.error().message();
     for (const auto& [age, count] : result.value()) {
@@ -293,7 +293,7 @@ TYPED_TEST(AggregateTest, HavingInOnAggregateStatement) {
 TYPED_TEST(AggregateTest, HavingBetweenOnAggregateStatement) {
     auto result = this->qs->template group_by<^^Person::age>()
                           .template sum<^^Person::salary>()
-                          .having(storm::orm::where::field<^^Person::age>().between(25, 35))
+                          .having(storm::orm::where::f<^^Person::age>().between(25, 35))
                           .execute();
     ASSERT_TRUE(result.has_value()) << "HAVING BETWEEN on AggregateStatement failed: " << result.error().message();
     for (const auto& [age, sum_salary] : result.value()) {
@@ -303,11 +303,11 @@ TYPED_TEST(AggregateTest, HavingBetweenOnAggregateStatement) {
 }
 
 TYPED_TEST(AggregateTest, HavingLogicalOnAggregateStatement) {
-    auto result = this->qs->template group_by<^^Person::age>()
-                          .template avg<^^Person::salary>()
-                          .having(storm::orm::where::field<^^Person::age>() >= 25 &&
-                                  storm::orm::where::field<^^Person::age>() <= 40)
-                          .execute();
+    auto result =
+            this->qs->template group_by<^^Person::age>()
+                    .template avg<^^Person::salary>()
+                    .having(storm::orm::where::f<^^Person::age>() >= 25 && storm::orm::where::f<^^Person::age>() <= 40)
+                    .execute();
     ASSERT_TRUE(result.has_value()) << "HAVING AND on AggregateStatement failed: " << result.error().message();
     for (const auto& [age, avg_salary] : result.value()) {
         EXPECT_GE(age, 25);
@@ -395,7 +395,7 @@ TYPED_TEST(AggregateTest, HavingWithOrderByAndLimit) {
     auto result = this->qs->template order_by<^^Person::age>()
                           .limit(3)
                           .template group_by<^^Person::age>()
-                          .having(storm::orm::where::field<^^Person::age>() > 25)
+                          .having(storm::orm::where::f<^^Person::age>() > 25)
                           .count()
                           .execute();
     ASSERT_TRUE(result.has_value()) << "HAVING + ORDER BY + LIMIT failed: " << result.error().message();
@@ -414,7 +414,7 @@ TYPED_TEST(AggregateTest, HavingWithOrderByAndLimit) {
 TYPED_TEST(AggregateTest, HavingWithOrderByOnly) {
     auto result = this->qs->template order_by<^^Person::age, false>()
                           .template group_by<^^Person::age>()
-                          .having(storm::orm::where::field<^^Person::age>() > 30)
+                          .having(storm::orm::where::f<^^Person::age>() > 30)
                           .count()
                           .execute();
     ASSERT_TRUE(result.has_value()) << "HAVING + ORDER BY failed: " << result.error().message();
@@ -431,7 +431,7 @@ TYPED_TEST(AggregateTest, HavingWithOrderByOnly) {
 TYPED_TEST(AggregateTest, HavingWithLimitOnly) {
     auto result = this->qs->limit(2)
                           .template group_by<^^Person::age>()
-                          .having(storm::orm::where::field<^^Person::age>() > 25)
+                          .having(storm::orm::where::f<^^Person::age>() > 25)
                           .count()
                           .execute();
     ASSERT_TRUE(result.has_value()) << "HAVING + LIMIT failed: " << result.error().message();
@@ -441,7 +441,7 @@ TYPED_TEST(AggregateTest, HavingWithLimitOnly) {
 TYPED_TEST(AggregateTest, HavingWithOffsetOnly) {
     auto result = this->qs->offset(1)
                           .template group_by<^^Person::age>()
-                          .having(storm::orm::where::field<^^Person::age>() > 25)
+                          .having(storm::orm::where::f<^^Person::age>() > 25)
                           .count()
                           .execute();
     ASSERT_TRUE(result.has_value()) << "HAVING + OFFSET failed: " << result.error().message();

--- a/tests/query/test_aggregate_optional.cpp
+++ b/tests/query/test_aggregate_optional.cpp
@@ -226,12 +226,11 @@ TYPED_TEST(AggregateTest, NegativeNumbersInWhere) {
             {.name = "Eve", .age = 10, .salary = 90000.0, .years_experience = 15},
     })));
 
-    auto result = this->qs->where(storm::orm::where::field<^^Person::age>() < 0).count().execute();
+    auto result = this->qs->where(storm::orm::where::f<^^Person::age>() < 0).count().execute();
     ASSERT_TRUE(result.has_value());
     EXPECT_EQ(result.value(), 2);
 
-    auto sum_neg =
-            this->qs->where(storm::orm::where::field<^^Person::age>() < 0).template sum<^^Person::age>().execute();
+    auto sum_neg = this->qs->where(storm::orm::where::f<^^Person::age>() < 0).template sum<^^Person::age>().execute();
     ASSERT_TRUE(sum_neg.has_value());
     EXPECT_EQ(sum_neg.value(), -15);
 }

--- a/tests/query/test_collate.cpp
+++ b/tests/query/test_collate.cpp
@@ -10,7 +10,7 @@ import std;
 #include "test_models.h" // NOSONAR cpp:S954
 using storm::QuerySet;
 using storm::orm::utilities::Collate;
-using storm::orm::where::field;
+using storm::orm::where::f;
 
 // SQLite-only: COLLATE NOCASE/BINARY/RTRIM are SQLite-specific collation sequences.
 // PostgreSQL uses different syntax (COLLATE "C", COLLATE "en_US").
@@ -154,7 +154,7 @@ TYPED_TEST(CollateTest, WhereEqualNoCase) {
     QuerySet<Person, TypeParam> qs;
 
     // Case-insensitive equality: "alice" should match "alice", "Alice", "ALICE"
-    auto result = qs.where(field<^^Person::name>().collate(Collate::NoCase) == "alice").select().execute();
+    auto result = qs.where(f<^^Person::name>().collate(Collate::NoCase) == "alice").select().execute();
     ASSERT_TRUE(result.has_value());
     EXPECT_EQ(result.value().size(), 3);
 }
@@ -163,7 +163,7 @@ TYPED_TEST(CollateTest, WhereNotEqualNoCase) {
     QuerySet<Person, TypeParam> qs;
 
     // Case-insensitive not-equal: exclude all "alice" variants → 5 remaining
-    auto result = qs.where(field<^^Person::name>().collate(Collate::NoCase) != "alice").select().execute();
+    auto result = qs.where(f<^^Person::name>().collate(Collate::NoCase) != "alice").select().execute();
     ASSERT_TRUE(result.has_value());
     EXPECT_EQ(result.value().size(), 5);
 }
@@ -173,7 +173,7 @@ TYPED_TEST(CollateTest, WhereGreaterNoCase) {
 
     // Case-insensitive greater: names > "bob" → charlie variants + leading-space bob
     // Actually "  bob" < "bob" even with NOCASE since space < 'b'
-    auto result = qs.where(field<^^Person::name>().collate(Collate::NoCase) > "bob").select().execute();
+    auto result = qs.where(f<^^Person::name>().collate(Collate::NoCase) > "bob").select().execute();
     ASSERT_TRUE(result.has_value());
     // "charlie", "Charlie" are > "bob" (case-insensitive)
     EXPECT_EQ(result.value().size(), 2);
@@ -182,7 +182,7 @@ TYPED_TEST(CollateTest, WhereGreaterNoCase) {
 TYPED_TEST(CollateTest, WhereGreaterEqualNoCase) {
     QuerySet<Person, TypeParam> qs;
 
-    auto result = qs.where(field<^^Person::name>().collate(Collate::NoCase) >= "bob").select().execute();
+    auto result = qs.where(f<^^Person::name>().collate(Collate::NoCase) >= "bob").select().execute();
     ASSERT_TRUE(result.has_value());
     // "bob", "BOB", "charlie", "Charlie" = 4
     EXPECT_EQ(result.value().size(), 4);
@@ -191,7 +191,7 @@ TYPED_TEST(CollateTest, WhereGreaterEqualNoCase) {
 TYPED_TEST(CollateTest, WhereLessNoCase) {
     QuerySet<Person, TypeParam> qs;
 
-    auto result = qs.where(field<^^Person::name>().collate(Collate::NoCase) < "bob").select().execute();
+    auto result = qs.where(f<^^Person::name>().collate(Collate::NoCase) < "bob").select().execute();
     ASSERT_TRUE(result.has_value());
     // "alice", "Alice", "ALICE", "  bob" = 4
     EXPECT_EQ(result.value().size(), 4);
@@ -200,7 +200,7 @@ TYPED_TEST(CollateTest, WhereLessNoCase) {
 TYPED_TEST(CollateTest, WhereLessEqualNoCase) {
     QuerySet<Person, TypeParam> qs;
 
-    auto result = qs.where(field<^^Person::name>().collate(Collate::NoCase) <= "bob").select().execute();
+    auto result = qs.where(f<^^Person::name>().collate(Collate::NoCase) <= "bob").select().execute();
     ASSERT_TRUE(result.has_value());
     // "alice" x3, "bob" x2, "  bob" = 6
     EXPECT_EQ(result.value().size(), 6);
@@ -214,7 +214,7 @@ TYPED_TEST(CollateTest, WhereLikeNoCase) {
     QuerySet<Person, TypeParam> qs;
 
     // LIKE with NOCASE: "A%" should match alice, Alice, ALICE
-    auto result = qs.where(field<^^Person::name>().collate(Collate::NoCase).like("a%")).select().execute();
+    auto result = qs.where(f<^^Person::name>().collate(Collate::NoCase).like("a%")).select().execute();
     ASSERT_TRUE(result.has_value());
     EXPECT_EQ(result.value().size(), 3);
 }
@@ -228,7 +228,7 @@ TYPED_TEST(CollateTest, WhereBetweenNoCase) {
 
     // BETWEEN with NOCASE: names between "alice" and "bob" (inclusive)
     auto result =
-            qs.where(field<^^Person::name>().collate(Collate::NoCase).between(std::string("alice"), std::string("bob")))
+            qs.where(f<^^Person::name>().collate(Collate::NoCase).between(std::string("alice"), std::string("bob")))
                     .select()
                     .execute();
     ASSERT_TRUE(result.has_value());
@@ -245,7 +245,7 @@ TYPED_TEST(CollateTest, WhereInNoCase) {
 
     // IN with NOCASE: match "alice" (case-insensitive) and "bob" (case-insensitive)
     // Note: IN comparisons in SQLite still use the collation of the left-hand operand
-    auto result = qs.where(field<^^Person::name>().collate(Collate::NoCase).in("alice", "bob")).select().execute();
+    auto result = qs.where(f<^^Person::name>().collate(Collate::NoCase).in("alice", "bob")).select().execute();
     ASSERT_TRUE(result.has_value());
     // "alice" x3, "bob" x2 = 5 (not "  bob" — it's "  bob" not "bob")
     EXPECT_EQ(result.value().size(), 5);
@@ -259,7 +259,7 @@ TYPED_TEST(CollateTest, WhereEqualBinary) {
     QuerySet<Person, TypeParam> qs;
 
     // COLLATE BINARY: exact case match
-    auto result = qs.where(field<^^Person::name>().collate(Collate::Binary) == "alice").select().execute();
+    auto result = qs.where(f<^^Person::name>().collate(Collate::Binary) == "alice").select().execute();
     ASSERT_TRUE(result.has_value());
     EXPECT_EQ(result.value().size(), 1); // Only lowercase "alice"
 }
@@ -271,7 +271,7 @@ TYPED_TEST(CollateTest, WhereEqualBinary) {
 TYPED_TEST(CollateTest, WhereCollateWithOrderByCollate) {
     QuerySet<Person, TypeParam> qs;
 
-    auto result = qs.where(field<^^Person::name>().collate(Collate::NoCase) >= "bob")
+    auto result = qs.where(f<^^Person::name>().collate(Collate::NoCase) >= "bob")
                           .template order_by<^^Person::name, Collate::NoCase>()
                           .select()
                           .execute();
@@ -308,7 +308,7 @@ TYPED_TEST(CollateTest, OrderByCollateWithLimitOffset) {
 TYPED_TEST(CollateTest, WhereCollateWithAndLogic) {
     QuerySet<Person, TypeParam> qs;
 
-    auto result = qs.where(field<^^Person::name>().collate(Collate::NoCase) == "alice" && field<^^Person::age>() > 30)
+    auto result = qs.where(f<^^Person::name>().collate(Collate::NoCase) == "alice" && f<^^Person::age>() > 30)
                           .select()
                           .execute();
     ASSERT_TRUE(result.has_value());
@@ -319,8 +319,8 @@ TYPED_TEST(CollateTest, WhereCollateWithAndLogic) {
 TYPED_TEST(CollateTest, WhereCollateWithOrLogic) {
     QuerySet<Person, TypeParam> qs;
 
-    auto result = qs.where(field<^^Person::name>().collate(Collate::NoCase) == "alice" ||
-                           field<^^Person::name>().collate(Collate::NoCase) == "charlie")
+    auto result = qs.where(f<^^Person::name>().collate(Collate::NoCase) == "alice" ||
+                           f<^^Person::name>().collate(Collate::NoCase) == "charlie")
                           .select()
                           .execute();
     ASSERT_TRUE(result.has_value());
@@ -336,8 +336,8 @@ TYPED_TEST(CollateTest, RepeatedCollateQueries) {
     QuerySet<Person, TypeParam> qs;
 
     // Same query twice — should get same result (caching correctness)
-    auto r1 = qs.where(field<^^Person::name>().collate(Collate::NoCase) == "bob").select().execute();
-    auto r2 = qs.where(field<^^Person::name>().collate(Collate::NoCase) == "bob").select().execute();
+    auto r1 = qs.where(f<^^Person::name>().collate(Collate::NoCase) == "bob").select().execute();
+    auto r2 = qs.where(f<^^Person::name>().collate(Collate::NoCase) == "bob").select().execute();
 
     ASSERT_TRUE(r1.has_value());
     ASSERT_TRUE(r2.has_value());
@@ -348,8 +348,8 @@ TYPED_TEST(CollateTest, DifferentCollateOnSameField) {
     QuerySet<Person, TypeParam> qs;
 
     // NOCASE vs BINARY on same field — different results (cache invalidation)
-    auto r_nocase = qs.where(field<^^Person::name>().collate(Collate::NoCase) == "alice").select().execute();
-    auto r_binary = qs.where(field<^^Person::name>().collate(Collate::Binary) == "alice").select().execute();
+    auto r_nocase = qs.where(f<^^Person::name>().collate(Collate::NoCase) == "alice").select().execute();
+    auto r_binary = qs.where(f<^^Person::name>().collate(Collate::Binary) == "alice").select().execute();
 
     ASSERT_TRUE(r_nocase.has_value());
     ASSERT_TRUE(r_binary.has_value());
@@ -365,7 +365,7 @@ TYPED_TEST(CollateTest, DifferentCollateOnSameField) {
 TYPED_TEST(CollateTest, WhereCollateNoMatch) {
     QuerySet<Person, TypeParam> qs;
 
-    auto result = qs.where(field<^^Person::name>().collate(Collate::NoCase) == "nonexistent").select().execute();
+    auto result = qs.where(f<^^Person::name>().collate(Collate::NoCase) == "nonexistent").select().execute();
     ASSERT_TRUE(result.has_value());
     EXPECT_EQ(result.value().size(), 0);
 }
@@ -387,7 +387,7 @@ TYPED_TEST(CollateTest, OrderBySqlGeneration) {
 TYPED_TEST(CollateTest, WhereCollateSqlGeneration) {
     QuerySet<Person, TypeParam> qs;
 
-    auto sql_result = qs.where(field<^^Person::name>().collate(Collate::NoCase) == "test").select().to_sql();
+    auto sql_result = qs.where(f<^^Person::name>().collate(Collate::NoCase) == "test").select().to_sql();
     ASSERT_TRUE(sql_result.has_value());
     const auto& sql = sql_result.value();
     EXPECT_NE(sql.find("name COLLATE NOCASE"), std::string::npos)

--- a/tests/query/test_distinct.cpp
+++ b/tests/query/test_distinct.cpp
@@ -8,7 +8,7 @@ import storm;
 import std;
 
 using storm::QuerySet;
-using storm::orm::where::field;
+using storm::orm::where::f;
 
 #include "test_models.h" // NOSONAR cpp:S954
 
@@ -624,8 +624,8 @@ TYPED_TEST(DistinctTest, DesiredSQLForDistinctWithJoin) {
      * Option C: SQL-style field selection
      *   msg_qs.template join<^^Message::sender>()
      *         .select_distinct(
-     *             field<&Message::content>(),
-     *             field<&Message::sender, &Person::name>()  // Joined field
+     *             f<&Message::content>(),
+     *             f<&Message::sender, &Person::name>()  // Joined field
      *         )
      *
      * Challenges:
@@ -765,7 +765,7 @@ TYPED_TEST(DistinctTest, DistinctWithWhereSingleField) {
     ASSERT_TRUE(insert_result.has_value());
 
     // SELECT DISTINCT age WHERE age > 22
-    auto result = queryset.where(field<^^Person::age>() > 22).template distinct<^^Person::age>().execute();
+    auto result = queryset.where(f<^^Person::age>() > 22).template distinct<^^Person::age>().execute();
     ASSERT_TRUE(result.has_value()) << "DISTINCT with WHERE failed: " << result.error().message();
 
     const auto& ages = result.value();
@@ -798,8 +798,7 @@ TYPED_TEST(DistinctTest, DistinctWithWhereMultipleFields) {
     ASSERT_TRUE(insert_result.has_value());
 
     // SELECT DISTINCT name, age WHERE age > 22
-    auto result =
-            queryset.where(field<^^Person::age>() > 22).template distinct<^^Person::name, ^^Person::age>().execute();
+    auto result = queryset.where(f<^^Person::age>() > 22).template distinct<^^Person::name, ^^Person::age>().execute();
     ASSERT_TRUE(result.has_value()) << "DISTINCT with WHERE failed: " << result.error().message();
 
     const auto& pairs = result.value();
@@ -827,7 +826,7 @@ TYPED_TEST(DistinctTest, DistinctWithWhereNoResults) {
     ASSERT_TRUE(insert_result.has_value());
 
     // SELECT DISTINCT name WHERE age > 100 (no matches)
-    auto result = queryset.where(field<^^Person::age>() > 100).template distinct<^^Person::name>().execute();
+    auto result = queryset.where(f<^^Person::age>() > 100).template distinct<^^Person::name>().execute();
     ASSERT_TRUE(result.has_value());
 
     const auto& names = result.value();
@@ -852,7 +851,7 @@ TYPED_TEST(DistinctTest, DistinctWithComplexWhere) {
     ASSERT_TRUE(insert_result.has_value());
 
     // SELECT DISTINCT age WHERE age >= 25 AND age <= 35
-    auto result = queryset.where(field<^^Person::age>().between(25, 35)).template distinct<^^Person::age>().execute();
+    auto result = queryset.where(f<^^Person::age>().between(25, 35)).template distinct<^^Person::age>().execute();
     ASSERT_TRUE(result.has_value());
 
     const auto& ages = result.value();
@@ -894,7 +893,7 @@ TYPED_TEST(DistinctTest, ChainingOrderWhereJoinDistinct) {
 
     // Test that WHERE -> JOIN -> DISTINCT works
     // Using content field to avoid ambiguous column names
-    auto result = msg_qs.where(field<^^Message::content>().like("%e%"))
+    auto result = msg_qs.where(f<^^Message::content>().like("%e%"))
                           .template join<^^Message::sender>()
                           .template distinct<^^Message::content>()
                           .execute();
@@ -910,7 +909,7 @@ TYPED_TEST(DistinctTest, ChainingOrderJoinWhereDistinct) {
     // Test that JOIN -> WHERE -> DISTINCT works
     // Using content field to avoid ambiguous column names
     auto result = msg_qs.template join<^^Message::sender>()
-                          .where(field<^^Message::content>().like("%e%"))
+                          .where(f<^^Message::content>().like("%e%"))
                           .template distinct<^^Message::content>()
                           .execute();
     ASSERT_TRUE(result.has_value()) << "JOIN -> WHERE -> DISTINCT failed: " << result.error().message();
@@ -930,7 +929,7 @@ TYPED_TEST(DistinctTest, DistinctDefaultPKWithWhere) {
     ASSERT_TRUE(insert_result.has_value());
 
     // SELECT DISTINCT id (default PK) WHERE age > 22
-    auto result = queryset.where(field<^^Person::age>() > 22).distinct().execute();
+    auto result = queryset.where(f<^^Person::age>() > 22).distinct().execute();
     ASSERT_TRUE(result.has_value());
 
     const auto& ids = result.value();
@@ -952,8 +951,8 @@ TYPED_TEST(DistinctTest, MultipleWhereClausesWithDistinct) {
     ASSERT_TRUE(insert_result.has_value());
 
     // Chain multiple WHERE clauses (should combine with AND)
-    auto result = queryset.where(field<^^Person::age>() > 22)
-                          .where(field<^^Person::age>() < 32)
+    auto result = queryset.where(f<^^Person::age>() > 22)
+                          .where(f<^^Person::age>() < 32)
                           .template distinct<^^Person::name>()
                           .execute();
     ASSERT_TRUE(result.has_value());
@@ -1229,7 +1228,7 @@ TYPED_TEST(DistinctTest, DistinctWithWhereOrderByLimit) {
     ASSERT_TRUE(insert_result.has_value());
 
     // SELECT DISTINCT name WHERE age > 25 ORDER BY name ASC LIMIT 2
-    auto result = queryset.where(field<^^Person::age>() > 25)
+    auto result = queryset.where(f<^^Person::age>() > 25)
                           .template order_by<^^Person::name>()
                           .limit(2)
                           .template distinct<^^Person::name>()
@@ -1427,7 +1426,7 @@ TYPED_TEST(DistinctTest, DistinctOptionalWithWhereOnOptional) {
     ASSERT_TRUE(insert_result.has_value());
 
     // SELECT DISTINCT name WHERE age > 20 (filters out NULLs)
-    auto result = queryset.where(field<^^Person::score>() > 20).template distinct<^^Person::name>().execute();
+    auto result = queryset.where(f<^^Person::score>() > 20).template distinct<^^Person::name>().execute();
     ASSERT_TRUE(result.has_value());
 
     const auto& names = result.value();
@@ -1573,7 +1572,7 @@ TYPED_TEST(DistinctTest, DifferentWhereExpressionsWithCaching) {
     std::ignore = queryset.insert(people).execute();
 
     // Query 1: age > 25
-    auto result1 = queryset.where(field<^^Person::age>() > 25).template distinct<^^Person::name>().execute();
+    auto result1 = queryset.where(f<^^Person::age>() > 25).template distinct<^^Person::name>().execute();
     ASSERT_TRUE(result1.has_value());
     EXPECT_EQ(result1.value().size(), 3); // Bob, Charlie, Dave
 
@@ -1581,14 +1580,14 @@ TYPED_TEST(DistinctTest, DifferentWhereExpressionsWithCaching) {
     queryset.reset();
 
     // Query 2: age > 35
-    auto result2 = queryset.where(field<^^Person::age>() > 35).template distinct<^^Person::name>().execute();
+    auto result2 = queryset.where(f<^^Person::age>() > 35).template distinct<^^Person::name>().execute();
     ASSERT_TRUE(result2.has_value());
     EXPECT_EQ(result2.value().size(), 1); // Dave only
 
     // Reset and Query 3: different condition
     queryset.reset();
 
-    auto result3 = queryset.where(field<^^Person::age>() < 30).template distinct<^^Person::name>().execute();
+    auto result3 = queryset.where(f<^^Person::age>() < 30).template distinct<^^Person::name>().execute();
     ASSERT_TRUE(result3.has_value());
     EXPECT_EQ(result3.value().size(), 1); // Alice only
 }
@@ -1637,7 +1636,7 @@ TYPED_TEST(DistinctTest, SqlVerifyDistinctMultiField) {
 // Test: DISTINCT + WHERE generates correct SQL
 TYPED_TEST(DistinctTest, SqlVerifyDistinctWithWhere) {
     QuerySet<Person, TypeParam> queryset;
-    auto sql = queryset.where(field<^^Person::age>() > 30).template distinct<^^Person::name>().sql();
+    auto                        sql = queryset.where(f<^^Person::age>() > 30).template distinct<^^Person::name>().sql();
     EXPECT_EQ(sql, "SELECT DISTINCT name FROM Person WHERE age > ?");
 }
 
@@ -1652,7 +1651,7 @@ TYPED_TEST(DistinctTest, SqlVerifyDistinctWithJoin) {
 TYPED_TEST(DistinctTest, SqlVerifyDistinctWithJoinAndWhere) {
     QuerySet<Message, TypeParam> msg_qs;
     auto                         sql = msg_qs.template join<^^Message::sender>()
-                       .where(field<^^Message::content>().like("%test%"))
+                       .where(f<^^Message::content>().like("%test%"))
                        .template distinct<^^Message::content>()
                        .sql();
     EXPECT_EQ(
@@ -1706,7 +1705,7 @@ TYPED_TEST(DistinctTest, SqlVerifyDistinctWithLimitOffset) {
 TYPED_TEST(DistinctTest, SqlVerifyDistinctFullCombo) {
     QuerySet<Message, TypeParam> msg_qs;
     auto                         sql = msg_qs.template join<^^Message::sender>()
-                       .where(field<^^Message::value>() > 10)
+                       .where(f<^^Message::value>() > 10)
                        .template order_by<^^Message::content>()
                        .limit(5)
                        .template distinct<^^Message::content>()

--- a/tests/query/test_expected_transform.cpp
+++ b/tests/query/test_expected_transform.cpp
@@ -11,7 +11,7 @@ import std;
 #include "test_seed_helpers.h"
 
 using storm::QuerySet;
-using storm::orm::where::field;
+using storm::orm::where::f;
 
 template <typename ConnType> class ExpectedTransformTest : public StormTestFixture<Person, ConnType> {
   protected:
@@ -49,7 +49,7 @@ TYPED_TEST(ExpectedTransformTest, HiveToVectorViaTransformMoves) {
 TYPED_TEST(ExpectedTransformTest, EmptyResultTransformYieldsEmptyVector) {
     QuerySet<Person, TypeParam> qs;
 
-    auto vec_result = qs.where(field<^^Person::age>() > 10000).select().execute().transform([](auto&& hive) {
+    auto vec_result = qs.where(f<^^Person::age>() > 10000).select().execute().transform([](auto&& hive) {
         return std::forward<decltype(hive)>(hive) | std::views::as_rvalue | std::ranges::to<std::vector<Person>>();
     });
 
@@ -76,7 +76,7 @@ TYPED_TEST(ExpectedTransformTest, ChainViewsInsideTransformMoves) {
 TYPED_TEST(ExpectedTransformTest, TransformPreservesWhereFilter) {
     QuerySet<Person, TypeParam> qs;
 
-    auto vec_result = qs.where(field<^^Person::age>() > 35).select().execute().transform([](auto&& hive) {
+    auto vec_result = qs.where(f<^^Person::age>() > 35).select().execute().transform([](auto&& hive) {
         return std::forward<decltype(hive)>(hive) | std::views::as_rvalue | std::ranges::to<std::vector<Person>>();
     });
 

--- a/tests/query/test_limit_offset.cpp
+++ b/tests/query/test_limit_offset.cpp
@@ -5,7 +5,7 @@ import storm;
 import std;
 
 using storm::QuerySet;
-using storm::orm::where::field;
+using storm::orm::where::f;
 
 #include "test_models.h" // NOSONAR cpp:S954
 #include "test_seed_helpers.h"
@@ -124,8 +124,7 @@ TYPED_TEST(LimitOffsetTest, LimitOffsetPagination) {
 TYPED_TEST(LimitOffsetTest, WhereWithOffsetNoLimit) {
     QuerySet<Person, TypeParam> qs;
 
-    auto result =
-            qs.template order_by<^^Person::name>().where(field<^^Person::age>() < 30).offset(2).select().execute();
+    auto result = qs.template order_by<^^Person::name>().where(f<^^Person::age>() < 30).offset(2).select().execute();
     ASSERT_TRUE(result.has_value()) << "SELECT WHERE with OFFSET failed: " << result.error().message();
 
     const auto& people = result.value();

--- a/tests/query/test_many_to_many.cpp
+++ b/tests/query/test_many_to_many.cpp
@@ -121,7 +121,7 @@ TYPED_TEST(M2MBaseTest, M2MJoinSqlShape) {
 TYPED_TEST(M2MBaseTest, M2MJoinSqlModifiersGoInsideSubquery) {
     QuerySet<Student, TypeParam> qs;
     auto                         sql = qs.template join<^^Student::courses>()
-                       .where(storm::orm::where::field<^^Student::age>() > 18)
+                       .where(storm::orm::where::f<^^Student::age>() > 18)
                        .template order_by<^^Student::name, false>()
                        .limit(2)
                        .select()
@@ -226,7 +226,7 @@ TYPED_TEST(M2MSeededTest, LeftJoinKeepsStudentsWithoutCourses) {
 TYPED_TEST(M2MSeededTest, EmptyResultSet) {
     QuerySet<Student, TypeParam> qs;
     auto                         rows = qs.template join<^^Student::courses>()
-                        .where(storm::orm::where::field<^^Student::age>() > 99)
+                        .where(storm::orm::where::f<^^Student::age>() > 99)
                         .select()
                         .execute();
     ASSERT_TRUE(rows.has_value()) << rows.error().message();

--- a/tests/query/test_many_to_many_modifiers.cpp
+++ b/tests/query/test_many_to_many_modifiers.cpp
@@ -8,7 +8,7 @@ import storm;
 import std;
 
 using storm::QuerySet;
-using storm::orm::where::field;
+using storm::orm::where::f;
 
 #include "test_models.h"     // NOSONAR cpp:S954
 #include "test_m2m_models.h" // NOSONAR cpp:S954
@@ -44,7 +44,7 @@ using Names = std::vector<std::string>;
 
 TYPED_TEST(M2MModifierTest, WhereFiltersBaseEntities) {
     QuerySet<Student, TypeParam> qs;
-    auto rows = qs.template join<^^Student::courses>().where(field<^^Student::age>() >= 22).select().execute();
+    auto rows = qs.template join<^^Student::courses>().where(f<^^Student::age>() >= 22).select().execute();
     ASSERT_TRUE(rows.has_value()) << rows.error().message();
     // Carol matches the WHERE but has no courses → dropped by INNER join
     ASSERT_EQ(rows->size(), 1U);
@@ -54,25 +54,24 @@ TYPED_TEST(M2MModifierTest, WhereFiltersBaseEntities) {
 }
 
 TYPED_TEST(M2MModifierTest, WhereAllSixComparisonOperators) {
-    EXPECT_EQ(this->names_matching(field<^^Student::age>() == 20), (Names{"Alice"}));
-    EXPECT_EQ(this->names_matching(field<^^Student::age>() != 20), (Names{"Bob"}));
-    EXPECT_EQ(this->names_matching(field<^^Student::age>() > 20), (Names{"Bob"}));
-    EXPECT_EQ(this->names_matching(field<^^Student::age>() >= 20), (Names{"Alice", "Bob"}));
-    EXPECT_EQ(this->names_matching(field<^^Student::age>() < 22), (Names{"Alice"}));
-    EXPECT_EQ(this->names_matching(field<^^Student::age>() <= 22), (Names{"Alice", "Bob"}));
+    EXPECT_EQ(this->names_matching(f<^^Student::age>() == 20), (Names{"Alice"}));
+    EXPECT_EQ(this->names_matching(f<^^Student::age>() != 20), (Names{"Bob"}));
+    EXPECT_EQ(this->names_matching(f<^^Student::age>() > 20), (Names{"Bob"}));
+    EXPECT_EQ(this->names_matching(f<^^Student::age>() >= 20), (Names{"Alice", "Bob"}));
+    EXPECT_EQ(this->names_matching(f<^^Student::age>() < 22), (Names{"Alice"}));
+    EXPECT_EQ(this->names_matching(f<^^Student::age>() <= 22), (Names{"Alice", "Bob"}));
 }
 
 TYPED_TEST(M2MModifierTest, WhereSpecialExpressionsAndLogic) {
-    EXPECT_EQ(this->names_matching(field<^^Student::age>().in(20, 25)), (Names{"Alice"}));
-    EXPECT_EQ(this->names_matching(field<^^Student::age>().between(19, 21)), (Names{"Alice"}));
-    EXPECT_EQ(this->names_matching(field<^^Student::name>().like("B%")), (Names{"Bob"}));
+    EXPECT_EQ(this->names_matching(f<^^Student::age>().in(20, 25)), (Names{"Alice"}));
+    EXPECT_EQ(this->names_matching(f<^^Student::age>().between(19, 21)), (Names{"Alice"}));
+    EXPECT_EQ(this->names_matching(f<^^Student::name>().like("B%")), (Names{"Bob"}));
     EXPECT_EQ(
-            this->names_matching(field<^^Student::name>().like("A%") || field<^^Student::age>() == 22),
-            (Names{"Alice", "Bob"})
+            this->names_matching(f<^^Student::name>().like("A%") || f<^^Student::age>() == 22), (Names{"Alice", "Bob"})
     );
     EXPECT_EQ(
             this->names_matching(
-                    (field<^^Student::age>() >= 20 && field<^^Student::age>() < 22) || field<^^Student::name>() == "Bob"
+                    (f<^^Student::age>() >= 20 && f<^^Student::age>() < 22) || f<^^Student::name>() == "Bob"
             ),
             (Names{"Alice", "Bob"})
     );
@@ -125,14 +124,14 @@ TYPED_TEST(M2MModifierTest, FirstReturnsCompleteEntity) {
 
 TYPED_TEST(M2MModifierTest, FirstOnEmptyReturnsNullopt) {
     QuerySet<Student, TypeParam> qs;
-    auto first = qs.template join<^^Student::courses>().where(field<^^Student::age>() > 99).first().execute();
+    auto first = qs.template join<^^Student::courses>().where(f<^^Student::age>() > 99).first().execute();
     ASSERT_TRUE(first.has_value()) << first.error().message();
     EXPECT_FALSE(first->has_value());
 }
 
 TYPED_TEST(M2MModifierTest, GetReturnsExactlyOne) {
     QuerySet<Student, TypeParam> qs;
-    auto got = qs.template join<^^Student::courses>().where(field<^^Student::name>() == "Bob").get().execute();
+    auto got = qs.template join<^^Student::courses>().where(f<^^Student::name>() == "Bob").get().execute();
     ASSERT_TRUE(got.has_value()) << got.error().message();
     EXPECT_EQ(got->name, "Bob");
     ASSERT_EQ(got->courses.size(), 1U);
@@ -143,7 +142,7 @@ TYPED_TEST(M2MModifierTest, GetAggregatesMultipleRelationsIntoOneEntity) {
     QuerySet<Student, TypeParam> qs;
     // Alice has TWO courses — two joined rows must aggregate into ONE entity,
     // not trip the "multiple rows" uniqueness check.
-    auto got = qs.template join<^^Student::courses>().where(field<^^Student::name>() == "Alice").get().execute();
+    auto got = qs.template join<^^Student::courses>().where(f<^^Student::name>() == "Alice").get().execute();
     ASSERT_TRUE(got.has_value()) << got.error().message();
     EXPECT_EQ(got->name, "Alice");
     EXPECT_EQ(got->courses.size(), 2U);
@@ -151,7 +150,7 @@ TYPED_TEST(M2MModifierTest, GetAggregatesMultipleRelationsIntoOneEntity) {
 
 TYPED_TEST(M2MModifierTest, GetZeroRowsIsError) {
     QuerySet<Student, TypeParam> qs;
-    auto got = qs.template join<^^Student::courses>().where(field<^^Student::name>() == "Zed").get().execute();
+    auto got = qs.template join<^^Student::courses>().where(f<^^Student::name>() == "Zed").get().execute();
     ASSERT_FALSE(got.has_value());
     EXPECT_TRUE(got.error().message().contains("No row found"));
 }
@@ -181,7 +180,7 @@ TYPED_TEST(M2MModifierTest, RowsGeneratorYieldsAggregatedEntities) {
 
 TYPED_TEST(M2MModifierTest, RowsGeneratorOnEmptyYieldsNothing) {
     QuerySet<Student, TypeParam> qs;
-    auto                         joined = qs.template join<^^Student::courses>().where(field<^^Student::age>() > 99);
+    auto                         joined = qs.template join<^^Student::courses>().where(f<^^Student::age>() > 99);
 
     std::size_t count = 0;
     for (auto&& row : joined.rows()) {

--- a/tests/query/test_many_to_many_multi.cpp
+++ b/tests/query/test_many_to_many_multi.cpp
@@ -67,7 +67,7 @@ TYPED_TEST(MultiM2MSqlTest, MultiM2MJoinSqlShape) {
 TYPED_TEST(MultiM2MSqlTest, MultiM2MModifiersBoundTheSharedBaseSet) {
     QuerySet<Member, TypeParam> qs;
     auto                        sql = qs.template join<^^Member::courses, ^^Member::clubs>()
-                       .where(storm::orm::where::field<^^Member::age>() > 18)
+                       .where(storm::orm::where::f<^^Member::age>() > 18)
                        .limit(2)
                        .select()
                        .sql();
@@ -150,7 +150,7 @@ TYPED_TEST(MultiM2MSeededTest, WhereOrderLimitBoundTheSharedBaseSet) {
     QuerySet<Member, TypeParam> qs;
     // age > 18 keeps all; ORDER BY age + LIMIT 2 bounds the BASE set to Ann, Ben.
     auto rows = qs.template left_join<^^Member::courses, ^^Member::clubs>()
-                        .where(storm::orm::where::field<^^Member::age>() > 18)
+                        .where(storm::orm::where::f<^^Member::age>() > 18)
                         .template order_by<^^Member::age>()
                         .limit(2)
                         .select()
@@ -171,7 +171,7 @@ TYPED_TEST(MultiM2MSeededTest, WhereOrderLimitBoundTheSharedBaseSet) {
 TYPED_TEST(MultiM2MSeededTest, EmptyResultSet) {
     QuerySet<Member, TypeParam> qs;
     auto                        rows = qs.template join<^^Member::courses, ^^Member::clubs>()
-                        .where(storm::orm::where::field<^^Member::age>() > 99)
+                        .where(storm::orm::where::f<^^Member::age>() > 99)
                         .select()
                         .execute();
     ASSERT_TRUE(rows.has_value()) << rows.error().message();
@@ -188,7 +188,7 @@ TYPED_TEST(MultiM2MSeededTest, FirstAndGetLoadBothRelations) {
     EXPECT_EQ((*first)->clubs.size(), 1U);
 
     auto got = qs.template left_join<^^Member::courses, ^^Member::clubs>()
-                       .where(storm::orm::where::field<^^Member::name>() == "Cat")
+                       .where(storm::orm::where::f<^^Member::name>() == "Cat")
                        .get()
                        .execute();
     ASSERT_TRUE(got.has_value()) << got.error().message();

--- a/tests/query/test_many_to_many_through.cpp
+++ b/tests/query/test_many_to_many_through.cpp
@@ -8,7 +8,7 @@ import storm;
 import std;
 
 using storm::QuerySet;
-using storm::orm::where::field;
+using storm::orm::where::f;
 
 #include "test_models.h"     // NOSONAR cpp:S954
 #include "test_m2m_models.h" // NOSONAR cpp:S954
@@ -74,7 +74,7 @@ TYPED_TEST(M2MThroughTest, ThroughEagerLoadIgnoresMetadata) {
 TYPED_TEST(M2MThroughTest, ThroughWithWhereOrderAndLimit) {
     QuerySet<Pupil, TypeParam> qs;
     auto                       rows = qs.template join<^^Pupil::courses>()
-                        .where(field<^^Pupil::age>() >= 11)
+                        .where(f<^^Pupil::age>() >= 11)
                         .template order_by<^^Pupil::name, false>()
                         .limit(1)
                         .select()
@@ -89,7 +89,7 @@ TYPED_TEST(M2MThroughTest, ThroughWithWhereOrderAndLimit) {
 TYPED_TEST(M2MThroughTest, JunctionModelQueriedDirectlyForMetadata) {
     QuerySet<Enrollment, TypeParam> qs;
     auto                            rows = qs.template join<^^Enrollment::pupil, ^^Enrollment::course>()
-                        .where(field<^^Enrollment::grade>() == "B")
+                        .where(f<^^Enrollment::grade>() == "B")
                         .select()
                         .execute();
     ASSERT_TRUE(rows.has_value()) << rows.error().message();

--- a/tests/query/test_order_by.cpp
+++ b/tests/query/test_order_by.cpp
@@ -11,7 +11,7 @@ import std;
 #include "test_seed_helpers.h"
 #include "test_select_runner.h"
 using storm::QuerySet;
-using storm::orm::where::field;
+using storm::orm::where::f;
 
 template <typename ConnType> auto insert_test_data(const std::vector<Person>& data) -> void {
     QuerySet<Person, ConnType> qs;
@@ -109,7 +109,7 @@ TYPED_TEST(OrderByTest, WhereWithMultipleOrderBy) {
     QuerySet<Person, TypeParam> qs;
 
     // Filter age >= 30 and order by age ASC, name DESC
-    auto result = qs.where(field<^^Person::age>() >= 30)
+    auto result = qs.where(f<^^Person::age>() >= 30)
                           .template order_by<^^Person::age, true, ^^Person::name, false>()
                           .select()
                           .execute();
@@ -197,7 +197,7 @@ TYPED_TEST(OrderByTest, ChainedWithMultipleClauses) {
     QuerySet<Person, TypeParam> qs;
 
     // Complex query: WHERE + ORDER BY + LIMIT + OFFSET (23 match age >= 25)
-    auto result = qs.where(field<^^Person::age>() >= 25)
+    auto result = qs.where(f<^^Person::age>() >= 25)
                           .template order_by<^^Person::age, ^^Person::name>()
                           .limit(5)
                           .offset(1)
@@ -527,7 +527,7 @@ TYPED_TEST(OrderByTest, EmptyResultWithMultipleOrderBy) {
     QuerySet<Person, TypeParam> qs;
 
     // Complex ORDER BY with no matching results
-    auto result = qs.where(field<^^Person::age>() > 100)
+    auto result = qs.where(f<^^Person::age>() > 100)
                           .template order_by<^^Person::age, false, ^^Person::name, true>()
                           .select()
                           .execute();

--- a/tests/query/test_reverse_fk.cpp
+++ b/tests/query/test_reverse_fk.cpp
@@ -8,7 +8,7 @@ import storm;
 import std;
 
 using storm::QuerySet;
-using storm::orm::where::field;
+using storm::orm::where::f;
 
 #include "test_models.h"            // NOSONAR cpp:S954
 #include "test_reverse_fk_models.h" // NOSONAR cpp:S954
@@ -133,7 +133,7 @@ TYPED_TEST(ReverseFKTest, InnerJoinDropsZeroRelationEntities) {
 // Owner rows carry their columns (title) and the FK pk.
 TYPED_TEST(ReverseFKTest, OwnerColumnsExtracted) {
     auto rows = QuerySet<RfPerson, TypeParam>()
-                        .where(field<^^RfPerson::id>() == 1)
+                        .where(f<^^RfPerson::id>() == 1)
                         .template left_join<^^RfPerson::tasks>()
                         .select()
                         .execute();
@@ -153,7 +153,7 @@ TYPED_TEST(ReverseFKTest, OwnerColumnsExtracted) {
 // WHERE bounds the BASE entities (the loaded persons), not the tasks.
 TYPED_TEST(ReverseFKTest, WhereAppliesToBaseEntities) {
     auto rows = QuerySet<RfPerson, TypeParam>()
-                        .where(field<^^RfPerson::age>() < 25)
+                        .where(f<^^RfPerson::age>() < 25)
                         .template left_join<^^RfPerson::tasks>()
                         .template order_by<^^RfPerson::id>()
                         .select()

--- a/tests/query/test_rows.cpp
+++ b/tests/query/test_rows.cpp
@@ -10,7 +10,7 @@ import std;
 #include "test_seed_helpers.h"
 
 using storm::QuerySet;
-using storm::orm::where::field;
+using storm::orm::where::f;
 
 template <typename ConnType> class RowsTest : public StormTestFixture<Person, ConnType> {
   protected:
@@ -62,7 +62,7 @@ TYPED_TEST(RowsTest, SingleRow) {
 TYPED_TEST(RowsTest, WhereFilter) {
     QuerySet<Person, TypeParam> qs;
     int                         count = 0;
-    for (auto&& result : qs.where(field<^^Person::age>() > 35).rows()) {
+    for (auto&& result : qs.where(f<^^Person::age>() > 35).rows()) {
         ASSERT_TRUE(result.has_value());
         EXPECT_GT(result.value().age, 35);
         ++count;
@@ -73,7 +73,7 @@ TYPED_TEST(RowsTest, WhereFilter) {
 
 TYPED_TEST(RowsTest, WhereComplex) {
     QuerySet<Person, TypeParam> qs;
-    auto                        expr  = field<^^Person::age>() > 30 || field<^^Person::name>() == "Alice";
+    auto                        expr  = f<^^Person::age>() > 30 || f<^^Person::name>() == "Alice";
     int                         count = 0;
     for (auto&& result : qs.where(expr).rows()) {
         ASSERT_TRUE(result.has_value());
@@ -117,7 +117,7 @@ TYPED_TEST(RowsTest, WithAllModifiers) {
     int                         count    = 0;
     int                         prev_age = -1;
     for (auto&& result :
-         qs.where(field<^^Person::age>() > 25).template order_by<^^Person::age>().limit(5).offset(2).rows()) {
+         qs.where(f<^^Person::age>() > 25).template order_by<^^Person::age>().limit(5).offset(2).rows()) {
         ASSERT_TRUE(result.has_value());
         EXPECT_GT(result.value().age, 25);
         EXPECT_GE(result.value().age, prev_age);
@@ -176,7 +176,7 @@ TYPED_TEST(RowsTest, MultipleGenerators) {
 
 TYPED_TEST(RowsTest, RepeatedCallsSameWhere) {
     QuerySet<Person, TypeParam> qs;
-    auto                        expr = field<^^Person::age>() > 30;
+    auto                        expr = f<^^Person::age>() > 30;
 
     int count1 = 0;
     for (auto&& result : qs.where(expr).rows()) {
@@ -199,14 +199,14 @@ TYPED_TEST(RowsTest, DifferentQueries) {
     QuerySet<Person, TypeParam> qs2;
 
     int count_young = 0;
-    for (auto&& result : qs1.where(field<^^Person::age>() < 30).rows()) {
+    for (auto&& result : qs1.where(f<^^Person::age>() < 30).rows()) {
         ASSERT_TRUE(result.has_value());
         EXPECT_LT(result.value().age, 30);
         ++count_young;
     }
 
     int count_old = 0;
-    for (auto&& result : qs2.where(field<^^Person::age>() >= 30).rows()) {
+    for (auto&& result : qs2.where(f<^^Person::age>() >= 30).rows()) {
         ASSERT_TRUE(result.has_value());
         EXPECT_GE(result.value().age, 30);
         ++count_old;
@@ -281,7 +281,7 @@ TYPED_TEST(RowsJoinTest, WithJoin) {
 TYPED_TEST(RowsJoinTest, WithJoinAndWhere) {
     QuerySet<Message, TypeParam> qs;
     int                          count = 0;
-    for (auto&& result : qs.template join<^^Message::sender>().where(field<^^Message::value>() > 30).rows()) {
+    for (auto&& result : qs.template join<^^Message::sender>().where(f<^^Message::value>() > 30).rows()) {
         ASSERT_TRUE(result.has_value());
         EXPECT_GT(result.value().value, 30);
         ++count;
@@ -329,7 +329,7 @@ TYPED_TEST(RowsTest, ViewsFilterCount) {
 TYPED_TEST(RowsTest, ViewsFilterWhereTransformCollect) {
     QuerySet<Person, TypeParam> qs;
     std::vector<int>            ages;
-    for (auto&& age : qs.where(field<^^Person::is_active>() == true).rows() | std::views::filter([](auto&& r) {
+    for (auto&& age : qs.where(f<^^Person::is_active>() == true).rows() | std::views::filter([](auto&& r) {
                           return r.has_value();
                       }) | std::views::transform([](auto&& r) { return r.value().age; })) {
         ages.push_back(age);

--- a/tests/query/test_setop.cpp
+++ b/tests/query/test_setop.cpp
@@ -8,7 +8,7 @@ import storm;
 import std;
 
 using storm::QuerySet;
-using storm::orm::where::field;
+using storm::orm::where::f;
 
 #include "test_models.h" // NOSONAR cpp:S954
 
@@ -33,8 +33,7 @@ TYPED_TEST(SetOpTest, UnionBasic) {
 
     // Left: 4 people with age above 40, right: 2 people with age below 24
     // No overlap, UNION yields 6
-    auto result =
-            qs_left.where(field<^^Person::age>() > 40).union_(qs_right.where(field<^^Person::age>() < 24)).execute();
+    auto result = qs_left.where(f<^^Person::age>() > 40).union_(qs_right.where(f<^^Person::age>() < 24)).execute();
     ASSERT_TRUE(result.has_value()) << result.error().message();
     EXPECT_EQ(result->size(), 6);
 }
@@ -46,8 +45,7 @@ TYPED_TEST(SetOpTest, UnionDeduplicates) {
     // age >= 40: Eve(40), Frank(45), Leo(42), Olivia(48), Sam(40), Victor(45) = 6
     // age <= 45: all except Olivia(48) = 24
     // UNION deduplicates -> all 25
-    auto result =
-            qs_left.where(field<^^Person::age>() >= 40).union_(qs_right.where(field<^^Person::age>() <= 45)).execute();
+    auto result = qs_left.where(f<^^Person::age>() >= 40).union_(qs_right.where(f<^^Person::age>() <= 45)).execute();
     ASSERT_TRUE(result.has_value()) << result.error().message();
     EXPECT_EQ(result->size(), 25);
 }
@@ -62,9 +60,7 @@ TYPED_TEST(SetOpTest, UnionAllKeepsDuplicates) {
 
     // age >= 40: 6, age <= 45: 24, overlap: 5
     // UNION ALL = 6 + 24 = 30
-    auto result = qs_left.where(field<^^Person::age>() >= 40)
-                          .union_all(qs_right.where(field<^^Person::age>() <= 45))
-                          .execute();
+    auto result = qs_left.where(f<^^Person::age>() >= 40).union_all(qs_right.where(f<^^Person::age>() <= 45)).execute();
     ASSERT_TRUE(result.has_value()) << result.error().message();
     EXPECT_EQ(result->size(), 30);
 }
@@ -79,8 +75,8 @@ TYPED_TEST(SetOpTest, ExceptBasic) {
 
     // Active (16) EXCEPT (active AND age>35: Frank,Leo,Olivia,Sam,Victor = 5)
     // Result = 11
-    auto result = qs_left.where(field<^^Person::is_active>() == true)
-                          .except_(qs_right.where(field<^^Person::is_active>() == true && field<^^Person::age>() > 35))
+    auto result = qs_left.where(f<^^Person::is_active>() == true)
+                          .except_(qs_right.where(f<^^Person::is_active>() == true && f<^^Person::age>() > 35))
                           .execute();
     ASSERT_TRUE(result.has_value()) << result.error().message();
     EXPECT_EQ(result->size(), 11);
@@ -95,8 +91,8 @@ TYPED_TEST(SetOpTest, IntersectBasic) {
     QuerySet<Person, TypeParam> qs_right;
 
     // Active(16) INTERSECT age>35(8) = active AND age>35: Frank,Leo,Olivia,Sam,Victor = 5
-    auto result = qs_left.where(field<^^Person::is_active>() == true)
-                          .intersect_(qs_right.where(field<^^Person::age>() > 35))
+    auto result = qs_left.where(f<^^Person::is_active>() == true)
+                          .intersect_(qs_right.where(f<^^Person::age>() > 35))
                           .execute();
     ASSERT_TRUE(result.has_value()) << result.error().message();
     EXPECT_EQ(result->size(), 5);
@@ -111,8 +107,8 @@ TYPED_TEST(SetOpTest, UnionBothWithWhere) {
     QuerySet<Person, TypeParam> qs_right;
 
     // 6 Engineering + 5 Sales, no overlap, UNION yields 11
-    auto result = qs_left.where(field<^^Person::department>() == "Engineering")
-                          .union_(qs_right.where(field<^^Person::department>() == "Sales"))
+    auto result = qs_left.where(f<^^Person::department>() == "Engineering")
+                          .union_(qs_right.where(f<^^Person::department>() == "Sales"))
                           .execute();
     ASSERT_TRUE(result.has_value()) << result.error().message();
     EXPECT_EQ(result->size(), 11);
@@ -127,8 +123,8 @@ TYPED_TEST(SetOpTest, UnionLeftWhereOnly) {
     QuerySet<Person, TypeParam> qs_right;
 
     // Engineering(6) UNION all(via age>0, 25) = 25
-    auto result = qs_left.where(field<^^Person::department>() == "Engineering")
-                          .union_(qs_right.where(field<^^Person::age>() > 0))
+    auto result = qs_left.where(f<^^Person::department>() == "Engineering")
+                          .union_(qs_right.where(f<^^Person::age>() > 0))
                           .execute();
     ASSERT_TRUE(result.has_value()) << result.error().message();
     EXPECT_EQ(result->size(), 25);
@@ -142,8 +138,8 @@ TYPED_TEST(SetOpTest, UnionWithOrderBy) {
     QuerySet<Person, TypeParam> qs_left;
     QuerySet<Person, TypeParam> qs_right;
 
-    auto result = qs_left.where(field<^^Person::department>() == "Engineering")
-                          .union_(qs_right.where(field<^^Person::department>() == "Sales"))
+    auto result = qs_left.where(f<^^Person::department>() == "Engineering")
+                          .union_(qs_right.where(f<^^Person::department>() == "Sales"))
                           .template order_by<^^Person::name>()
                           .execute();
     ASSERT_TRUE(result.has_value()) << result.error().message();
@@ -164,8 +160,8 @@ TYPED_TEST(SetOpTest, UnionWithOrderByAndLimit) {
     QuerySet<Person, TypeParam> qs_left;
     QuerySet<Person, TypeParam> qs_right;
 
-    auto result = qs_left.where(field<^^Person::department>() == "Engineering")
-                          .union_(qs_right.where(field<^^Person::department>() == "Sales"))
+    auto result = qs_left.where(f<^^Person::department>() == "Engineering")
+                          .union_(qs_right.where(f<^^Person::department>() == "Sales"))
                           .template order_by<^^Person::name>()
                           .limit(3)
                           .execute();
@@ -181,8 +177,8 @@ TYPED_TEST(SetOpTest, UnionWithOrderByLimitOffset) {
     QuerySet<Person, TypeParam> qs_left;
     QuerySet<Person, TypeParam> qs_right;
 
-    auto result = qs_left.where(field<^^Person::department>() == "Engineering")
-                          .union_(qs_right.where(field<^^Person::department>() == "Sales"))
+    auto result = qs_left.where(f<^^Person::department>() == "Engineering")
+                          .union_(qs_right.where(f<^^Person::department>() == "Sales"))
                           .template order_by<^^Person::name>()
                           .limit(3)
                           .offset(2)
@@ -199,8 +195,8 @@ TYPED_TEST(SetOpTest, UnionWithLimitOnly) {
     QuerySet<Person, TypeParam> qs_left;
     QuerySet<Person, TypeParam> qs_right;
 
-    auto result = qs_left.where(field<^^Person::department>() == "Engineering")
-                          .union_(qs_right.where(field<^^Person::department>() == "Sales"))
+    auto result = qs_left.where(f<^^Person::department>() == "Engineering")
+                          .union_(qs_right.where(f<^^Person::department>() == "Sales"))
                           .limit(5)
                           .execute();
     ASSERT_TRUE(result.has_value()) << result.error().message();
@@ -217,10 +213,9 @@ TYPED_TEST(SetOpTest, ThreeWayUnion) {
     QuerySet<Person, TypeParam> qs3;
 
     // 6 Engineering + 5 Sales + 4 HR, no overlap, UNION yields 15
-    auto builder = qs1.where(field<^^Person::department>() == "Engineering")
-                           .union_(qs2.where(field<^^Person::department>() == "Sales"));
-    auto result =
-            std::move(builder).union_(qs3.where(field<^^Person::department>() == "HR").capture_operand()).execute();
+    auto builder = qs1.where(f<^^Person::department>() == "Engineering")
+                           .union_(qs2.where(f<^^Person::department>() == "Sales"));
+    auto result = std::move(builder).union_(qs3.where(f<^^Person::department>() == "HR").capture_operand()).execute();
     ASSERT_TRUE(result.has_value()) << result.error().message();
     EXPECT_EQ(result->size(), 15);
 }
@@ -238,9 +233,9 @@ TYPED_TEST(SetOpTest, MixedOpsUnionThenExcept) {
     // Engineering(6) UNION Sales(5) = 11
     // age>40: Frank(45),Leo(42),Olivia(48),Victor(45) = 4
     // Result = 11 - 4 = 7
-    auto builder = qs1.where(field<^^Person::department>() == "Engineering")
-                           .union_(qs2.where(field<^^Person::department>() == "Sales"));
-    auto result = std::move(builder).except_(qs3.where(field<^^Person::age>() > 40).capture_operand()).execute();
+    auto builder = qs1.where(f<^^Person::department>() == "Engineering")
+                           .union_(qs2.where(f<^^Person::department>() == "Sales"));
+    auto result = std::move(builder).except_(qs3.where(f<^^Person::age>() > 40).capture_operand()).execute();
     ASSERT_TRUE(result.has_value()) << result.error().message();
     EXPECT_EQ(result->size(), 7);
 }
@@ -254,8 +249,8 @@ TYPED_TEST(SetOpTest, IntersectNoCommon) {
     QuerySet<Person, TypeParam> qs_right;
 
     // Engineering INTERSECT Sales = empty
-    auto result = qs_left.where(field<^^Person::department>() == "Engineering")
-                          .intersect_(qs_right.where(field<^^Person::department>() == "Sales"))
+    auto result = qs_left.where(f<^^Person::department>() == "Engineering")
+                          .intersect_(qs_right.where(f<^^Person::department>() == "Sales"))
                           .execute();
     ASSERT_TRUE(result.has_value()) << result.error().message();
     EXPECT_EQ(result->size(), 0);
@@ -269,8 +264,7 @@ TYPED_TEST(SetOpTest, UnionBothEmpty) {
     QuerySet<Person, TypeParam> qs_left;
     QuerySet<Person, TypeParam> qs_right;
 
-    auto result =
-            qs_left.where(field<^^Person::age>() > 100).union_(qs_right.where(field<^^Person::age>() < 0)).execute();
+    auto result = qs_left.where(f<^^Person::age>() > 100).union_(qs_right.where(f<^^Person::age>() < 0)).execute();
     ASSERT_TRUE(result.has_value()) << result.error().message();
     EXPECT_EQ(result->size(), 0);
 }
@@ -284,8 +278,8 @@ TYPED_TEST(SetOpTest, ExceptAllMatch) {
     QuerySet<Person, TypeParam> qs_right;
 
     // Engineering EXCEPT Engineering = empty
-    auto result = qs_left.where(field<^^Person::department>() == "Engineering")
-                          .except_(qs_right.where(field<^^Person::department>() == "Engineering"))
+    auto result = qs_left.where(f<^^Person::department>() == "Engineering")
+                          .except_(qs_right.where(f<^^Person::department>() == "Engineering"))
                           .execute();
     ASSERT_TRUE(result.has_value()) << result.error().message();
     EXPECT_EQ(result->size(), 0);
@@ -299,7 +293,7 @@ TYPED_TEST(SetOpTest, ToSqlUnion) {
     QuerySet<Person, TypeParam> qs_left;
     QuerySet<Person, TypeParam> qs_right;
 
-    auto sql = qs_left.where(field<^^Person::age>() > 30).union_(qs_right.where(field<^^Person::age>() < 25)).to_sql();
+    auto sql = qs_left.where(f<^^Person::age>() > 30).union_(qs_right.where(f<^^Person::age>() < 25)).to_sql();
     ASSERT_TRUE(sql.has_value()) << sql.error().message();
     EXPECT_TRUE(sql->find("UNION") != std::string::npos) << "SQL should contain UNION: " << *sql;
     EXPECT_TRUE(sql->find("UNION ALL") == std::string::npos) << "SQL should not contain UNION ALL: " << *sql;
@@ -309,8 +303,7 @@ TYPED_TEST(SetOpTest, ToSqlUnionAll) {
     QuerySet<Person, TypeParam> qs_left;
     QuerySet<Person, TypeParam> qs_right;
 
-    auto sql =
-            qs_left.where(field<^^Person::age>() > 30).union_all(qs_right.where(field<^^Person::age>() < 25)).to_sql();
+    auto sql = qs_left.where(f<^^Person::age>() > 30).union_all(qs_right.where(f<^^Person::age>() < 25)).to_sql();
     ASSERT_TRUE(sql.has_value()) << sql.error().message();
     EXPECT_TRUE(sql->find("UNION ALL") != std::string::npos) << "SQL should contain UNION ALL: " << *sql;
 }
@@ -319,7 +312,7 @@ TYPED_TEST(SetOpTest, ToSqlExcept) {
     QuerySet<Person, TypeParam> qs_left;
     QuerySet<Person, TypeParam> qs_right;
 
-    auto sql = qs_left.where(field<^^Person::age>() > 30).except_(qs_right.where(field<^^Person::age>() < 25)).to_sql();
+    auto sql = qs_left.where(f<^^Person::age>() > 30).except_(qs_right.where(f<^^Person::age>() < 25)).to_sql();
     ASSERT_TRUE(sql.has_value()) << sql.error().message();
     EXPECT_TRUE(sql->find("EXCEPT") != std::string::npos) << "SQL should contain EXCEPT: " << *sql;
 }
@@ -328,8 +321,7 @@ TYPED_TEST(SetOpTest, ToSqlIntersect) {
     QuerySet<Person, TypeParam> qs_left;
     QuerySet<Person, TypeParam> qs_right;
 
-    auto sql =
-            qs_left.where(field<^^Person::age>() > 30).intersect_(qs_right.where(field<^^Person::age>() < 40)).to_sql();
+    auto sql = qs_left.where(f<^^Person::age>() > 30).intersect_(qs_right.where(f<^^Person::age>() < 40)).to_sql();
     ASSERT_TRUE(sql.has_value()) << sql.error().message();
     EXPECT_TRUE(sql->find("INTERSECT") != std::string::npos) << "SQL should contain INTERSECT: " << *sql;
 }
@@ -343,8 +335,8 @@ TYPED_TEST(SetOpTest, SelfUnion) {
     QuerySet<Person, TypeParam> qs_right;
 
     // UNION deduplicates -> same as one side
-    auto result = qs_left.where(field<^^Person::department>() == "Engineering")
-                          .union_(qs_right.where(field<^^Person::department>() == "Engineering"))
+    auto result = qs_left.where(f<^^Person::department>() == "Engineering")
+                          .union_(qs_right.where(f<^^Person::department>() == "Engineering"))
                           .execute();
     ASSERT_TRUE(result.has_value()) << result.error().message();
     EXPECT_EQ(result->size(), 6);
@@ -358,8 +350,8 @@ TYPED_TEST(SetOpTest, SelfUnionAll) {
     QuerySet<Person, TypeParam> qs_left;
     QuerySet<Person, TypeParam> qs_right;
 
-    auto result = qs_left.where(field<^^Person::department>() == "Engineering")
-                          .union_all(qs_right.where(field<^^Person::department>() == "Engineering"))
+    auto result = qs_left.where(f<^^Person::department>() == "Engineering")
+                          .union_all(qs_right.where(f<^^Person::department>() == "Engineering"))
                           .execute();
     ASSERT_TRUE(result.has_value()) << result.error().message();
     EXPECT_EQ(result->size(), 12);
@@ -373,8 +365,8 @@ TYPED_TEST(SetOpTest, UnionSingleRow) {
     QuerySet<Person, TypeParam> qs_left;
     QuerySet<Person, TypeParam> qs_right;
 
-    auto result = qs_left.where(field<^^Person::name>() == "Alice")
-                          .union_(qs_right.where(field<^^Person::name>() == "Alice"))
+    auto result = qs_left.where(f<^^Person::name>() == "Alice")
+                          .union_(qs_right.where(f<^^Person::name>() == "Alice"))
                           .execute();
     ASSERT_TRUE(result.has_value()) << result.error().message();
     EXPECT_EQ(result->size(), 1);
@@ -390,8 +382,7 @@ TYPED_TEST(SetOpTest, UnionAllLargeResult) {
     QuerySet<Person, TypeParam> qs_right;
 
     // UNION ALL of all 25 with all 25 = 50
-    auto result =
-            qs_left.where(field<^^Person::age>() > 0).union_all(qs_right.where(field<^^Person::age>() > 0)).execute();
+    auto result = qs_left.where(f<^^Person::age>() > 0).union_all(qs_right.where(f<^^Person::age>() > 0)).execute();
     ASSERT_TRUE(result.has_value()) << result.error().message();
     EXPECT_EQ(result->size(), 50);
 }
@@ -404,8 +395,8 @@ TYPED_TEST(SetOpTest, ToSqlWithModifiers) {
     QuerySet<Person, TypeParam> qs_left;
     QuerySet<Person, TypeParam> qs_right;
 
-    auto sql = qs_left.where(field<^^Person::age>() > 30)
-                       .union_(qs_right.where(field<^^Person::age>() < 25))
+    auto sql = qs_left.where(f<^^Person::age>() > 30)
+                       .union_(qs_right.where(f<^^Person::age>() < 25))
                        .template order_by<^^Person::name>()
                        .limit(5)
                        .to_sql();
@@ -425,8 +416,8 @@ TYPED_TEST(SetOpTest, UnionWithNotEquals) {
 
     // department != "Engineering" (19) UNION department == "Sales" (5)
     // Sales is subset of non-Engineering -> UNION = 19
-    auto result = qs_left.where(field<^^Person::department>() != "Engineering")
-                          .union_(qs_right.where(field<^^Person::department>() == "Sales"))
+    auto result = qs_left.where(f<^^Person::department>() != "Engineering")
+                          .union_(qs_right.where(f<^^Person::department>() == "Sales"))
                           .execute();
     ASSERT_TRUE(result.has_value()) << result.error().message();
     EXPECT_EQ(result->size(), 19);
@@ -443,8 +434,8 @@ TYPED_TEST(SetOpTest, UnionWithDoubleWhere) {
     // salary >= 90000: Eve(92k),Leo(95k),Olivia(98k),Sam(90k),Victor(93k) = 5
     // salary < 40000: Paul(32k),Yara(35k) = 2
     // No overlap -> UNION = 7
-    auto result = qs_left.where(field<^^Person::salary>() >= 90000.0)
-                          .union_(qs_right.where(field<^^Person::salary>() < 40000.0))
+    auto result = qs_left.where(f<^^Person::salary>() >= 90000.0)
+                          .union_(qs_right.where(f<^^Person::salary>() < 40000.0))
                           .execute();
     ASSERT_TRUE(result.has_value()) << result.error().message();
     EXPECT_EQ(result->size(), 7);
@@ -457,8 +448,8 @@ TYPED_TEST(SetOpTest, ExceptWithDoubleWhere) {
     // salary >= 80000 (8): Jack,Leo,Frank,Olivia,Sam,Victor,Xander,Eve
     // salary >= 90000 (5): Eve,Leo,Olivia,Sam,Victor
     // EXCEPT = 3: Jack(85k),Frank(88k),Xander(82k)
-    auto result = qs_left.where(field<^^Person::salary>() >= 80000.0)
-                          .except_(qs_right.where(field<^^Person::salary>() >= 90000.0))
+    auto result = qs_left.where(f<^^Person::salary>() >= 80000.0)
+                          .except_(qs_right.where(f<^^Person::salary>() >= 90000.0))
                           .execute();
     ASSERT_TRUE(result.has_value()) << result.error().message();
     EXPECT_EQ(result->size(), 3);
@@ -478,8 +469,8 @@ TYPED_TEST(SetOpTest, UnionWithOrWhere) {
     //   No overlap -> 6
     // Right: department == "HR" -> Diana,Jack,Paul,Uma = 4
     // UNION: 6+4 - Paul(overlap) = 9
-    auto result = qs_left.where(field<^^Person::age>() < 25 || field<^^Person::salary>() > 90000.0)
-                          .union_(qs_right.where(field<^^Person::department>() == "HR"))
+    auto result = qs_left.where(f<^^Person::age>() < 25 || f<^^Person::salary>() > 90000.0)
+                          .union_(qs_right.where(f<^^Person::department>() == "HR"))
                           .execute();
     ASSERT_TRUE(result.has_value()) << result.error().message();
     EXPECT_EQ(result->size(), 9);
@@ -503,9 +494,9 @@ TYPED_TEST(SetOpTest, IntersectWithComplexNested) {
     // INTERSECT: rows in both = those from 8 that have salary>50k
     //   Frank(88k)✓,Leo(95k)✓,Olivia(98k)✓,Victor(93k)✓,Jack(85k)✓,Uma(69k)✓ = 6
     //   Diana(48k)✗,Paul(32k)✗ -> 6
-    auto result = qs_left.where((field<^^Person::age>() > 40 && field<^^Person::is_active>() == true) ||
-                                field<^^Person::department>() == "HR")
-                          .intersect_(qs_right.where(field<^^Person::salary>() > 50000.0))
+    auto result = qs_left.where((f<^^Person::age>() > 40 && f<^^Person::is_active>() == true) ||
+                                f<^^Person::department>() == "HR")
+                          .intersect_(qs_right.where(f<^^Person::salary>() > 50000.0))
                           .execute();
     ASSERT_TRUE(result.has_value()) << result.error().message();
     EXPECT_EQ(result->size(), 6);
@@ -522,8 +513,8 @@ TYPED_TEST(SetOpTest, UnionWithLike) {
     // name LIKE "A%" -> Alice = 1
     // name LIKE "B%" -> Bob = 1
     // UNION = 2
-    auto result = qs_left.where(field<^^Person::name>().like("A%"))
-                          .union_(qs_right.where(field<^^Person::name>().like("B%")))
+    auto result = qs_left.where(f<^^Person::name>().like("A%"))
+                          .union_(qs_right.where(f<^^Person::name>().like("B%")))
                           .execute();
     ASSERT_TRUE(result.has_value()) << result.error().message();
     EXPECT_EQ(result->size(), 2);
@@ -540,8 +531,8 @@ TYPED_TEST(SetOpTest, ExceptWithBetween) {
     // Left: age BETWEEN 30 AND 40 -> Bob,Charlie,Eve,Henry,Ivy,Jack,Nick,Quinn,Rachel,Sam,Uma,Xander = 12
     // Right: age BETWEEN 35 AND 40 -> Charlie,Eve,Jack,Nick,Rachel,Sam,Xander = 7
     // EXCEPT = 5: Bob(30),Henry(33),Ivy(30),Quinn(30),Uma(33)
-    auto result = qs_left.where(field<^^Person::age>().between(30, 40))
-                          .except_(qs_right.where(field<^^Person::age>().between(35, 40)))
+    auto result = qs_left.where(f<^^Person::age>().between(30, 40))
+                          .except_(qs_right.where(f<^^Person::age>().between(35, 40)))
                           .execute();
     ASSERT_TRUE(result.has_value()) << result.error().message();
     EXPECT_EQ(result->size(), 5);
@@ -558,8 +549,8 @@ TYPED_TEST(SetOpTest, IntersectWithIn) {
     // Left: age IN (25, 30, 35) -> Alice,Bob,Charlie,Grace,Ivy,Karen,Nick,Quinn = 8
     // Right: department == "Engineering" -> Alice,Eve,Ivy,Leo,Quinn,Victor = 6
     // INTERSECT = Alice,Ivy,Quinn = 3
-    auto result = qs_left.where(field<^^Person::age>().in(25, 30, 35))
-                          .intersect_(qs_right.where(field<^^Person::department>() == "Engineering"))
+    auto result = qs_left.where(f<^^Person::age>().in(25, 30, 35))
+                          .intersect_(qs_right.where(f<^^Person::department>() == "Engineering"))
                           .execute();
     ASSERT_TRUE(result.has_value()) << result.error().message();
     EXPECT_EQ(result->size(), 3);
@@ -573,8 +564,8 @@ TYPED_TEST(SetOpTest, UnionWithOrderByDesc) {
     QuerySet<Person, TypeParam> qs_left;
     QuerySet<Person, TypeParam> qs_right;
 
-    auto result = qs_left.where(field<^^Person::department>() == "Engineering")
-                          .union_(qs_right.where(field<^^Person::department>() == "Sales"))
+    auto result = qs_left.where(f<^^Person::department>() == "Engineering")
+                          .union_(qs_right.where(f<^^Person::department>() == "Sales"))
                           .template order_by<^^Person::age, false>()
                           .execute();
     ASSERT_TRUE(result.has_value()) << result.error().message();
@@ -596,8 +587,8 @@ TYPED_TEST(SetOpTest, UnionWithOffsetOnly) {
     QuerySet<Person, TypeParam> qs_right;
 
     // Engineering(6) UNION Sales(5) = 11, skip first 5 -> 6
-    auto result = qs_left.where(field<^^Person::department>() == "Engineering")
-                          .union_(qs_right.where(field<^^Person::department>() == "Sales"))
+    auto result = qs_left.where(f<^^Person::department>() == "Engineering")
+                          .union_(qs_right.where(f<^^Person::department>() == "Sales"))
                           .offset(5)
                           .execute();
     ASSERT_TRUE(result.has_value()) << result.error().message();
@@ -616,11 +607,11 @@ TYPED_TEST(SetOpTest, UnionAllLarge100Plus) {
     QuerySet<Person, TypeParam> qs5;
 
     // 5x UNION ALL of all 25 = 125
-    auto builder = qs1.where(field<^^Person::age>() > 0).union_all(qs2.where(field<^^Person::age>() > 0));
+    auto builder = qs1.where(f<^^Person::age>() > 0).union_all(qs2.where(f<^^Person::age>() > 0));
     auto result  = std::move(builder)
-                          .union_all(qs3.where(field<^^Person::age>() > 0).capture_operand())
-                          .union_all(qs4.where(field<^^Person::age>() > 0).capture_operand())
-                          .union_all(qs5.where(field<^^Person::age>() > 0).capture_operand())
+                          .union_all(qs3.where(f<^^Person::age>() > 0).capture_operand())
+                          .union_all(qs4.where(f<^^Person::age>() > 0).capture_operand())
+                          .union_all(qs5.where(f<^^Person::age>() > 0).capture_operand())
                           .execute();
     ASSERT_TRUE(result.has_value()) << result.error().message();
     EXPECT_EQ(result->size(), 125);
@@ -634,8 +625,8 @@ TYPED_TEST(SetOpTest, RepeatedExecution) {
     QuerySet<Person, TypeParam> qs_left;
     QuerySet<Person, TypeParam> qs_right;
 
-    auto builder = qs_left.where(field<^^Person::department>() == "Engineering")
-                           .union_(qs_right.where(field<^^Person::department>() == "Sales"));
+    auto builder = qs_left.where(f<^^Person::department>() == "Engineering")
+                           .union_(qs_right.where(f<^^Person::department>() == "Sales"));
 
     auto result1 = builder.execute();
     ASSERT_TRUE(result1.has_value()) << result1.error().message();
@@ -663,10 +654,8 @@ TYPED_TEST(SetOpTest, ExceptThenUnion) {
     // EXCEPT: Engineering rows NOT in age>40 -> Alice,Eve(40 not >40),Ivy,Quinn = 4
     // HR: Diana,Jack,Paul,Uma = 4
     // UNION = 8
-    auto builder =
-            qs1.where(field<^^Person::department>() == "Engineering").except_(qs2.where(field<^^Person::age>() > 40));
-    auto result =
-            std::move(builder).union_(qs3.where(field<^^Person::department>() == "HR").capture_operand()).execute();
+    auto builder = qs1.where(f<^^Person::department>() == "Engineering").except_(qs2.where(f<^^Person::age>() > 40));
+    auto result  = std::move(builder).union_(qs3.where(f<^^Person::department>() == "HR").capture_operand()).execute();
     ASSERT_TRUE(result.has_value()) << result.error().message();
     EXPECT_EQ(result->size(), 8);
 }
@@ -684,9 +673,9 @@ TYPED_TEST(SetOpTest, IntersectThenUnionAll) {
     // Active(16) INTERSECT age>35(8) = active AND age>35: Frank,Leo,Olivia,Sam,Victor = 5
     // HR: Diana,Jack,Paul,Uma = 4
     // UNION ALL = 9
-    auto builder = qs1.where(field<^^Person::is_active>() == true).intersect_(qs2.where(field<^^Person::age>() > 35));
+    auto builder = qs1.where(f<^^Person::is_active>() == true).intersect_(qs2.where(f<^^Person::age>() > 35));
     auto result =
-            std::move(builder).union_all(qs3.where(field<^^Person::department>() == "HR").capture_operand()).execute();
+            std::move(builder).union_all(qs3.where(f<^^Person::department>() == "HR").capture_operand()).execute();
     ASSERT_TRUE(result.has_value()) << result.error().message();
     EXPECT_EQ(result->size(), 9);
 }
@@ -702,11 +691,11 @@ TYPED_TEST(SetOpTest, FourWayUnion) {
     QuerySet<Person, TypeParam> qs4;
 
     // 6 Engineering + 5 Sales + 4 HR + 5 Marketing, no overlap, UNION yields 20
-    auto builder = qs1.where(field<^^Person::department>() == "Engineering")
-                           .union_(qs2.where(field<^^Person::department>() == "Sales"));
+    auto builder = qs1.where(f<^^Person::department>() == "Engineering")
+                           .union_(qs2.where(f<^^Person::department>() == "Sales"));
     auto result = std::move(builder)
-                          .union_(qs3.where(field<^^Person::department>() == "HR").capture_operand())
-                          .union_(qs4.where(field<^^Person::department>() == "Marketing").capture_operand())
+                          .union_(qs3.where(f<^^Person::department>() == "HR").capture_operand())
+                          .union_(qs4.where(f<^^Person::department>() == "Marketing").capture_operand())
                           .execute();
     ASSERT_TRUE(result.has_value()) << result.error().message();
     EXPECT_EQ(result->size(), 20);
@@ -726,12 +715,12 @@ TYPED_TEST(SetOpTest, AllFourOpsChained) {
     // Uses UNION ALL + EXCEPT + UNION (same precedence, left-to-right in all backends).
     // Avoids INTERSECT which has higher precedence in PostgreSQL vs left-to-right in SQLite.
     // Eng(6) UNION ALL Sales(5)=11 → EXCEPT age>40=7 → UNION HR(4)=11 → EXCEPT !active=7
-    auto builder = qs1.where(field<^^Person::department>() == "Engineering")
-                           .union_all(qs2.where(field<^^Person::department>() == "Sales"));
+    auto builder = qs1.where(f<^^Person::department>() == "Engineering")
+                           .union_all(qs2.where(f<^^Person::department>() == "Sales"));
     auto result = std::move(builder)
-                          .except_(qs3.where(field<^^Person::age>() > 40).capture_operand())
-                          .union_(qs4.where(field<^^Person::department>() == "HR").capture_operand())
-                          .except_(qs5.where(field<^^Person::is_active>() == false).capture_operand())
+                          .except_(qs3.where(f<^^Person::age>() > 40).capture_operand())
+                          .union_(qs4.where(f<^^Person::department>() == "HR").capture_operand())
+                          .except_(qs5.where(f<^^Person::is_active>() == false).capture_operand())
                           .execute();
     ASSERT_TRUE(result.has_value()) << result.error().message();
     EXPECT_EQ(result->size(), 7);

--- a/tests/query/test_sql_verify.cpp
+++ b/tests/query/test_sql_verify.cpp
@@ -7,7 +7,7 @@ import storm;
 import std;
 
 using storm::QuerySet;
-using storm::orm::where::field;
+using storm::orm::where::f;
 
 #include "test_models.h" // NOSONAR cpp:S954
 
@@ -64,7 +64,7 @@ TYPED_TEST(SqlVerifyTest, SelectSimple) {
 
 TYPED_TEST(SqlVerifyTest, SelectWithWhere) {
     QuerySet<Person, TypeParam> qs;
-    auto                        sql = qs.where(field<^^Person::age>() > 30).select().sql();
+    auto                        sql = qs.where(f<^^Person::age>() > 30).select().sql();
     EXPECT_EQ(
             sql,
             "SELECT id, name, age, salary, is_active, years_experience, department, score, nickname, avatar"
@@ -85,7 +85,7 @@ TYPED_TEST(SqlVerifyTest, SelectWithJoin) {
 
 TYPED_TEST(SqlVerifyTest, SelectWithJoinAndWhere) {
     QuerySet<Message, TypeParam> qs;
-    auto sql = qs.template join<^^Message::sender>().where(field<^^Message::value>() > 10).select().sql();
+    auto sql = qs.template join<^^Message::sender>().where(f<^^Message::value>() > 10).select().sql();
     EXPECT_EQ(
             sql,
             "SELECT t1.id, t1.content, t1.value, t2.id, t2.name, t2.age, t2.salary,"
@@ -146,7 +146,7 @@ TYPED_TEST(SqlVerifyTest, SelectWithOffsetOnly) {
 TYPED_TEST(SqlVerifyTest, SelectFullCombo) {
     QuerySet<Message, TypeParam> qs;
     auto                         sql = qs.template join<^^Message::sender>()
-                       .where(field<^^Message::value>() > 10)
+                       .where(f<^^Message::value>() > 10)
                        .template order_by<^^Message::content>()
                        .limit(5)
                        .offset(2)
@@ -180,7 +180,7 @@ TYPED_TEST(SqlVerifyTest, FirstSimple) {
 
 TYPED_TEST(SqlVerifyTest, FirstWithWhere) {
     QuerySet<Person, TypeParam> qs;
-    auto                        sql = qs.where(field<^^Person::age>() > 30).first().sql();
+    auto                        sql = qs.where(f<^^Person::age>() > 30).first().sql();
     EXPECT_EQ(
             sql,
             "SELECT id, name, age, salary, is_active, years_experience, department, score, nickname, avatar"
@@ -200,7 +200,7 @@ TYPED_TEST(SqlVerifyTest, GetSimple) {
 
 TYPED_TEST(SqlVerifyTest, GetWithWhere) {
     QuerySet<Person, TypeParam> qs;
-    auto                        sql = qs.where(field<^^Person::id>() == 1).get().sql();
+    auto                        sql = qs.where(f<^^Person::id>() == 1).get().sql();
     EXPECT_EQ(
             sql,
             "SELECT id, name, age, salary, is_active, years_experience, department, score, nickname, avatar"
@@ -358,7 +358,7 @@ TYPED_TEST(SqlVerifyTest, AggregateCountSimple) {
 
 TYPED_TEST(SqlVerifyTest, AggregateCountWithWhere) {
     QuerySet<Person, TypeParam> qs;
-    auto                        sql = qs.where(field<^^Person::age>() > 30).count().sql();
+    auto                        sql = qs.where(f<^^Person::age>() > 30).count().sql();
     EXPECT_EQ(sql, "SELECT COUNT(*) FROM Person WHERE age > ?");
 }
 
@@ -400,7 +400,7 @@ TYPED_TEST(SqlVerifyTest, AggregateCountWithJoin) {
 
 TYPED_TEST(SqlVerifyTest, AggregateCountWithJoinAndWhere) {
     QuerySet<Message, TypeParam> qs;
-    auto sql = qs.template join<^^Message::sender>().where(field<^^Message::value>() > 10).count().sql();
+    auto sql = qs.template join<^^Message::sender>().where(f<^^Message::value>() > 10).count().sql();
     EXPECT_EQ(sql, "SELECT COUNT(*) FROM Message t1 INNER JOIN Person t2 ON t2.id = t1.sender_id WHERE value > ?");
 }
 
@@ -422,7 +422,7 @@ TYPED_TEST(SqlVerifyTest, GroupBySum) {
 
 TYPED_TEST(SqlVerifyTest, GroupByWithWhere) {
     QuerySet<Person, TypeParam> qs;
-    auto                        sql = qs.where(field<^^Person::is_active>() == true)
+    auto                        sql = qs.where(f<^^Person::is_active>() == true)
                        .template group_by<^^Person::department>()
                        .template count<>()
                        .sql();
@@ -433,17 +433,17 @@ TYPED_TEST(SqlVerifyTest, GroupByWithHaving) {
     QuerySet<Person, TypeParam> qs;
     auto                        sql = qs.template group_by<^^Person::department>()
                        .template count<>()
-                       .having(field<^^Person::department>() == "Engineering")
+                       .having(f<^^Person::department>() == "Engineering")
                        .sql();
     EXPECT_EQ(sql, "SELECT department, COUNT(*) FROM Person GROUP BY department HAVING department = ?");
 }
 
 TYPED_TEST(SqlVerifyTest, GroupByWithWhereAndHaving) {
     QuerySet<Person, TypeParam> qs;
-    auto                        sql = qs.where(field<^^Person::age>() > 25)
+    auto                        sql = qs.where(f<^^Person::age>() > 25)
                        .template group_by<^^Person::department>()
                        .template count<>()
-                       .having(field<^^Person::department>() == "Engineering")
+                       .having(f<^^Person::department>() == "Engineering")
                        .sql();
     EXPECT_EQ(sql, "SELECT department, COUNT(*) FROM Person WHERE age > ? GROUP BY department HAVING department = ?");
 }
@@ -492,7 +492,7 @@ TYPED_TEST(SqlVerifyTest, GroupByWithJoin) {
 TYPED_TEST(SqlVerifyTest, UnionSimple) {
     QuerySet<Person, TypeParam> qs1;
     QuerySet<Person, TypeParam> qs2;
-    auto sql = qs1.where(field<^^Person::age>() > 40).union_(qs2.where(field<^^Person::age>() < 25)).sql();
+    auto sql = qs1.where(f<^^Person::age>() > 40).union_(qs2.where(f<^^Person::age>() < 25)).sql();
     EXPECT_EQ(
             sql,
             "SELECT id, name, age, salary, is_active, years_experience, department, score, nickname, avatar"
@@ -505,7 +505,7 @@ TYPED_TEST(SqlVerifyTest, UnionSimple) {
 TYPED_TEST(SqlVerifyTest, UnionAllSimple) {
     QuerySet<Person, TypeParam> qs1;
     QuerySet<Person, TypeParam> qs2;
-    auto sql = qs1.where(field<^^Person::age>() > 40).union_all(qs2.where(field<^^Person::age>() < 25)).sql();
+    auto sql = qs1.where(f<^^Person::age>() > 40).union_all(qs2.where(f<^^Person::age>() < 25)).sql();
     EXPECT_EQ(
             sql,
             "SELECT id, name, age, salary, is_active, years_experience, department, score, nickname, avatar"
@@ -518,7 +518,7 @@ TYPED_TEST(SqlVerifyTest, UnionAllSimple) {
 TYPED_TEST(SqlVerifyTest, ExceptSimple) {
     QuerySet<Person, TypeParam> qs1;
     QuerySet<Person, TypeParam> qs2;
-    auto                        sql = qs1.except_(qs2.where(field<^^Person::age>() < 25)).sql();
+    auto                        sql = qs1.except_(qs2.where(f<^^Person::age>() < 25)).sql();
     EXPECT_EQ(
             sql,
             "SELECT id, name, age, salary, is_active, years_experience, department, score, nickname, avatar"
@@ -531,7 +531,7 @@ TYPED_TEST(SqlVerifyTest, ExceptSimple) {
 TYPED_TEST(SqlVerifyTest, IntersectSimple) {
     QuerySet<Person, TypeParam> qs1;
     QuerySet<Person, TypeParam> qs2;
-    auto sql = qs1.where(field<^^Person::age>() > 30).intersect_(qs2.where(field<^^Person::is_active>() == true)).sql();
+    auto sql = qs1.where(f<^^Person::age>() > 30).intersect_(qs2.where(f<^^Person::is_active>() == true)).sql();
     EXPECT_EQ(
             sql,
             "SELECT id, name, age, salary, is_active, years_experience, department, score, nickname, avatar"
@@ -544,8 +544,8 @@ TYPED_TEST(SqlVerifyTest, IntersectSimple) {
 TYPED_TEST(SqlVerifyTest, SetOpWithOrderByAndLimit) {
     QuerySet<Person, TypeParam> qs1;
     QuerySet<Person, TypeParam> qs2;
-    auto                        sql = qs1.where(field<^^Person::age>() > 40)
-                       .union_(qs2.where(field<^^Person::age>() < 25))
+    auto                        sql = qs1.where(f<^^Person::age>() > 40)
+                       .union_(qs2.where(f<^^Person::age>() < 25))
                        .template order_by<^^Person::name>()
                        .limit(10)
                        .sql();

--- a/tests/query/test_values.cpp
+++ b/tests/query/test_values.cpp
@@ -8,7 +8,7 @@ import storm;
 import std;
 
 using storm::QuerySet;
-using storm::orm::where::field;
+using storm::orm::where::f;
 
 #include "test_models.h" // NOSONAR cpp:S954
 
@@ -195,7 +195,7 @@ TYPED_TEST(ValuesTest, WithWhereSingleField) {
     ASSERT_TRUE(insert_result.has_value());
 
     // SELECT name WHERE age > 22
-    auto result = queryset.where(field<^^Person::age>() > 22).template values<^^Person::name>().execute();
+    auto result = queryset.where(f<^^Person::age>() > 22).template values<^^Person::name>().execute();
     ASSERT_TRUE(result.has_value()) << "values with WHERE failed: " << result.error().message();
 
     const auto& names = result.value();
@@ -218,8 +218,8 @@ TYPED_TEST(ValuesTest, WithMultipleWhereClauses) {
     ASSERT_TRUE(insert_result.has_value());
 
     // Chain multiple WHERE clauses (AND)
-    auto result = queryset.where(field<^^Person::age>() > 22)
-                          .where(field<^^Person::age>() < 32)
+    auto result = queryset.where(f<^^Person::age>() > 22)
+                          .where(f<^^Person::age>() < 32)
                           .template values<^^Person::name>()
                           .execute();
     ASSERT_TRUE(result.has_value());
@@ -244,7 +244,7 @@ TYPED_TEST(ValuesTest, WithComplexWhere) {
     ASSERT_TRUE(insert_result.has_value());
 
     // SELECT name WHERE age BETWEEN 25 AND 35
-    auto result = queryset.where(field<^^Person::age>().between(25, 35)).template values<^^Person::name>().execute();
+    auto result = queryset.where(f<^^Person::age>().between(25, 35)).template values<^^Person::name>().execute();
     ASSERT_TRUE(result.has_value());
 
     const auto& names = result.value();
@@ -259,7 +259,7 @@ TYPED_TEST(ValuesTest, WithWhereNoResults) {
     auto                insert_result = queryset.insert(people).execute();
     ASSERT_TRUE(insert_result.has_value());
 
-    auto result = queryset.where(field<^^Person::age>() > 100).template values<^^Person::name>().execute();
+    auto result = queryset.where(f<^^Person::age>() > 100).template values<^^Person::name>().execute();
     ASSERT_TRUE(result.has_value());
     EXPECT_EQ(result.value().size(), 0);
 }
@@ -290,7 +290,7 @@ TYPED_TEST(ValuesTest, WithJoinAndWhere) {
     QuerySet<Message, TypeParam> msg_qs;
 
     auto result = msg_qs.template join<^^Message::sender>()
-                          .where(field<^^Message::content>().like("%o%")) // Hello, World, Goodbye
+                          .where(f<^^Message::content>().like("%o%")) // Hello, World, Goodbye
                           .template values<^^Message::content>()
                           .execute();
     ASSERT_TRUE(result.has_value()) << "values with JOIN and WHERE failed: " << result.error().message();
@@ -434,7 +434,7 @@ TYPED_TEST(ValuesTest, WithWhereOrderByLimit) {
     auto insert_result = queryset.insert(people).execute();
     ASSERT_TRUE(insert_result.has_value());
 
-    auto result = queryset.where(field<^^Person::age>() > 25)
+    auto result = queryset.where(f<^^Person::age>() > 25)
                           .template order_by<^^Person::name>()
                           .limit(2)
                           .template values<^^Person::name>()
@@ -555,14 +555,14 @@ TYPED_TEST(ValuesTest, DifferentWhereExpressionsWithCaching) {
     std::ignore = queryset.insert(people).execute();
 
     // Query 1: age > 25
-    auto result1 = queryset.where(field<^^Person::age>() > 25).template values<^^Person::name>().execute();
+    auto result1 = queryset.where(f<^^Person::age>() > 25).template values<^^Person::name>().execute();
     ASSERT_TRUE(result1.has_value());
     EXPECT_EQ(result1.value().size(), 3); // Bob, Charlie, Dave
 
     queryset.reset();
 
     // Query 2: age > 35
-    auto result2 = queryset.where(field<^^Person::age>() > 35).template values<^^Person::name>().execute();
+    auto result2 = queryset.where(f<^^Person::age>() > 35).template values<^^Person::name>().execute();
     ASSERT_TRUE(result2.has_value());
     EXPECT_EQ(result2.value().size(), 1); // Dave only
 }

--- a/tests/query/test_where.cpp
+++ b/tests/query/test_where.cpp
@@ -15,7 +15,7 @@ using storm::orm::where::ComparisonExpr;
 using storm::orm::where::CompOp;
 using storm::orm::where::Expr;
 using storm::orm::where::ExpressionVariant;
-using storm::orm::where::field;
+using storm::orm::where::f;
 
 // Test fixture for WHERE operations — templated on database backend
 template <typename ConnType> class WhereTest : public StormTestFixture<Person, ConnType> {
@@ -40,9 +40,9 @@ TYPED_TEST_SUITE(WhereTest, DatabaseTypes);
 TYPED_TEST(WhereTest, WhereThreeConditions) {
     QuerySet<Person, TypeParam> queryset;
 
-    auto expr1  = field<^^Person::age>() >= 28;
-    auto expr2  = field<^^Person::age>() <= 35;
-    auto expr3  = field<^^Person::name>() != "Charlie";
+    auto expr1  = f<^^Person::age>() >= 28;
+    auto expr2  = f<^^Person::age>() <= 35;
+    auto expr3  = f<^^Person::name>() != "Charlie";
     auto result = queryset.where(expr1 && expr2 && expr3).select().execute();
     ASSERT_TRUE(result.has_value()) << "WHERE failed: " << result.error().message();
 
@@ -53,7 +53,7 @@ TYPED_TEST(WhereTest, WhereThreeConditions) {
 // Test: WHERE with complex expression
 TYPED_TEST(WhereTest, WhereComplexExpression) {
     this->check_where_count(
-            (field<^^Person::age>() < 30 || field<^^Person::age>() > 35) && field<^^Person::name>() != "Charlie", 18
+            (f<^^Person::age>() < 30 || f<^^Person::age>() > 35) && f<^^Person::name>() != "Charlie", 18
     );
 }
 
@@ -62,7 +62,7 @@ TYPED_TEST(WhereTest, WhereReturnsCopyReusable) {
     QuerySet<Person, TypeParam> queryset;
 
     // where() returns a new QuerySet — original unchanged
-    auto filtered = queryset.where(field<^^Person::age>() >= 25);
+    auto filtered = queryset.where(f<^^Person::age>() >= 25);
 
     auto result1 = filtered.select().execute();
     ASSERT_TRUE(result1.has_value());
@@ -74,7 +74,7 @@ TYPED_TEST(WhereTest, WhereReturnsCopyReusable) {
     ASSERT_EQ(result2.value().size(), 23) << "State should persist after first select()";
 
     // Chaining further narrows without affecting the original filtered copy
-    auto narrower = filtered.where(field<^^Person::age>() < 40);
+    auto narrower = filtered.where(f<^^Person::age>() < 40);
     auto result3  = narrower.select().execute();
     ASSERT_TRUE(result3.has_value());
     ASSERT_EQ(result3.value().size(), 17) << "Expected 17 people with age >= 25 AND age < 40";
@@ -139,7 +139,7 @@ TYPED_TEST(WhereJoinTest, WhereWithJoin) {
     QuerySet<Message, TypeParam> queryset;
 
     // SELECT with JOIN and WHERE filtering by Person.age
-    auto result = queryset.template join<^^Message::sender>().where(field<^^Person::age>() >= 10).select().execute();
+    auto result = queryset.template join<^^Message::sender>().where(f<^^Person::age>() >= 10).select().execute();
     ASSERT_TRUE(result.has_value()) << "WHERE + JOIN failed: " << result.error().message();
 
     const auto& messages = result.value();
@@ -162,8 +162,8 @@ TYPED_TEST(WhereJoinTest, WhereWithJoin) {
 TYPED_TEST(WhereJoinTest, WhereWithJoinMultipleConditions) {
     QuerySet<Message, TypeParam> queryset;
 
-    auto expr1  = field<^^Person::age>() > 5;
-    auto expr2  = field<^^Message::content>().like("%from%");
+    auto expr1  = f<^^Person::age>() > 5;
+    auto expr2  = f<^^Message::content>().like("%from%");
     auto result = queryset.template join<^^Message::sender>().where(expr1 && expr2).select().execute();
     ASSERT_TRUE(result.has_value()) << "WHERE + JOIN failed: " << result.error().message();
 
@@ -177,7 +177,7 @@ TYPED_TEST(WhereJoinTest, WhereWithNaturalOperators) {
 
     // Using natural 'and' operator (also works with &&)
     auto result = queryset.template join<^^Message::sender>()
-                          .where(field<^^Person::age>() > 5 and field<^^Message::content>().like("%from%"))
+                          .where(f<^^Person::age>() > 5 and f<^^Message::content>().like("%from%"))
                           .select()
                           .execute();
     ASSERT_TRUE(result.has_value()) << "WHERE + JOIN failed: " << result.error().message();
@@ -193,14 +193,14 @@ TYPED_TEST(WhereJoinTest, WhereWithNaturalOperators) {
 // Test: Natural operators with complex expressions (same logic as WhereComplexExpression, different syntax)
 TYPED_TEST(WhereTest, WhereNaturalOperatorsComplex) {
     this->check_where_count(
-            (field<^^Person::age>() < 30 or field<^^Person::age>() > 35) and field<^^Person::name>() != "Charlie", 18
+            (f<^^Person::age>() < 30 or f<^^Person::age>() > 35) and f<^^Person::name>() != "Charlie", 18
     );
 }
 
 // Test: Reusing WHERE conditions across multiple queries
 TYPED_TEST(WhereTest, WhereReuseCondition) {
     // Store condition in variable
-    auto age_condition = field<^^Person::age>() > 25;
+    auto age_condition = f<^^Person::age>() > 25;
 
     // First use - should return 20 people with age > 25
     QuerySet<Person, TypeParam> queryset1;
@@ -216,7 +216,7 @@ TYPED_TEST(WhereTest, WhereReuseCondition) {
 
     // Combine reused condition with new one
     QuerySet<Person, TypeParam> queryset3;
-    auto result3 = queryset3.where(age_condition and field<^^Person::name>() == "Bob").select().execute();
+    auto result3 = queryset3.where(age_condition and f<^^Person::name>() == "Bob").select().execute();
     ASSERT_TRUE(result3.has_value()) << "Combined WHERE failed: " << result3.error().message();
     ASSERT_EQ(result3.value().size(), 1) << "Expected 1 person matching both conditions";
     auto it = result3.value().begin();
@@ -233,9 +233,9 @@ TYPED_TEST(WhereTest, WhereReuseCondition) {
 // Test: Building composable filter library
 TYPED_TEST(WhereTest, WhereComposableFilters) {
     // Create reusable filter components
-    auto young_filter       = field<^^Person::age>() < 30;
-    auto old_filter         = field<^^Person::age>() >= 35;
-    auto name_starts_with_a = field<^^Person::name>().like("A%");
+    auto young_filter       = f<^^Person::age>() < 30;
+    auto old_filter         = f<^^Person::age>() >= 35;
+    auto name_starts_with_a = f<^^Person::name>().like("A%");
 
     // Use filters independently with fresh QuerySets
     QuerySet<Person, TypeParam> qs1;
@@ -272,7 +272,7 @@ TYPED_TEST(WhereTest, ReusableBaseQuerySet) {
     QuerySet<Person, TypeParam> queryset;
 
     // Create a base filtered QuerySet (age >= 25)
-    auto base = queryset.where(field<^^Person::age>() >= 25);
+    auto base = queryset.where(f<^^Person::age>() >= 25);
 
     // Reuse base filter multiple times
     auto result1 = base.select().execute();
@@ -285,7 +285,7 @@ TYPED_TEST(WhereTest, ReusableBaseQuerySet) {
     ASSERT_EQ(result2.value().size(), 23) << "Base filter should persist";
 
     // Refine the base filter — creates new copy, base unchanged
-    auto adults = base.where(field<^^Person::age>() >= 30).select().execute();
+    auto adults = base.where(f<^^Person::age>() >= 30).select().execute();
     ASSERT_TRUE(adults.has_value());
     ASSERT_EQ(adults.value().size(), 16) << "Expected 16 people (age >= 25 AND age >= 30)";
 
@@ -300,19 +300,19 @@ TYPED_TEST(WhereTest, ProgressiveQueryBuilding) {
     QuerySet<Person, TypeParam> queryset;
 
     // Start with broad filter
-    auto q1      = queryset.where(field<^^Person::age>() >= 25);
+    auto q1      = queryset.where(f<^^Person::age>() >= 25);
     auto result1 = q1.select().execute();
     ASSERT_TRUE(result1.has_value());
     EXPECT_EQ(result1.value().size(), 23) << "23 people have age >= 25";
 
     // Narrow it down
-    auto q2      = q1.where(field<^^Person::age>() < 35);
+    auto q2      = q1.where(f<^^Person::age>() < 35);
     auto result2 = q2.select().execute();
     ASSERT_TRUE(result2.has_value());
     EXPECT_EQ(result2.value().size(), 12) << "Expected 12 people (25 <= age < 35)";
 
     // Add another condition (names starting with certain letter)
-    auto q3      = q2.where(field<^^Person::name>().like("D%"));
+    auto q3      = q2.where(f<^^Person::name>().like("D%"));
     auto result3 = q3.select().execute();
     ASSERT_TRUE(result3.has_value());
     EXPECT_EQ(result3.value().size(), 1) << "Expected 1 person matching all conditions (Diana)";
@@ -328,9 +328,9 @@ TYPED_TEST(WhereTest, ChainingBuildsComplexFilter) {
     QuerySet<Person, TypeParam> queryset;
 
     // Build up complex filter via chaining
-    auto filtered = queryset.where(field<^^Person::age>() >= 25)
-                            .where(field<^^Person::age>() < 40)
-                            .where(field<^^Person::name>().like("D%"));
+    auto filtered = queryset.where(f<^^Person::age>() >= 25)
+                            .where(f<^^Person::age>() < 40)
+                            .where(f<^^Person::name>().like("D%"));
 
     auto result = filtered.select().execute();
     ASSERT_TRUE(result.has_value());
@@ -343,7 +343,7 @@ TYPED_TEST(WhereTest, ChainingBuildsComplexFilter) {
     EXPECT_EQ(all_people.value().size(), 25) << "Original should have all rows";
 
     // Can create a different filter from the same base
-    auto age25 = queryset.where(field<^^Person::age>() == 25).select().execute();
+    auto age25 = queryset.where(f<^^Person::age>() == 25).select().execute();
     ASSERT_TRUE(age25.has_value());
     EXPECT_EQ(age25.value().size(), 3) << "Different filter from same base (Alice, Grace, Karen)";
 }
@@ -353,7 +353,7 @@ TYPED_TEST(WhereTest, WhereDoesNotMutateOriginal) {
     QuerySet<Person, TypeParam> queryset;
 
     // Call where() — original should be unchanged
-    auto filtered = queryset.where(field<^^Person::age>() > 30);
+    auto filtered = queryset.where(f<^^Person::age>() > 30);
     auto all      = queryset.select().execute();
     ASSERT_TRUE(all.has_value());
     EXPECT_EQ(all.value().size(), 25) << "Original QuerySet must not be mutated by where()";
@@ -369,7 +369,7 @@ TYPED_TEST(WhereTest, WhereInLoopWithoutReset) {
     QuerySet<Person, TypeParam> queryset;
 
     for (int i = 0; i < 10; ++i) {
-        auto result = queryset.where(field<^^Person::age>() > 30).count().execute();
+        auto result = queryset.where(f<^^Person::age>() > 30).count().execute();
         ASSERT_TRUE(result.has_value()) << "Iteration " << i << " failed: " << result.error().message();
         EXPECT_EQ(result.value(), 13) << "Each iteration should return 13 (no accumulation)";
     }
@@ -384,8 +384,8 @@ TYPED_TEST(WhereTest, WhereInLoopWithoutReset) {
 TYPED_TEST(WhereTest, WhereChainingReturnsNewCopies) {
     QuerySet<Person, TypeParam> queryset;
 
-    auto q1 = queryset.where(field<^^Person::age>() >= 25);
-    auto q2 = q1.where(field<^^Person::age>() < 35);
+    auto q1 = queryset.where(f<^^Person::age>() >= 25);
+    auto q2 = q1.where(f<^^Person::age>() < 35);
 
     // Original, q1, q2 should all be independent
     auto all = queryset.select().execute();
@@ -411,14 +411,14 @@ TYPED_TEST(WhereTest, WhereInEmptyValuesReturnsFalse) {
     QuerySet<Person, TypeParam> queryset;
 
     // .in() with no arguments creates InExpression with empty vector → "1 = 0"
-    auto result = queryset.where(field<^^Person::age>().in()).select().execute();
+    auto result = queryset.where(f<^^Person::age>().in()).select().execute();
     ASSERT_TRUE(result.has_value()) << "Empty IN should succeed";
     EXPECT_TRUE(result.value().empty()) << "Empty IN (1=0) should match nothing";
 }
 
 // Test: Expr::get() accessor
 TYPED_TEST(WhereTest, ExprGetReturnsValidPointer) {
-    auto expr = field<^^Person::age>() > 25;
+    auto expr = f<^^Person::age>() > 25;
     auto ptr  = expr.get();
     EXPECT_NE(ptr, nullptr) << "Expr::get() should return a valid pointer";
 }
@@ -448,7 +448,7 @@ TYPED_TEST(WhereTest, ExprDirectConstructionFromVariant) {
 TYPED_TEST(WhereTest, IsNull_MethodSyntax) {
     QuerySet<Person, TypeParam> queryset;
 
-    auto result = queryset.where(field<^^Person::score>().is_null()).select().execute();
+    auto result = queryset.where(f<^^Person::score>().is_null()).select().execute();
     ASSERT_TRUE(result.has_value()) << "IS NULL failed: " << result.error().message();
     EXPECT_EQ(result.value().size(), 10) << "Expected 10 people with NULL score";
 }
@@ -457,7 +457,7 @@ TYPED_TEST(WhereTest, IsNull_MethodSyntax) {
 TYPED_TEST(WhereTest, IsNotNull_MethodSyntax) {
     QuerySet<Person, TypeParam> queryset;
 
-    auto result = queryset.where(field<^^Person::score>().is_not_null()).select().execute();
+    auto result = queryset.where(f<^^Person::score>().is_not_null()).select().execute();
     ASSERT_TRUE(result.has_value()) << "IS NOT NULL failed: " << result.error().message();
     EXPECT_EQ(result.value().size(), 15) << "Expected 15 people with non-NULL score";
 }
@@ -466,7 +466,7 @@ TYPED_TEST(WhereTest, IsNotNull_MethodSyntax) {
 TYPED_TEST(WhereTest, IsNull_NulloptSyntax) {
     QuerySet<Person, TypeParam> queryset;
 
-    auto result = queryset.where(field<^^Person::score>() == std::nullopt).select().execute();
+    auto result = queryset.where(f<^^Person::score>() == std::nullopt).select().execute();
     ASSERT_TRUE(result.has_value()) << "== nullopt failed: " << result.error().message();
     EXPECT_EQ(result.value().size(), 10) << "Expected 10 people with NULL score (nullopt syntax)";
 }
@@ -475,7 +475,7 @@ TYPED_TEST(WhereTest, IsNull_NulloptSyntax) {
 TYPED_TEST(WhereTest, IsNotNull_NulloptSyntax) {
     QuerySet<Person, TypeParam> queryset;
 
-    auto result = queryset.where(field<^^Person::score>() != std::nullopt).select().execute();
+    auto result = queryset.where(f<^^Person::score>() != std::nullopt).select().execute();
     ASSERT_TRUE(result.has_value()) << "!= nullopt failed: " << result.error().message();
     EXPECT_EQ(result.value().size(), 15) << "Expected 15 people with non-NULL score (nullopt syntax)";
 }
@@ -484,7 +484,7 @@ TYPED_TEST(WhereTest, IsNotNull_NulloptSyntax) {
 TYPED_TEST(WhereTest, IsNull_StringField) {
     QuerySet<Person, TypeParam> queryset;
 
-    auto result = queryset.where(field<^^Person::nickname>().is_null()).select().execute();
+    auto result = queryset.where(f<^^Person::nickname>().is_null()).select().execute();
     ASSERT_TRUE(result.has_value()) << "IS NULL on nickname failed: " << result.error().message();
     // Count people with nickname = std::nullopt in PEOPLE_25
     std::size_t expected_null_nicknames = 0;
@@ -501,7 +501,7 @@ TYPED_TEST(WhereTest, IsNull_StringField) {
 TYPED_TEST(WhereTest, IsNull_AndCombination) {
     QuerySet<Person, TypeParam> queryset;
 
-    auto result = queryset.where(field<^^Person::score>().is_null() && field<^^Person::age>() > 30).select().execute();
+    auto result = queryset.where(f<^^Person::score>().is_null() && f<^^Person::age>() > 30).select().execute();
     ASSERT_TRUE(result.has_value()) << "IS NULL AND failed: " << result.error().message();
     // NULL score AND age > 30: Charlie(35), Eve(40), Henry(33), Jack(38), Olivia(48), Quinn(30→no), Sam(40) = 6
     std::size_t expected = 0;
@@ -517,7 +517,7 @@ TYPED_TEST(WhereTest, IsNull_AndCombination) {
 TYPED_TEST(WhereTest, IsNull_OrCombination) {
     QuerySet<Person, TypeParam> queryset;
 
-    auto result = queryset.where(field<^^Person::score>().is_null() || field<^^Person::age>() < 25).select().execute();
+    auto result = queryset.where(f<^^Person::score>().is_null() || f<^^Person::age>() < 25).select().execute();
     ASSERT_TRUE(result.has_value()) << "IS NULL OR failed: " << result.error().message();
     // NULL score (10) OR age < 25 (Paul=22, Yara=22 — but Yara has score=92, Paul has score=40)
     std::size_t expected = 0;
@@ -535,10 +535,8 @@ TYPED_TEST(WhereTest, IsNull_EmptyResult) {
 
     // age is NOT optional — it's always set, so IS NULL on a non-optional field won't make sense
     // Instead, filter to only non-NULL scores first, then check IS NULL on score → 0 results
-    auto result = queryset.where(field<^^Person::score>().is_not_null())
-                          .where(field<^^Person::score>().is_null())
-                          .select()
-                          .execute();
+    auto result =
+            queryset.where(f<^^Person::score>().is_not_null()).where(f<^^Person::score>().is_null()).select().execute();
     ASSERT_TRUE(result.has_value()) << "IS NULL empty result failed: " << result.error().message();
     EXPECT_EQ(result.value().size(), 0) << "IS NOT NULL AND IS NULL should match nothing";
 }
@@ -549,8 +547,7 @@ TYPED_TEST(WhereJoinTest, IsNull_WithJoin) {
 
     // In WhereJoinTest fixture, Person rows are inserted without score → all NULL
     // So IS NULL on score matches all 4 messages
-    auto result =
-            queryset.template join<^^Message::sender>().where(field<^^Person::score>().is_null()).select().execute();
+    auto result = queryset.template join<^^Message::sender>().where(f<^^Person::score>().is_null()).select().execute();
     ASSERT_TRUE(result.has_value()) << "IS NULL with JOIN failed: " << result.error().message();
     EXPECT_EQ(result.value().size(), 4) << "Expected 4 messages (all senders have NULL score in this fixture)";
 }
@@ -572,7 +569,7 @@ class WhereNullCollateTest : public StormTestFixture<Person, SqliteConn> {
 TEST_F(WhereNullCollateTest, IsNull_Collated) {
     QuerySet<Person, SqliteConn> queryset;
 
-    auto result = queryset.where(field<^^Person::nickname>().collate(storm::orm::utilities::Collate::NoCase).is_null())
+    auto result = queryset.where(f<^^Person::nickname>().collate(storm::orm::utilities::Collate::NoCase).is_null())
                           .select()
                           .execute();
     ASSERT_TRUE(result.has_value()) << "Collated IS NULL failed: " << result.error().message();

--- a/tests/query/test_where_complex.cpp
+++ b/tests/query/test_where_complex.cpp
@@ -7,16 +7,16 @@ import std;
 #include "test_models.h" // NOSONAR cpp:S954
 #include "test_seed_helpers.h"
 
-using storm::orm::where::field;
+using storm::orm::where::f;
 
 template <typename ConnType> class ComplexWhereTest : public PersonSeedFixture<ConnType> {};
 
 TYPED_TEST_SUITE(ComplexWhereTest, DatabaseTypes);
 
 TYPED_TEST(ComplexWhereTest, OrWithAnd) {
-    auto young    = field<^^Person::age>() < 26;
-    auto old      = field<^^Person::age>() > 35;
-    auto mkt      = field<^^Person::department>() == "Marketing";
+    auto young    = f<^^Person::age>() < 26;
+    auto old      = f<^^Person::age>() > 35;
+    auto mkt      = f<^^Person::department>() == "Marketing";
     auto combined = young || (old && mkt);
 
     auto result = this->qs->where(combined).select().execute();
@@ -25,8 +25,8 @@ TYPED_TEST(ComplexWhereTest, OrWithAnd) {
 }
 
 TYPED_TEST(ComplexWhereTest, NestedAndOr) {
-    auto eng_young = field<^^Person::department>() == "Engineering" && field<^^Person::age>() < 30;
-    auto sales_old = field<^^Person::department>() == "Sales" && field<^^Person::age>() > 29;
+    auto eng_young = f<^^Person::department>() == "Engineering" && f<^^Person::age>() < 30;
+    auto sales_old = f<^^Person::department>() == "Sales" && f<^^Person::age>() > 29;
 
     auto result = this->qs->where(eng_young || sales_old).select().execute();
     ASSERT_TRUE(result.has_value());

--- a/tests/query/test_where_lifetime.cpp
+++ b/tests/query/test_where_lifetime.cpp
@@ -11,7 +11,7 @@ import std;
 
 using storm::QuerySet;
 using storm::orm::where::Expr;
-using storm::orm::where::field;
+using storm::orm::where::f;
 
 // Lifetime safety for WHERE comparison operands (#352).
 //
@@ -47,7 +47,7 @@ TYPED_TEST(WhereLifetimeTest, StringViewOperandSurvivesDeferredBind) {
     Expr expr = [] {
         auto             owner = std::make_unique<std::string>("Bob");
         std::string_view view  = *owner;
-        return field<^^Person::name>() == view; // node must copy "Bob", not keep a view into *owner
+        return f<^^Person::name>() == view; // node must copy "Bob", not keep a view into *owner
     }();
     // `owner` is freed here; ASAN poisons its buffer.
 
@@ -59,7 +59,7 @@ TYPED_TEST(WhereLifetimeTest, CharPtrOperandSurvivesDeferredBind) {
     Expr expr = [] {
         auto        owner = std::make_unique<std::array<char, 4>>(std::array<char, 4>{'B', 'o', 'b', '\0'});
         const char* ptr   = owner->data();
-        return field<^^Person::name>() == ptr; // node must copy "Bob", not keep the char*
+        return f<^^Person::name>() == ptr; // node must copy "Bob", not keep the char*
     }();
 
     expect_single_bob<TypeParam>(expr);
@@ -81,7 +81,7 @@ TEST_F(WhereLifetimeCollateTest, CollatedStringViewOperandSurvivesDeferredBind) 
     Expr expr = [] {
         auto             owner = std::make_unique<std::string>("bob");
         std::string_view view  = *owner;
-        return field<^^Person::name>().collate(storm::orm::utilities::Collate::NoCase) == view;
+        return f<^^Person::name>().collate(storm::orm::utilities::Collate::NoCase) == view;
     }();
 
     // Case-insensitive match: "bob" finds "Bob".

--- a/tests/schema/test_sql_inspection.cpp
+++ b/tests/schema/test_sql_inspection.cpp
@@ -9,7 +9,7 @@ import std;
 #include "test_models.h"
 
 using storm::QuerySet;
-using storm::orm::where::field;
+using storm::orm::where::f;
 
 // ============================================================================
 // Test fixture
@@ -48,7 +48,7 @@ TYPED_TEST(SqlInspectionTest, SelectBareToSql) {
 
 TYPED_TEST(SqlInspectionTest, SelectWithWhereToSql) {
     QuerySet<Person, TypeParam> qs;
-    auto                        result = qs.where(field<^^Person::age>() > 30).select().to_sql();
+    auto                        result = qs.where(f<^^Person::age>() > 30).select().to_sql();
     ASSERT_TRUE(result.has_value()) << "to_sql() failed: " << result.error().message();
 
     const std::string& sql = result.value();
@@ -61,7 +61,7 @@ TYPED_TEST(SqlInspectionTest, SelectWithWhereToSql) {
 
 TYPED_TEST(SqlInspectionTest, SelectWithStringWhereToSql) {
     QuerySet<Person, TypeParam> qs;
-    auto                        result = qs.where(field<^^Person::name>() == "Alice").select().to_sql();
+    auto                        result = qs.where(f<^^Person::name>() == "Alice").select().to_sql();
     ASSERT_TRUE(result.has_value()) << "to_sql() failed: " << result.error().message();
 
     const std::string& sql = result.value();
@@ -102,7 +102,7 @@ TYPED_TEST(SqlInspectionTest, SelectWithOrderByToSql) {
 
 TYPED_TEST(SqlInspectionTest, SelectWithWhereAndLimitToSql) {
     QuerySet<Person, TypeParam> qs;
-    auto                        result = qs.where(field<^^Person::age>() > 25).limit(5).select().to_sql();
+    auto                        result = qs.where(f<^^Person::age>() > 25).limit(5).select().to_sql();
     ASSERT_TRUE(result.has_value()) << "to_sql() failed: " << result.error().message();
 
     const std::string& sql = result.value();
@@ -116,12 +116,12 @@ TYPED_TEST(SqlInspectionTest, SelectOperatorsToSql) {
     QuerySet<Person, TypeParam> qs;
 
     // Test all comparison operators generate proper SQL
-    auto r_eq = qs.where(field<^^Person::age>() == 30).select().to_sql();
-    auto r_ne = qs.where(field<^^Person::age>() != 30).select().to_sql();
-    auto r_gt = qs.where(field<^^Person::age>() > 30).select().to_sql();
-    auto r_ge = qs.where(field<^^Person::age>() >= 30).select().to_sql();
-    auto r_lt = qs.where(field<^^Person::age>() < 30).select().to_sql();
-    auto r_le = qs.where(field<^^Person::age>() <= 30).select().to_sql();
+    auto r_eq = qs.where(f<^^Person::age>() == 30).select().to_sql();
+    auto r_ne = qs.where(f<^^Person::age>() != 30).select().to_sql();
+    auto r_gt = qs.where(f<^^Person::age>() > 30).select().to_sql();
+    auto r_ge = qs.where(f<^^Person::age>() >= 30).select().to_sql();
+    auto r_lt = qs.where(f<^^Person::age>() < 30).select().to_sql();
+    auto r_le = qs.where(f<^^Person::age>() <= 30).select().to_sql();
 
     ASSERT_TRUE(r_eq.has_value());
     ASSERT_TRUE(r_ne.has_value());
@@ -140,7 +140,7 @@ TYPED_TEST(SqlInspectionTest, SelectOperatorsToSql) {
 
 TYPED_TEST(SqlInspectionTest, SelectWithInToSql) {
     QuerySet<Person, TypeParam> qs;
-    auto                        result = qs.where(field<^^Person::age>().in(20, 25, 30)).select().to_sql();
+    auto                        result = qs.where(f<^^Person::age>().in(20, 25, 30)).select().to_sql();
     ASSERT_TRUE(result.has_value()) << "to_sql() failed: " << result.error().message();
 
     const std::string& sql = result.value();
@@ -152,7 +152,7 @@ TYPED_TEST(SqlInspectionTest, SelectWithInToSql) {
 
 TYPED_TEST(SqlInspectionTest, SelectWithBetweenToSql) {
     QuerySet<Person, TypeParam> qs;
-    auto                        result = qs.where(field<^^Person::age>().between(20, 40)).select().to_sql();
+    auto                        result = qs.where(f<^^Person::age>().between(20, 40)).select().to_sql();
     ASSERT_TRUE(result.has_value()) << "to_sql() failed: " << result.error().message();
 
     const std::string& sql = result.value();
@@ -163,7 +163,7 @@ TYPED_TEST(SqlInspectionTest, SelectWithBetweenToSql) {
 
 TYPED_TEST(SqlInspectionTest, SelectWithLikeToSql) {
     QuerySet<Person, TypeParam> qs;
-    auto                        result = qs.where(field<^^Person::name>().like("A%")).select().to_sql();
+    auto                        result = qs.where(f<^^Person::name>().like("A%")).select().to_sql();
     ASSERT_TRUE(result.has_value()) << "to_sql() failed: " << result.error().message();
 
     const std::string& sql = result.value();
@@ -173,7 +173,7 @@ TYPED_TEST(SqlInspectionTest, SelectWithLikeToSql) {
 
 TYPED_TEST(SqlInspectionTest, SelectWithAndOrToSql) {
     QuerySet<Person, TypeParam> qs;
-    auto result = qs.where((field<^^Person::age>() > 25) && (field<^^Person::age>() < 50)).select().to_sql();
+    auto result = qs.where((f<^^Person::age>() > 25) && (f<^^Person::age>() < 50)).select().to_sql();
     ASSERT_TRUE(result.has_value()) << "to_sql() failed: " << result.error().message();
 
     const std::string& sql = result.value();
@@ -198,7 +198,7 @@ TYPED_TEST(SqlInspectionTest, FirstBareToSql) {
 
 TYPED_TEST(SqlInspectionTest, FirstWithWhereToSql) {
     QuerySet<Person, TypeParam> qs;
-    auto                        result = qs.where(field<^^Person::age>() > 25).first().to_sql();
+    auto                        result = qs.where(f<^^Person::age>() > 25).first().to_sql();
     ASSERT_TRUE(result.has_value()) << "first().to_sql() failed: " << result.error().message();
 
     const std::string& sql = result.value();
@@ -233,7 +233,7 @@ TYPED_TEST(SqlInspectionTest, GetBareToSql) {
 
 TYPED_TEST(SqlInspectionTest, GetWithWhereToSql) {
     QuerySet<Person, TypeParam> qs;
-    auto                        result = qs.where(field<^^Person::id>() == 42).get().to_sql();
+    auto                        result = qs.where(f<^^Person::id>() == 42).get().to_sql();
     ASSERT_TRUE(result.has_value()) << "get().to_sql() failed: " << result.error().message();
 
     const std::string& sql = result.value();

--- a/tests/schema/test_types.cpp
+++ b/tests/schema/test_types.cpp
@@ -20,7 +20,7 @@ using std::chrono::system_clock;
 using std::chrono::year;
 using std::chrono::year_month_day;
 using storm::QuerySet;
-using storm::orm::where::field;
+using storm::orm::where::f;
 
 // ===== INTEGER TYPES TESTS =====
 
@@ -1241,7 +1241,7 @@ TYPED_TEST(EnumTypesTest, WhereEnumEqual) {
     auto insert_result = qs.insert(batch).execute();
     ASSERT_TRUE(insert_result.has_value());
 
-    auto selected = qs.where(field<^^ExtendedTypes::color>() == Color::Green).select().execute();
+    auto selected = qs.where(f<^^ExtendedTypes::color>() == Color::Green).select().execute();
     ASSERT_TRUE(selected.has_value());
     ASSERT_EQ(selected.value().size(), 1);
     EXPECT_EQ(selected.value().begin()->label, "g");
@@ -1257,7 +1257,7 @@ TYPED_TEST(EnumTypesTest, WhereEnumNotEqual) {
     auto insert_result = qs.insert(batch).execute();
     ASSERT_TRUE(insert_result.has_value());
 
-    auto selected = qs.where(field<^^ExtendedTypes::color>() != Color::Red).select().execute();
+    auto selected = qs.where(f<^^ExtendedTypes::color>() != Color::Red).select().execute();
     ASSERT_TRUE(selected.has_value());
     EXPECT_EQ(selected.value().size(), 2);
 }
@@ -1272,7 +1272,7 @@ TYPED_TEST(EnumTypesTest, WhereEnumBetween) {
     auto insert_result = qs.insert(batch).execute();
     ASSERT_TRUE(insert_result.has_value());
 
-    auto selected = qs.where(field<^^ExtendedTypes::color>().between(Color::Green, Color::Blue)).select().execute();
+    auto selected = qs.where(f<^^ExtendedTypes::color>().between(Color::Green, Color::Blue)).select().execute();
     ASSERT_TRUE(selected.has_value());
     EXPECT_EQ(selected.value().size(), 2);
 }

--- a/tests/test_select_runner.h
+++ b/tests/test_select_runner.h
@@ -32,22 +32,22 @@ using storm::orm::query_builder::dispatch_field;
 
 template <std::meta::info FieldInfo, typename ValueType>
 constexpr auto build_where_expr(std::string_view op, ValueType value) {
-    using storm::orm::where::field;
-    if constexpr (requires { field<FieldInfo>() == value; }) {
+    using storm::orm::where::f;
+    if constexpr (requires { f<FieldInfo>() == value; }) {
         if (op == "==")
-            return field<FieldInfo>() == value;
+            return f<FieldInfo>() == value;
         if (op == "!=")
-            return field<FieldInfo>() != value;
+            return f<FieldInfo>() != value;
         if (op == ">")
-            return field<FieldInfo>() > value;
+            return f<FieldInfo>() > value;
         if (op == ">=")
-            return field<FieldInfo>() >= value;
+            return f<FieldInfo>() >= value;
         if (op == "<")
-            return field<FieldInfo>() < value;
+            return f<FieldInfo>() < value;
         if (op == "<=")
-            return field<FieldInfo>() <= value;
+            return f<FieldInfo>() <= value;
     }
-    return field<FieldInfo>() == value;
+    return f<FieldInfo>() == value;
 }
 
 // FK resolver for test models (Message::sender → Person).
@@ -68,7 +68,7 @@ inline constexpr NoOpFkResolver no_op_fk{};
 
 // Recursively build a WHERE expression from a compile-time WhereNode tree.
 template <int N, const auto &Tc, typename Model> auto build_where_node_expr() {
-    using storm::orm::where::field;
+    using storm::orm::where::f;
     if constexpr (Tc.where_nodes[N].left < 0) {
         constexpr auto fi = dispatch_field<Model>(Tc.where_nodes[N].field.view());
         if constexpr (Tc.where_nodes[N].value_dbl != 0.0)


### PR DESCRIPTION
## What

Renames the WHERE-clause field helper `where::field<>` → `where::f<>` so query expressions read more compactly:

```cpp
qs.where(f<^^Person::age>() > 25 && f<^^Person::name>() == "Alice")
```

## Why

Explored ways to match the terse `Model::field == x` ergonomics from the [wrocpp tiny-orm post](https://wrocpp.github.io/posts/tiny-orm/) without giving up Storm's plain, macro-free structs. Conclusions:

- `^^` is a built-in operator — not overloadable.
- Bare `Model::field == x` requires the member type to be replaced by a column object (what the blog hides) — Storm deliberately keeps `age` a real `int`.
- A generated `F<Model>` handle works but costs one free-standing `consteval { define_one<Model>(); }` line per model (P2996 has no lazy injection).
- String-literal UDLs throw away member identity → no compile-time validation, no type, not navigable.

So `f<^^Person::age>()` is already the shortest spelling that keeps the member reference in the type system (checked + IDE-navigable). This PR just shortens the name.

## Scope

Pure identifier rename. `has_field` / `dispatch_field` / `append_field` helpers and `.field` struct members are untouched. Codegen is unchanged.

## Verification

- Debug build + 2118 tests pass
- ASAN+UBSAN: 2118/2118, no violations
- TSAN: 2118/2118, no races
- Pre-commit hook: format, tidy, tests (SQLite+PG), 100% coverage all green
- Benchmark skipped intentionally — a function rename produces identical machine code

Historical `docs/superpowers/plans/*` left as snapshots; active docs + CLAUDE.md updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)