### PR TITLE
chore(src): remove dead code — get_update_sql_static + preserves_bindings

### DIFF
--- a/src/db/postgresql_statement.cppm
+++ b/src/db/postgresql_statement.cppm
@@ -19,10 +19,9 @@ export namespace storm::db::postgresql {
         using Error = postgresql::Error;
 
         // Constants for step return codes
-        static constexpr int         ROW_AVAILABLE      = 1;
-        static constexpr int         NO_MORE_ROWS       = 0;
-        static constexpr bool        preserves_bindings = false; // reset() clears params
-        static constexpr std::size_t MAX_DB_VARIABLES   = 999;   // matches BaseStatement::MAX_DB_VARIABLES
+        static constexpr int         ROW_AVAILABLE    = 1;
+        static constexpr int         NO_MORE_ROWS     = 0;
+        static constexpr std::size_t MAX_DB_VARIABLES = 999; // matches BaseStatement::MAX_DB_VARIABLES
 
         explicit Statement(PGconn* conn, std::string stmt_name) : conn_(conn), stmt_name_(std::move(stmt_name)) {
             param_values_.reserve(MAX_DB_VARIABLES);

--- a/src/db/sqlite.cppm
+++ b/src/db/sqlite.cppm
@@ -252,9 +252,8 @@ export namespace storm::db::sqlite {
         }
 
         // Constants for return codes (make them constexpr for compile-time checks)
-        static constexpr int  ROW_AVAILABLE      = SQLITE_ROW;
-        static constexpr int  NO_MORE_ROWS       = SQLITE_DONE;
-        static constexpr bool preserves_bindings = true; // sqlite3_reset() preserves bindings
+        static constexpr int ROW_AVAILABLE = SQLITE_ROW;
+        static constexpr int NO_MORE_ROWS  = SQLITE_DONE;
 
       private:
         StmtPtr       stmt_;

--- a/src/orm/statements/update.cppm
+++ b/src/orm/statements/update.cppm
@@ -178,12 +178,6 @@ export namespace storm::orm::statements {
         static constexpr auto           update_sql_array  = build_update_sql_array();
         static inline const std::string update_sql_string = std::string(update_sql_array);
 
-      public:
-        // Public access to UPDATE SQL for QuerySet optimization
-        static auto get_update_sql_static() -> const std::string& {
-            return update_sql_string;
-        }
-
       private:
         // Generate UPDATE SQL string (compile-time computed, runtime accessible)
         static auto get_update_sql() -> const std::string& {


### PR DESCRIPTION
## Summary

Removes two symbols with **zero callers** anywhere in `src/` or `tests/`, found during a full per-file read of `src/`:

1. **`UpdateStatement::get_update_sql_static()`** (`update.cppm`) — a `public` duplicate of the `private` `get_update_sql()`; both just return `update_sql_string`. Nothing in src or tests calls the public variant.

2. **`Statement::preserves_bindings`** (`sqlite.cppm` = `true`, `postgresql_statement.cppm` = `false`) — a `static constexpr bool` trait read by nobody.

## Why `preserves_bindings` is removed, not wired up

It looked like a latent optimization (SQLite keeps bound params across `reset()`, PG clears them — so binding could be skipped on reuse). It isn't applicable to Storm's design: the statement cache keys on **SQL text**, and every cached-statement reuse binds **fresh values** (a new object / new WHERE params each call). Preserved bindings only help when re-executing with *identical* values, which the ORM never does. The trait is also **not part of the `DatabaseStatement` concept**, so removal is safe.

## Verification

Pre-commit hook (mandatory) — all 5 checks passed:
- clang-format ✓
- module BMIs ✓
- clang-tidy `--diff --fix` ✓
- tests (SQLite + PostgreSQL) — **2230 passed, 0 failed** ✓
- coverage — **100%** ✓

Pure symbol removal; generated SQL is byte-identical, so no benchmark needed.

## Scope

`+5 −13` across 3 files (the column re-alignment is clang-format normalizing the `static constexpr` block after the longest member was removed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)