### PR TITLE
fix(where): between() text operands bypass normalize_operand (#406)

### DIFF
--- a/src/orm/where.cppm
+++ b/src/orm/where.cppm
@@ -339,6 +339,20 @@ export namespace storm::orm::where {
         );
     }
 
+    // Build a value-owning BetweenExpr from its bounds. Both bounds go through normalize_operand
+    // (#406): text operands are copied into an owning std::string (closes the deferred-bind dangle
+    // #352 fixed for comparisons) and enums fold to int — the same rules as make_comparison_expr.
+    template <typename V>
+    [[nodiscard]] auto make_between_expr(const std::string& field_name, V&& min_val, V&& max_val) -> Expr {
+        auto stored_min = normalize_operand(std::forward<V>(min_val));
+        auto stored_max = normalize_operand(std::forward<V>(max_val));
+        return Expr(
+                std::make_shared<ExpressionVariant>(BetweenExpr<decltype(stored_min)>{
+                        .field_name_ = field_name, .min_val_ = std::move(stored_min), .max_val_ = std::move(stored_max)
+                })
+        );
+    }
+
     // CollatedField proxy - wraps field name with COLLATE clause
     // Created via f<^^Person::name>().collate(Collate::NoCase)
     // All comparison operators produce SQL like: "name COLLATE NOCASE = ?"
@@ -400,13 +414,7 @@ export namespace storm::orm::where {
         }
 
         template <typename V> auto between(V&& min_val, V&& max_val) const -> Expr {
-            return Expr(
-                    std::make_shared<ExpressionVariant>(BetweenExpr<std::decay_t<V>>{
-                            .field_name_ = collated_name_,
-                            .min_val_    = std::forward<V>(min_val),
-                            .max_val_    = std::forward<V>(max_val)
-                    })
-            );
+            return where::make_between_expr(collated_name_, std::forward<V>(min_val), std::forward<V>(max_val));
         }
 
       private:
@@ -499,25 +507,9 @@ export namespace storm::orm::where {
         }
 
         template <typename V> auto between(V&& min_val, V&& max_val) const -> Expr {
-            using D = std::decay_t<V>;
-            if constexpr (std::is_enum_v<D>) {
-                using StoredType = int;
-                return Expr(
-                        std::make_shared<ExpressionVariant>(BetweenExpr<StoredType>{
-                                .field_name_ = std::string(field_name_sv),
-                                .min_val_    = static_cast<StoredType>(static_cast<std::underlying_type_t<D>>(min_val)),
-                                .max_val_    = static_cast<StoredType>(static_cast<std::underlying_type_t<D>>(max_val))
-                        })
-                );
-            } else {
-                return Expr(
-                        std::make_shared<ExpressionVariant>(BetweenExpr<D>{
-                                .field_name_ = std::string(field_name_sv),
-                                .min_val_    = std::forward<V>(min_val),
-                                .max_val_    = std::forward<V>(max_val)
-                        })
-                );
-            }
+            return where::make_between_expr(
+                    std::string(field_name_sv), std::forward<V>(min_val), std::forward<V>(max_val)
+            );
         }
 
       private:

--- a/tests/query/test_where_lifetime.cpp
+++ b/tests/query/test_where_lifetime.cpp
@@ -88,4 +88,42 @@ TEST_F(WhereLifetimeCollateTest, CollatedStringViewOperandSurvivesDeferredBind) 
     expect_single_bob<SqliteConn>(expr);
 }
 
+// Test: between() string-literal operands survive a deferred bind (#406).
+// between() used to store text operands by value-decay (BetweenExpr<const char*>),
+// bypassing the #352 normalize_operand text-copy. A string literal then dangles only
+// if the literal's storage dies — but a literal lives for the whole program, so to
+// prove the copy we route through a heap buffer that dies before the deferred bind.
+TYPED_TEST(WhereLifetimeTest, BetweenStringOperandSurvivesDeferredBind) {
+    // "Bob" BETWEEN "Bob" AND "Bob" matches exactly the one Bob.
+    Expr expr = [] {
+        auto        lo_owner = std::make_unique<std::array<char, 4>>(std::array<char, 4>{'B', 'o', 'b', '\0'});
+        auto        hi_owner = std::make_unique<std::array<char, 4>>(std::array<char, 4>{'B', 'o', 'b', '\0'});
+        const char* lo       = lo_owner->data();
+        const char* hi       = hi_owner->data();
+        return f<^^Person::name>().between(lo, hi); // node must copy, not keep the char*
+    }();
+
+    expect_single_bob<TypeParam>(expr);
+}
+
+// Test: between() with a literal compiles and binds correctly (#406 DoD).
+TYPED_TEST(WhereLifetimeTest, BetweenStringLiteralCompilesAndBinds) {
+    Expr expr = f<^^Person::name>().between("Bob", "Bob");
+    expect_single_bob<TypeParam>(expr);
+}
+
+// Test: CollatedField::between() string operands survive a deferred bind (#406).
+TEST_F(WhereLifetimeCollateTest, CollatedBetweenStringOperandSurvivesDeferredBind) {
+    Expr expr = [] {
+        auto        lo_owner = std::make_unique<std::array<char, 4>>(std::array<char, 4>{'b', 'o', 'b', '\0'});
+        auto        hi_owner = std::make_unique<std::array<char, 4>>(std::array<char, 4>{'b', 'o', 'b', '\0'});
+        const char* lo       = lo_owner->data();
+        const char* hi       = hi_owner->data();
+        return f<^^Person::name>().collate(storm::orm::utilities::Collate::NoCase).between(lo, hi);
+    }();
+
+    // Case-insensitive: "bob" BETWEEN-bounds finds "Bob".
+    expect_single_bob<SqliteConn>(expr);
+}
+
 // NOLINTEND(misc-const-correctness,performance-unnecessary-value-param,performance-unnecessary-copy-initialization)


### PR DESCRIPTION
## Summary

`Field::between()` and `CollatedField::between()` stored text operands by value-decay (`BetweenExpr<std::decay_t<V>>`), bypassing the `normalize_operand` text-copy hardening added for comparison operators in #352. A `const char*` / string-literal operand either failed to compile (no `BetweenExpr<const char*>` variant alternative) or stored a pointer that could dangle, since `where()` is deferred — the same lifetime trap #352 fixed for `==`/`>`/etc.

## Fix

Add `make_between_expr` mirroring `make_comparison_expr`: both bounds route through `normalize_operand`, so text operands are copied into an owning `std::string` (closes the deferred-bind dangle) and enums fold to `int`. This also removes the enum-to-int conversion that was duplicated across both `between()` overloads. The hot `BetweenExpr::bind_impl` path is unchanged.

## Tests

Mirror the #352 regression in `test_where_lifetime.cpp`:
- `between()` with `const char*` from a dead heap buffer survives a deferred bind (ASAN-clean)
- `between("Bob","Bob")` string-literal compiles and binds correctly
- `CollatedField::between()` string operands survive a deferred bind

## Verification

- Debug + ASAN+UBSAN: full suite green (1200 tests ASAN, 2235 with PG), 100% coverage
- Existing `EnumTypesTest.WhereEnumBetween` / `CollateTest.WhereBetweenNoCase` still pass — enum folding and collation preserved through the shared helper
- clang-tidy `--diff` clean on staged lines

Closes #406

🤖 Generated with [Claude Code](https://claude.com/claude-code)