### PR TITLE
fix(pg): DEALLOCATE server-side prepared statement in Statement dtor (#417)

### DIFF
--- a/src/db/postgresql_statement.cppm
+++ b/src/db/postgresql_statement.cppm
@@ -30,9 +30,14 @@ export namespace storm::db::postgresql {
             param_formats_.reserve(MAX_DB_VARIABLES);
         }
 
-        // Destructor - clears any pending result
+        // Destructor — DEALLOCATEs the server-side prepared statement (issue #417).
+        // SQLite finalizes on eviction via its unique_ptr deleter; PG must do the
+        // same here or the server-side `_storm_N` statement leaks for the
+        // connection's lifetime when the bounded L3 cache evicts this entry.
+        // finalize() is best-effort and noexcept-safe, and clears stmt_name_ so a
+        // moved-from Statement (whose name was swapped away) does nothing.
         ~Statement() {
-            clear_result();
+            finalize();
         }
 
         // Move semantics — swap-based to keep the field list in one place.

--- a/tests/db/test_pg_stmt_leak.cpp
+++ b/tests/db/test_pg_stmt_leak.cpp
@@ -1,0 +1,70 @@
+#include <gtest/gtest.h>
+#include "test_db_helpers.h"
+
+// NOLINTBEGIN(cppcoreguidelines-non-private-member-variables-in-classes,misc-non-private-member-variables-in-classes,readability-identifier-length)
+
+import storm;
+import std;
+
+// ============================================================================
+// Issue #417 — server-side prepared-statement leak on cache eviction
+//
+// The bounded L3 statement cache (#273) evicts entries via CLOCK once it is
+// full. SQLite finalizes the evicted statement through its unique_ptr deleter;
+// PostgreSQL must symmetrically DEALLOCATE the server-side `_storm_N` prepared
+// statement, or it accumulates on the backend for the connection's lifetime.
+//
+// This test runs ONLY against a real PostgreSQL server (auto-skips without
+// STORM_PG_CONNSTR). It churns far more distinct SQL than the cache holds, then
+// reads pg_prepared_statements to assert the server-side count stays bounded by
+// the cache capacity rather than growing with the churn count.
+// ============================================================================
+
+namespace {
+
+    using PgConnection = storm::db::postgresql::Connection;
+
+    // Read the number of live server-side prepared statements on this connection.
+    auto count_server_prepared(PgConnection& conn) -> std::int64_t {
+        auto stmt = conn.prepare("SELECT count(*) FROM pg_prepared_statements");
+        EXPECT_TRUE(stmt.has_value());
+        auto step = stmt->step();
+        EXPECT_TRUE(step.has_value());
+        EXPECT_TRUE(step.value());
+        return stmt->extract_int64(0);
+    }
+
+    TEST(PgStatementLeak, CacheEvictionDeallocatesServerSide) {
+        if (!storm::test::backend_available<PgConnection>()) {
+            GTEST_SKIP() << "PostgreSQL not available (STORM_PG_CONNSTR unset / unreachable)";
+        }
+
+        constexpr std::size_t kCapacity = 8;
+        constexpr int         kChurn    = 200; // >> kCapacity → forces many evictions
+
+        PgConnection::Config config;
+        config.statement_cache_capacity = kCapacity;
+
+        auto conn_result = PgConnection::open(storm::test::get_connection_string<PgConnection>(), config);
+        ASSERT_TRUE(conn_result.has_value());
+        PgConnection& conn = conn_result.value();
+
+        // Churn many distinct SELECTs through prepare_cached(). Each unique SQL is
+        // a fresh server-side prepared statement; once the cache is full, every
+        // new one evicts (and must DEALLOCATE) an old one.
+        for (int i = 0; i < kChurn; ++i) {
+            auto stmt = conn.prepare_cached(std::format("SELECT {}", i));
+            ASSERT_TRUE(stmt.has_value()) << "iteration " << i;
+        }
+
+        // The pg_prepared_statements probe itself uses prepare() (unnamed lifetime
+        // here is a fresh `_storm_N`), so allow a small slack above capacity.
+        const std::int64_t live = count_server_prepared(conn);
+        EXPECT_LE(live, static_cast<std::int64_t>(kCapacity) + 4)
+                << "server-side prepared statements grew without bound: " << live << " after churning " << kChurn
+                << " distinct SQL through a cache of capacity " << kCapacity;
+    }
+
+} // namespace
+
+// NOLINTEND(cppcoreguidelines-non-private-member-variables-in-classes,misc-non-private-member-variables-in-classes,readability-identifier-length)

--- a/tests/mock_libpq/mock_libpq.cpp
+++ b/tests/mock_libpq/mock_libpq.cpp
@@ -70,6 +70,10 @@ namespace {
         int exec_calls          = 0;
         int exec_prepared_calls = 0;
 
+        // Exec query tracking
+        std::string last_exec_query;
+        int         deallocate_calls = 0;
+
         auto reset() -> void {
             connectdb_null     = false;
             conn_status        = CONNECTION_OK;
@@ -94,6 +98,9 @@ namespace {
             prepare_calls       = 0;
             exec_calls          = 0;
             exec_prepared_calls = 0;
+
+            last_exec_query  = "";
+            deallocate_calls = 0;
         }
     };
 
@@ -213,6 +220,14 @@ namespace storm::test {
         return g_mock_config.exec_prepared_calls;
     }
 
+    auto MockPqConfig::get_last_exec_query() -> std::string {
+        return g_mock_config.last_exec_query;
+    }
+
+    auto MockPqConfig::get_deallocate_call_count() -> int {
+        return g_mock_config.deallocate_calls;
+    }
+
 } // namespace storm::test
 
 // ============================================================================
@@ -311,8 +326,12 @@ auto PQexecPrepared(
 
 auto PQexec(const PGconn* conn, const char* query) -> PGresult* {
     (void)conn;
-    (void)query;
     g_mock_config.exec_calls++;
+    if (query != nullptr) {
+        g_mock_config.last_exec_query = query;
+        if (std::strncmp(query, "DEALLOCATE", 10) == 0)
+            g_mock_config.deallocate_calls++;
+    }
 
     // Check for fail-on-call-N
     if (g_mock_config.exec_fail_on_call == g_mock_config.exec_calls) {

--- a/tests/mock_libpq/mock_libpq.h
+++ b/tests/mock_libpq/mock_libpq.h
@@ -99,6 +99,12 @@ class MockPqConfig {
     static auto get_exec_call_count() -> int;
     static auto get_exec_prepared_call_count() -> int;
 
+    // Exec query inspection (records the most recent PQexec() query string, e.g.
+    // a DEALLOCATE issued by the Statement destructor) and a count of how many
+    // PQexec() queries began with "DEALLOCATE".
+    static auto get_last_exec_query() -> std::string;
+    static auto get_deallocate_call_count() -> int;
+
   private:
     static MockPqConfig instance_;
 };

--- a/tests/mock_libpq/test_orm_pg_mock_errors.cpp
+++ b/tests/mock_libpq/test_orm_pg_mock_errors.cpp
@@ -1047,6 +1047,51 @@ namespace {
     }
 
     // ============================================================================
+    // Statement destructor DEALLOCATE (issue #417)
+    //
+    // On cache eviction the unique_ptr<Statement> is destroyed. SQLite finalizes
+    // via the unique_ptr deleter; PG must symmetrically DEALLOCATE the server-side
+    // prepared statement, or it leaks on the backend for the connection lifetime.
+    // ============================================================================
+
+    TEST_F(PgStatementErrorTest, DestructorDeallocatesPreparedStatement) {
+        auto conn_result = PgConnection::open("host=localhost");
+        ASSERT_TRUE(conn_result.has_value());
+
+        {
+            auto stmt_result = conn_result->prepare("SELECT 1");
+            ASSERT_TRUE(stmt_result.has_value());
+            // No explicit finalize() — rely on the destructor when stmt_result
+            // (the std::expected holding the Statement) leaves this scope.
+        }
+
+        // The destructor must have issued exactly one DEALLOCATE for the
+        // server-side prepared statement.
+        EXPECT_EQ(MockPqConfig::get_deallocate_call_count(), 1);
+        EXPECT_TRUE(MockPqConfig::get_last_exec_query().starts_with("DEALLOCATE"))
+                << "last PQexec was: " << MockPqConfig::get_last_exec_query();
+    }
+
+    TEST_F(PgStatementErrorTest, MovedFromStatementDoesNotDeallocate) {
+        auto conn_result = PgConnection::open("host=localhost");
+        ASSERT_TRUE(conn_result.has_value());
+
+        {
+            auto stmt_result = conn_result->prepare("SELECT 1");
+            ASSERT_TRUE(stmt_result.has_value());
+
+            // Move the statement out; the moved-from source must NOT deallocate
+            // when it is destroyed (its stmt_name_ was swapped away).
+            PgStatement moved = std::move(*stmt_result);
+            // `moved` deallocates once here; `*stmt_result` (moved-from) must not.
+        }
+
+        // Exactly one DEALLOCATE total — no double-free / error spam from the
+        // moved-from husk.
+        EXPECT_EQ(MockPqConfig::get_deallocate_call_count(), 1);
+    }
+
+    // ============================================================================
     // Execute success test
     // ============================================================================
 


### PR DESCRIPTION
## Summary

The PostgreSQL `Statement` destructor only freed the local `PGresult`; it never issued `DEALLOCATE` for the server-side prepared statement created by `PQprepare`. On bounded-L3-cache eviction (#273) the C++ `Statement` was destroyed but the server-side `_storm_N` prepared statement stayed allocated for the connection's lifetime — a server-side leak that grows without bound under churning SQL on long-lived pooled connections.

SQLite finalizes symmetrically via its `unique_ptr` deleter; PG did not. This restores the symmetry.

## Fix

The destructor now calls the existing `finalize()`, which best-effort `DEALLOCATE`s the statement (noexcept-safe, failures swallowed) and clears `stmt_name_` so a moved-from `Statement` (name swapped away) does nothing — no double-free, no error spam.

Reusing `finalize()` is more surgical than the issue's inline snippet: it already handles the noexcept-safe `PQexec`/`PQclear` and a NAMEDATALEN-bounded buffer.

## Tests

- **mock libpq** (always runs): destructor issues exactly one `DEALLOCATE`; a moved-from husk issues none. Adds `last_exec_query` / `deallocate_call_count` tracking to the mock.
- **real PG** (`tests/db/test_pg_stmt_leak.cpp`, auto-skips without `STORM_PG_CONNSTR`): churn 200 distinct SQL through a capacity-8 cache, then assert `pg_prepared_statements` stays bounded. Verified failing without the fix (201 live statements) and passing with it.

## Verification

- All 2236 tests pass (SQLite + PG).
- ASAN+UBSAN and TSAN: clean.
- Coverage: 100%.

## Definition of done

- [x] PG `Statement` destructor issues `DEALLOCATE` for a live, non-moved-from prepared statement.
- [x] Moved-from `Statement` does NOT attempt `DEALLOCATE` (no double-free / no error spam).
- [x] Destructor stays noexcept-safe (failures swallowed).
- [x] Test (PG, CI): churn more distinct SQL than cache capacity, assert server-side count bounded via `pg_prepared_statements`.
- [x] No regression on the SQLite path (unchanged).

Closes #417

🤖 Generated with [Claude Code](https://claude.com/claude-code)