### PR TITLE
fix(orm): implement update_all() — symmetric full-table UPDATE escape hatch (#409)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -455,7 +455,8 @@ qs.where(f<^^Person::age>() > 30).erase().execute();   // → std::expected<void
 qs.where(f<^^Person::salary>() < 50000)
   .update<^^Person::salary, ^^Person::is_active>(Person{.salary=60000, .is_active=true})
   .execute();                                          // → std::expected<void, Error>
-// Empty where() is refused (no full-table write).
+// Empty where() is refused (no full-table write); update_all<>() is the explicit wipe (#409).
+qs.update_all<^^Person::department>(Person{.department="Global"}).execute(); // UPDATE … SET, no WHERE
 
 // Public transaction API (#415) — storm::begin(conn) returns an RAII
 // storm::TransactionGuard<ConnType> (both re-exported from `storm`). BEGIN on

--- a/docs/features/CRUD_OPERATIONS.md
+++ b/docs/features/CRUD_OPERATIONS.md
@@ -199,6 +199,17 @@ QuerySet<Person>().update<^^Person::age>(Person{.age = 0}).execute();
 // → std::unexpected: refuses full-table write
 ```
 
+To intentionally update every row, use the explicit `update_all<...>()` (the symmetric
+counterpart of `erase_all()`):
+
+```cpp
+QuerySet<Person>().update_all<^^Person::department>(Person{.department = "Global"}).execute();
+// UPDATE Person SET department=?   (no WHERE — explicit full-table write)
+```
+
+`update_all<...>()` shares the SET-clause behaviour of conditional `update<...>()`: FK
+columns emit `<name>_id` and `auto_update` fields are auto-appended and stamped `now()`.
+
 Returns `std::expected<void, Error>` (consistent with the rest of the CRUD family).
 The primary key cannot be a SET target (compile-time rejected).
 

--- a/src/orm/queryset.cppm
+++ b/src/orm/queryset.cppm
@@ -294,6 +294,15 @@ export namespace storm {
                     .template query_where<Members...>(proto, where_expr_);
         }
 
+        // Update all rows (#409) — UPDATE <table> SET <set> with NO WHERE clause.
+        // SET columns are the Members... NTTPs; values come from `proto`. The explicit
+        // full-table escape hatch named by update<>()'s empty-WHERE refusal (mirrors erase_all()).
+        template <std::meta::info... Members>
+            requires(sizeof...(Members) > 0)
+        [[nodiscard]] auto update_all(const T& proto [[clang::lifetimebound]]) {
+            return orm::statements::UpdateStatement<T, ConnType>(conn_).template query_all<Members...>(proto);
+        }
+
         // Reset WHERE, JOIN, LIMIT, and OFFSET state
         // Use this to clear conditions and start fresh with the same QuerySet instance
         // Example:

--- a/src/orm/statements/update.cppm
+++ b/src/orm/statements/update.cppm
@@ -209,6 +209,20 @@ export namespace storm::orm::statements {
             return sql;
         }
 
+        // Full-table UPDATE (#409): build "UPDATE <table> SET <set_clause>" with NO WHERE.
+        // Same SET clause as the conditional path (Members... + unlisted auto_update fields);
+        // it just omits the WHERE — the explicit escape hatch mirroring DELETE's delete_all_sql.
+        template <std::meta::info... Members> static auto build_update_all_sql() -> std::string {
+            static const std::string set_clause = std::string(build_conditional_set_clause<Members...>());
+            std::string              sql;
+            sql.reserve(Base::table_name_.size() + set_clause.size() + 16);
+            sql += "UPDATE ";
+            sql += Base::table_name_;
+            sql += " SET ";
+            sql += set_clause;
+            return sql;
+        }
+
       public:
         explicit UpdateStatement(std::shared_ptr<ConnType> conn) : conn_(std::move(conn)) {}
 
@@ -259,7 +273,7 @@ export namespace storm::orm::statements {
         // Conditional bulk UPDATE (#403): UPDATE <table> SET <set> WHERE <where_expr>.
         // SET columns are the Members... pack; values come from `proto`. A null where_expr
         // is refused at execute()/to_sql() time so a dropped where() cannot write the whole
-        // table (update_all() would be the explicit full-table path — not yet implemented).
+        // table (update_all() is the explicit full-table path — see UpdateAllQuery, #409).
         template <std::meta::info... Members> struct ConditionalUpdateQuery {
             UpdateStatement                  stmt;
             const T&                         proto;
@@ -277,6 +291,25 @@ export namespace storm::orm::statements {
         auto query_where(const T& proto [[clang::lifetimebound]], orm::where::ExpressionVariantPtr where_expr)
                 -> ConditionalUpdateQuery<Members...> {
             return {std::move(*this), proto, std::move(where_expr)};
+        }
+
+        // Full-table UPDATE (#409): UPDATE <table> SET <set> with NO WHERE. The explicit
+        // escape hatch named by the empty-WHERE refusal, mirroring DeleteAllQuery.
+        template <std::meta::info... Members> struct UpdateAllQuery {
+            UpdateStatement    stmt;
+            const T&           proto;
+            [[nodiscard]] auto execute() -> std::expected<void, Error> {
+                return stmt.template execute_all<Members...>(proto);
+            }
+            [[nodiscard]] auto to_sql() -> std::expected<std::string, Error> {
+                return stmt.template to_sql_all<Members...>(proto);
+            }
+        };
+
+        template <std::meta::info... Members>
+            requires(sizeof...(Members) > 0 && (is_settable_member<Members>() && ...))
+        auto query_all(const T& proto [[clang::lifetimebound]]) -> UpdateAllQuery<Members...> {
+            return {std::move(*this), proto};
         }
 
         // Returns SQL string with bound parameters inlined for a single UPDATE (for debugging)
@@ -471,6 +504,24 @@ export namespace storm::orm::statements {
             return bind_unlisted_auto_updates<Members...>(stmt, param_index, now, typename Base::field_indices_t{});
         }
 
+        // Prepare `sql`, reset, then bind the SET values — the prefix shared by the
+        // conditional (WHERE, #403) and full-table (#409) paths. Conditional appends WHERE.
+        template <std::meta::info... Members>
+        [[nodiscard]] auto prepare_bind_set(const std::string& sql, const T& proto, int& param_index)
+                -> std::expected<Statement*, Error> {
+            auto prepare_result = conn_->prepare_cached(sql);
+            if (!prepare_result) {
+                return std::unexpected(prepare_result.error());
+            }
+            Statement* stmt = *prepare_result;
+            stmt->reset();
+            param_index = 1;
+            if (auto set_result = bind_conditional_set<Members...>(stmt, proto, param_index); !set_result) {
+                return std::unexpected(set_result.error());
+            }
+            return stmt;
+        }
+
         // Empty-WHERE check + prepare + SET-then-WHERE bind. Shared by execute/to_sql.
         template <std::meta::info... Members>
         [[nodiscard]] auto ready_conditional_update(const T& proto, const orm::where::ExpressionVariantPtr& where_expr)
@@ -478,16 +529,14 @@ export namespace storm::orm::statements {
             if (!where_expr) [[unlikely]] {
                 return empty_where_error();
             }
-            auto prepare_result = conn_->prepare_cached(build_conditional_update_sql<Members...>(*where_expr));
-            if (!prepare_result) {
-                return std::unexpected(prepare_result.error());
+            int  param_index = 0; // set by prepare_bind_set; WHERE bind continues from it
+            auto stmt_result = prepare_bind_set<Members...>(
+                    build_conditional_update_sql<Members...>(*where_expr), proto, param_index
+            );
+            if (!stmt_result) {
+                return stmt_result;
             }
-            Statement* stmt = *prepare_result;
-            stmt->reset();
-            int param_index = 1;
-            if (auto set_result = bind_conditional_set<Members...>(stmt, proto, param_index); !set_result) {
-                return std::unexpected(set_result.error());
-            }
+            Statement* stmt = *stmt_result;
             // WHERE params continue from param_index (same continuation as bind_having_params).
             if (auto where_result = Base::template bind_having_params<Statement, Error>(stmt, where_expr, param_index);
                 !where_result) {
@@ -496,10 +545,17 @@ export namespace storm::orm::statements {
             return stmt;
         }
 
+        // Full-table UPDATE (#409): prepare + bind SET only (no WHERE). No empty-WHERE
+        // guard — writing the whole table is the documented intent here.
         template <std::meta::info... Members>
-        [[nodiscard]] auto execute_where(const T& proto, const orm::where::ExpressionVariantPtr& where_expr)
+        [[nodiscard]] auto ready_update_all(const T& proto) -> std::expected<Statement*, Error> {
+            int param_index = 0; // out-param; no WHERE bind follows, so the final value is unused
+            return prepare_bind_set<Members...>(build_update_all_sql<Members...>(), proto, param_index);
+        }
+
+        // Terminal shapes shared by the conditional and full-table paths: execute / expand.
+        [[nodiscard]] static auto run_execute(std::expected<Statement*, Error> stmt_result)
                 -> std::expected<void, Error> {
-            auto stmt_result = ready_conditional_update<Members...>(proto, where_expr);
             if (!stmt_result) {
                 return std::unexpected(stmt_result.error());
             }
@@ -508,15 +564,34 @@ export namespace storm::orm::statements {
             }
             return {};
         }
-
-        template <std::meta::info... Members>
-        [[nodiscard]] auto to_sql_where(const T& proto, const orm::where::ExpressionVariantPtr& where_expr)
+        [[nodiscard]] static auto run_to_sql(std::expected<Statement*, Error> stmt_result)
                 -> std::expected<std::string, Error> {
-            auto stmt_result = ready_conditional_update<Members...>(proto, where_expr);
             if (!stmt_result) {
                 return std::unexpected(stmt_result.error());
             }
             return (*stmt_result)->expanded_sql();
+        }
+
+        template <std::meta::info... Members>
+        [[nodiscard]] auto execute_where(const T& proto, const orm::where::ExpressionVariantPtr& where_expr)
+                -> std::expected<void, Error> {
+            return run_execute(ready_conditional_update<Members...>(proto, where_expr));
+        }
+
+        template <std::meta::info... Members>
+        [[nodiscard]] auto to_sql_where(const T& proto, const orm::where::ExpressionVariantPtr& where_expr)
+                -> std::expected<std::string, Error> {
+            return run_to_sql(ready_conditional_update<Members...>(proto, where_expr));
+        }
+
+        template <std::meta::info... Members>
+        [[nodiscard]] auto execute_all(const T& proto) -> std::expected<void, Error> {
+            return run_execute(ready_update_all<Members...>(proto));
+        }
+
+        template <std::meta::info... Members>
+        [[nodiscard]] auto to_sql_all(const T& proto) -> std::expected<std::string, Error> {
+            return run_to_sql(ready_update_all<Members...>(proto));
         }
 
       private:

--- a/tests/crud/test_conditional_update.cpp
+++ b/tests/crud/test_conditional_update.cpp
@@ -319,6 +319,8 @@ TYPED_TEST(ConditionalUpdateTest, EmptyWhereIsRefused) {
     storm::QuerySet<Person, TypeParam> qs;
     auto                               result = qs.template update<^^Person::age>(Person{.age = 0}).execute();
     ASSERT_FALSE(result.has_value()) << "update<...>() with no where() must refuse";
+    // The refusal message must point at update_all() — the method that actually exists (#409).
+    EXPECT_TRUE(result.error().message().contains("update_all()")) << result.error().message();
     EXPECT_EQ(this->getPerson(1).age, 30) << "Table must be untouched";
 }
 
@@ -402,6 +404,61 @@ TYPED_TEST(ConditionalUpdateTest, NoTimestampNoExtraColumn) {
     const auto set_clause = s.substr(set_pos + 4, where_pos - (set_pos + 4));
     EXPECT_FALSE(set_clause.contains(',')) << "no extra column appended: " << set_clause;
     EXPECT_TRUE(set_clause.contains("age")) << set_clause;
+}
+
+// --- update_all(): explicit full-table write (#409) ------------------------
+// Symmetry with erase_all(): the documented escape hatch for an unfiltered update.
+TYPED_TEST(ConditionalUpdateTest, UpdateAllWritesEveryRow) {
+    storm::QuerySet<Person, TypeParam> qs;
+    ASSERT_TRUE(qs.template update_all<^^Person::department>(Person{.department = "Global"}).execute().has_value());
+    // Every seeded row must now carry the new department.
+    for (int id = 1; id <= 5; ++id) {
+        EXPECT_EQ(this->getPerson(id).department, "Global") << "row " << id << " not updated";
+    }
+}
+
+TYPED_TEST(ConditionalUpdateTest, UpdateAllMultipleColumns) {
+    storm::QuerySet<Person, TypeParam> qs;
+    ASSERT_TRUE((qs.template update_all<^^Person::age, ^^Person::is_active>(Person{.age = 99, .is_active = true})
+                         .execute()
+                         .has_value()));
+    for (int id = 1; id <= 5; ++id) {
+        EXPECT_EQ(this->getPerson(id).age, 99) << "row " << id;
+        EXPECT_TRUE(this->getPerson(id).is_active) << "row " << id;
+    }
+}
+
+TYPED_TEST(ConditionalUpdateTest, UpdateAllToSqlHasNoWhere) {
+    storm::QuerySet<Person, TypeParam> qs;
+    auto                               sql = qs.template update_all<^^Person::salary>(Person{.salary = 1.0}).to_sql();
+    ASSERT_TRUE(sql.has_value());
+    EXPECT_TRUE(sql.value().contains("UPDATE")) << sql.value();
+    EXPECT_TRUE(sql.value().contains("SET")) << sql.value();
+    EXPECT_TRUE(sql.value().contains("salary")) << sql.value();
+    EXPECT_FALSE(sql.value().contains("WHERE")) << "update_all() must emit no WHERE: " << sql.value();
+}
+
+// auto_update column is auto-appended and stamped on the full-table write too.
+TYPED_TEST(ConditionalUpdateTest, UpdateAllStampsAutoUpdate) {
+    using std::chrono::system_clock;
+    using storm::orm::where::f;
+    storm::QuerySet<TimestampedRecord, TypeParam> tqs;
+    const auto                                    stale = system_clock::time_point{};
+    ASSERT_TRUE(tqs.insert(TimestampedRecord{.id = 0, .name = "seed", .created_at = stale, .updated_at = stale})
+                        .execute()
+                        .has_value());
+    auto sql = tqs.template update_all<^^TimestampedRecord::name>(TimestampedRecord{.name = "renamed"}).to_sql();
+    ASSERT_TRUE(sql.has_value());
+    EXPECT_TRUE(sql.value().contains("updated_at")) << sql.value() << "auto_update must be auto-appended";
+
+    ASSERT_TRUE(tqs.template update_all<^^TimestampedRecord::name>(TimestampedRecord{.name = "renamed"})
+                        .execute()
+                        .has_value());
+    auto rows = tqs.where(f<^^TimestampedRecord::name>() == "renamed").select().execute();
+    ASSERT_TRUE(rows.has_value());
+    ASSERT_EQ(rows.value().size(), 1U);
+    EXPECT_GT(rows.value().begin()->updated_at.time_since_epoch().count(), stale.time_since_epoch().count())
+            << "auto_update column must advance past the stale value";
 }
 
 // NOLINTEND(readability-implicit-bool-conversion)


### PR DESCRIPTION
## Summary

`update<>()`'s empty-WHERE refusal told users to call `update_all()`, but that method **never existed** — a dead-end error message and an API asymmetry vs. DELETE's `erase_all()`.

This implements the issue's **preferred** fix (symmetry): `QuerySet::update_all<Members...>(proto)` mirroring `erase_all()`.

## Changes

- **`QuerySet::update_all<Members...>(proto)`** — builds `UPDATE <table> SET <set>` with **no** WHERE; returns a proxy with `.execute()` / `.to_sql()`.
- SET clause is identical to conditional `update<>()`: explicit `Members...` (FK cols emit `<name>_id`) **+** unlisted `auto_update` fields stamped `now()` — reuses `build_conditional_set_clause` / `bind_conditional_set`.
- The conditional and full-table paths now share `prepare_bind_set` (prepare → reset → bind SET) and `run_execute` / `run_to_sql` terminal shapes (DRY; conditional path appends the WHERE bind). **The PK-update hot path is untouched.**
- The empty-WHERE error message now names a method that genuinely exists.
- Docs updated: `CLAUDE.md` QuerySet API block + `docs/features/CRUD_OPERATIONS.md`.

## Tests (both SQLite + PostgreSQL)

- `EmptyWhereIsRefused` now **asserts the message names `update_all()`**.
- `UpdateAllWritesEveryRow`, `UpdateAllMultipleColumns`, `UpdateAllToSqlHasNoWhere` (no WHERE), `UpdateAllStampsAutoUpdate`.

All 2313 tests pass; clean under ASAN+UBSAN and TSAN; coverage 100%.

Closes #409

🤖 Generated with [Claude Code](https://claude.com/claude-code)