### PR TITLE
docs(types): signed-storage caveat for 64-bit unsigned fields (#419)

### DIFF
--- a/docs/reference/FIELD_TYPES.md
+++ b/docs/reference/FIELD_TYPES.md
@@ -13,9 +13,34 @@ Storm ORM supports all standard SQLite types through compile-time type dispatch 
 | `int64_t` | INTEGER | `bind_int64()` | `extract_int64()` |
 | `long` | INTEGER | `bind_int64()` | `extract_int64()` |
 | `long long` | INTEGER | `bind_int64()` | `extract_int64()` |
-| `uint64_t` | INTEGER | `bind_int64()` (cast) | `extract_int64()` (cast) |
-| `unsigned long` | INTEGER | `bind_int64()` (cast) | `extract_int64()` (cast) |
-| `unsigned long long` | INTEGER | `bind_int64()` (cast) | `extract_int64()` (cast) |
+| `uint64_t` | INTEGER | `bind_int64()` (cast ⚠️) | `extract_int64()` (cast ⚠️) |
+| `unsigned long` | INTEGER | `bind_int64()` (cast ⚠️) | `extract_int64()` (cast ⚠️) |
+| `unsigned long long` | INTEGER | `bind_int64()` (cast ⚠️) | `extract_int64()` (cast ⚠️) |
+
+> ⚠️ **Signed storage caveat for 64-bit unsigned types (#419).** Neither SQLite
+> nor PostgreSQL has an unsigned 64-bit integer type. Storm maps `uint64_t` /
+> `unsigned long` / `unsigned long long` to a **signed** 8-byte column (`INTEGER`
+> on SQLite, `BIGINT` on PostgreSQL) and casts to `std::int64_t` at bind time.
+>
+> - **Values ≤ `INT64_MAX` (`9223372036854775807`, i.e. 2⁶³−1) are exact** — no caveat.
+> - **Values > `INT64_MAX` (the upper half of the unsigned range) are stored as a
+>   negative `int64`** (two's-complement reinterpretation). For such values:
+>   1. **Equality still round-trips.** A `SELECT` through Storm casts the stored
+>      signed bits back to unsigned, recovering the original value, so `WHERE col = v`
+>      and reading the field both work.
+>   2. **Ordering is wrong.** `ORDER BY`, `>`, `<`, `BETWEEN` sort by the *signed*
+>      interpretation, so a `uint64` of `2⁶³ + 1` sorts **before** `1`.
+>   3. **External readers see a negative number.** Raw SQL, a BI/report tool, or
+>      another application querying the column directly sees the signed value, not
+>      the intended unsigned one. (PostgreSQL `BIGINT` would also *reject* the true
+>      unsigned value with `bigint out of range`; Storm avoids that error only
+>      because it pre-casts to signed.)
+>
+> **Recommendation:** if you need the full unsigned 64-bit range *with* correct
+> ordering and external readability, store the value as `TEXT` (zero-padded) or a
+> `BLOB` you compare/sort yourself, rather than the native integer column. This
+> behavior is identical on SQLite and PostgreSQL and is pinned by
+> `Uint64SignedStorageTest` in `tests/schema/test_types.cpp`.
 
 **Usage:**
 ```cpp

--- a/shared/models.h
+++ b/shared/models.h
@@ -72,6 +72,7 @@ struct ExtendedTypes {
     float approx{};
     unsigned int u_int{};
     long long ll_signed{};
+    std::uint64_t big_unsigned{}; // 64-bit unsigned — stored as signed int64 (#419)
     std::optional<double> opt_double;
     std::optional<int64_t> opt_int64;
     std::string label;

--- a/tests/schema/test_types.cpp
+++ b/tests/schema/test_types.cpp
@@ -1842,5 +1842,77 @@ TEST(PgDialectTypesSchemaTest, OptionalSpecialTypesSqliteUnchanged) {
     EXPECT_NE(sql.find("opt_bool INTEGER"), std::string::npos) << "SQLite should use INTEGER for opt bool: " << sql;
 }
 
+// ===== 64-BIT UNSIGNED SIGNED-STORAGE CAVEAT TESTS (#419) =====
+//
+// uint64_t / unsigned long / unsigned long long are bound and stored as a signed
+// int64 (SQLite has no unsigned integer; PostgreSQL maps them to BIGINT, also
+// signed). For values <= INT64_MAX everything is exact. For values > INT64_MAX the
+// value wraps to a negative int64 on write. It still round-trips for EQUALITY
+// (the read casts the signed bits back to unsigned), but:
+//   1. ORDER BY / range comparisons sort by the signed reinterpretation, so a huge
+//      uint64 (>= 2^63) sorts *before* a small one.
+//   2. Any external reader (raw SQL, BI tool) sees the negative signed value.
+// These tests PIN that behavior so it is intentional, not accidental. See
+// docs/reference/FIELD_TYPES.md "Signed storage caveat for 64-bit unsigned types".
+
+template <typename ConnType> class Uint64SignedStorageTest : public StormTestFixture<ExtendedTypes, ConnType> {};
+TYPED_TEST_SUITE(Uint64SignedStorageTest, DatabaseTypes);
+
+// A uint64 > INT64_MAX round-trips for EQUALITY: the read casts the stored signed
+// bits back to unsigned, recovering the exact value.
+TYPED_TEST(Uint64SignedStorageTest, ValueAboveInt64MaxRoundTripsForEquality) {
+    constexpr std::uint64_t            above_max = (std::uint64_t{1} << 63) + 1; // 2^63 + 1 > INT64_MAX
+    QuerySet<ExtendedTypes, TypeParam> qs;
+
+    auto result = qs.insert(ExtendedTypes{.big_unsigned = above_max, .label = "above_max"}).execute();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+
+    auto selected = qs.select().execute();
+    ASSERT_TRUE(selected.has_value()) << selected.error().message();
+    ASSERT_EQ(selected.value().size(), 1);
+    EXPECT_EQ(selected.value().begin()->big_unsigned, above_max);
+}
+
+// The full unsigned 64-bit max also round-trips for equality.
+TYPED_TEST(Uint64SignedStorageTest, Uint64MaxRoundTripsForEquality) {
+    constexpr std::uint64_t            u64_max = std::numeric_limits<std::uint64_t>::max();
+    QuerySet<ExtendedTypes, TypeParam> qs;
+
+    auto result = qs.insert(ExtendedTypes{.big_unsigned = u64_max, .label = "u64_max"}).execute();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+
+    auto selected = qs.select().execute();
+    ASSERT_TRUE(selected.has_value()) << selected.error().message();
+    EXPECT_EQ(selected.value().begin()->big_unsigned, u64_max);
+}
+
+// DOCUMENTED TRAP: ORDER BY sorts by the SIGNED interpretation. A uint64 >= 2^63 is
+// stored as a negative int64, so it sorts BEFORE a small value — the opposite of
+// unsigned order. This is intentional given signed storage (#419).
+TYPED_TEST(Uint64SignedStorageTest, OrderBySortsBySignedInterpretation) {
+    constexpr std::uint64_t            above_max = (std::uint64_t{1} << 63) + 1; // huge: stored negative
+    constexpr std::uint64_t            small     = 1;                            // stored as +1
+    QuerySet<ExtendedTypes, TypeParam> qs;
+
+    auto result = qs.insert(std::vector<ExtendedTypes>{
+                                    {.big_unsigned = above_max, .label = "huge"},
+                                    {.big_unsigned = small, .label = "small"},
+                            })
+                          .execute();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+
+    // ORDER BY big_unsigned ASC. By unsigned value, "small" (1) < "huge" (2^63+1),
+    // so "small" should come first. But signed storage flips it: the huge value is
+    // a negative int64, so "huge" sorts FIRST. We pin the (wrong-for-unsigned) order.
+    auto selected = qs.template order_by<^^ExtendedTypes::big_unsigned>().select().execute();
+    ASSERT_TRUE(selected.has_value()) << selected.error().message();
+    ASSERT_EQ(selected.value().size(), 2);
+    auto it = selected.value().begin();
+    // uint64 >= 2^63 sorts first (signed storage), not last.
+    EXPECT_EQ(it->label, "huge");
+    ++it;
+    EXPECT_EQ(it->label, "small");
+}
+
 // NOLINTEND(readability-identifier-length,readability-uppercase-literal-suffix,modernize-use-std-numbers)
 // NOLINTEND(misc-const-correctness)


### PR DESCRIPTION
## What

Documents the inherent signed-storage limitation of 64-bit unsigned field types and pins the behavior with tests on both backends.

`uint64_t` / `unsigned long` / `unsigned long long` bind and store as a **signed** int64 (SQLite `INTEGER`, PostgreSQL `BIGINT` — both signed 8-byte). Values > `INT64_MAX` wrap to a negative int64:

1. **Equality round-trips** — the read casts the stored signed bits back to unsigned.
2. **Ordering is wrong** — `ORDER BY` / `>` / `<` / `BETWEEN` sort by the signed interpretation, so a `uint64` of `2^63 + 1` sorts *before* `1`.
3. **External readers see a negative number.**

## Verification (empirical, both backends)

Confirmed on real SQLite **and** real PostgreSQL that the behavior is identical. PostgreSQL's `BIGINT` is no escape hatch — it is also signed and `ERROR: bigint out of range` on the true unsigned value; Storm avoids that only by pre-casting to signed. (PG's `NUMERIC` could hold the full range, but Storm does not map to it.)

## Decision

**Document (Option 1)** — the issue's recommendation. A `static_assert` would break existing valid uses ≤ `INT64_MAX`; an order-preserving encoding changes the on-disk format and external readability. An opt-in encoding can be a follow-up if demanded.

## Changes

- `docs/reference/FIELD_TYPES.md` — signed-storage caveat + TEXT/BLOB recommendation for the full unsigned range.
- `tests/schema/test_types.cpp` — `Uint64SignedStorageTest`: round-trip for `2^63+1` and `uint64_max`, plus an `ORDER BY` signed-interpretation pin. Passes on SQLite + PostgreSQL, clean under ASAN+UBSAN.
- `shared/models.h` — added `ExtendedTypes::big_unsigned` (`std::uint64_t`) test field.

Closes #419

🤖 Generated with [Claude Code](https://claude.com/claude-code)