### PR TITLE
refactor(orm): split UpdateStatement + BaseStatement to clear S1448 (#434)

### DIFF
--- a/.claude/agents/dev.md
+++ b/.claude/agents/dev.md
@@ -20,7 +20,7 @@ When implementing features:
    - Bulk SQL when batch ≤ `999/field_count`; chunked transactions for larger batches
    - `SMALL_THRESHOLD=10`: always bulk SQL for very small batches
    - `FALLBACK_BATCH_SIZE=50`: safe minimum constant in the adaptive algorithm
-6. Use `execute_with_transaction()` from BaseStatement for transaction management
+6. Use `TransactionGuard` (`storm::begin(conn)`) for transaction management — cooperative with batch ops (#415)
 7. Cache SQL strings using static methods like `get_insert_sql()`
 8. Handle `SQLITE_MAX_VARIABLE_NUMBER` (999) in all batch operations
 

--- a/.claude/agents/perf.md
+++ b/.claude/agents/perf.md
@@ -29,7 +29,7 @@ You are the performance specialist for Storm ORM, with expertise in benchmarking
   - `FALLBACK_BATCH_SIZE=50`: safe minimum constant in adaptive algorithm
 - **DELETE**: IN clause chunking — max chunk = `(999 * 4) / 5 = 799` (80% of SQLite limit)
 - Respect `SQLITE_MAX_VARIABLE_NUMBER` (999) in all batch operations
-- Wrap large batches in explicit transactions via `execute_with_transaction()`
+- Wrap large batches in explicit transactions via `TransactionGuard` (`storm::begin(conn)`)
 
 ### 3. SQL Generation Review
 - Prefer static SQL generation using `std::format` (no constexpr due to compiler limitations)

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -33,7 +33,7 @@ You are a senior C++ code reviewer specializing in the Storm ORM project, with d
 
 ### 4. BaseStatement Consolidation
 - New statement classes inherit from `BaseStatement<T>`
-- Common execution patterns use `execute_with_transaction()` from BaseStatement
+- Batch transactions use `TransactionGuard` (`storm::begin(conn)`), not raw BEGIN/COMMIT
 - SQL string caching via static methods like `get_insert_sql()`
 - Minimize code duplication through shared binding helpers
 

--- a/docs/architecture/OVERVIEW.md
+++ b/docs/architecture/OVERVIEW.md
@@ -83,9 +83,12 @@ src/
     ├── utilities.cppm              # ConstexprString, SQLCache
     └── statements/
         ├── base.cppm               # BaseStatement utilities
+        ├── extract.cppm            # ColumnExtractor — row→value converters (#434)
+        ├── field_names.cppm        # FieldNameGrammar — column-list SQL builders (#434)
         ├── insert.cppm             # InsertStatement
         ├── select.cppm             # SelectStatement + JOIN
         ├── update.cppm             # UpdateStatement
+        ├── update_grammar.cppm     # UpdateGrammar — UPDATE SQL builders (#434)
         ├── erase.cppm              # EraseStatement
         └── join.cppm               # JoinStatement (SQL builder)
 ```

--- a/docs/development/ADDING_FEATURES.md
+++ b/docs/development/ADDING_FEATURES.md
@@ -224,12 +224,13 @@ auto bind_all(Statement& stmt, const T& obj, std::index_sequence<Is...>) {
 ### Transaction Wrapping
 
 ```cpp
-auto execute_batch(std::span<const T> objects) {
-    return Base::execute_with_transaction([&]() {
-        for (const auto& obj : objects) {
-            execute_single(obj);
-        }
-    });
+auto execute_batch(std::span<const T> objects) -> std::expected<void, Error> {
+    auto txn = TransactionGuard<ConnType>::begin(conn_);   // RAII; auto-ROLLBACK on early return
+    if (!txn) return std::unexpected(txn.error());
+    for (const auto& obj : objects) {
+        if (auto r = execute_single(obj); !r) return r;    // guard rolls back on scope exit
+    }
+    return txn->commit();
 }
 ```
 

--- a/docs/development/COMMON_TASKS.md
+++ b/docs/development/COMMON_TASKS.md
@@ -80,7 +80,7 @@ for (int i = 0; i < 100; ++i) {
 
 ## Optimizing Statement Performance
 
-1. **Use BaseStatement utilities**: `execute_with_transaction()`, shared binding
+1. **Use shared utilities**: `TransactionGuard` (`storm::begin`) for batch transactions, BaseStatement shared binding
 2. **Implement compile-time field binding** with index sequences and fold expressions
 3. **Smart thresholds**: Consider SQLite variable limit (999)
 4. **Cache SQL strings**: Static methods + thread-local caching

--- a/docs/development/PERFORMANCE_TIPS.md
+++ b/docs/development/PERFORMANCE_TIPS.md
@@ -110,10 +110,12 @@ if (success) {
 Nested lambdas add overhead from captures, indirect calls, and inlining barriers:
 
 ```cpp
-// ❌ SLOW: Nested lambdas (90% efficiency)
-execute_with_transaction(conn, true,
+// ❌ SLOW: Nested-lambda monadic wrappers (90% efficiency).
+// (The old execute_with_transaction/execute_with_statement helpers that encoded
+//  this shape were removed in #434 once every caller had moved to flat code.)
+prepare_and_transact(conn, true,
     [this, objects]() {                          // Lambda 1: captures
-        return execute_with_statement(conn, sql,
+        return run_with_statement(conn, sql,
             [this, objects](auto& stmt) {        // Lambda 2: captures again
                 for (...) { ... }
             });

--- a/src/orm/statements/aggregate.cppm
+++ b/src/orm/statements/aggregate.cppm
@@ -13,6 +13,7 @@ import std;
 
 import storm_db_concept;
 import storm_orm_statements_base;
+import storm_orm_statements_extract;
 import storm_orm_statements_join;
 import storm_orm_statements_orderby;
 import storm_orm_utilities;
@@ -386,13 +387,10 @@ export namespace storm::orm::statements {
             ResultType result;
             // LCOV_EXCL_START — if constexpr: only one branch instantiated per NumOps
             if constexpr (NumOps == 1) {
-                result = Base::template extract_column_value<ResultType>(stmt, 0);
+                result = ColumnExtractor::template extract_column_value<ResultType>(stmt, 0);
             } else {
-                result = ResultType{
-                        Base::template extract_column_value<OpResult<std::tuple_element_t<Is, std::tuple<Ops...>>>>(
-                                stmt, Is
-                        )...
-                };
+                result = ResultType{ColumnExtractor::template extract_column_value<
+                        OpResult<std::tuple_element_t<Is, std::tuple<Ops...>>>>(stmt, Is)...};
             }
             // LCOV_EXCL_STOP
 
@@ -406,10 +404,9 @@ export namespace storm::orm::statements {
                 Statement* stmt, std::index_sequence<GIs...> /*unused*/, std::index_sequence<AIs...> /*unused*/
         ) -> GroupedTuple {
             return GroupedTuple{
-                    Base::template extract_column_value<typename GroupFieldType<GIs>::type>(stmt, GIs)...,
-                    Base::template extract_column_value<OpResult<std::tuple_element_t<AIs, std::tuple<Ops...>>>>(
-                            stmt, NumGroupFields + AIs
-                    )...
+                    ColumnExtractor::template extract_column_value<typename GroupFieldType<GIs>::type>(stmt, GIs)...,
+                    ColumnExtractor::template extract_column_value<
+                            OpResult<std::tuple_element_t<AIs, std::tuple<Ops...>>>>(stmt, NumGroupFields + AIs)...
             };
         }
 
@@ -564,13 +561,10 @@ export namespace storm::orm::statements {
             }
 
             if constexpr (NumOps == 1) {
-                return Base::template extract_column_value<ResultType>(stmt, 0);
+                return ColumnExtractor::template extract_column_value<ResultType>(stmt, 0);
             } else {
-                return ResultType{
-                        Base::template extract_column_value<OpResult<std::tuple_element_t<Is, std::tuple<Ops...>>>>(
-                                stmt, Is
-                        )...
-                };
+                return ResultType{ColumnExtractor::template extract_column_value<
+                        OpResult<std::tuple_element_t<Is, std::tuple<Ops...>>>>(stmt, Is)...};
             }
         }
 

--- a/src/orm/statements/base.cppm
+++ b/src/orm/statements/base.cppm
@@ -1,7 +1,8 @@
 module;
 
 // Single cohesive class template; thresholds intentionally relaxed (see #264 finding).
-// `duplicate` removed in #277 Phase 3 (for_each_field_name + bind_bulk_objects_impl + bind_expr_or_reset helpers).
+// `duplicate` removed in #277 Phase 3 (bind_bulk_objects_impl + bind_expr_or_reset helpers; the
+// for_each_field_name dedup now lives in storm_orm_statements_field_names, #434).
 
 #include <meta>
 
@@ -12,6 +13,8 @@ import std;
 import storm_db_concept;
 import storm_orm_field_attr;
 import storm_orm_utilities;
+import storm_orm_statements_extract;
+import storm_orm_statements_field_names;
 import storm_orm_statements_orderby;
 import storm_orm_where;
 
@@ -341,8 +344,7 @@ export namespace storm::orm::statements {
     // Shared reflection utilities for all statement types
     template <typename T>
         requires ModelWithPrimaryKey<T>
-    class BaseStatement { // NOSONAR(cpp:S1448) - statement base centralises all shared reflection utilities; splitting
-                          // would scatter compile-time SQL logic
+    class BaseStatement {
       public:
         // Compile-time accessor for table name (used in SQL generation)
         static consteval auto get_table_name() -> std::string_view {
@@ -465,78 +467,11 @@ export namespace storm::orm::statements {
             return result;
         }
 
-        // Shared iterator over data members, honouring SkipPrimaryKey, invoking
-        // `body(i, is_fk, name)` per emitted field. The size-calculator and the
-        // list-builder used to spell out this loop independently.
-        template <bool SkipPrimaryKey, typename Body> static consteval auto for_each_field_name(Body body) -> void {
-            bool first = true;
-            for (std::size_t i = 0; i < field_count_; ++i) {
-                if constexpr (SkipPrimaryKey) {
-                    if (all_members_[i] == primary_key_) {
-                        continue;
-                    }
-                }
-                auto       field_attr = std::meta::annotation_of_type<meta::FieldAttr>(all_members_[i]);
-                bool const is_fk      = field_attr.has_value() && field_attr.value() == meta::FieldAttr::fk;
-                body(i, is_fk, !first);
-                first = false;
-            }
-        }
-
-        // Unified field name size calculation at compile-time
-        // Template parameter controls whether to skip primary key (for INSERT vs SELECT)
-        template <bool SkipPrimaryKey> static consteval auto calculate_field_names_size_impl() -> std::size_t {
-            std::size_t size = 0;
-            for_each_field_name<SkipPrimaryKey>([&](std::size_t i, bool is_fk, bool needs_comma) {
-                if (needs_comma) {
-                    size += 2; // ", "
-                }
-                size += std::meta::identifier_of(all_members_[i]).size();
-                if (is_fk) {
-                    size += 3; // "_id"
-                }
-            });
-            return size;
-        }
-
-        // Calculate size of all field names string at compile-time
-        static consteval auto calculate_field_names_size() -> std::size_t {
-            return calculate_field_names_size_impl<false>();
-        }
-
-        // Calculate size of non-PK field names string at compile-time
-        static consteval auto calculate_non_pk_field_names_size() -> std::size_t {
-            return calculate_field_names_size_impl<true>();
-        }
-
-        // Unified field name list builder at compile-time
-        // Template parameter controls whether to skip primary key (for INSERT vs SELECT)
-        template <bool SkipPrimaryKey> static consteval auto build_field_names_list_impl() {
-            constexpr std::size_t size = calculate_field_names_size_impl<SkipPrimaryKey>() + 10;
-            ConstexprString<size> result;
-            for_each_field_name<SkipPrimaryKey>([&](std::size_t i, bool is_fk, bool needs_comma) {
-                if (needs_comma) {
-                    result.append(", ");
-                }
-                result.append(std::meta::identifier_of(all_members_[i]));
-                if (is_fk) {
-                    result.append("_id");
-                }
-            });
-            return result;
-        }
-
-        // Build comma-separated list of all field names (for SELECT statements)
-        // FK fields are mapped to their column names (User sender → sender_id)
-        static consteval auto build_all_field_names_list() {
-            return build_field_names_list_impl<false>();
-        }
-
-        // Build comma-separated list of NON-PRIMARY KEY fields (for INSERT statements)
-        // Excludes primary key to allow auto-increment
-        static consteval auto build_non_pk_field_names_list() {
-            return build_field_names_list_impl<true>();
-        }
+        // Field-name SQL grammar (#434): for_each_field_name + the size-calculators and
+        // list-builders that produce "col1, col2, fk_id, ..." now live in
+        // FieldNameGrammar<BaseStatement>. INSERT/SELECT call it directly; this class uses
+        // it only to seed field_names_array_ below.
+        using FieldNames = FieldNameGrammar<BaseStatement>;
 
       public:
         // Pre-computed field information - made public for QuerySet and JOIN optimization
@@ -547,7 +482,7 @@ export namespace storm::orm::statements {
         // loosened, instead of producing UB at the divide.
         static_assert(field_count_ >= 1, "A model must have at least one field (its primary key)");
         static constexpr auto           all_members_       = get_all_field_members<field_count_>();
-        static constexpr auto           field_names_array_ = build_all_field_names_list();
+        static constexpr auto           field_names_array_ = FieldNames::build_all_field_names_list();
         static inline const std::string field_names_       = std::string(field_names_array_);
 
         // True if T has any auto_create/auto_update field (#209). Gates the per-operation
@@ -797,182 +732,6 @@ export namespace storm::orm::statements {
             );
         }
 
-        // ---- Storage-class predicates ---------------------------------------------------
-        // Each predicate groups the source types that share one extract_* backend call.
-        // Used by extract_column_value() to dispatch by storage class, not by source type.
-
-        template <typename FT>
-        static constexpr bool is_int_stored_v =
-                std::is_same_v<FT, int> || std::is_same_v<FT, short> || std::is_same_v<FT, unsigned short> ||
-                std::is_same_v<FT, unsigned int> || std::is_same_v<FT, signed char> ||
-                std::is_same_v<FT, unsigned char> || std::is_same_v<FT, char>;
-
-        template <typename FT>
-        static constexpr bool is_int64_stored_v =
-                std::is_same_v<FT, std::int64_t> || std::is_same_v<FT, long> || std::is_same_v<FT, long long> ||
-                std::is_same_v<FT, std::uint64_t> || std::is_same_v<FT, unsigned long> ||
-                std::is_same_v<FT, unsigned long long>;
-
-        template <typename FT> static constexpr bool is_integer_stored_v = is_int_stored_v<FT> || is_int64_stored_v<FT>;
-
-        template <typename FT>
-        static constexpr bool is_floating_stored_v = std::is_same_v<FT, double> || std::is_same_v<FT, float>;
-
-        template <typename FT>
-        static constexpr bool is_blob_stored_v =
-                std::is_same_v<FT, std::vector<std::uint8_t>> || std::is_same_v<FT, std::vector<unsigned char>> ||
-                std::is_same_v<FT, std::vector<std::byte>>;
-
-        template <typename FT>
-        static constexpr bool is_text_stored_v = std::is_same_v<FT, std::chrono::year_month_day> ||
-                                                 std::is_same_v<FT, std::chrono::system_clock::time_point> ||
-                                                 std::is_same_v<FT, std::filesystem::path> ||
-                                                 std::is_same_v<FT, utilities::UUID> || std::is_same_v<FT, std::string>;
-
-        // ---- Storage-class extraction helpers --------------------------------------------
-        // Each helper handles one storage class. extract_column_value() dispatches to
-        // exactly one helper per FieldType. All marked always_inline so the call site
-        // collapses to the same machine code as the inlined branch did before.
-
-        template <typename Statement>
-        [[nodiscard]] __attribute__((always_inline)) static auto read_text_view(Statement* stmt, int col_idx) noexcept
-                -> std::string_view {
-            const unsigned char* text = stmt->extract_text_ptr(col_idx);
-            if (text == nullptr) {
-                return {};
-            }
-            return std::string_view(reinterpret_cast<const char*>(text), stmt->extract_bytes(col_idx));
-        }
-
-        template <typename FieldType, typename Statement>
-        [[nodiscard]] __attribute__((always_inline)) static auto extract_int_like(Statement* stmt, int col_idx) noexcept
-                -> FieldType {
-            if constexpr (is_int_stored_v<FieldType>) {
-                return static_cast<FieldType>(stmt->extract_int(col_idx));
-            } else {
-                static_assert(is_int64_stored_v<FieldType>, "extract_int_like: caller must pre-check storage class");
-                return static_cast<FieldType>(stmt->extract_int64(col_idx));
-            }
-        }
-
-        template <typename FieldType, typename Statement>
-        [[nodiscard]] __attribute__((always_inline)) static auto
-        extract_floating_like(Statement* stmt, int col_idx) noexcept -> FieldType {
-            if constexpr (std::is_same_v<FieldType, double>) {
-                return stmt->extract_double(col_idx);
-            } else {
-                static_assert(
-                        std::is_same_v<FieldType, float>, "extract_floating_like: caller must pre-check storage class"
-                );
-                return stmt->extract_float(col_idx);
-            }
-        }
-
-        template <typename FieldType, typename Statement>
-        [[nodiscard]] __attribute__((always_inline)) static auto extract_enum(Statement* stmt, int col_idx) noexcept
-                -> FieldType {
-            using Underlying = std::underlying_type_t<FieldType>;
-            if constexpr (sizeof(Underlying) <= sizeof(int)) {
-                return static_cast<FieldType>(stmt->extract_int(col_idx));
-            } else {
-                return static_cast<FieldType>(stmt->extract_int64(col_idx));
-            }
-        }
-
-        template <typename FieldType, typename Statement>
-        [[nodiscard]] __attribute__((always_inline)) static auto
-        extract_text_like(Statement* stmt, int col_idx) noexcept -> FieldType {
-            const std::string_view view = read_text_view(stmt, col_idx);
-            if constexpr (std::is_same_v<FieldType, std::chrono::year_month_day>) {
-                // LCOV_EXCL_START — NOT NULL column, defensive fallback for empty text
-                if (view.empty()) {
-                    return FieldType{};
-                }
-                // LCOV_EXCL_STOP
-                return utilities::chrono_conv::string_to_ymd(view);
-            } else if constexpr (std::is_same_v<FieldType, std::chrono::system_clock::time_point>) {
-                // LCOV_EXCL_START — NOT NULL column, defensive fallback for empty text
-                if (view.empty()) {
-                    return FieldType{};
-                }
-                // LCOV_EXCL_STOP
-                return utilities::chrono_conv::string_to_tp(view);
-            } else if constexpr (std::is_same_v<FieldType, std::filesystem::path>) {
-                // LCOV_EXCL_START — NOT NULL column, defensive fallback for empty text
-                if (view.empty()) {
-                    return FieldType{};
-                }
-                // LCOV_EXCL_STOP
-                return std::filesystem::path(std::string(view));
-            } else if constexpr (std::is_same_v<FieldType, utilities::UUID>) {
-                // LCOV_EXCL_START — NOT NULL column, defensive fallback for empty text
-                if (view.empty()) {
-                    return FieldType{};
-                }
-                // LCOV_EXCL_STOP
-                return utilities::UUID{std::string(view)};
-            } else {
-                static_assert(std::is_same_v<FieldType, std::string>, "extract_text_like: unhandled text storage type");
-                return FieldType(view);
-            }
-        }
-
-        template <typename FieldType, typename Statement>
-        [[nodiscard]] __attribute__((always_inline)) static auto
-        extract_blob_like(Statement* stmt, int col_idx) noexcept -> FieldType {
-            const void* blob = stmt->extract_blob_ptr(col_idx);
-            const int   size = stmt->extract_bytes(col_idx);
-            if (blob == nullptr || size <= 0) {
-                return FieldType{};
-            }
-            using Byte       = typename FieldType::value_type;
-            const auto* data = static_cast<const Byte*>(blob);
-            return FieldType(data, data + size);
-        }
-
-      public:
-        // Shared column extraction utility — returns value of specified type from given
-        // column index. Dispatches by storage class to one of the extract_* helpers above.
-        // Supported FieldType groups: optional<T>, bool, int-stored ints, int64-stored
-        // ints, enum, double, float, chrono duration, text-stored types, blob-stored types.
-        // Public so the free two-query join helpers (join.cppm, #398) can extract rows.
-        template <typename FieldType, typename Statement>
-        [[nodiscard]] __attribute__((always_inline)) static auto
-        extract_column_value(Statement* stmt, int col_idx) noexcept -> FieldType {
-            if constexpr (utilities::is_optional_v<FieldType>) {
-                using InnerType = typename FieldType::value_type;
-                if (stmt->is_null(col_idx)) {
-                    return std::nullopt;
-                }
-                return FieldType{extract_column_value<InnerType>(stmt, col_idx)};
-            } else if constexpr (std::is_same_v<FieldType, bool>) {
-                return stmt->extract_bool(col_idx);
-            } else if constexpr (is_integer_stored_v<FieldType>) {
-                return extract_int_like<FieldType>(stmt, col_idx);
-            } else if constexpr (std::is_enum_v<FieldType>) {
-                return extract_enum<FieldType>(stmt, col_idx);
-            } else if constexpr (is_floating_stored_v<FieldType>) {
-                return extract_floating_like<FieldType>(stmt, col_idx);
-            } else if constexpr (utilities::is_chrono_duration_v<FieldType>) {
-                return FieldType{static_cast<typename FieldType::rep>(stmt->extract_int64(col_idx))};
-            } else if constexpr (is_text_stored_v<FieldType>) {
-                return extract_text_like<FieldType>(stmt, col_idx);
-            } else if constexpr (is_blob_stored_v<FieldType>) {
-                return extract_blob_like<FieldType>(stmt, col_idx);
-            } else {
-                // FieldType-dependent false so the assertion only fires when this
-                // branch is selected (i.e. when none of the supported groups matched).
-                static_assert(
-                        !std::is_same_v<FieldType, FieldType>,
-                        "Unsupported field type for column extraction. Supported types: "
-                        "int, int64_t, long, short, char, unsigned variants, enum, "
-                        "float, double, bool, std::string, chrono types, "
-                        "filesystem::path, UUID, std::optional<T>, "
-                        "std::vector<uint8_t>, std::vector<std::byte>"
-                );
-            }
-        }
-
       protected:
         // =====================================================================
         // COLUMN EXTRACTION HELPERS - Moved here from SelectStatement so that
@@ -991,7 +750,7 @@ export namespace storm::orm::statements {
                 obj.[:member:] = std::nullopt;
             } else {
                 InnerFKType fk_inner{};
-                fk_inner.[:fk_pk_member:] = extract_column_value<PKType>(stmt, Index);
+                fk_inner.[:fk_pk_member:] = ColumnExtractor::extract_column_value<PKType>(stmt, Index);
                 obj.[:member:]            = std::move(fk_inner);
             }
         }
@@ -1010,10 +769,10 @@ export namespace storm::orm::statements {
                         obj.[:member:]              = FieldType{};
                         constexpr auto fk_pk_member = find_fk_primary_key<FieldType>();
                         using PKType                = std::remove_cvref_t<decltype(obj.[:member:].[:fk_pk_member:])>;
-                        obj.[:member:].[:fk_pk_member:] = extract_column_value<PKType>(stmt, Index);
+                        obj.[:member:].[:fk_pk_member:] = ColumnExtractor::extract_column_value<PKType>(stmt, Index);
                     }
                 } else {
-                    obj.[:member:] = extract_column_value<FieldType>(stmt, Index);
+                    obj.[:member:] = ColumnExtractor::extract_column_value<FieldType>(stmt, Index);
                 }
             }
         }
@@ -1029,140 +788,6 @@ export namespace storm::orm::statements {
         template <typename Statement>
         __attribute__((always_inline)) static void extract_all_columns(Statement* stmt, T& obj) noexcept {
             extract_all_columns_impl(stmt, obj, field_indices_t{});
-        }
-
-        // Transaction management utilities
-        template <typename ConnType>
-        [[nodiscard]] static auto begin_transaction(ConnType& conn) noexcept
-                -> std::expected<void, typename ConnType::Error> {
-            return conn.execute("BEGIN TRANSACTION");
-        }
-
-        template <typename ConnType>
-        [[nodiscard]] static auto commit_transaction(ConnType& conn) noexcept
-                -> std::expected<void, typename ConnType::Error> {
-            return conn.execute("COMMIT");
-        }
-
-        template <typename ConnType> static auto rollback_transaction(ConnType& conn) noexcept -> void {
-            (void)conn.execute("ROLLBACK");
-        }
-
-        // Utility to determine if transaction should be used
-        template <typename ContainerType> // NOSONAR(cpp:S6024) - static member needed for access to class template
-                                          // context
-        static constexpr auto should_use_transaction(const ContainerType& container) -> bool {
-            return container.size() > 1;
-        }
-
-        // Unified statement execution logic for cached/non-cached connections
-        template <typename ConnType, typename PrepareFunc, typename BindExecuteFunc>
-        [[nodiscard]] static auto execute_statement(
-                ConnType&                      conn,
-                const std::string&             sql,
-                [[maybe_unused]] PrepareFunc&& prepare_func,
-                BindExecuteFunc&&              bind_execute_func
-        ) noexcept -> decltype(bind_execute_func(std::declval<typename ConnType::Statement>())) {
-            // Use cached prepared statement if available
-            if constexpr (requires { conn.prepare_cached(sql); }) {
-                return conn.prepare_cached(sql).and_then(
-                        [bind_execute_func = std::forward<BindExecuteFunc>(bind_execute_func)](
-                                auto* stmt
-                        ) -> decltype(bind_execute_func(std::declval<typename ConnType::Statement>())) {
-                            return bind_execute_func(*stmt);
-                        }
-                );
-            } else {
-                // Fallback to regular prepare
-                return conn.prepare(sql).and_then(
-                        [bind_execute_func = std::forward<BindExecuteFunc>(bind_execute_func)](
-                                typename ConnType::Statement stmt
-                        ) -> decltype(bind_execute_func(std::move(stmt))) { return bind_execute_func(std::move(stmt)); }
-                );
-            }
-        }
-
-        // Unified transaction wrapper for batch operations
-        template <typename ConnType, typename Operation>
-        [[nodiscard]] static auto
-        execute_with_transaction(ConnType& conn, bool use_transaction, const Operation& op) noexcept -> decltype(op()) {
-            if (!use_transaction) {
-                return op();
-            }
-
-            // Begin transaction with monadic composition
-            return begin_transaction(conn).and_then([&op, &conn]() -> decltype(op()) {
-                auto op_result = op();
-                if (!op_result) {
-                    rollback_transaction(conn);
-                    return op_result;
-                }
-
-                // Commit transaction
-                if (auto commit_result = commit_transaction(conn); !commit_result) {
-                    rollback_transaction(conn);
-                    return std::unexpected(commit_result.error());
-                }
-
-                return op_result;
-            });
-        }
-
-        // Generic helper for executing with cached or non-cached statements
-        template <typename ConnType, typename ExecuteFunc>
-        [[nodiscard]] static auto
-        execute_with_statement(ConnType& conn, const std::string& sql, const ExecuteFunc& execute_func) noexcept
-                -> decltype(execute_func(std::declval<typename ConnType::Statement&>())) {
-            // Try cached statement first if available
-            if constexpr (requires { conn.prepare_cached(sql); }) {
-                return conn.prepare_cached(sql).and_then([&execute_func](auto* stmt) -> decltype(auto) {
-                    return execute_func(*stmt);
-                });
-            } else {
-                // Fallback to regular prepare
-                return conn.prepare(sql).and_then(
-                        [&execute_func](typename ConnType::Statement stmt) mutable -> decltype(auto) {
-                            return execute_func(stmt);
-                        }
-                );
-            }
-        }
-
-        // Monadic helper for bind and execute operations
-        template <typename BindResult, typename Statement>
-        [[nodiscard]] static auto bind_and_execute(BindResult bind_result, Statement& stmt) noexcept -> BindResult {
-            return bind_result.and_then([&stmt]() -> decltype(auto) { return stmt.execute(); });
-        }
-
-        // Monadic helper for reset, bind, and execute sequence
-        template <typename Statement, typename BindFunc>
-        [[nodiscard]] static auto reset_bind_and_execute(Statement& stmt, const BindFunc& bind_func) noexcept
-                -> decltype(bind_func(stmt)) {
-            stmt.reset();
-            return bind_func(stmt).and_then([&stmt]() -> decltype(auto) { return stmt.execute(); });
-        }
-
-        // Dispatch helper for WHERE/JOIN execution paths
-        // Eliminates repeated branching logic in aggregate statements
-        template <typename SimpleF, typename WhereF, typename JoinF, typename WhereJoinF>
-        [[nodiscard]] static auto dispatch_execute(
-                bool              has_join,
-                bool              has_where,
-                const SimpleF&    simple_fn,
-                const WhereF&     where_fn,
-                const JoinF&      join_fn,
-                const WhereJoinF& where_join_fn
-        ) -> decltype(simple_fn()) {
-            if (has_join && has_where) {
-                return where_join_fn();
-            }
-            if (has_join) {
-                return join_fn();
-            }
-            if (has_where) {
-                return where_fn();
-            }
-            return simple_fn();
         }
 
         // =====================================================================

--- a/src/orm/statements/distinct.cppm
+++ b/src/orm/statements/distinct.cppm
@@ -12,6 +12,7 @@ import std;
 
 import storm_db_concept;
 import storm_orm_statements_base;
+import storm_orm_statements_extract;
 import storm_orm_statements_join;
 import storm_orm_statements_orderby;
 import storm_orm_utilities;
@@ -259,14 +260,13 @@ export namespace storm::orm::statements {
             while ((rc = stmt->step_raw()) == Statement::ROW_AVAILABLE) {
                 if constexpr (NumFields == 1) {
                     using FieldType = std::tuple_element_t<0, FieldTypesTuple>;
-                    results.insert(Base::template extract_column_value<FieldType>(stmt, 0));
+                    results.insert(ColumnExtractor::template extract_column_value<FieldType>(stmt, 0));
                 } else {
                     [&]<std::size_t... Is>(std::index_sequence<Is...>) {
                         results.insert(
                                 std::make_tuple(
-                                        Base::template extract_column_value<std::tuple_element_t<Is, FieldTypesTuple>>(
-                                                stmt, Is
-                                        )...
+                                        ColumnExtractor::template extract_column_value<
+                                                std::tuple_element_t<Is, FieldTypesTuple>>(stmt, Is)...
                                 )
                         );
                     }(std::make_index_sequence<NumFields>{});

--- a/src/orm/statements/erase.cppm
+++ b/src/orm/statements/erase.cppm
@@ -423,7 +423,7 @@ export namespace storm::orm::statements {
 
       protected: // Changed to protected so BaseStatement can access
         // Execute large batches using chunked IN clauses
-        // NOTE: Transaction is handled by caller (execute_with_transaction in base.cppm)
+        // NOTE: Transaction is handled by the caller via TransactionGuard (#415).
         // Optimized: pre-cache max bulk statement, only lookup remainder once
         [[nodiscard]] __attribute__((hot)) auto execute_chunked(std::span<const T> objects)
                 -> std::expected<void, Error> {

--- a/src/orm/statements/extract.cppm
+++ b/src/orm/statements/extract.cppm
@@ -1,0 +1,204 @@
+module;
+
+// Column value extraction (#434): the storage-class predicates and extract_* helpers that
+// turn a result-row column into a typed C++ value. Split out of BaseStatement — this logic
+// depends only on the Statement's extract_* API and utilities, never on the model type T,
+// so it is a stateless free utility. Keeping it here lets BaseStatement stay cohesive
+// (cpp:S1448) without scattering the dispatch.
+
+#include <meta>
+
+export module storm_orm_statements_extract;
+
+import std;
+
+import storm_orm_utilities;
+
+export namespace storm::orm::statements {
+
+    // Stateless column extractor. All members are static templates keyed on FieldType /
+    // Statement; there is no per-model state, so a single type serves every statement class.
+    struct ColumnExtractor {
+        // ---- Storage-class predicates ---------------------------------------------------
+        // Each predicate groups the source types that share one extract_* backend call.
+        // Used by extract_column_value() to dispatch by storage class, not by source type.
+
+        template <typename FT>
+        static constexpr bool is_int_stored_v =
+                std::is_same_v<FT, int> || std::is_same_v<FT, short> || std::is_same_v<FT, unsigned short> ||
+                std::is_same_v<FT, unsigned int> || std::is_same_v<FT, signed char> ||
+                std::is_same_v<FT, unsigned char> || std::is_same_v<FT, char>;
+
+        template <typename FT>
+        static constexpr bool is_int64_stored_v =
+                std::is_same_v<FT, std::int64_t> || std::is_same_v<FT, long> || std::is_same_v<FT, long long> ||
+                std::is_same_v<FT, std::uint64_t> || std::is_same_v<FT, unsigned long> ||
+                std::is_same_v<FT, unsigned long long>;
+
+        template <typename FT> static constexpr bool is_integer_stored_v = is_int_stored_v<FT> || is_int64_stored_v<FT>;
+
+        template <typename FT>
+        static constexpr bool is_floating_stored_v = std::is_same_v<FT, double> || std::is_same_v<FT, float>;
+
+        template <typename FT>
+        static constexpr bool is_blob_stored_v =
+                std::is_same_v<FT, std::vector<std::uint8_t>> || std::is_same_v<FT, std::vector<unsigned char>> ||
+                std::is_same_v<FT, std::vector<std::byte>>;
+
+        template <typename FT>
+        static constexpr bool is_text_stored_v = std::is_same_v<FT, std::chrono::year_month_day> ||
+                                                 std::is_same_v<FT, std::chrono::system_clock::time_point> ||
+                                                 std::is_same_v<FT, std::filesystem::path> ||
+                                                 std::is_same_v<FT, utilities::UUID> || std::is_same_v<FT, std::string>;
+
+        // ---- Storage-class extraction helpers --------------------------------------------
+        // Each helper handles one storage class. extract_column_value() dispatches to
+        // exactly one helper per FieldType. All marked always_inline so the call site
+        // collapses to the same machine code as the inlined branch did before.
+
+        template <typename Statement>
+        [[nodiscard]] __attribute__((always_inline)) static auto read_text_view(Statement* stmt, int col_idx) noexcept
+                -> std::string_view {
+            const unsigned char* text = stmt->extract_text_ptr(col_idx);
+            if (text == nullptr) {
+                return {};
+            }
+            return std::string_view(reinterpret_cast<const char*>(text), stmt->extract_bytes(col_idx));
+        }
+
+        // Read an integer column and static_cast it to Target, choosing the 32- vs 64-bit
+        // backend by UseInt32. Shared by the int-stored and enum dispatch paths.
+        template <typename Target, bool UseInt32, typename Statement>
+        [[nodiscard]] __attribute__((always_inline)) static auto read_int_sized(Statement* stmt, int col_idx) noexcept
+                -> Target {
+            if constexpr (UseInt32) {
+                return static_cast<Target>(stmt->extract_int(col_idx));
+            } else {
+                return static_cast<Target>(stmt->extract_int64(col_idx));
+            }
+        }
+
+        template <typename FieldType, typename Statement>
+        [[nodiscard]] __attribute__((always_inline)) static auto extract_int_like(Statement* stmt, int col_idx) noexcept
+                -> FieldType {
+            static_assert(
+                    is_int_stored_v<FieldType> || is_int64_stored_v<FieldType>,
+                    "extract_int_like: caller must pre-check storage class"
+            );
+            return read_int_sized<FieldType, is_int_stored_v<FieldType>>(stmt, col_idx);
+        }
+
+        template <typename FieldType, typename Statement>
+        [[nodiscard]] __attribute__((always_inline)) static auto
+        extract_floating_like(Statement* stmt, int col_idx) noexcept -> FieldType {
+            if constexpr (std::is_same_v<FieldType, double>) {
+                return stmt->extract_double(col_idx);
+            } else {
+                static_assert(
+                        std::is_same_v<FieldType, float>, "extract_floating_like: caller must pre-check storage class"
+                );
+                return stmt->extract_float(col_idx);
+            }
+        }
+
+        template <typename FieldType, typename Statement>
+        [[nodiscard]] __attribute__((always_inline)) static auto extract_enum(Statement* stmt, int col_idx) noexcept
+                -> FieldType {
+            using Underlying = std::underlying_type_t<FieldType>;
+            return read_int_sized<FieldType, (sizeof(Underlying) <= sizeof(int))>(stmt, col_idx);
+        }
+
+        template <typename FieldType, typename Statement>
+        [[nodiscard]] __attribute__((always_inline)) static auto
+        extract_text_like(Statement* stmt, int col_idx) noexcept -> FieldType {
+            const std::string_view view = read_text_view(stmt, col_idx);
+            if constexpr (std::is_same_v<FieldType, std::chrono::year_month_day>) {
+                // LCOV_EXCL_START — NOT NULL column, defensive fallback for empty text
+                if (view.empty()) {
+                    return FieldType{};
+                }
+                // LCOV_EXCL_STOP
+                return utilities::chrono_conv::string_to_ymd(view);
+            } else if constexpr (std::is_same_v<FieldType, std::chrono::system_clock::time_point>) {
+                // LCOV_EXCL_START — NOT NULL column, defensive fallback for empty text
+                if (view.empty()) {
+                    return FieldType{};
+                }
+                // LCOV_EXCL_STOP
+                return utilities::chrono_conv::string_to_tp(view);
+            } else if constexpr (std::is_same_v<FieldType, std::filesystem::path>) {
+                // LCOV_EXCL_START — NOT NULL column, defensive fallback for empty text
+                if (view.empty()) {
+                    return FieldType{};
+                }
+                // LCOV_EXCL_STOP
+                return std::filesystem::path(std::string(view));
+            } else if constexpr (std::is_same_v<FieldType, utilities::UUID>) {
+                // LCOV_EXCL_START — NOT NULL column, defensive fallback for empty text
+                if (view.empty()) {
+                    return FieldType{};
+                }
+                // LCOV_EXCL_STOP
+                return utilities::UUID{std::string(view)};
+            } else {
+                static_assert(std::is_same_v<FieldType, std::string>, "extract_text_like: unhandled text storage type");
+                return FieldType(view);
+            }
+        }
+
+        template <typename FieldType, typename Statement>
+        [[nodiscard]] __attribute__((always_inline)) static auto
+        extract_blob_like(Statement* stmt, int col_idx) noexcept -> FieldType {
+            const void* blob = stmt->extract_blob_ptr(col_idx);
+            const int   size = stmt->extract_bytes(col_idx);
+            if (blob == nullptr || size <= 0) {
+                return FieldType{};
+            }
+            using Byte       = typename FieldType::value_type;
+            const auto* data = static_cast<const Byte*>(blob);
+            return FieldType(data, data + size);
+        }
+
+        // Shared column extraction utility — returns value of specified type from given
+        // column index. Dispatches by storage class to one of the extract_* helpers above.
+        // Supported FieldType groups: optional<T>, bool, int-stored ints, int64-stored
+        // ints, enum, double, float, chrono duration, text-stored types, blob-stored types.
+        template <typename FieldType, typename Statement>
+        [[nodiscard]] __attribute__((always_inline)) static auto
+        extract_column_value(Statement* stmt, int col_idx) noexcept -> FieldType {
+            if constexpr (utilities::is_optional_v<FieldType>) {
+                using InnerType = typename FieldType::value_type;
+                if (stmt->is_null(col_idx)) {
+                    return std::nullopt;
+                }
+                return FieldType{extract_column_value<InnerType>(stmt, col_idx)};
+            } else if constexpr (std::is_same_v<FieldType, bool>) {
+                return stmt->extract_bool(col_idx);
+            } else if constexpr (is_integer_stored_v<FieldType>) {
+                return extract_int_like<FieldType>(stmt, col_idx);
+            } else if constexpr (std::is_enum_v<FieldType>) {
+                return extract_enum<FieldType>(stmt, col_idx);
+            } else if constexpr (is_floating_stored_v<FieldType>) {
+                return extract_floating_like<FieldType>(stmt, col_idx);
+            } else if constexpr (utilities::is_chrono_duration_v<FieldType>) {
+                return FieldType{static_cast<typename FieldType::rep>(stmt->extract_int64(col_idx))};
+            } else if constexpr (is_text_stored_v<FieldType>) {
+                return extract_text_like<FieldType>(stmt, col_idx);
+            } else if constexpr (is_blob_stored_v<FieldType>) {
+                return extract_blob_like<FieldType>(stmt, col_idx);
+            } else {
+                // FieldType-dependent false so the assertion only fires when this
+                // branch is selected (i.e. when none of the supported groups matched).
+                static_assert(
+                        !std::is_same_v<FieldType, FieldType>,
+                        "Unsupported field type for column extraction. Supported types: "
+                        "int, int64_t, long, short, char, unsigned variants, enum, "
+                        "float, double, bool, std::string, chrono types, "
+                        "filesystem::path, UUID, std::optional<T>, "
+                        "std::vector<uint8_t>, std::vector<std::byte>"
+                );
+            }
+        }
+    };
+
+} // namespace storm::orm::statements

--- a/src/orm/statements/field_names.cppm
+++ b/src/orm/statements/field_names.cppm
@@ -1,0 +1,101 @@
+module;
+
+// Compile-time field-name SQL grammar (#434): builds the comma-separated column lists that
+// INSERT and SELECT splice into their statements ("col1, col2, fk_id, ..."). Split out of
+// BaseStatement so that class stays cohesive (cpp:S1448). Stateless — every member derives
+// from the persisted-field reflection BaseStatement already computed (all_members_,
+// primary_key_, field_count_), passed in as the Base template parameter.
+
+#include <meta>
+
+export module storm_orm_statements_field_names;
+
+import std;
+
+import storm_orm_field_attr;
+import storm_orm_utilities;
+
+export namespace storm::orm::statements {
+
+    using storm::orm::utilities::ConstexprString;
+
+    namespace meta {
+        using storm::meta::FieldAttr;
+    }
+
+    template <typename Base> struct FieldNameGrammar {
+        // Shared iterator over data members, honouring SkipPrimaryKey, invoking
+        // `body(i, is_fk, name)` per emitted field. The size-calculator and the
+        // list-builder used to spell out this loop independently.
+        template <bool SkipPrimaryKey, typename Body> static consteval auto for_each_field_name(Body body) -> void {
+            bool first = true;
+            for (std::size_t i = 0; i < Base::field_count_; ++i) {
+                if constexpr (SkipPrimaryKey) {
+                    if (Base::all_members_[i] == Base::primary_key_) {
+                        continue;
+                    }
+                }
+                auto       field_attr = std::meta::annotation_of_type<meta::FieldAttr>(Base::all_members_[i]);
+                bool const is_fk      = field_attr.has_value() && field_attr.value() == meta::FieldAttr::fk;
+                body(i, is_fk, !first);
+                first = false;
+            }
+        }
+
+        // Unified field name size calculation at compile-time
+        // Template parameter controls whether to skip primary key (for INSERT vs SELECT)
+        template <bool SkipPrimaryKey> static consteval auto calculate_field_names_size_impl() -> std::size_t {
+            std::size_t size = 0;
+            for_each_field_name<SkipPrimaryKey>([&](std::size_t i, bool is_fk, bool needs_comma) {
+                if (needs_comma) {
+                    size += 2; // ", "
+                }
+                size += std::meta::identifier_of(Base::all_members_[i]).size();
+                if (is_fk) {
+                    size += 3; // "_id"
+                }
+            });
+            return size;
+        }
+
+        // Calculate size of all field names string at compile-time
+        static consteval auto calculate_field_names_size() -> std::size_t {
+            return calculate_field_names_size_impl<false>();
+        }
+
+        // Calculate size of non-PK field names string at compile-time
+        static consteval auto calculate_non_pk_field_names_size() -> std::size_t {
+            return calculate_field_names_size_impl<true>();
+        }
+
+        // Unified field name list builder at compile-time
+        // Template parameter controls whether to skip primary key (for INSERT vs SELECT)
+        template <bool SkipPrimaryKey> static consteval auto build_field_names_list_impl() {
+            constexpr std::size_t size = calculate_field_names_size_impl<SkipPrimaryKey>() + 10;
+            ConstexprString<size> result;
+            for_each_field_name<SkipPrimaryKey>([&](std::size_t i, bool is_fk, bool needs_comma) {
+                if (needs_comma) {
+                    result.append(", ");
+                }
+                result.append(std::meta::identifier_of(Base::all_members_[i]));
+                if (is_fk) {
+                    result.append("_id");
+                }
+            });
+            return result;
+        }
+
+        // Build comma-separated list of all field names (for SELECT statements)
+        // FK fields are mapped to their column names (User sender → sender_id)
+        static consteval auto build_all_field_names_list() {
+            return build_field_names_list_impl<false>();
+        }
+
+        // Build comma-separated list of NON-PRIMARY KEY fields (for INSERT statements)
+        // Excludes primary key to allow auto-increment
+        static consteval auto build_non_pk_field_names_list() {
+            return build_field_names_list_impl<true>();
+        }
+    };
+
+} // namespace storm::orm::statements

--- a/src/orm/statements/insert.cppm
+++ b/src/orm/statements/insert.cppm
@@ -10,6 +10,7 @@ export module storm_orm_statements_insert;
 import std;
 
 import storm_orm_statements_base;
+import storm_orm_statements_field_names;
 import storm_orm_utilities;
 import storm_orm_transaction;
 import storm_db_concept;
@@ -71,7 +72,7 @@ export namespace storm::orm::statements {
             size += 2; // " ("
 
             // Field names length
-            size += Base::calculate_field_names_size();
+            size += FieldNameGrammar<Base>::calculate_field_names_size();
 
             size += VALUES_OPEN; // ") VALUES ("
 
@@ -95,7 +96,7 @@ export namespace storm::orm::statements {
             result.append("INSERT INTO ");
             result.append(Base::table_name_);
             result.append(" (");
-            result.append(Base::build_non_pk_field_names_list());
+            result.append(FieldNameGrammar<Base>::build_non_pk_field_names_list());
             result.append(") VALUES (");
             result.append(placeholders_);
             if constexpr (WithReturning) {
@@ -125,7 +126,7 @@ export namespace storm::orm::statements {
             size += INSERT_INTO; // "INSERT INTO "
             size += Base::table_name_.size();
             size += 2; // " ("
-            size += Base::calculate_field_names_size();
+            size += FieldNameGrammar<Base>::calculate_field_names_size();
             size += VALUES_OPEN; // ") VALUES "
             size += 1;           // null terminator
             return size;
@@ -139,7 +140,7 @@ export namespace storm::orm::statements {
             result.append("INSERT INTO ");
             result.append(Base::table_name_);
             result.append(" (");
-            result.append(Base::build_non_pk_field_names_list());
+            result.append(FieldNameGrammar<Base>::build_non_pk_field_names_list());
             result.append(") VALUES ");
 
             return result;

--- a/src/orm/statements/join.cppm
+++ b/src/orm/statements/join.cppm
@@ -8,6 +8,7 @@ export module storm_orm_statements_join;
 import std;
 
 import storm_orm_statements_base;
+import storm_orm_statements_extract;
 import storm_orm_statements_orderby;
 import storm_orm_utilities;
 import storm_orm_where;
@@ -126,7 +127,7 @@ export namespace storm::orm::statements {
             }
         }
         InnerFK inner{};
-        inner.[:fk_pk:] = RelatedBase::template extract_column_value<PKType>(stmt, col);
+        inner.[:fk_pk:] = ColumnExtractor::template extract_column_value<PKType>(stmt, col);
         rel.[:Member:]  = std::move(inner);
     }
 
@@ -140,7 +141,7 @@ export namespace storm::orm::statements {
         if constexpr (meta::is_fk_field(member)) {
             extract_relation_fk_column<RelatedBase, Related, FieldType, member>(stmt, rel, col);
         } else {
-            rel.[:member:] = RelatedBase::template extract_column_value<FieldType>(stmt, col);
+            rel.[:member:] = ColumnExtractor::template extract_column_value<FieldType>(stmt, col);
         }
     }
 
@@ -527,7 +528,7 @@ export namespace storm::orm::statements {
                     return;
                 } else {
                     using FieldType = std::remove_cvref_t<decltype(obj.[:member:])>;
-                    obj.[:member:]  = Base::template extract_column_value<FieldType>(stmt, col_idx);
+                    obj.[:member:]  = ColumnExtractor::template extract_column_value<FieldType>(stmt, col_idx);
                     col_idx++;
                 }
             }
@@ -550,7 +551,7 @@ export namespace storm::orm::statements {
             if constexpr (FieldIdx < FKBase::field_count_) {
                 constexpr auto member = FKBase::all_members_[FieldIdx];
                 using FieldType       = std::remove_cvref_t<decltype(fk_obj.[:member:])>;
-                fk_obj.[:member:]     = Base::template extract_column_value<FieldType>(stmt, col_idx);
+                fk_obj.[:member:]     = ColumnExtractor::template extract_column_value<FieldType>(stmt, col_idx);
             }
         }
 

--- a/src/orm/statements/select.cppm
+++ b/src/orm/statements/select.cppm
@@ -13,6 +13,7 @@ import std;
 
 import storm_orm_generator;
 import storm_orm_statements_base;
+import storm_orm_statements_field_names;
 import storm_orm_statements_join;
 import storm_orm_statements_orderby;
 import storm_orm_transaction;
@@ -38,7 +39,7 @@ export namespace storm::orm::statements {
             using utilities::sql_len::SELECT;
             std::size_t size = 0;
             size += SELECT; // "SELECT "
-            size += Base::calculate_field_names_size();
+            size += FieldNameGrammar<Base>::calculate_field_names_size();
             size += FROM; // " FROM "
             size += Base::table_name_.size();
             size += 1; // null terminator
@@ -51,7 +52,7 @@ export namespace storm::orm::statements {
             ConstexprString<sql_size> result;
 
             result.append("SELECT ");
-            result.append(Base::build_all_field_names_list());
+            result.append(FieldNameGrammar<Base>::build_all_field_names_list());
             result.append(" FROM ");
             result.append(Base::table_name_);
 

--- a/src/orm/statements/update.cppm
+++ b/src/orm/statements/update.cppm
@@ -11,6 +11,7 @@ export module storm_orm_statements_update;
 import std;
 
 import storm_orm_statements_base;
+import storm_orm_statements_update_grammar;
 import storm_orm_utilities;
 import storm_orm_transaction;
 import storm_orm_where;
@@ -30,158 +31,16 @@ export namespace storm::orm::statements {
         using Error      = typename ConnType::Error;
         using Statement  = typename ConnType::Statement;
 
-        // Helper to get non-primary-key field count
-        static consteval auto get_updatable_field_count() -> std::size_t {
-            std::size_t count = 0;
-            for (const auto& member : Base::all_members_) {
-                if (member != Base::primary_key_) {
-                    ++count;
-                }
-            }
-            return count;
-        }
-
-        static constexpr std::size_t updatable_field_count_ = get_updatable_field_count();
-
-        // Helper to build field assignments string for UPDATE SQL
-        static consteval auto build_field_assignments() {
-            // Get all members directly
-            auto members = std::meta::nonstatic_data_members_of(^^T, std::meta::access_context::unchecked());
-            auto pk      = Base::primary_key_;
-
-            ConstexprString<utilities::buffer_size::SQL_MEDIUM> result;
-            bool                                                first = true;
-
-            for (const auto& member : members) {
-                if (member != pk) {
-                    if (!first) {
-                        result.append(", ");
-                    }
-                    // Check if this is a FK field
-                    auto field_attr = std::meta::annotation_of_type<meta::FieldAttr>(member);
-                    if (field_attr.has_value() && field_attr.value() == meta::FieldAttr::fk) {
-                        // FK field: use field_name_id
-                        result.append(std::meta::identifier_of(member));
-                        result.append("_id=?");
-                    } else {
-                        result.append(std::meta::identifier_of(member));
-                        result.append("=?");
-                    }
-                    first = false;
-                }
-            }
-
-            return result;
-        }
-
-        static constexpr auto field_assignments_ = build_field_assignments();
-
-        // --- Conditional bulk UPDATE (#403): SET-clause built from explicit member NTTPs ---
-
-        // Index of a member info within Base::all_members_ (compile-time).
-        static consteval auto index_of_member(std::meta::info member) -> std::size_t {
-            for (std::size_t i = 0; i < Base::all_members_.size(); ++i) {
-                if (Base::all_members_[i] == member) {
-                    return i;
-                }
-            }
-            std::unreachable(); // guarded by is_settable_member() at the call site
-        }
-
-        // Each SET target must be a non-static data member of T and not the primary key.
-        template <std::meta::info Member> static consteval auto is_settable_member() -> bool {
-            return std::meta::is_nonstatic_data_member(Member) && Member != Base::primary_key_;
-        }
-
-        // Append "<name>=?" (or "<name>_id=?" for FK fields) for one member.
-        template <typename Buf> static consteval auto append_one_assignment(Buf& buf, std::meta::info member) -> void {
-            buf.append(std::meta::identifier_of(member));
-            auto field_attr = std::meta::annotation_of_type<meta::FieldAttr>(member);
-            if (field_attr.has_value() && field_attr.value() == meta::FieldAttr::fk) {
-                buf.append("_id=?");
-            } else {
-                buf.append("=?");
-            }
-        }
-
-        // Is `member` an auto_update field NOT already present in the explicit pack?
-        template <std::meta::info... Members>
-        static consteval auto is_unlisted_auto_update(std::meta::info member) -> bool {
-            return Base::is_auto_update_field(member) && ((member != Members) && ...);
-        }
-
-        // Build the SET clause for the explicit Members... pack, then append any
-        // auto_update field of T that the caller did not list. The column ORDER
-        // here is the canonical bind order used by bind_conditional_set().
-        template <std::meta::info... Members> static consteval auto build_conditional_set_clause() {
-            ConstexprString<utilities::buffer_size::SQL_MEDIUM> result;
-            bool                                                first = true;
-            // (1) explicit members, in the given order
-            (
-                    [&] {
-                        if (!first) {
-                            result.append(", ");
-                        }
-                        append_one_assignment(result, Members);
-                        first = false;
-                    }(),
-                    ...
-            );
-            // (2) auto_update fields not already listed (stamped now() at bind time)
-            for (const auto& member : Base::all_members_) {
-                if (is_unlisted_auto_update<Members...>(member)) {
-                    if (!first) {
-                        result.append(", ");
-                    }
-                    result.append(std::meta::identifier_of(member));
-                    result.append("=?");
-                    first = false;
-                }
-            }
-            return result;
-        }
-
-        // Compile-time UPDATE SQL size calculation
-        static consteval auto calculate_update_sql_size() -> std::size_t {
-            using utilities::sql_len::SET;
-            using utilities::sql_len::UPDATE;
-            using utilities::sql_len::WHERE;
-            std::size_t size = 0;
-            size += UPDATE; // "UPDATE "
-            size += Base::table_name_.size();
-            size += SET; // " SET "
-            size += field_assignments_.len;
-            size += WHERE; // " WHERE "
-            size += Base::pk_name_.size();
-            size += 4; // " = ?"
-            size += 1; // null terminator
-            return size;
-        }
-
-        // Build UPDATE SQL at compile-time using ConstexprString
-        static consteval auto build_update_sql_array() {
-            constexpr std::size_t     sql_size = calculate_update_sql_size() + utilities::sql_len::LARGE_BUFFER;
-            ConstexprString<sql_size> result;
-
-            result.append("UPDATE ");
-            result.append(Base::table_name_);
-            result.append(" SET ");
-            result.append(std::string_view(field_assignments_.data.data(), field_assignments_.len));
-            result.append(" WHERE ");
-            result.append(Base::pk_name_);
-            result.append(" = ?");
-
-            return result;
-        }
-
-        // Pre-computed UPDATE SQL generated at compile-time
-        static constexpr auto           update_sql_array  = build_update_sql_array();
-        static inline const std::string update_sql_string = std::string(update_sql_array);
+        // Compile-time UPDATE SQL grammar (#434): every "how the SQL is spelled" helper —
+        // build_field_assignments, build_conditional_set_clause, the SQL string, the
+        // is_settable_member/index_of_member/is_unlisted_auto_update reflection predicates —
+        // lives in UpdateGrammar<T>. Split out to keep this class cohesive (cpp:S1448).
+        using Grammar = UpdateGrammar<T>;
 
       private:
         // Generate UPDATE SQL string (compile-time computed, runtime accessible)
         static auto get_update_sql() -> const std::string& {
-            return update_sql_string;
+            return Grammar::update_sql_string;
         }
 
         // std::unexpected returned when update<...>() is called with no WHERE filter,
@@ -197,8 +56,9 @@ export namespace storm::orm::statements {
         // dynamic path — not a compile-time ConstexprString.
         template <std::meta::info... Members>
         static auto build_conditional_update_sql(const orm::where::ExpressionVariant& expr) -> std::string {
-            static const std::string set_clause = std::string(build_conditional_set_clause<Members...>());
-            std::string              sql;
+            static const std::string set_clause =
+                    std::string(Grammar::template build_conditional_set_clause<Members...>());
+            std::string sql;
             sql.reserve(Base::table_name_.size() + set_clause.size() + 32);
             sql += "UPDATE ";
             sql += Base::table_name_;
@@ -213,8 +73,9 @@ export namespace storm::orm::statements {
         // Same SET clause as the conditional path (Members... + unlisted auto_update fields);
         // it just omits the WHERE — the explicit escape hatch mirroring DELETE's delete_all_sql.
         template <std::meta::info... Members> static auto build_update_all_sql() -> std::string {
-            static const std::string set_clause = std::string(build_conditional_set_clause<Members...>());
-            std::string              sql;
+            static const std::string set_clause =
+                    std::string(Grammar::template build_conditional_set_clause<Members...>());
+            std::string sql;
             sql.reserve(Base::table_name_.size() + set_clause.size() + 16);
             sql += "UPDATE ";
             sql += Base::table_name_;
@@ -231,7 +92,7 @@ export namespace storm::orm::statements {
         // execute/to_sql shapes that genuinely differ.
         struct QueryBase {
             [[nodiscard]] static auto sql() -> std::string {
-                return update_sql_string;
+                return Grammar::update_sql_string;
             }
         };
 
@@ -287,7 +148,7 @@ export namespace storm::orm::statements {
         };
 
         template <std::meta::info... Members>
-            requires(sizeof...(Members) > 0 && (is_settable_member<Members>() && ...))
+            requires(sizeof...(Members) > 0 && (Grammar::template is_settable_member<Members>() && ...))
         auto query_where(const T& proto [[clang::lifetimebound]], orm::where::ExpressionVariantPtr where_expr)
                 -> ConditionalUpdateQuery<Members...> {
             return {std::move(*this), proto, std::move(where_expr)};
@@ -307,7 +168,7 @@ export namespace storm::orm::statements {
         };
 
         template <std::meta::info... Members>
-            requires(sizeof...(Members) > 0 && (is_settable_member<Members>() && ...))
+            requires(sizeof...(Members) > 0 && (Grammar::template is_settable_member<Members>() && ...))
         auto query_all(const T& proto [[clang::lifetimebound]]) -> UpdateAllQuery<Members...> {
             return {std::move(*this), proto};
         }
@@ -468,7 +329,7 @@ export namespace storm::orm::statements {
             std::expected<void, Error> result{};
             (
                     [&] {
-                        if constexpr (is_unlisted_auto_update<Members...>(Base::all_members_[Is])) {
+                        if constexpr (Grammar::template is_unlisted_auto_update<Members...>(Base::all_members_[Is])) {
                             if (result.has_value()) {
                                 result = Base::template bind_one<ConnType>(stmt, param_index, now);
                             }
@@ -491,7 +352,7 @@ export namespace storm::orm::statements {
             //     auto_update member is stamped now() (matches single-row UPDATE), and a
             //     listed auto_create member binds the proto's stored value.
             std::expected<void, Error> result{};
-            ((result = Base::template bind_field_at_index<ConnType, index_of_member(Members), false, true>(
+            ((result = Base::template bind_field_at_index<ConnType, Grammar::index_of_member(Members), false, true>(
                       stmt, proto, param_index, now
               ),
               result.has_value()) &&

--- a/src/orm/statements/update_grammar.cppm
+++ b/src/orm/statements/update_grammar.cppm
@@ -1,0 +1,168 @@
+module;
+
+// Compile-time UPDATE SQL grammar (#434): the consteval "how UPDATE SQL is spelled" helpers,
+// split out of UpdateStatement so that class stays cohesive and under the method threshold
+// (cpp:S1448). Stateless and connection-free — every member derives purely from reflection
+// over the model type T (via Base = BaseStatement<T>).
+
+#include <meta>
+
+export module storm_orm_statements_update_grammar;
+
+import std;
+
+import storm_orm_statements_base;
+import storm_orm_utilities;
+
+export namespace storm::orm::statements {
+
+    using storm::orm::utilities::ConstexprString;
+
+    template <typename T> struct UpdateGrammar {
+        using Base = BaseStatement<T>;
+
+        // Helper to build field assignments string for UPDATE SQL
+        static consteval auto build_field_assignments() {
+            // Get all members directly
+            auto members = std::meta::nonstatic_data_members_of(^^T, std::meta::access_context::unchecked());
+            auto pk      = Base::primary_key_;
+
+            ConstexprString<utilities::buffer_size::SQL_MEDIUM> result;
+            bool                                                first = true;
+
+            for (const auto& member : members) {
+                if (member != pk) {
+                    if (!first) {
+                        result.append(", ");
+                    }
+                    // Check if this is a FK field
+                    auto field_attr = std::meta::annotation_of_type<meta::FieldAttr>(member);
+                    if (field_attr.has_value() && field_attr.value() == meta::FieldAttr::fk) {
+                        // FK field: use field_name_id
+                        result.append(std::meta::identifier_of(member));
+                        result.append("_id=?");
+                    } else {
+                        result.append(std::meta::identifier_of(member));
+                        result.append("=?");
+                    }
+                    first = false;
+                }
+            }
+
+            return result;
+        }
+
+        static constexpr auto field_assignments_ = build_field_assignments();
+
+        // --- Conditional bulk UPDATE (#403): SET-clause built from explicit member NTTPs ---
+
+        // Index of a member info within Base::all_members_ (compile-time).
+        static consteval auto index_of_member(std::meta::info member) -> std::size_t {
+            for (std::size_t i = 0; i < Base::all_members_.size(); ++i) {
+                if (Base::all_members_[i] == member) {
+                    return i;
+                }
+            }
+            std::unreachable(); // guarded by is_settable_member() at the call site
+        }
+
+        // Each SET target must be a non-static data member of T and not the primary key.
+        template <std::meta::info Member> static consteval auto is_settable_member() -> bool {
+            return std::meta::is_nonstatic_data_member(Member) && Member != Base::primary_key_;
+        }
+
+        // Append "<name>=?" (or "<name>_id=?" for FK fields) for one member.
+        template <typename Buf> static consteval auto append_one_assignment(Buf& buf, std::meta::info member) -> void {
+            buf.append(std::meta::identifier_of(member));
+            auto field_attr = std::meta::annotation_of_type<meta::FieldAttr>(member);
+            if (field_attr.has_value() && field_attr.value() == meta::FieldAttr::fk) {
+                buf.append("_id=?");
+            } else {
+                buf.append("=?");
+            }
+        }
+
+        // True when `member` carries the auto_update timestamp annotation (#209). Mirrors
+        // BaseStatement::is_auto_update_field, inlined here because that member is protected
+        // and UpdateGrammar does not inherit from BaseStatement.
+        static consteval auto is_auto_update_field(std::meta::info member) -> bool {
+            auto field_attr = std::meta::annotation_of_type<meta::FieldAttr>(member);
+            return field_attr.has_value() && field_attr.value() == meta::FieldAttr::auto_update;
+        }
+
+        // Is `member` an auto_update field NOT already present in the explicit pack?
+        template <std::meta::info... Members>
+        static consteval auto is_unlisted_auto_update(std::meta::info member) -> bool {
+            return is_auto_update_field(member) && ((member != Members) && ...);
+        }
+
+        // Build the SET clause for the explicit Members... pack, then append any
+        // auto_update field of T that the caller did not list. The column ORDER
+        // here is the canonical bind order used by bind_conditional_set().
+        template <std::meta::info... Members> static consteval auto build_conditional_set_clause() {
+            ConstexprString<utilities::buffer_size::SQL_MEDIUM> result;
+            bool                                                first = true;
+            // (1) explicit members, in the given order
+            (
+                    [&] {
+                        if (!first) {
+                            result.append(", ");
+                        }
+                        append_one_assignment(result, Members);
+                        first = false;
+                    }(),
+                    ...
+            );
+            // (2) auto_update fields not already listed (stamped now() at bind time)
+            for (const auto& member : Base::all_members_) {
+                if (is_unlisted_auto_update<Members...>(member)) {
+                    if (!first) {
+                        result.append(", ");
+                    }
+                    result.append(std::meta::identifier_of(member));
+                    result.append("=?");
+                    first = false;
+                }
+            }
+            return result;
+        }
+
+        // Compile-time UPDATE SQL size calculation
+        static consteval auto calculate_update_sql_size() -> std::size_t {
+            using utilities::sql_len::SET;
+            using utilities::sql_len::UPDATE;
+            using utilities::sql_len::WHERE;
+            std::size_t size = 0;
+            size += UPDATE; // "UPDATE "
+            size += Base::table_name_.size();
+            size += SET; // " SET "
+            size += field_assignments_.len;
+            size += WHERE; // " WHERE "
+            size += Base::pk_name_.size();
+            size += 4; // " = ?"
+            size += 1; // null terminator
+            return size;
+        }
+
+        // Build UPDATE SQL at compile-time using ConstexprString
+        static consteval auto build_update_sql_array() {
+            constexpr std::size_t     sql_size = calculate_update_sql_size() + utilities::sql_len::LARGE_BUFFER;
+            ConstexprString<sql_size> result;
+
+            result.append("UPDATE ");
+            result.append(Base::table_name_);
+            result.append(" SET ");
+            result.append(std::string_view(field_assignments_.data.data(), field_assignments_.len));
+            result.append(" WHERE ");
+            result.append(Base::pk_name_);
+            result.append(" = ?");
+
+            return result;
+        }
+
+        // Pre-computed UPDATE SQL generated at compile-time
+        static constexpr auto           update_sql_array  = build_update_sql_array();
+        static inline const std::string update_sql_string = std::string(update_sql_array);
+    };
+
+} // namespace storm::orm::statements


### PR DESCRIPTION
Closes #434

## Why

PR #433 (#409 `update_all`) auto-merged into `develop` **before** `SonarCloud Code Analysis` was a required GitHub check, landing a MAJOR `cpp:S1448` on `develop`: `UpdateStatement` had **37 methods** (limit 35). `BaseStatement` only passed because it carried a `// NOSONAR(cpp:S1448)` suppression while actually holding ~55 methods.

`S1448` is **not** in the project's approved NOSONAR list, so both classes are split for real.

## What

- **`UpdateGrammar<T>`** (`update_grammar.cppm`) — the consteval "how UPDATE SQL is spelled" helpers (`build_field_assignments`, `build_conditional_set_clause`, the SQL string, `is_settable_member`/`index_of_member`/`is_unlisted_auto_update`). Also drops the dead `get_updatable_field_count`. `UpdateStatement` → ~28 methods.
- **`ColumnExtractor`** (`extract.cppm`) — stateless storage-class predicates + `extract_*` row→value converters. `extract_int_like`/`extract_enum` now share one `read_int_sized` helper. `join`/`aggregate`/`distinct` call it directly.
- **`FieldNameGrammar<Base>`** (`field_names.cppm`) — compile-time column-list SQL builders (`for_each_field_name` + size/list builders). `insert`/`select` call it directly.
- **Deleted the dead transaction/execution helper cluster** (`begin`/`commit`/`rollback_transaction`, `should_use_transaction`, `execute_statement`, `execute_with_transaction`, `execute_with_statement`, `bind_and_execute`, `reset_bind_and_execute`, `dispatch_execute`) — zero live callers, superseded by `TransactionGuard` (#415). **Removed `BaseStatement`'s `NOSONAR(S1448)`.**

Pure refactor: moved code is `consteval` or `always_inline` static helpers, relocated across module boundaries with identical call shapes. Hot single/bulk INSERT/SELECT/UPDATE paths unchanged.

## Verification

- ✅ 2313/2313 tests pass (SQLite + PG-mock); pre-commit hook: format, clang-tidy, tests, **100% coverage**
- ✅ ASAN+UBSAN clean
- ✅ TSAN clean
- ✅ Release benchmarks in baseline range (INSERT ~5.9M items/s, SELECT ~5M items/s, RMS 0–1%)
- ✅ Docs + agent files updated (stale `execute_with_transaction` → `TransactionGuard`)

## Definition of done

- [x] `UpdateStatement` method count < 35 (S1448 clears)
- [x] `BaseStatement` NOSONAR removed; split under threshold
- [x] Hot single/bulk UPDATE path unchanged (no perf regression)
- [x] Full test suite green (SQLite + PG-mock)
- [ ] SonarCloud gate: zero new issues, zero new duplications

🤖 Generated with [Claude Code](https://claude.com/claude-code)