### PR TITLE
refactor(orm): consolidate FieldAttr predicates into the field_attr leaf (#421)

### DIFF
--- a/src/orm/field_attr.cppm
+++ b/src/orm/field_attr.cppm
@@ -72,6 +72,31 @@ export namespace storm::meta {
         return attr == primary || attr == primary_autoincrement;
     }
 
+    // Per-attribute field predicates (#421): the single source of truth for the
+    // `annotation_of_type<FieldAttr>(member) == FieldAttr::X` idiom, so the same
+    // test cannot drift between statement modules. FK detection lives in is_fk_field
+    // below (an fk<...> class-template annotation, not a FieldAttr enumerator).
+    consteval auto is_unique(std::meta::info member) -> bool {
+        auto attr = std::meta::annotation_of_type<FieldAttr>(member);
+        return attr.has_value() && attr.value() == FieldAttr::unique;
+    }
+
+    consteval auto is_indexed(std::meta::info member) -> bool {
+        auto attr = std::meta::annotation_of_type<FieldAttr>(member);
+        return attr.has_value() && attr.value() == FieldAttr::indexed;
+    }
+
+    // auto_create stamps now() on INSERT only; auto_update on both INSERT and UPDATE (#209).
+    consteval auto is_auto_create(std::meta::info member) -> bool {
+        auto attr = std::meta::annotation_of_type<FieldAttr>(member);
+        return attr.has_value() && attr.value() == FieldAttr::auto_create;
+    }
+
+    consteval auto is_auto_update(std::meta::info member) -> bool {
+        auto attr = std::meta::annotation_of_type<FieldAttr>(member);
+        return attr.has_value() && attr.value() == FieldAttr::auto_update;
+    }
+
     // A 64-bit unsigned source type — the set that needs an explicit storage
     // annotation (#436). Signed-64 and all smaller types are unaffected.
     template <typename T>

--- a/src/orm/statements/base.cppm
+++ b/src/orm/statements/base.cppm
@@ -32,6 +32,13 @@ export namespace storm::orm::statements {
         using storm::meta::ref_action_sql; // NOLINT(misc-unused-using-decls) — used by storm_orm_schema
         using storm::meta::RefAction;
 
+        // Per-attribute predicates (#421) re-exposed from the leaf so statement modules
+        // keep the meta:: qualifier (mirrors FieldAttr).
+        using storm::meta::is_auto_create;
+        using storm::meta::is_auto_update;
+        using storm::meta::is_indexed;
+        using storm::meta::is_unique;
+
         // Many-to-many annotation (#203, #431). Phase 1 (auto-generated junction table):
         //   [[= storm::meta::many_to_many<>]] std::vector<Course> courses;
         //   [[= storm::meta::many_to_many<RefAction::Restrict>]] std::vector<Course> courses;
@@ -451,28 +458,22 @@ export namespace storm::orm::statements {
             return meta::is_fk_field(member);
         }
 
-        // Unique field detection
+        // Per-attribute predicates forward to the storm_orm_field_attr leaf (#421),
+        // the single source of truth for the FieldAttr-annotation test.
         static consteval auto is_unique_field(std::meta::info member) -> bool {
-            auto field_attr = std::meta::annotation_of_type<meta::FieldAttr>(member);
-            return field_attr.has_value() && field_attr.value() == meta::FieldAttr::unique;
+            return meta::is_unique(member);
         }
 
-        // Indexed field detection (explicit [[= FieldAttr::indexed]])
         static consteval auto is_indexed_field(std::meta::info member) -> bool {
-            auto field_attr = std::meta::annotation_of_type<meta::FieldAttr>(member);
-            return field_attr.has_value() && field_attr.value() == meta::FieldAttr::indexed;
+            return meta::is_indexed(member);
         }
 
-        // Auto-timestamp detection (#209): auto_create stamps now() on INSERT only;
-        // auto_update stamps now() on both INSERT and UPDATE.
         static consteval auto is_auto_create_field(std::meta::info member) -> bool {
-            auto field_attr = std::meta::annotation_of_type<meta::FieldAttr>(member);
-            return field_attr.has_value() && field_attr.value() == meta::FieldAttr::auto_create;
+            return meta::is_auto_create(member);
         }
 
         static consteval auto is_auto_update_field(std::meta::info member) -> bool {
-            auto field_attr = std::meta::annotation_of_type<meta::FieldAttr>(member);
-            return field_attr.has_value() && field_attr.value() == meta::FieldAttr::auto_update;
+            return meta::is_auto_update(member);
         }
 
         // True when `member` should be stamped with now() on this operation: auto_update

--- a/src/orm/statements/update_grammar.cppm
+++ b/src/orm/statements/update_grammar.cppm
@@ -80,12 +80,12 @@ export namespace storm::orm::statements {
             }
         }
 
-        // True when `member` carries the auto_update timestamp annotation (#209). Mirrors
-        // BaseStatement::is_auto_update_field, inlined here because that member is protected
-        // and UpdateGrammar does not inherit from BaseStatement.
+        // True when `member` carries the auto_update timestamp annotation (#209).
+        // Forwards to the storm_orm_field_attr leaf (#421) — the single source of
+        // truth — since BaseStatement::is_auto_update_field is protected and
+        // UpdateGrammar does not inherit from BaseStatement.
         static consteval auto is_auto_update_field(std::meta::info member) -> bool {
-            auto field_attr = std::meta::annotation_of_type<meta::FieldAttr>(member);
-            return field_attr.has_value() && field_attr.value() == meta::FieldAttr::auto_update;
+            return meta::is_auto_update(member);
         }
 
         // Is `member` an auto_update field NOT already present in the explicit pack?


### PR DESCRIPTION
## Summary

Consolidates the per-attribute `FieldAttr` predicates into the dependency-free `storm_orm_field_attr` leaf module (`storm::meta`), so the `annotation_of_type<FieldAttr>(member) == FieldAttr::X` idiom lives in exactly one place — extending the "two variants can never drift" guarantee `is_primary_attr` already provides. Companion to #387.

## What changed

- **`field_attr.cppm`** — add `is_unique`, `is_indexed`, `is_auto_create`, `is_auto_update` to `storm::meta`, alongside the existing `is_primary_attr` / `is_fk_field` / `has_*_attr` siblings.
- **`base.cppm`** — `BaseStatement::is_unique_field` / `is_indexed_field` / `is_auto_create_field` / `is_auto_update_field` now forward to the leaf; the four predicates are re-exposed in the local `statements::meta` namespace via `using` (mirrors `FieldAttr`).
- **`update_grammar.cppm`** — drops its duplicate `is_auto_update_field` (previously inlined because `BaseStatement`'s is `protected`); forwards to the leaf.

## Note on stale issue evidence

The issue's FK-specific evidence is stale — the codebase moved on:
- #431 made FK an `fk<...>` class-template annotation (not a `FieldAttr::fk` enumerator), so there is **no inlined `== FieldAttr::fk` idiom** anywhere (all grep hits are comments).
- `meta::is_fk_field` already lives **only** in the leaf; `BaseStatement::is_fk_field` is already a thin forwarder; `base.cppm:60` is `m2m_annotation_type_of`, not a duplicate FK predicate.

So this PR handles what genuinely remained: the four other per-attribute predicates + the `update_grammar` duplicate. See the updated DoD on the issue.

## Verification

`consteval` only — zero runtime impact, behavior identical (no benchmark needed per the issue).

- Debug: **2346 tests pass**
- ASAN+UBSAN: **2346 tests pass**
- TSAN: **2346 tests pass**
- clang-format / clang-tidy / coverage (100%): pass

Closes #421

🤖 Generated with [Claude Code](https://claude.com/claude-code)
