### PR TITLE
refactor(orm): extract canonical <identifier>[_id] column-name writer (#422)

### DIFF
--- a/src/orm/field_attr.cppm
+++ b/src/orm/field_attr.cppm
@@ -162,6 +162,29 @@ export namespace storm::meta {
         return fk_annotation_type_of(member).has_value();
     }
 
+    // Canonical column-name writer (#422): a member's SQL column is its identifier, plus
+    // the "_id" suffix when the member is an FK (`User sender` → `sender_id`). This logic
+    // was open-coded in every SQL builder (field_names, distinct, update, join, schema)
+    // alongside a matching size-calculator that had to stay byte-exact. Route both through
+    // this pair so the append and the size can never drift.
+    //
+    // `buf` is any buffer with `.append(std::string_view)` — the compile-time
+    // ConstexprString and a runtime std::string both qualify. consteval (like every
+    // builder that calls it) so it is constant-evaluated, never emitted as runtime code.
+    consteval void append_column_name(auto& buf, std::meta::info member) {
+        buf.append(std::meta::identifier_of(member));
+        if (is_fk_field(member)) {
+            buf.append("_id");
+        }
+    }
+
+    // Byte size append_column_name() will emit for `member`: the identifier length, plus
+    // 3 for "_id" when the member is an FK. The exact companion to append_column_name —
+    // every size-calculator that pairs with it must use this so the buffer fits precisely.
+    consteval auto column_name_size(std::meta::info member) -> std::size_t {
+        return std::meta::identifier_of(member).size() + (is_fk_field(member) ? 3 : 0);
+    }
+
     // The ON DELETE RefAction of an fk<...> FK, or std::nullopt when the field is not an FK
     // or carries the default RESTRICT (caller emits no clause then, keeping the
     // plain-REFERENCES DDL byte-identical).

--- a/src/orm/schema.cppm
+++ b/src/orm/schema.cppm
@@ -601,12 +601,7 @@ export namespace storm::orm::schema {
                 if (i > 0) {
                     sql.append(", ");
                 }
-                if (Base::is_fk_field(IdxType::fields[i])) {
-                    sql.append(std::meta::identifier_of(IdxType::fields[i]));
-                    sql.append("_id");
-                } else {
-                    sql.append(std::meta::identifier_of(IdxType::fields[i]));
-                }
+                storm::meta::append_column_name(sql, IdxType::fields[i]); // #422 — emits FK "_id"
             }
             sql.append(")");
             return sql;

--- a/src/orm/statements/base.cppm
+++ b/src/orm/statements/base.cppm
@@ -74,8 +74,11 @@ export namespace storm::orm::statements {
         // Foreign-key annotation (#431) lives in the storm_orm_field_attr leaf module so
         // every statement module can detect FK fields without importing this one. Re-exposed
         // here so statement modules keep using the meta:: qualifier (mirrors FieldAttr).
-        using storm::meta::fk;                    // NOLINT(misc-unused-using-decls)
-        using storm::meta::Fk;                    // NOLINT(misc-unused-using-decls)
+        using storm::meta::
+                append_column_name; // NOLINT(misc-unused-using-decls) — #422 canonical <identifier>[_id] writer
+        using storm::meta::column_name_size; // NOLINT(misc-unused-using-decls) — #422 its byte-exact size companion
+        using storm::meta::fk;               // NOLINT(misc-unused-using-decls)
+        using storm::meta::Fk;               // NOLINT(misc-unused-using-decls)
         using storm::meta::fk_annotation_type_of; // NOLINT(misc-unused-using-decls)
         using storm::meta::fk_on_delete_action_of;
         using storm::meta::is_fk_field;

--- a/src/orm/statements/distinct.cppm
+++ b/src/orm/statements/distinct.cppm
@@ -64,10 +64,7 @@ export namespace storm::orm::statements {
 
         // Calculate field size at compile-time
         template <std::size_t I> static consteval auto get_field_size() -> std::size_t {
-            std::size_t size = std::meta::identifier_of(member_infos_[I]).size();
-            if constexpr (meta::is_fk_field(member_infos_[I])) {
-                size += 3; // "_id"
-            }
+            std::size_t size = meta::column_name_size(member_infos_[I]);
             if constexpr (I > 0) {
                 size += 2; // ", "
             }
@@ -82,10 +79,7 @@ export namespace storm::orm::statements {
 
         // Append column name for field I (with FK _id suffix if needed)
         template <std::size_t I, std::size_t N> static consteval void append_column_name(ConstexprString<N>& result) {
-            result.append(std::meta::identifier_of(member_infos_[I]));
-            if constexpr (meta::is_fk_field(member_infos_[I])) {
-                result.append("_id");
-            }
+            meta::append_column_name(result, member_infos_[I]);
         }
 
         // Build a "<prefix>col1, <prefix>col2, ..." field list at compile time.

--- a/src/orm/statements/field_names.cppm
+++ b/src/orm/statements/field_names.cppm
@@ -19,15 +19,11 @@ export namespace storm::orm::statements {
 
     using storm::orm::utilities::ConstexprString;
 
-    namespace meta {
-        using storm::meta::FieldAttr;
-        using storm::meta::is_fk_field;
-    } // namespace meta
-
     template <typename Base> struct FieldNameGrammar {
         // Shared iterator over data members, honouring SkipPrimaryKey, invoking
-        // `body(i, is_fk, name)` per emitted field. The size-calculator and the
-        // list-builder used to spell out this loop independently.
+        // `body(i, needs_comma)` per emitted field. The size-calculator and the
+        // list-builder used to spell out this loop independently. The FK "_id" suffix
+        // is derived inside storm::meta::append_column_name/column_name_size (#422).
         template <bool SkipPrimaryKey, typename Body> static consteval auto for_each_field_name(Body body) -> void {
             bool first = true;
             for (std::size_t i = 0; i < Base::field_count_; ++i) {
@@ -36,8 +32,7 @@ export namespace storm::orm::statements {
                         continue;
                     }
                 }
-                bool const is_fk = meta::is_fk_field(Base::all_members_[i]);
-                body(i, is_fk, !first);
+                body(i, !first);
                 first = false;
             }
         }
@@ -46,14 +41,11 @@ export namespace storm::orm::statements {
         // Template parameter controls whether to skip primary key (for INSERT vs SELECT)
         template <bool SkipPrimaryKey> static consteval auto calculate_field_names_size_impl() -> std::size_t {
             std::size_t size = 0;
-            for_each_field_name<SkipPrimaryKey>([&](std::size_t i, bool is_fk, bool needs_comma) {
+            for_each_field_name<SkipPrimaryKey>([&](std::size_t i, bool needs_comma) {
                 if (needs_comma) {
                     size += 2; // ", "
                 }
-                size += std::meta::identifier_of(Base::all_members_[i]).size();
-                if (is_fk) {
-                    size += 3; // "_id"
-                }
+                size += storm::meta::column_name_size(Base::all_members_[i]);
             });
             return size;
         }
@@ -73,14 +65,11 @@ export namespace storm::orm::statements {
         template <bool SkipPrimaryKey> static consteval auto build_field_names_list_impl() {
             constexpr std::size_t size = calculate_field_names_size_impl<SkipPrimaryKey>() + 10;
             ConstexprString<size> result;
-            for_each_field_name<SkipPrimaryKey>([&](std::size_t i, bool is_fk, bool needs_comma) {
+            for_each_field_name<SkipPrimaryKey>([&](std::size_t i, bool needs_comma) {
                 if (needs_comma) {
                     result.append(", ");
                 }
-                result.append(std::meta::identifier_of(Base::all_members_[i]));
-                if (is_fk) {
-                    result.append("_id");
-                }
+                storm::meta::append_column_name(result, Base::all_members_[i]);
             });
             return result;
         }

--- a/src/orm/statements/join.cppm
+++ b/src/orm/statements/join.cppm
@@ -206,10 +206,7 @@ export namespace storm::orm::statements {
         for (std::size_t i = 0; i < RelatedBase::field_count_; ++i) {
             result.append(", ");
             result.append(sep_prefix);
-            result.append(std::meta::identifier_of(RelatedBase::all_members_[i]));
-            if (meta::is_fk_field(RelatedBase::all_members_[i])) {
-                result.append("_id");
-            }
+            meta::append_column_name(result, RelatedBase::all_members_[i]); // #422 — emits FK "_id"
         }
     }
 
@@ -770,10 +767,7 @@ export namespace storm::orm::statements {
                     result.append(", ");
                 }
                 result.append("t1.");
-                result.append(std::meta::identifier_of(Base::all_members_[i]));
-                if (Base::is_fk_field(Base::all_members_[i])) {
-                    result.append("_id");
-                }
+                meta::append_column_name(result, Base::all_members_[i]); // #422 — emits FK "_id"
                 first = false;
             }
             return result;
@@ -1010,10 +1004,10 @@ export namespace storm::orm::statements {
         static_assert(!std::same_as<Owner, T>, "reverse_fk must point from a different model (#398)");
 
         // FK column on the owning table: "<fk identifier>_id" (e.g. "assignee_id").
+        // FkField is always an FK, so append_column_name (#422) emits the "_id".
         static constexpr auto fk_col_arr_ = []() consteval {
             ConstexprString<std::meta::identifier_of(FkField).size() + 4> name;
-            name.append(std::meta::identifier_of(FkField));
-            name.append("_id");
+            meta::append_column_name(name, FkField);
             return name;
         }();
         static constexpr std::string_view fk_col_v_ = fk_col_arr_.view();
@@ -1061,10 +1055,7 @@ export namespace storm::orm::statements {
                     sql.append(", ");
                 }
                 sql.append("t1.");
-                sql.append(std::meta::identifier_of(Base::all_members_[i]));
-                if (Base::is_fk_field(Base::all_members_[i])) {
-                    sql.append("_id");
-                }
+                meta::append_column_name(sql, Base::all_members_[i]); // #422 — emits FK "_id"
                 first = false;
             }
             sql.append(" FROM ");

--- a/src/orm/statements/update_grammar.cppm
+++ b/src/orm/statements/update_grammar.cppm
@@ -35,15 +35,9 @@ export namespace storm::orm::statements {
                     if (!first) {
                         result.append(", ");
                     }
-                    // Check if this is a FK field
-                    if (meta::is_fk_field(member)) {
-                        // FK field: use field_name_id
-                        result.append(std::meta::identifier_of(member));
-                        result.append("_id=?");
-                    } else {
-                        result.append(std::meta::identifier_of(member));
-                        result.append("=?");
-                    }
+                    // "<col>[_id]=?" — column-name writer (#422) emits the FK "_id" suffix.
+                    meta::append_column_name(result, member);
+                    result.append("=?");
                     first = false;
                 }
             }
@@ -72,12 +66,8 @@ export namespace storm::orm::statements {
 
         // Append "<name>=?" (or "<name>_id=?" for FK fields) for one member.
         template <typename Buf> static consteval auto append_one_assignment(Buf& buf, std::meta::info member) -> void {
-            buf.append(std::meta::identifier_of(member));
-            if (meta::is_fk_field(member)) {
-                buf.append("_id=?");
-            } else {
-                buf.append("=?");
-            }
+            meta::append_column_name(buf, member); // #422 — emits the FK "_id" suffix
+            buf.append("=?");
         }
 
         // True when `member` carries the auto_update timestamp annotation (#209).


### PR DESCRIPTION
Closes #422.

## Summary

The "append a column name, adding the `_id` suffix when the member is an FK" logic was open-coded in every SQL builder, each paired with a byte-exact size-calculator that had to stay in lockstep. This adds one canonical pair to the `storm_orm_field_attr` leaf and routes every member-based builder through it.

```cpp
consteval void append_column_name(auto& buf, std::meta::info member);  // identifier + "_id" iff FK
consteval auto column_name_size(std::meta::info member) -> std::size_t; // its exact byte companion
```

Both `consteval` (constant-evaluated at every call site, never emitted as runtime code).

## Sites routed

- `field_names.cppm` — size + builder (the established lockstep model; `is_fk` param dropped from `for_each_field_name`)
- `distinct.cppm` — `get_field_size` + `append_column_name`
- `update_grammar.cppm` — `build_field_assignments` + `append_one_assignment` (name part; `"=?"` appended after)
- `join.cppm` — `append_relation_columns`, `build_base_cols`, `build_complete_sql`, reverse-FK `fk_col`
- `schema.cppm` — composite-index column list

## Out of scope (structurally different `_id` literals)

m2m junction columns built from **type names**, the `_id INTEGER NOT NULL` **type-fused** FK suffix in `append_fk_column_def`, JOIN ON-clause built from **runtime string views** (`fk_field_names_[Is]`), and CREATE INDEX **name** suffixes — none take a `std::meta::info member`, so routing them would not simplify.

## Verification

- **Generated SQL byte-identical**: `tests/query/test_sql_verify.cpp` (exact-SQL assertions) + full ctest **2346/2346** (incl. PostgreSQL) pass unchanged.
- **No Release regression**: consteval-only change; runtime SQL strings identical; INSERT N:1 nominal.
- **ASAN+UBSAN** clean (2346/2346), **TSAN** clean (2346/2346).
- Rebased onto #421 (PR #446), which moved the FieldAttr predicates into the same leaf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)