### PR TITLE
feat(where): reject relation members in f<>() at compile time (#408)

### DIFF
--- a/.claude/agents/dev.md
+++ b/.claude/agents/dev.md
@@ -57,7 +57,7 @@ When adding or modifying modules:
 2. **Prevent circular dependencies**: identify shared dependencies that should be extracted to a base module
 3. **Enforce naming**: module names use underscores (e.g., `storm_db_sqlite`, not `storm.db.sqlite`)
 4. **Minimize coupling**: modules should have minimal import surface area
-5. **Extract shared leaves**: dependency-free shared declarations live in leaf modules (e.g. `storm_orm_field_attr` for `FieldAttr`/`is_primary_attr`, `storm_db_concept`) — never duplicate definitions to break a cycle (#387)
+5. **Extract shared leaves**: dependency-free shared declarations live in leaf modules (e.g. `storm_orm_field_attr` for `FieldAttr`/`is_primary_attr`, `storm_db_concept`) — never duplicate definitions to break a cycle (#387). The m2m/reverse-fk annotation TYPES (`ManyToMany`, `ReverseFk`) and the relation-detection predicates (`is_m2m_field`, `is_reverse_fk_field`, `is_relation_field`) live in the `storm_orm_relation_meta` leaf (#408) so `storm_orm_where` can gate `f<>()` against relation members without importing `storm_orm_statements_base` (which would cycle — base already imports where); base re-exposes them into `storm::orm::statements::meta`, the resolution/junction logic (`reverse_fk_target_of`, `m2m_junction_on_delete_of`, …) stays in base
 
 When documenting module structure, provide ASCII dependency graphs showing import relationships and build order.
 

--- a/docs/architecture/OVERVIEW.md
+++ b/docs/architecture/OVERVIEW.md
@@ -80,6 +80,7 @@ src/
 └── orm/
     ├── queryset.cppm               # QuerySet interface
     ├── field_attr.cppm             # FieldAttr annotation enum (leaf module, #387)
+    ├── relation_meta.cppm          # m2m/reverse-fk annotation types + is_relation_field (leaf module, #408)
     ├── utilities.cppm              # ConstexprString, SQLCache
     └── statements/
         ├── base.cppm               # BaseStatement utilities
@@ -100,6 +101,7 @@ storm (main module)
 ├── storm_db_concept
 ├── storm_db_sqlite
 ├── storm_orm_field_attr
+├── storm_orm_relation_meta
 ├── storm_orm_statements_base
 ├── storm_orm_utilities
 ├── storm_orm_statements_{insert,update,erase,select,join}

--- a/docs/features/WHERE_CLAUSES.md
+++ b/docs/features/WHERE_CLAUSES.md
@@ -14,6 +14,13 @@ auto results = QuerySet<Person>()
 
 The `f<^^Member>()` function creates a field expression for type-safe comparisons at compile time.
 
+`f<>()` accepts only persisted columns. Passing a relation member — a many-to-many
+container (`[[= storm::many_to_many]]`) or a reverse-FK container
+(`[[= storm::reverse_fk<...>]]`) — is a **compile-time error** (#408): those are not
+columns, so a WHERE clause on one would reference a non-existent column. The constraint
+fails at the call site instead of producing an opaque "no such column" at prepare time.
+Filter on a relation's own columns by joining to it (`join<^^T::field>()`) first.
+
 ## Comparison Operators
 
 All 6 comparison operators are supported.

--- a/src/orm/relation_meta.cppm
+++ b/src/orm/relation_meta.cppm
@@ -1,0 +1,97 @@
+module;
+
+#include <meta>
+
+export module storm_orm_relation_meta;
+
+import std;
+
+import storm_orm_field_attr; // RefAction (junction ON DELETE policy)
+
+// Dependency-free leaf module (#408): the relation-annotation TYPES (ManyToMany,
+// ReverseFk) and the "is this member a relation, not a persisted column?" detection
+// predicates. Extracted here from storm_orm_statements_base so storm_orm_where can
+// reject relation members in f<>() without importing the statement module (which
+// would create a layering cycle — base.cppm already imports where.cppm). Same leaf
+// pattern as storm_orm_field_attr (#387), which holds the FK annotation + is_fk_field.
+//
+// Symbols live in storm::meta (alongside is_fk_field); storm_orm_statements_base
+// re-exposes them into storm::orm::statements::meta so existing meta:: callers and
+// the public storm.cppm re-exports are unchanged.
+export namespace storm::meta {
+
+    // Many-to-many annotation (#203, #431). Phase 1 (auto-generated junction table):
+    //   [[= storm::meta::many_to_many<>]] std::vector<Course> courses;
+    //   [[= storm::meta::many_to_many<RefAction::Restrict>]] std::vector<Course> courses;
+    // Phase 2 (explicit junction model):
+    //   [[= storm::meta::many_to_many_through<Enrollment>]] std::vector<Course> courses;
+    // A class-template annotation carries the optional through-model type AND the
+    // junction ON DELETE policy (#431, both junction sides). Through type stays at
+    // template arg [0] so is_m2m_auto / m2m_through_t are unchanged; the RefAction is
+    // arg [1], defaulting to CASCADE (an orphaned junction row is meaningless).
+    template <typename Through = void, RefAction JunctionOnDelete = RefAction::Cascade> struct ManyToMany {
+        using through_type                            = Through;
+        static constexpr RefAction junction_on_delete = JunctionOnDelete;
+    };
+    template <RefAction JunctionOnDelete = RefAction::Cascade>
+    inline constexpr ManyToMany<void, JunctionOnDelete>              many_to_many{};
+    template <typename Through> inline constexpr ManyToMany<Through> many_to_many_through{};
+
+    // The TYPE of `member`'s annotation that is a specialization of `template_info`,
+    // if any. Shared by m2m_annotation_type_of / reverse_fk_annotation_type_of — the
+    // two class-template annotations differ only by which template to match.
+    consteval auto annotation_type_specializing(std::meta::info member, std::meta::info template_info)
+            -> std::optional<std::meta::info> {
+        for (const auto annotation : std::meta::annotations_of(member)) {
+            const auto type = std::meta::type_of(annotation);
+            if (std::meta::has_template_arguments(type) && std::meta::template_of(type) == template_info) {
+                return type;
+            }
+        }
+        return std::nullopt;
+    }
+
+    // Reflection of the ManyToMany<...> annotation TYPE carried by `member`, if any.
+    consteval auto m2m_annotation_type_of(std::meta::info member) -> std::optional<std::meta::info> {
+        return annotation_type_specializing(member, ^^ManyToMany);
+    }
+
+    consteval auto is_m2m_field(std::meta::info member) -> bool {
+        return m2m_annotation_type_of(member).has_value();
+    }
+
+    // Reverse-FK annotation (#398): on a container member of the base model, it
+    // declares the eager-load destination for "all <Base>, each with the <Owner>s
+    // that point at them". The template argument is EITHER:
+    //   - the owning model type — [[= reverse_fk<^^Task>]] vector<Task> tasks;
+    //     (resolved to that model's unique FK back at the base), OR
+    //   - a specific FK field — [[= reverse_fk<^^Task::assignee>]] vector<Task> tasks;
+    //     (names the exact FK; the disambiguator when the owner has several FKs to
+    //     the base, e.g. assignee vs reviewer).
+    // The type form works when the owner is only forward-declared at the annotation
+    // site (the cyclic Base⟷Owner case); the field form needs the owner complete.
+    // Like ManyToMany, it is a class-template annotation (FieldAttr is an enum, so a
+    // templated enumerator is impossible).
+    template <std::meta::info Target> struct ReverseFk {
+        static constexpr std::meta::info target = Target;
+    };
+    template <std::meta::info Target> inline constexpr ReverseFk<Target> reverse_fk{};
+
+    // Reflection of the ReverseFk<...> annotation TYPE carried by `member`, if any.
+    consteval auto reverse_fk_annotation_type_of(std::meta::info member) -> std::optional<std::meta::info> {
+        return annotation_type_specializing(member, ^^ReverseFk);
+    }
+
+    consteval auto is_reverse_fk_field(std::meta::info member) -> bool {
+        return reverse_fk_annotation_type_of(member).has_value();
+    }
+
+    // Combined relation-field predicate (#398): m2m container OR reverse_fk container.
+    // The single chokepoint for "not a persisted column" — schema/CRUD invisibility
+    // for both relation kinds falls out of every persisted-field array filtering here.
+    // Gates f<>() (#408) so a WHERE clause on a relation member fails at the call site.
+    consteval auto is_relation_field(std::meta::info member) -> bool {
+        return is_m2m_field(member) || is_reverse_fk_field(member);
+    }
+
+} // namespace storm::meta

--- a/src/orm/statements/base.cppm
+++ b/src/orm/statements/base.cppm
@@ -12,6 +12,7 @@ import std;
 
 import storm_db_concept;
 import storm_orm_field_attr;
+import storm_orm_relation_meta;
 import storm_orm_utilities;
 import storm_orm_statements_extract;
 import storm_orm_statements_field_names;
@@ -39,37 +40,21 @@ export namespace storm::orm::statements {
         using storm::meta::is_indexed;
         using storm::meta::is_unique;
 
-        // Many-to-many annotation (#203, #431). Phase 1 (auto-generated junction table):
-        //   [[= storm::meta::many_to_many<>]] std::vector<Course> courses;
-        //   [[= storm::meta::many_to_many<RefAction::Restrict>]] std::vector<Course> courses;
-        // Phase 2 (explicit junction model):
-        //   [[= storm::meta::many_to_many_through<Enrollment>]] std::vector<Course> courses;
-        // A class-template annotation carries the optional through-model type AND the
-        // junction ON DELETE policy (#431, both junction sides). Through type stays at
-        // template arg [0] so is_m2m_auto / m2m_through_t are unchanged; the RefAction is
-        // arg [1], defaulting to CASCADE (an orphaned junction row is meaningless).
-        template <typename Through = void, RefAction JunctionOnDelete = RefAction::Cascade> struct ManyToMany {
-            using through_type                            = Through;
-            static constexpr RefAction junction_on_delete = JunctionOnDelete;
-        };
-        template <RefAction JunctionOnDelete = RefAction::Cascade>
-        inline constexpr ManyToMany<void, JunctionOnDelete>              many_to_many{};
-        template <typename Through> inline constexpr ManyToMany<Through> many_to_many_through{};
-
-        // Reflection of the ManyToMany<...> annotation TYPE carried by `member`, if any.
-        consteval auto m2m_annotation_type_of(std::meta::info member) -> std::optional<std::meta::info> {
-            for (const auto annotation : std::meta::annotations_of(member)) {
-                const auto type = std::meta::type_of(annotation);
-                if (std::meta::has_template_arguments(type) && std::meta::template_of(type) == ^^ManyToMany) {
-                    return type;
-                }
-            }
-            return std::nullopt;
-        }
-
-        consteval auto is_m2m_field(std::meta::info member) -> bool {
-            return m2m_annotation_type_of(member).has_value();
-        }
+        // Many-to-many (#203, #431) and reverse-FK (#398) annotation TYPES and their
+        // "is this a relation member, not a persisted column?" detection predicates live
+        // in the storm_orm_relation_meta leaf module (#408) so storm_orm_where can gate
+        // f<>() without importing this module. Re-exposed here so statement modules keep
+        // the meta:: qualifier (mirrors how FK detection is re-exposed from field_attr).
+        using storm::meta::is_m2m_field;
+        using storm::meta::is_relation_field; // NOLINT(misc-unused-using-decls) — #408 chokepoint
+        using storm::meta::is_reverse_fk_field;
+        using storm::meta::m2m_annotation_type_of;
+        using storm::meta::many_to_many;         // NOLINT(misc-unused-using-decls) — model-declaration spelling
+        using storm::meta::many_to_many_through; // NOLINT(misc-unused-using-decls) — model-declaration spelling
+        using storm::meta::ManyToMany;           // NOLINT(misc-unused-using-decls) — re-exported for storm.cppm
+        using storm::meta::reverse_fk;           // NOLINT(misc-unused-using-decls) — model-declaration spelling
+        using storm::meta::reverse_fk_annotation_type_of;
+        using storm::meta::ReverseFk; // NOLINT(misc-unused-using-decls) — re-exported for storm.cppm
 
         // Foreign-key annotation (#431) lives in the storm_orm_field_attr leaf module so
         // every statement module can detect FK fields without importing this one. Re-exposed
@@ -82,38 +67,6 @@ export namespace storm::orm::statements {
         using storm::meta::fk_annotation_type_of; // NOLINT(misc-unused-using-decls)
         using storm::meta::fk_on_delete_action_of;
         using storm::meta::is_fk_field;
-
-        // Reverse-FK annotation (#398): on a container member of the base model, it
-        // declares the eager-load destination for "all <Base>, each with the <Owner>s
-        // that point at them". The template argument is EITHER:
-        //   - the owning model type — [[= reverse_fk<^^Task>]] vector<Task> tasks;
-        //     (resolved to that model's unique FK back at the base), OR
-        //   - a specific FK field — [[= reverse_fk<^^Task::assignee>]] vector<Task> tasks;
-        //     (names the exact FK; the disambiguator when the owner has several FKs to
-        //     the base, e.g. assignee vs reviewer).
-        // The type form works when the owner is only forward-declared at the annotation
-        // site (the cyclic Base⟷Owner case); the field form needs the owner complete.
-        // Like ManyToMany, it is a class-template annotation (FieldAttr is an enum, so a
-        // templated enumerator is impossible).
-        template <std::meta::info Target> struct ReverseFk {
-            static constexpr std::meta::info target = Target;
-        };
-        template <std::meta::info Target> inline constexpr ReverseFk<Target> reverse_fk{};
-
-        // Reflection of the ReverseFk<...> annotation TYPE carried by `member`, if any.
-        consteval auto reverse_fk_annotation_type_of(std::meta::info member) -> std::optional<std::meta::info> {
-            for (const auto annotation : std::meta::annotations_of(member)) {
-                const auto type = std::meta::type_of(annotation);
-                if (std::meta::has_template_arguments(type) && std::meta::template_of(type) == ^^ReverseFk) {
-                    return type;
-                }
-            }
-            return std::nullopt;
-        }
-
-        consteval auto is_reverse_fk_field(std::meta::info member) -> bool {
-            return reverse_fk_annotation_type_of(member).has_value();
-        }
 
         // The raw template argument of a reverse_fk member's annotation — either an
         // owner type (^^Task) or an FK field (^^Task::assignee). The join machinery
@@ -177,13 +130,6 @@ export namespace storm::orm::statements {
                 std::unreachable(); // ReverseFKFieldOf guarantees a unique FK exists
             }
             return target; // already an FK field
-        }
-
-        // Combined relation-field predicate (#398): m2m container OR reverse_fk container.
-        // The single chokepoint for "not a persisted column" — schema/CRUD invisibility
-        // for both relation kinds falls out of every persisted-field array filtering here.
-        consteval auto is_relation_field(std::meta::info member) -> bool {
-            return is_m2m_field(member) || is_reverse_fk_field(member);
         }
 
         // True for m2m members WITHOUT a through model (auto-generated junction table).

--- a/src/orm/where.cppm
+++ b/src/orm/where.cppm
@@ -10,7 +10,8 @@ export module storm_orm_where;
 
 import std;
 
-import storm_orm_utilities; // For ConstexprString
+import storm_orm_utilities;     // For ConstexprString
+import storm_orm_relation_meta; // is_relation_field — reject m2m/reverse_fk members in f<>() (#408)
 
 export namespace storm::orm::where {
 
@@ -357,7 +358,7 @@ export namespace storm::orm::where {
     // Created via f<^^Person::name>().collate(Collate::NoCase)
     // All comparison operators produce SQL like: "name COLLATE NOCASE = ?"
     template <std::meta::info MemberInfo>
-        requires(std::meta::is_nonstatic_data_member(MemberInfo))
+        requires(std::meta::is_nonstatic_data_member(MemberInfo) && !storm::meta::is_relation_field(MemberInfo))
     class CollatedField {
       public:
         using FieldType = typename[:std::meta::type_of(MemberInfo):];
@@ -432,7 +433,7 @@ export namespace storm::orm::where {
     // Field proxy - stores reflection info as template parameter
     // Provides compile-time IN expression and runtime comparison/special methods
     template <std::meta::info MemberInfo>
-        requires(std::meta::is_nonstatic_data_member(MemberInfo))
+        requires(std::meta::is_nonstatic_data_member(MemberInfo) && !storm::meta::is_relation_field(MemberInfo))
     class Field {
       public:
         static constexpr auto field_name_sv = std::meta::identifier_of(MemberInfo);
@@ -532,8 +533,9 @@ export namespace storm::orm::where {
     // COMPILE-TIME VALIDATION: Uses P2996 to ensure MemberInfo is a valid field
     template <std::meta::info MemberInfo>
         requires(
-                std::meta::is_nonstatic_data_member(MemberInfo) && std::meta::has_identifier(MemberInfo)
-        ) // Ensures field has a name
+                std::meta::is_nonstatic_data_member(MemberInfo) && std::meta::has_identifier(MemberInfo) &&
+                !storm::meta::is_relation_field(MemberInfo)
+        ) // a named, persisted column — not an m2m/reverse_fk relation member (#408)
     constexpr auto f() {
         // Additional compile-time validation: field must be accessible
         static_assert(

--- a/tests/query/test_many_to_many.cpp
+++ b/tests/query/test_many_to_many.cpp
@@ -32,6 +32,20 @@ static_assert(!storm::orm::statements::FKFieldOf<Student, ^^Student::courses>);
 static_assert(storm::orm::statements::M2MFieldOf<Pupil, ^^Pupil::courses>);
 
 // ============================================================================
+// Compile-time: f<>() rejects m2m relation members (#408)
+// An m2m container is not a persisted column — a WHERE clause on it would
+// reference a non-existent column, so f<>() must fail at the call site.
+// ============================================================================
+
+template <auto M>
+concept FCallableM2M = requires { storm::orm::where::f<M>(); };
+
+static_assert(!FCallableM2M<^^Student::courses>, "m2m member rejected by f<>()");
+static_assert(!FCallableM2M<^^Pupil::courses>, "m2m_through member rejected by f<>()");
+static_assert(FCallableM2M<^^Student::name>, "persisted column still accepted");
+static_assert(FCallableM2M<^^Student::age>, "persisted column still accepted");
+
+// ============================================================================
 // Compile-time: related-type extraction from containers via std::meta
 // ============================================================================
 

--- a/tests/query/test_reverse_fk.cpp
+++ b/tests/query/test_reverse_fk.cpp
@@ -48,6 +48,20 @@ static_assert(stmt::JoinableFields<RfPerson, ^^RfPerson::tasks>);
 static_assert(stmt::JoinableFields<RfPerson, ^^RfTask::assignee>);
 
 // ============================================================================
+// Compile-time: f<>() rejects reverse_fk relation members (#408)
+// A reverse_fk container is not a persisted column — a WHERE clause on it would
+// reference a non-existent column, so f<>() must fail at the call site.
+// ============================================================================
+
+template <auto M>
+concept FCallableRfk = requires { storm::orm::where::f<M>(); };
+
+static_assert(!FCallableRfk<^^RfPerson::tasks>, "reverse_fk member rejected by f<>()");
+static_assert(!FCallableRfk<^^RfBoard::notes>, "reverse_fk member rejected by f<>()");
+static_assert(FCallableRfk<^^RfPerson::name>, "persisted column still accepted");
+static_assert(FCallableRfk<^^RfTask::assignee>, "FK column still accepted");
+
+// ============================================================================
 // Schema: reverse_fk creates NO junction table and is not a column
 // ============================================================================
 


### PR DESCRIPTION
## Summary

`f<>()` accepted any non-static data member, including many-to-many (#203) and
reverse-FK (#398) containers. Those are not persisted columns, so a WHERE clause on
one compiled into SQL referencing a non-existent column and only failed at *prepare
time* with an opaque `no such column`.

This adds `!is_relation_field(MemberInfo)` to `f()`, `Field`, and `CollatedField` so a
relation-member operand fails at the **call site** with a clear constraint violation
(CLAUDE.md rule 11), matching how `JoinableFields` / `FKFieldOf` already gate join
selectors.

## Layering

`base.cppm` already imports `where.cppm`, so `where` cannot import `base` (cycle). The
relation-annotation **types** (`ManyToMany`, `ReverseFk`) and detection predicates
(`is_m2m_field`, `is_reverse_fk_field`, `is_relation_field`) are extracted into a new
dependency-free leaf module **`storm_orm_relation_meta`** (same pattern as
`storm_orm_field_attr`, #387). `base` re-exposes them into
`storm::orm::statements::meta` so existing callers and `storm.cppm` re-exports are
unchanged; the resolution/junction logic stays in `base`.

## Tests

Concept-based `static_assert`s prove `f<>()` rejects an m2m container
(`^^Student::courses`, `^^Pupil::courses`) and a reverse-FK container
(`^^RfPerson::tasks`, `^^RfBoard::notes`) while still accepting real columns and FK
fields.

## Verification

- Full debug suite green (SQLite + PostgreSQL), 100% coverage
- clang-format + clang-tidy clean
- ASAN+UBSAN build + affected suites clean

## Definition of done

- [x] `f<relation-member>()` is a compile error with a clear message (m2m AND reverse-fk)
- [x] No layering cycle introduced (`where` imports the new leaf, not `base`)
- [x] Test for both an m2m and a reverse-fk member
- [x] Existing valid `f<>()` usages still compile (full suite regression)

Closes #408

🤖 Generated with [Claude Code](https://claude.com/claude-code)