### PR TITLE
refactor(api): add [[nodiscard]] to all QuerySet/statement builders

### DIFF
--- a/src/orm/queryset.cppm
+++ b/src/orm/queryset.cppm
@@ -56,12 +56,12 @@ export namespace storm {
         // LCOV_EXCL_STOP
 
         // Erase single object - returns proxy with .execute() and .to_sql()
-        auto erase(const T& obj [[clang::lifetimebound]]) {
+        [[nodiscard]] auto erase(const T& obj [[clang::lifetimebound]]) {
             return orm::statements::EraseStatement<T, ConnType>(conn_).query(obj);
         }
 
         // Bulk erase - returns proxy with .execute() and .to_sql()
-        auto erase(std::span<const T> objects [[clang::lifetimebound]]) {
+        [[nodiscard]] auto erase(std::span<const T> objects [[clang::lifetimebound]]) {
             return orm::statements::EraseStatement<T, ConnType>(conn_).query(objects);
         }
 
@@ -84,20 +84,20 @@ export namespace storm {
         // (SFINAE: only accept T, not span/container)
         template <orm::statements::ReturnId R = orm::statements::ReturnId::Yes, typename U = T>
             requires std::same_as<std::remove_cvref_t<U>, T>
-        auto insert(const U& obj [[clang::lifetimebound]]) {
+        [[nodiscard]] auto insert(const U& obj [[clang::lifetimebound]]) {
             return orm::statements::InsertStatement<T, ConnType>(conn_).template query<R>(obj);
         }
 
         // Bulk insert - returns proxy with .execute() and .to_sql()
         // Default (no template arg): .execute() returns std::expected<void, Error>
         // ReturnId::Yes: .execute() returns std::expected<std::vector<int64_t>, Error>
-        auto
+        [[nodiscard]] auto
         insert(std::span<const T>                            objects [[clang::lifetimebound]],
                std::optional<orm::statements::InsertOptions> opts = std::nullopt) {
             return orm::statements::InsertStatement<T, ConnType>(conn_).query(objects, opts);
         }
         template <orm::statements::ReturnId R>
-        auto
+        [[nodiscard]] auto
         insert(std::span<const T>                            objects [[clang::lifetimebound]],
                std::optional<orm::statements::InsertOptions> opts = std::nullopt) {
             return orm::statements::InsertStatement<T, ConnType>(conn_).template query<R>(objects, opts);
@@ -214,7 +214,7 @@ export namespace storm {
         // OPTIMIZATION: Returns cached DistinctStatement for optimal performance
         // Returns DistinctStatement by value - connection-level prepare_cached() handles SQL caching
         // No static thread_local needed since actual statement caching is at connection level
-        template <std::meta::info... FieldInfos> constexpr auto distinct() {
+        template <std::meta::info... FieldInfos> [[nodiscard]] constexpr auto distinct() {
             if constexpr (sizeof...(FieldInfos) == 0) {
                 using StmtType = orm::statements::
                         DistinctStatement<T, ConnType, orm::statements::BaseStatement<T>::primary_key_>;
@@ -235,7 +235,7 @@ export namespace storm {
         // including duplicates. Works with WHERE, JOIN, ORDER BY, LIMIT/OFFSET.
         template <std::meta::info... FieldInfos>
             requires(sizeof...(FieldInfos) > 0)
-        constexpr auto values() {
+        [[nodiscard]] constexpr auto values() {
             using StmtType = orm::statements::ValuesStatement<T, ConnType, FieldInfos...>;
             return StmtType{conn_, where_expr_, join_stmt_, limit_value_, offset_value_, order_by_wrapper_};
         }
@@ -273,12 +273,12 @@ export namespace storm {
         // (SFINAE: only accept T, not span/container)
         template <typename U = T>
             requires std::same_as<std::remove_cvref_t<U>, T>
-        auto update(const U& obj [[clang::lifetimebound]]) {
+        [[nodiscard]] auto update(const U& obj [[clang::lifetimebound]]) {
             return orm::statements::UpdateStatement<T, ConnType>(conn_).query(obj);
         }
 
         // Bulk update - returns proxy with .execute() and .to_sql()
-        auto update(std::span<const T> objects [[clang::lifetimebound]]) {
+        [[nodiscard]] auto update(std::span<const T> objects [[clang::lifetimebound]]) {
             return orm::statements::UpdateStatement<T, ConnType>(conn_).query(objects);
         }
 
@@ -325,7 +325,7 @@ export namespace storm {
         //   qs.where(age > 25).group_by<^^Person::years_exp>().count().execute()
         template <std::meta::info... GroupFieldInfos>
             requires(sizeof...(GroupFieldInfos) > 0)
-        auto group_by() {
+        [[nodiscard]] auto group_by() {
             return orm::statements::GroupByBuilder<T, ConnType, GroupFieldInfos...>{
                     {conn_, where_expr_, join_stmt_, limit_value_, offset_value_, order_by_wrapper_, nullptr}
             };
@@ -335,28 +335,28 @@ export namespace storm {
         // =====================================================================
 
         template <bool F_ = Finalized_>
-        auto union_(const QuerySet<T, ConnType, false>& other)
+        [[nodiscard]] auto union_(const QuerySet<T, ConnType, false>& other)
             requires(!F_)
         {
             return make_setop_builder(other, orm::statements::SetOpType::Union);
         }
 
         template <bool F_ = Finalized_>
-        auto union_all(const QuerySet<T, ConnType, false>& other)
+        [[nodiscard]] auto union_all(const QuerySet<T, ConnType, false>& other)
             requires(!F_)
         {
             return make_setop_builder(other, orm::statements::SetOpType::UnionAll);
         }
 
         template <bool F_ = Finalized_>
-        auto except_(const QuerySet<T, ConnType, false>& other)
+        [[nodiscard]] auto except_(const QuerySet<T, ConnType, false>& other)
             requires(!F_)
         {
             return make_setop_builder(other, orm::statements::SetOpType::Except);
         }
 
         template <bool F_ = Finalized_>
-        auto intersect_(const QuerySet<T, ConnType, false>& other)
+        [[nodiscard]] auto intersect_(const QuerySet<T, ConnType, false>& other)
             requires(!F_)
         {
             return make_setop_builder(other, orm::statements::SetOpType::Intersect);
@@ -381,7 +381,7 @@ export namespace storm {
         //        queryset.where(age > 30).sum<^^Person::age>().execute()
         //        queryset.join<FK>().sum<^^Person::salary>().execute()
         // Returns statement by value - connection-level prepare_cached() handles SQL caching
-        template <std::meta::info... FieldInfos> auto sum() {
+        template <std::meta::info... FieldInfos> [[nodiscard]] auto sum() {
             using StmtType = orm::statements::AggregateStatement<
                     T,
                     ConnType,
@@ -396,7 +396,7 @@ export namespace storm {
         //        queryset.where(age > 30).count().execute()
         //        queryset.join<FK>().count().execute()
         // Returns statement by value - connection-level prepare_cached() handles SQL caching
-        template <std::meta::info... FieldInfos> auto count() {
+        template <std::meta::info... FieldInfos> [[nodiscard]] auto count() {
             using StmtType = orm::statements::AggregateStatement<
                     T,
                     ConnType,
@@ -410,7 +410,7 @@ export namespace storm {
         // Usage: queryset.avg<^^Person::salary>().execute()
         //        queryset.where(department == "Engineering").avg<^^Person::salary>().execute()
         // Returns statement by value - connection-level prepare_cached() handles SQL caching
-        template <std::meta::info... FieldInfos> auto avg() {
+        template <std::meta::info... FieldInfos> [[nodiscard]] auto avg() {
             using StmtType = orm::statements::AggregateStatement<
                     T,
                     ConnType,
@@ -424,7 +424,7 @@ export namespace storm {
         // Usage: queryset.min<^^Person::age>().execute()
         //        queryset.where(active == true).min<^^Person::age>().execute()
         // Returns statement by value - connection-level prepare_cached() handles SQL caching
-        template <std::meta::info... FieldInfos> auto min() {
+        template <std::meta::info... FieldInfos> [[nodiscard]] auto min() {
             using StmtType = orm::statements::AggregateStatement<
                     T,
                     ConnType,
@@ -438,7 +438,7 @@ export namespace storm {
         // Usage: queryset.max<^^Person::age>().execute()
         //        queryset.where(department == "Sales").max<^^Person::salary>().execute()
         // Returns statement by value - connection-level prepare_cached() handles SQL caching
-        template <std::meta::info... FieldInfos> auto max() {
+        template <std::meta::info... FieldInfos> [[nodiscard]] auto max() {
             using StmtType = orm::statements::AggregateStatement<
                     T,
                     ConnType,
@@ -452,7 +452,7 @@ export namespace storm {
         // Usage: queryset.count_distinct<^^Person::age>().execute()
         //        queryset.where(active == true).count_distinct<^^Person::department>().execute()
         // Returns statement by value - connection-level prepare_cached() handles SQL caching
-        template <std::meta::info FieldInfo> auto count_distinct() {
+        template <std::meta::info FieldInfo> [[nodiscard]] auto count_distinct() {
             using StmtType = orm::statements::AggregateStatement<
                     T,
                     ConnType,

--- a/src/orm/statements/aggregate.cppm
+++ b/src/orm/statements/aggregate.cppm
@@ -237,20 +237,20 @@ export namespace storm::orm::statements {
             , having_expr_(std::move(p.having_expr)) {}
 
         // HAVING clause - only available when GROUP BY is present
-        auto having(orm::where::ExpressionVariantPtr expr)
+        [[nodiscard]] auto having(orm::where::ExpressionVariantPtr expr)
             requires HasGroupBy
         {
             return AggregateStatement<T, ConnType, GroupFields, Ops...>{make_params(std::move(expr))};
         }
 
         // Chaining methods (only for non-GROUP BY queries building aggregates)
-        template <std::meta::info... FieldInfos> auto sum() {
+        template <std::meta::info... FieldInfos> [[nodiscard]] auto sum() {
             return AggregateStatement<T, ConnType, GroupFields, Ops..., AggregateOp<AggregateType::SUM, FieldInfos...>>{
                     make_params()
             };
         }
 
-        template <std::meta::info... FieldInfos> auto count() {
+        template <std::meta::info... FieldInfos> [[nodiscard]] auto count() {
             return AggregateStatement<
                     T,
                     ConnType,
@@ -259,19 +259,19 @@ export namespace storm::orm::statements {
                     AggregateOp<AggregateType::COUNT, FieldInfos...>>{make_params()};
         }
 
-        template <std::meta::info... FieldInfos> auto avg() {
+        template <std::meta::info... FieldInfos> [[nodiscard]] auto avg() {
             return AggregateStatement<T, ConnType, GroupFields, Ops..., AggregateOp<AggregateType::AVG, FieldInfos...>>{
                     make_params()
             };
         }
 
-        template <std::meta::info... FieldInfos> auto min() {
+        template <std::meta::info... FieldInfos> [[nodiscard]] auto min() {
             return AggregateStatement<T, ConnType, GroupFields, Ops..., AggregateOp<AggregateType::MIN, FieldInfos...>>{
                     make_params()
             };
         }
 
-        template <std::meta::info... FieldInfos> auto max() {
+        template <std::meta::info... FieldInfos> [[nodiscard]] auto max() {
             return AggregateStatement<T, ConnType, GroupFields, Ops..., AggregateOp<AggregateType::MAX, FieldInfos...>>{
                     make_params()
             };
@@ -672,35 +672,35 @@ export namespace storm::orm::statements {
         explicit GroupByBuilder(AggregateParams<ConnType> p) : params_(std::move(p)) {}
 
         // HAVING clause - stores expression and returns new GroupByBuilder
-        auto having(orm::where::ExpressionVariantPtr expr) {
+        [[nodiscard]] auto having(orm::where::ExpressionVariantPtr expr) {
             auto p        = params_;
             p.having_expr = std::move(expr);
             return GroupByBuilder<T, ConnType, GroupFieldInfos...>{std::move(p)};
         }
 
-        template <std::meta::info... FieldInfos> auto count() {
+        template <std::meta::info... FieldInfos> [[nodiscard]] auto count() {
             return AggregateStatement<T, ConnType, GBFields, AggregateOp<AggregateType::COUNT, FieldInfos...>>{params_};
         }
 
-        template <std::meta::info... FieldInfos> auto count_distinct() {
+        template <std::meta::info... FieldInfos> [[nodiscard]] auto count_distinct() {
             return AggregateStatement<T, ConnType, GBFields, AggregateOp<AggregateType::COUNT_DISTINCT, FieldInfos...>>{
                     params_
             };
         }
 
-        template <std::meta::info... FieldInfos> auto sum() {
+        template <std::meta::info... FieldInfos> [[nodiscard]] auto sum() {
             return AggregateStatement<T, ConnType, GBFields, AggregateOp<AggregateType::SUM, FieldInfos...>>{params_};
         }
 
-        template <std::meta::info... FieldInfos> auto avg() {
+        template <std::meta::info... FieldInfos> [[nodiscard]] auto avg() {
             return AggregateStatement<T, ConnType, GBFields, AggregateOp<AggregateType::AVG, FieldInfos...>>{params_};
         }
 
-        template <std::meta::info... FieldInfos> auto min() {
+        template <std::meta::info... FieldInfos> [[nodiscard]] auto min() {
             return AggregateStatement<T, ConnType, GBFields, AggregateOp<AggregateType::MIN, FieldInfos...>>{params_};
         }
 
-        template <std::meta::info... FieldInfos> auto max() {
+        template <std::meta::info... FieldInfos> [[nodiscard]] auto max() {
             return AggregateStatement<T, ConnType, GBFields, AggregateOp<AggregateType::MAX, FieldInfos...>>{params_};
         }
 

--- a/src/orm/statements/erase.cppm
+++ b/src/orm/statements/erase.cppm
@@ -233,7 +233,7 @@ export namespace storm::orm::statements {
             }
         };
 
-        auto query(const T& obj [[clang::lifetimebound]]) -> SingleQuery {
+        [[nodiscard]] auto query(const T& obj [[clang::lifetimebound]]) -> SingleQuery {
             return {std::move(*this), obj};
         }
         // LIFETIME CONTRACT (issue #357, finding B): the returned BulkQuery holds a
@@ -242,13 +242,13 @@ export namespace storm::orm::statements {
         // container that dies before .execute()/.to_sql() runs still dangles silently at
         // runtime. Treat the proxy as single-expression-use: keep the backing container
         // alive until the terminal call completes.
-        auto query(std::span<const T> objects [[clang::lifetimebound]]) -> BulkQuery {
+        [[nodiscard]] auto query(std::span<const T> objects [[clang::lifetimebound]]) -> BulkQuery {
             return {std::move(*this), objects};
         }
-        auto query_all() -> DeleteAllQuery {
+        [[nodiscard]] auto query_all() -> DeleteAllQuery {
             return {std::move(*this)};
         }
-        auto query_where(orm::where::ExpressionVariantPtr where_expr) -> ConditionalDeleteQuery {
+        [[nodiscard]] auto query_where(orm::where::ExpressionVariantPtr where_expr) -> ConditionalDeleteQuery {
             return {std::move(*this), std::move(where_expr)};
         }
 

--- a/src/orm/statements/insert.cppm
+++ b/src/orm/statements/insert.cppm
@@ -283,7 +283,7 @@ export namespace storm::orm::statements {
             }
         };
 
-        template <ReturnId R = ReturnId::Yes> auto query(const T& obj [[clang::lifetimebound]]) {
+        template <ReturnId R = ReturnId::Yes> [[nodiscard]] auto query(const T& obj [[clang::lifetimebound]]) {
             if constexpr (R == ReturnId::Yes) {
                 return SingleQuery{std::move(*this), obj};
             } else {
@@ -297,13 +297,13 @@ export namespace storm::orm::statements {
         // dangles silently at runtime. Treat the proxy as single-expression-use: keep the
         // backing container alive until the terminal call completes. Same for the
         // ReturnId-templated overload below.
-        auto
+        [[nodiscard]] auto
         query(std::span<const T> objects [[clang::lifetimebound]], std::optional<InsertOptions> opts = std::nullopt)
                 -> BulkQuery {
             return {std::move(*this), objects, opts};
         }
         template <ReturnId R>
-        auto
+        [[nodiscard]] auto
         query(std::span<const T> objects [[clang::lifetimebound]], std::optional<InsertOptions> opts = std::nullopt) {
             if constexpr (R == ReturnId::Yes) {
                 return BulkReturningQuery{std::move(*this), objects, opts};

--- a/src/orm/statements/setop.cppm
+++ b/src/orm/statements/setop.cppm
@@ -48,23 +48,23 @@ export namespace storm::orm::statements {
         }
 
         // clang-format off
-        template <typename U> requires std::same_as<U, T> auto union_    (SetOpOperand<U> operand) -> SetOpBuilder&& { return add_operand(std::move(operand), SetOpType::Union);     }
-        template <typename U> requires std::same_as<U, T> auto union_all (SetOpOperand<U> operand) -> SetOpBuilder&& { return add_operand(std::move(operand), SetOpType::UnionAll);  }
-        template <typename U> requires std::same_as<U, T> auto except_   (SetOpOperand<U> operand) -> SetOpBuilder&& { return add_operand(std::move(operand), SetOpType::Except);    }
-        template <typename U> requires std::same_as<U, T> auto intersect_(SetOpOperand<U> operand) -> SetOpBuilder&& { return add_operand(std::move(operand), SetOpType::Intersect); }
+        template <typename U> requires std::same_as<U, T> [[nodiscard]] auto union_    (SetOpOperand<U> operand) -> SetOpBuilder&& { return add_operand(std::move(operand), SetOpType::Union);     }
+        template <typename U> requires std::same_as<U, T> [[nodiscard]] auto union_all (SetOpOperand<U> operand) -> SetOpBuilder&& { return add_operand(std::move(operand), SetOpType::UnionAll);  }
+        template <typename U> requires std::same_as<U, T> [[nodiscard]] auto except_   (SetOpOperand<U> operand) -> SetOpBuilder&& { return add_operand(std::move(operand), SetOpType::Except);    }
+        template <typename U> requires std::same_as<U, T> [[nodiscard]] auto intersect_(SetOpOperand<U> operand) -> SetOpBuilder&& { return add_operand(std::move(operand), SetOpType::Intersect); }
         // clang-format on
 
-        template <auto... Args> auto order_by() -> SetOpBuilder&& {
+        template <auto... Args> [[nodiscard]] auto order_by() -> SetOpBuilder&& {
             order_by_wrapper_ = make_order_by_wrapper<Args...>();
             return std::move(*this);
         }
 
-        auto limit(int n) -> SetOpBuilder&& {
+        [[nodiscard]] auto limit(int n) -> SetOpBuilder&& {
             limit_value_ = n;
             return std::move(*this);
         }
 
-        auto offset(int n) -> SetOpBuilder&& {
+        [[nodiscard]] auto offset(int n) -> SetOpBuilder&& {
             offset_value_ = n;
             return std::move(*this);
         }

--- a/src/orm/statements/update.cppm
+++ b/src/orm/statements/update.cppm
@@ -164,7 +164,7 @@ export namespace storm::orm::statements {
       public:
         explicit UpdateStatement(std::shared_ptr<ConnType> conn) : conn_(std::move(conn)) {}
 
-        auto query(const T& obj [[clang::lifetimebound]]) -> detail::SingleQuery<T, ConnType> {
+        [[nodiscard]] auto query(const T& obj [[clang::lifetimebound]]) -> detail::SingleQuery<T, ConnType> {
             return {{}, std::move(*this), obj};
         }
         // LIFETIME CONTRACT (issue #357, finding B): the returned BulkQuery holds a
@@ -173,20 +173,23 @@ export namespace storm::orm::statements {
         // container that dies before .execute()/.to_sql() runs still dangles silently at
         // runtime. Treat the proxy as single-expression-use: keep the backing container
         // alive until the terminal call completes.
-        auto query(std::span<const T> objects [[clang::lifetimebound]]) -> detail::BulkQuery<T, ConnType> {
+        [[nodiscard]] auto query(std::span<const T> objects [[clang::lifetimebound]])
+                -> detail::BulkQuery<T, ConnType> {
             return {{}, std::move(*this), objects};
         }
 
         template <std::meta::info... Members>
             requires(sizeof...(Members) > 0 && (Grammar::template is_settable_member<Members>() && ...))
-        auto query_where(const T& proto [[clang::lifetimebound]], orm::where::ExpressionVariantPtr where_expr)
+        [[nodiscard]] auto
+        query_where(const T& proto [[clang::lifetimebound]], orm::where::ExpressionVariantPtr where_expr)
                 -> detail::ConditionalUpdateQuery<T, ConnType, Members...> {
             return {std::move(*this), proto, std::move(where_expr)};
         }
 
         template <std::meta::info... Members>
             requires(sizeof...(Members) > 0 && (Grammar::template is_settable_member<Members>() && ...))
-        auto query_all(const T& proto [[clang::lifetimebound]]) -> detail::UpdateAllQuery<T, ConnType, Members...> {
+        [[nodiscard]] auto query_all(const T& proto [[clang::lifetimebound]])
+                -> detail::UpdateAllQuery<T, ConnType, Members...> {
             return {std::move(*this), proto};
         }
 


### PR DESCRIPTION
## What

Adds `[[nodiscard]]` to every QuerySet/statement **builder** method whose return value is a proxy meant to be terminated with `.execute()` / `.to_sql()`.

Before this change the attribute was applied inconsistently: `erase()` (conditional) and `erase_all()` had it, but `erase(obj)`/`erase(span)`, `insert(...)`, `update(...)`, the scalar aggregates (`sum`/`count`/`avg`/`min`/`max`/`count_distinct`), `distinct`/`values`, `group_by`, the set-op builders (`union_`/`union_all`/`except_`/`intersect_`/`order_by`/`limit`/`offset`), and the `AggregateStatement`/`GroupByBuilder` chaining methods did not.

## Why

Discarding e.g. `qs.insert(person);` or `qs.count();` silently builds a query that **never runs** — exactly the footgun `[[nodiscard]]` exists to catch. This makes the discipline uniform across `queryset.cppm` and all statement builders.

Surfaced by a full C++ Core Guidelines (F.7) review of `src/` via the `cpp-coding-standards` agent.

## Scope / safety

- **Compile-time only** — `[[nodiscard]]` generates no code: zero runtime/perf impact (no benchmark needed), no behavior change.
- Builds clean under `-Werror`, which **proves no existing call site** (src/tests/benchmarks) discards any of these results — this is pure hardening.
- All 2433 tests pass; pre-commit gate green incl. **100.0% line coverage**.

## Follow-up

Remaining **style/minor** Core-Guidelines findings (named constants, `std::format` over concatenation, `explicit` conversions, the `std::move`-on-const-ref nit, schema DDL `[[nodiscard]]`) are tracked in #454.

Files: `queryset.cppm`, `statements/{aggregate,erase,insert,setop,update}.cppm`

🤖 Generated with [Claude Code](https://claude.com/claude-code)