### PR TITLE
feat(upsert): ON CONFLICT DO UPDATE / DO NOTHING (#205)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -483,6 +483,11 @@ qs.where(f<^^Person::salary>() < 50000)
 // Empty where() is refused (no full-table write); update_all<>() is the explicit wipe (#409).
 qs.update_all<^^Person::department>(Person{.department="Global"}).execute(); // UPDATE … SET, no WHERE
 
+// Upsert (#205) — single-row INSERT ... ON CONFLICT (target) DO UPDATE / DO NOTHING.
+// Conflict target must be a unique field / UniqueIndex (compile-time checked).
+qs.insert(p).on_conflict<^^Person::name>().update<^^Person::age>().execute(); // std::expected<int64_t, Error>
+qs.insert(p).on_conflict<^^Person::name>().nothing().execute();                // std::expected<std::optional<int64_t>, Error>
+
 // Public transaction API (#415) — storm::begin(conn) returns an RAII
 // storm::TransactionGuard<ConnType> (both re-exported from `storm`). BEGIN on
 // begin(), explicit txn->commit(), auto-ROLLBACK on early return / throw / scope

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,7 @@ Documentation for users of Storm ORM — patterns, features, and field/migration
 - **[WHERE Clauses](guide/features/WHERE_CLAUSES.md)** - Type-safe filtering with pure C++26 reflection
 - **[JOIN Operations](guide/features/JOIN_OPERATIONS.md)** - Single and multi-FK JOINs with type erasure
 - **[Batch Operations](guide/features/BATCH_OPERATIONS.md)** - Bulk INSERT/UPDATE/DELETE with smart thresholds
+- **[UPSERT Operations](guide/features/UPSERT.md)** - Single-row ON CONFLICT DO UPDATE / DO NOTHING
 - **[Referential Integrity](guide/features/REFERENTIAL_INTEGRITY.md)** - Always-on FK constraints, junction FOREIGN KEYs, SQLite PRAGMA
 - **[Connection Tuning](guide/features/CONNECTION_TUNING.md)** - SQLite busy_timeout default, optional WAL, pooled concurrency
 

--- a/docs/guide/features/UPSERT.md
+++ b/docs/guide/features/UPSERT.md
@@ -1,0 +1,59 @@
+# UPSERT Operations
+
+Storm supports single-row `INSERT ... ON CONFLICT` through the insert proxy.
+Choose an explicit unique conflict target, then select either `DO UPDATE` or
+`DO NOTHING`. The target is checked at compile time: it must be a unique field
+or exactly match a declared `UniqueIndex`. Primary keys are omitted from inserts
+and therefore cannot be conflict targets.
+
+## DO UPDATE
+
+`update<Members...>()` overwrites the listed columns with the attempted
+insert's values. It always returns the ID of the row that was inserted or
+updated.
+
+```cpp
+auto result = qs.insert(user)
+    .on_conflict<^^User::email>()
+    .update<^^User::name, ^^User::age>()
+    .execute();  // std::expected<int64_t, storm::db::Error>
+```
+
+```sql
+INSERT INTO User (name, email, age) VALUES (?, ?, ?)
+ON CONFLICT (email) DO UPDATE SET name=excluded.name, age=excluded.age
+RETURNING id
+```
+
+Only the `update<...>()` members are overwritten. An `auto_update` timestamp is
+also refreshed automatically. Foreign-key members use their database column
+name (`owner_id`) in both the conflict target and update clause.
+
+## DO NOTHING
+
+`nothing()` inserts a row when the target is new and skips it when it already
+exists.
+
+```cpp
+auto result = qs.insert(user)
+    .on_conflict<^^User::email>()
+    .nothing()
+    .execute();  // std::expected<std::optional<int64_t>, storm::db::Error>
+```
+
+```sql
+INSERT INTO User (name, email, age) VALUES (?, ?, ?)
+ON CONFLICT (email) DO NOTHING
+RETURNING id
+```
+
+| Operation | Result type | Conflict result |
+| --- | --- | --- |
+| `.update<...>()` | `std::expected<int64_t, Error>` | Existing row is updated; its ID is returned. |
+| `.nothing()` | `std::expected<std::optional<int64_t>, Error>` | No row is changed; the value is `std::nullopt`. |
+
+`DO NOTHING` is useful for get-or-create flows, but it does **not** return the
+existing row's ID when a conflict is skipped. Use `DO UPDATE` when the ID is
+needed on every call.
+
+Bulk insert spans are not supported by the upsert chain.

--- a/docs/superpowers/plans/2026-06-22-upsert-on-conflict.md
+++ b/docs/superpowers/plans/2026-06-22-upsert-on-conflict.md
@@ -1,0 +1,888 @@
+# Upsert (`ON CONFLICT`) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add single-row `INSERT ... ON CONFLICT (target) DO UPDATE / DO NOTHING` to the `QuerySet` insert proxy.
+
+**Architecture:** A new `consteval` grammar module (`UpsertGrammar<T>`) builds the conflict clause from reflection and appends it to the existing compile-time INSERT...RETURNING SQL. New proxy structs on `InsertStatement` (`ConflictTarget` → `UpdateUpsertQuery` / `NothingUpsertQuery`) carry the conflict target + SET columns as NTTPs and dispatch to two new execute paths. The upsert chain drops `ReturnId`: `.update<>()` returns `expected<int64_t>`, `.nothing()` returns `expected<optional<int64_t>>`.
+
+**Tech Stack:** C++26 (clang-p2996 reflection), Storm ORM modules, GoogleTest TYPED_TEST over SQLite + PostgreSQL.
+
+## Global Constraints
+
+- **Spec:** `docs/superpowers/specs/2026-06-22-upsert-design.md` — every task implements part of it.
+- **Branch:** work in worktree `.claude/worktrees/feature-205-upsert` on `feature/205-upsert-on-conflict`. NEVER edit files in the main `/storm_develop/` tree (edits there silently vanish from this build).
+- **TDD (rule #9):** write tests → run (MUST fail) → implement → run (pass). Never implement before a failing test.
+- **Build presets:** Debug `cmake --preset ninja-debug && cmake --build --preset ninja-debug`; tests `ctest --preset ninja-debug` or filtered `./build/debug/tests/storm_tests --gtest_filter="UpsertTest.*"`.
+- **No CMake changes:** `src/` and `tests/` use GLOB auto-discovery for `.cppm`/`.cpp`. Re-run `cmake --preset ninja-debug` after adding a new file so the glob refreshes.
+- **Compile-time errors:** use `requires` constraints, never `throw` in `consteval` (rule #11).
+- **`import std;`** + textual `#include <meta>` BEFORE the module imports in reflection TUs (the `.cppm` pattern in update_grammar.cppm).
+- **Column-name writer (#422):** always emit columns via `storm::meta::append_column_name(buf, member)` so FK fields get the `_id` suffix consistently.
+- **600-line hook limit:** `insert.cppm` is already 604 lines. If adding proxies trips the file-size hook, move the new proxy structs into a sibling `namespace detail` block (pattern from #438) or accept the `.lint-skip` only as a last resort.
+- **SonarCloud "Storm Strict":** zero new issues / duplication. Use `std::format` not concat (S6185), `||`/`&&` not `or`/`and` (S3659), `public:` in fixtures (S3656), `emplace_back` (S6003).
+
+---
+
+## File Structure
+
+- **Create** `src/orm/statements/upsert_grammar.cppm` — `UpsertGrammar<T>`: `consteval` conflict-target list, `excluded.col` SET-clause builder, and per-`<Target...,SetCols...>` upsert SQL string. Mirrors `update_grammar.cppm`.
+- **Modify** `src/orm/statements/insert.cppm` — `on_conflict<Target...>()` on `SingleQuery`/`VoidQuery`; new `ConflictTarget`, `UpdateUpsertQuery`, `NothingUpsertQuery` proxies; `execute_upsert_update` / `execute_upsert_nothing` paths. Import `storm_orm_statements_upsert_grammar` + `storm_orm_indexes`.
+- **Create** `tests/crud/test_upsert.cpp` — TYPED_TEST suite over `DatabaseTypes`.
+- **Create** `docs/guide/features/UPSERT.md` — user docs.
+- **Modify** `docs/README.md`, `CLAUDE.md` — link + API row.
+
+---
+
+## Task 1: `UpsertGrammar<T>` — conflict-target + SET clause builders
+
+**Files:**
+- Create: `src/orm/statements/upsert_grammar.cppm`
+- Test: `tests/crud/test_upsert.cpp` (compile-time SQL-string assertions only in this task)
+
+**Interfaces:**
+- Consumes: `BaseStatement<T>` (`Base::all_members_`, `Base::primary_key_`, `Base::pk_name_`, `Base::table_name_`), `storm::meta::append_column_name`, `storm::meta::is_auto_update`, `InsertStatement<T,ConnType>::insert_returning_sql_array` (via re-derivation — see step 3).
+- Produces:
+  - `UpsertGrammar<T>::build_conflict_target<Target...>()` → `ConstexprString` of `(col1, col2, ...)` (FK-aware).
+  - `UpsertGrammar<T>::build_excluded_set_clause<SetCols...>()` → `ConstexprString` of `col=excluded.col, ...` (+ unlisted auto_update appended as `col=?`).
+  - `UpsertGrammar<T>::is_settable_member<Member>()` → `bool`.
+  - `UpsertGrammar<T>::is_unlisted_auto_update<SetCols...>(member)` → `bool`.
+
+- [ ] **Step 1: Write the failing test** — append to (new) `tests/crud/test_upsert.cpp`:
+
+```cpp
+#include <gtest/gtest.h>
+#include "test_db_helpers.h"
+#include <sqlite3.h>
+
+import storm;
+import std;
+
+#include "test_models.h" // NOSONAR cpp:S954
+#include "test_seed_helpers.h"
+
+namespace {
+using storm::orm::statements::UpsertGrammar;
+}
+
+// Grammar emits a single-column conflict target via the FK-aware writer.
+TEST(UpsertGrammarTest, ConflictTargetSingleColumn) {
+    constexpr auto target = UpsertGrammar<Person>::build_conflict_target<^^Person::name>();
+    const std::string s(target);
+    EXPECT_EQ(s, "(name)");
+}
+
+// Grammar emits col=excluded.col for each listed SET column.
+TEST(UpsertGrammarTest, ExcludedSetClauseMultipleColumns) {
+    constexpr auto set = UpsertGrammar<Person>::build_excluded_set_clause<^^Person::age, ^^Person::salary>();
+    const std::string s(set);
+    EXPECT_EQ(s, "age=excluded.age, salary=excluded.salary");
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cmake --preset ninja-debug && cmake --build --preset ninja-debug 2>&1 | tail -20`
+Expected: FAIL — `UpsertGrammar` not declared / module `storm_orm_statements_upsert_grammar` not found.
+
+- [ ] **Step 3: Write `src/orm/statements/upsert_grammar.cppm`**
+
+```cpp
+module;
+
+// Compile-time UPSERT (ON CONFLICT) SQL grammar (#205): the consteval helpers
+// that spell the conflict-target list and the `excluded.col` DO UPDATE SET
+// clause, split out of InsertStatement to keep that class cohesive. Stateless
+// and connection-free — every member derives purely from reflection over T.
+
+#include <meta>
+
+export module storm_orm_statements_upsert_grammar;
+
+import std;
+
+import storm_orm_statements_base;
+import storm_orm_utilities;
+
+export namespace storm::orm::statements {
+
+    using storm::orm::utilities::ConstexprString;
+
+    template <typename T> struct UpsertGrammar {
+        using Base = BaseStatement<T>;
+
+        // (col1, col2, ...) — conflict-target column list, FK "_id"-aware (#422).
+        template <std::meta::info... Target> static consteval auto build_conflict_target() {
+            ConstexprString<utilities::buffer_size::SQL_SMALL> result;
+            result.append("(");
+            bool first = true;
+            (
+                    [&] {
+                        if (!first) {
+                            result.append(", ");
+                        }
+                        meta::append_column_name(result, Target);
+                        first = false;
+                    }(),
+                    ...
+            );
+            result.append(")");
+            return result;
+        }
+
+        // Each SET target must be a non-static data member of T and not the PK.
+        template <std::meta::info Member> static consteval auto is_settable_member() -> bool {
+            return std::meta::is_nonstatic_data_member(Member) && Member != Base::primary_key_;
+        }
+
+        // True when `member` carries auto_update (#209) and is NOT in the explicit pack.
+        template <std::meta::info... SetCols>
+        static consteval auto is_unlisted_auto_update(std::meta::info member) -> bool {
+            return meta::is_auto_update(member) && ((member != SetCols) && ...);
+        }
+
+        // "col=excluded.col, ..." for the explicit SetCols pack, then any
+        // auto_update field of T not already listed, appended as "col=?" (bound
+        // now() at execution). The column ORDER of the auto_update tail is the
+        // canonical bind order used by the execute path.
+        template <std::meta::info... SetCols> static consteval auto build_excluded_set_clause() {
+            ConstexprString<utilities::buffer_size::SQL_MEDIUM> result;
+            bool first = true;
+            (
+                    [&] {
+                        if (!first) {
+                            result.append(", ");
+                        }
+                        meta::append_column_name(result, SetCols);
+                        result.append("=excluded.");
+                        meta::append_column_name(result, SetCols);
+                        first = false;
+                    }(),
+                    ...
+            );
+            for (const auto& member : Base::all_members_) {
+                if (is_unlisted_auto_update<SetCols...>(member)) {
+                    if (!first) {
+                        result.append(", ");
+                    }
+                    result.append(std::meta::identifier_of(member));
+                    result.append("=?");
+                    first = false;
+                }
+            }
+            return result;
+        }
+    };
+
+} // namespace storm::orm::statements
+```
+
+- [ ] **Step 4: Export the new module from `storm`** — verify `src/storm.cppm` re-exports statement modules. Run:
+
+```bash
+grep -n "statements_update_grammar\|export import" src/storm.cppm | head
+```
+
+If `update_grammar` is exported there, add the same line for `upsert_grammar`. If statement modules are pulled transitively (no explicit line), no change needed. Mirror whatever `update_grammar` does.
+
+- [ ] **Step 5: Re-glob and build**
+
+Run: `cmake --preset ninja-debug && cmake --build --preset ninja-debug 2>&1 | tail -20`
+Expected: build succeeds (the new `.cppm` is globbed in).
+
+- [ ] **Step 6: Run the grammar tests**
+
+Run: `ctest --preset ninja-debug -R UpsertGrammarTest --output-on-failure`
+Expected: PASS (2 tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/orm/statements/upsert_grammar.cppm src/storm.cppm tests/crud/test_upsert.cpp
+git commit -m "feat(upsert): UpsertGrammar conflict-target + excluded SET clause (#205)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Upsert SQL string builder (full statement)
+
+**Files:**
+- Modify: `src/orm/statements/upsert_grammar.cppm`
+- Test: `tests/crud/test_upsert.cpp`
+
+**Interfaces:**
+- Consumes: Task 1 grammar; `InsertStatement<T,ConnType>` private SQL fragments. Because `UpsertGrammar` is connection-free but the INSERT prefix depends only on `T` (not `ConnType`), re-derive the prefix from `BaseStatement<T>` + `FieldNameGrammar<Base>` rather than reaching into `InsertStatement`.
+- Produces:
+  - `UpsertGrammar<T>::build_upsert_sql<DoUpdate, Target...>()` returning the full SQL `ConstexprString` (when `DoUpdate==false`, SetCols are ignored — DO NOTHING). For DO UPDATE, see Task overload below.
+  - Two static strings via a helper template `upsert_sql_string<bool DoUpdate, target-pack, setcol-pack>` — but C++ can't take two NTTP packs in one template. **Resolution:** split into two entry points:
+    - `build_update_upsert_sql<Target..., /*sep*/ SetCols...>()` is impossible (two packs). Instead the SET clause is passed as a precomputed `ConstexprString` value argument. See step 3.
+
+- [ ] **Step 1: Write the failing test** — append to `tests/crud/test_upsert.cpp`:
+
+```cpp
+// Full DO NOTHING statement for Person conflicting on name.
+TEST(UpsertGrammarTest, FullSqlDoNothing) {
+    const std::string sql = UpsertGrammar<Person>::nothing_sql<^^Person::name>();
+    EXPECT_TRUE(sql.starts_with("INSERT INTO person ")) << sql;
+    EXPECT_NE(sql.find("ON CONFLICT (name) DO NOTHING"), std::string::npos) << sql;
+    EXPECT_TRUE(sql.ends_with("RETURNING id")) << sql;
+}
+
+// Full DO UPDATE statement, conflict on name, set age.
+TEST(UpsertGrammarTest, FullSqlDoUpdate) {
+    const std::string sql = UpsertGrammar<Person>::update_sql<^^Person::name>(
+            UpsertGrammar<Person>::build_excluded_set_clause<^^Person::age>());
+    EXPECT_NE(sql.find("ON CONFLICT (name) DO UPDATE SET age=excluded.age"), std::string::npos) << sql;
+    EXPECT_TRUE(sql.ends_with("RETURNING id")) << sql;
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cmake --build --preset ninja-debug 2>&1 | tail -20`
+Expected: FAIL — `nothing_sql` / `update_sql` not declared.
+
+- [ ] **Step 3: Add the SQL assemblers to `upsert_grammar.cppm`** (inside `struct UpsertGrammar<T>`, after `build_excluded_set_clause`):
+
+```cpp
+        import storm_orm_statements_field_names; // (top of file, with other imports)
+
+        // INSERT INTO <table> (<non-pk cols>) VALUES (<placeholders>) ON CONFLICT
+        // The INSERT prefix + RETURNING suffix are identical to InsertStatement's
+        // RETURNING variant; re-derived here from reflection so this module stays
+        // connection-free.
+        static consteval auto build_insert_prefix() {
+            ConstexprString<utilities::buffer_size::SQL_LARGE> result;
+            result.append("INSERT INTO ");
+            result.append(Base::table_name_);
+            result.append(" (");
+            result.append(FieldNameGrammar<Base>::build_non_pk_field_names_list());
+            result.append(") VALUES (");
+            result.append(InsertPlaceholders<T>::value); // see step 4
+            result.append(")");
+            return result;
+        }
+
+        // DO NOTHING full statement (compile-time constant per Target...).
+        template <std::meta::info... Target> static auto nothing_sql() -> const std::string& {
+            static const std::string s = [] {
+                std::string out(build_insert_prefix());
+                out += " ON CONFLICT ";
+                out += std::string(build_conflict_target<Target...>());
+                out += " DO NOTHING RETURNING ";
+                out += std::string(Base::pk_name_);
+                return out;
+            }();
+            return s;
+        }
+
+        // DO UPDATE full statement. SET clause passed in as a value (two NTTP
+        // packs can't share one template parameter list).
+        template <std::meta::info... Target, std::size_t N>
+        static auto update_sql(const ConstexprString<N>& set_clause) -> std::string {
+            std::string out(build_insert_prefix());
+            out += " ON CONFLICT ";
+            out += std::string(build_conflict_target<Target...>());
+            out += " DO UPDATE SET ";
+            out += std::string(set_clause);
+            out += " RETURNING ";
+            out += std::string(Base::pk_name_);
+            return out;
+        }
+```
+
+NOTE: `build_non_pk_field_names_list()` and `InsertPlaceholders` placeholder text live in `InsertStatement`. If they are not reachable as standalone helpers, lift the placeholder builder (`build_placeholders()` from insert.cppm lines 42-60) into `FieldNameGrammar` or a small free helper so both modules share it (DRY). Verify with:
+
+```bash
+grep -n "build_non_pk_field_names_list\|build_placeholders" src/orm/statements/field_names.cppm src/orm/statements/insert.cppm
+```
+
+If `build_placeholders` is private to `InsertStatement`, add a `consteval` `build_placeholders()` to `FieldNameGrammar<Base>` (mirroring insert.cppm:42-57, skipping `Base::primary_key_`) and have InsertStatement call it — small, test-covered refactor that removes the duplication.
+
+- [ ] **Step 4: Build, run, verify pass**
+
+Run: `cmake --build --preset ninja-debug 2>&1 | tail -20 && ctest --preset ninja-debug -R UpsertGrammarTest --output-on-failure`
+Expected: 4 grammar tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/orm/statements/upsert_grammar.cppm src/orm/statements/field_names.cppm src/orm/statements/insert.cppm tests/crud/test_upsert.cpp
+git commit -m "feat(upsert): full ON CONFLICT SQL assemblers (DO UPDATE / DO NOTHING) (#205)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Compile-time validation constraints
+
+**Files:**
+- Modify: `src/orm/statements/upsert_grammar.cppm`
+- Test: `tests/crud/test_upsert.cpp` (positive compile + `static_assert` checks)
+
+**Interfaces:**
+- Consumes: `storm::indexes_t<T>` (`UniqueIndex<...>::fields`), `storm::meta::is_unique`, `Task 1` `is_settable_member`.
+- Produces:
+  - concept `ConflictTargetUnique<T, Target...>`.
+  - concept `UpsertSettable<T, SetCols...>`.
+
+- [ ] **Step 1: Write the failing test** — append to `tests/crud/test_upsert.cpp`:
+
+```cpp
+// Positive: a single unique field IS a valid conflict target.
+static_assert(storm::orm::statements::ConflictTargetUnique<Person, ^^Person::name>);
+// Positive: the UniqueIndex<name, department> column set IS valid.
+static_assert(storm::orm::statements::ConflictTargetUnique<Person, ^^Person::name, ^^Person::department>);
+// Negative: a non-unique column is NOT a valid conflict target.
+static_assert(!storm::orm::statements::ConflictTargetUnique<Person, ^^Person::age>);
+// Negative: the PK is NOT settable.
+static_assert(!storm::orm::statements::UpsertSettable<Person, ^^Person::id>);
+// Positive: a normal column IS settable.
+static_assert(storm::orm::statements::UpsertSettable<Person, ^^Person::age>);
+
+TEST(UpsertGrammarTest, ConstraintsCompile) { SUCCEED(); }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cmake --build --preset ninja-debug 2>&1 | tail -25`
+Expected: FAIL — `ConflictTargetUnique` / `UpsertSettable` not declared.
+
+- [ ] **Step 3: Add the concepts to `upsert_grammar.cppm`** (after `import` lines; needs `import storm_orm_indexes;` and `import storm_orm_field_attr;`):
+
+```cpp
+    // True if the Target... column set exactly matches some UniqueIndex<...> in Indexes<T>.
+    template <typename T, std::meta::info... Target>
+    consteval auto target_matches_unique_index() -> bool {
+        constexpr std::array targets{Target...};
+        bool matched = false;
+        [&]<typename... Idx>(std::tuple<Idx...>*) {
+            (
+                    [&] {
+                        if constexpr (Idx::unique) {
+                            if (Idx::fields.size() == targets.size()) {
+                                bool all = true;
+                                for (std::size_t i = 0; i < targets.size(); ++i) {
+                                    if (Idx::fields[i] != targets[i]) {
+                                        all = false;
+                                    }
+                                }
+                                if (all) {
+                                    matched = true;
+                                }
+                            }
+                        }
+                    }(),
+                    ...);
+        }(static_cast<storm::indexes_t<T>*>(nullptr));
+        return matched;
+    }
+
+    // A valid conflict target: every Target is a data member of T, AND either a
+    // single FieldAttr::unique field, or the PK, or a matching UniqueIndex<...>.
+    template <typename T, std::meta::info... Target>
+    concept ConflictTargetUnique = ((std::meta::is_nonstatic_data_member(Target)) && ...) && (
+            (sizeof...(Target) == 1 &&
+             ((storm::meta::is_unique(Target) ||
+               Target == BaseStatement<T>::primary_key_) && ...)) ||
+            target_matches_unique_index<T, Target...>());
+
+    // A valid SET target: a non-static data member of T that is not the PK.
+    template <typename T, std::meta::info... SetCols>
+    concept UpsertSettable = (UpsertGrammar<T>::template is_settable_member<SetCols>() && ...);
+```
+
+NOTE: `BaseStatement<T>::primary_key_` must be reachable. If it is `protected`, use `UpsertGrammar<T>::Base::primary_key_` via a public `static consteval auto pk() { return Base::primary_key_; }` helper, or compare against `storm::meta::find_primary_key(^^T)` if that free helper exists. Verify:
+
+```bash
+grep -n "primary_key_\|find_primary_key" src/orm/statements/base.cppm | head
+```
+
+- [ ] **Step 4: Build, run, verify pass**
+
+Run: `cmake --build --preset ninja-debug 2>&1 | tail -20 && ctest --preset ninja-debug -R UpsertGrammarTest --output-on-failure`
+Expected: all grammar tests PASS (the `static_assert`s compile).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/orm/statements/upsert_grammar.cppm tests/crud/test_upsert.cpp
+git commit -m "feat(upsert): ConflictTargetUnique + UpsertSettable constraints (#205)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Execute paths on `InsertStatement`
+
+**Files:**
+- Modify: `src/orm/statements/insert.cppm`
+- Test: `tests/crud/test_upsert.cpp`
+
+**Interfaces:**
+- Consumes: `UpsertGrammar<T>` (Task 1-2), `Base::bind_non_pk_fields_impl`, `Base::batch_now()`, `conn_->prepare_cached`, `Statement::step_raw/extract_int64/reset/ROW_AVAILABLE/NO_MORE_ROWS`.
+- Produces (public on `InsertStatement<T,ConnType>`):
+  - `execute_upsert_nothing<Target...>(const T&) -> std::expected<std::optional<std::int64_t>, Error>`
+  - `execute_upsert_update<Target..., N>(const T&, const ConstexprString<N>& set_clause, /*auto_update bind plan*/) -> std::expected<std::int64_t, Error>`
+
+  Bind contract: both bind the object's non-PK fields (same order/binder as plain INSERT). DO UPDATE additionally binds `now()` for each **unlisted auto_update** column, in `all_members_` declaration order, AFTER the VALUES params (because `excluded.col` SET targets need no params; only the trailing `col=?` auto_update tail does).
+
+- [ ] **Step 1: Write the failing test** — append to `tests/crud/test_upsert.cpp`:
+
+```cpp
+template <typename ConnType> class UpsertTest : public StormTestFixture<Person, ConnType> {};
+TYPED_TEST_SUITE(UpsertTest, DatabaseTypes);
+
+// DO NOTHING: first insert returns an id; conflicting second returns nullopt.
+TYPED_TEST(UpsertTest, DoNothingSkipsOnConflict) {
+    storm::QuerySet<Person, TypeParam> qs;
+    Person const a{.name = "Ann", .age = 30, .department = "Eng"};
+
+    auto first = qs.insert(a).template on_conflict<^^Person::name>().nothing().execute();
+    ASSERT_TRUE(first.has_value());
+    ASSERT_TRUE(first.value().has_value()) << "new row → id present";
+    EXPECT_GT(first.value().value(), 0);
+
+    Person const dup{.name = "Ann", .age = 99, .department = "Eng"};
+    auto second = qs.insert(dup).template on_conflict<^^Person::name>().nothing().execute();
+    ASSERT_TRUE(second.has_value());
+    EXPECT_FALSE(second.value().has_value()) << "conflict → nullopt (skipped)";
+
+    // Existing row untouched (age still 30).
+    auto row = qs.where(storm::orm::where::f<^^Person::name>() == std::string("Ann")).select().execute();
+    ASSERT_TRUE(row.has_value());
+    ASSERT_EQ(row.value().size(), 1);
+    EXPECT_EQ(row.value().begin()->age, 30) << "DO NOTHING must not overwrite";
+}
+
+// DO UPDATE: conflicting insert overwrites the listed column and returns the id.
+TYPED_TEST(UpsertTest, DoUpdateOverwritesListedColumn) {
+    storm::QuerySet<Person, TypeParam> qs;
+    Person const a{.name = "Bob", .age = 30, .department = "Eng"};
+    auto first = qs.insert(a).template on_conflict<^^Person::name>()
+                         .template update<^^Person::age>().execute();
+    ASSERT_TRUE(first.has_value());
+    const std::int64_t id = first.value();
+
+    Person const upd{.name = "Bob", .age = 45, .department = "Eng"};
+    auto second = qs.insert(upd).template on_conflict<^^Person::name>()
+                          .template update<^^Person::age>().execute();
+    ASSERT_TRUE(second.has_value());
+    EXPECT_EQ(second.value(), id) << "DO UPDATE returns the conflicting row's id";
+
+    auto row = qs.where(storm::orm::where::f<^^Person::name>() == std::string("Bob")).select().execute();
+    ASSERT_TRUE(row.has_value());
+    ASSERT_EQ(row.value().size(), 1);
+    EXPECT_EQ(row.value().begin()->age, 45) << "DO UPDATE overwrites age";
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cmake --build --preset ninja-debug 2>&1 | tail -25`
+Expected: FAIL — `on_conflict` not a member of the insert proxy.
+
+- [ ] **Step 3: Add execute paths to `InsertStatement`** (public section, near `execute_single_optimized`, insert.cppm ~line 394). Import at top: `import storm_orm_statements_upsert_grammar;` and `import storm_orm_indexes;`.
+
+```cpp
+        // Upsert DO NOTHING — RETURNING yields the new id, or no row when skipped.
+        template <std::meta::info... Target>
+        [[nodiscard]] auto execute_upsert_nothing(const T& obj)
+                -> std::expected<std::optional<std::int64_t>, Error> {
+            const std::string& sql = UpsertGrammar<T>::template nothing_sql<Target...>();
+            auto prepared = prepare_and_bind(sql, obj);
+            if (!prepared) {
+                return std::unexpected(prepared.error());
+            }
+            Statement* stmt = *prepared;
+            const int rc = stmt->step_raw();
+            std::optional<std::int64_t> out;
+            if (rc == Statement::ROW_AVAILABLE) {
+                out = stmt->extract_int64(0);
+            }
+            stmt->reset();
+            if (rc == Statement::ROW_AVAILABLE || rc == Statement::NO_MORE_ROWS) {
+                return out; // value() set when a row came back, nullopt when skipped
+            }
+            return std::unexpected(Error{rc, stmt->get_error_message()});
+        }
+
+        // Upsert DO UPDATE — always touches a row, so RETURNING always yields the id.
+        // set_clause is the precomputed "col=excluded.col, ..." (+ auto_update tail).
+        template <std::meta::info... Target, std::meta::info... SetCols>
+        [[nodiscard]] auto execute_upsert_update(const T& obj)
+                -> std::expected<std::int64_t, Error> {
+            const std::string sql = UpsertGrammar<T>::template update_sql<Target...>(
+                    UpsertGrammar<T>::template build_excluded_set_clause<SetCols...>());
+            auto stmt_res = conn_->prepare_cached(sql);
+            if (!stmt_res) {
+                return std::unexpected(stmt_res.error());
+            }
+            Statement* stmt = *stmt_res;
+            // (1) bind VALUES params (non-PK fields, same as plain INSERT).
+            if (auto b = bind_all_fields(*stmt, obj); !b) {
+                return std::unexpected(b.error());
+            }
+            // (2) bind the trailing auto_update now() params (excluded.col targets bind nothing).
+            if (auto b = bind_upsert_auto_updates<SetCols...>(*stmt, obj); !b) {
+                return std::unexpected(b.error());
+            }
+            const int rc = stmt->step_raw();
+            if (rc == Statement::ROW_AVAILABLE) {
+                std::int64_t id = stmt->extract_int64(0);
+                stmt->reset();
+                return id;
+            }
+            stmt->reset();
+            return std::unexpected(Error{rc, stmt->get_error_message()});
+        }
+
+      private:
+        // Bind now() for each unlisted auto_update column, in declaration order,
+        // starting at the param index right after the VALUES placeholders.
+        template <std::meta::info... SetCols>
+        [[nodiscard]] auto bind_upsert_auto_updates(Statement& stmt, const T& /*obj*/) noexcept
+                -> std::expected<void, Error> {
+            int param_index = static_cast<int>(placeholders_count()) + 1; // 1-based, after VALUES
+            const auto now = Base::batch_now();
+            std::expected<void, Error> result{};
+            [&]<std::size_t... Is>(std::index_sequence<Is...>) {
+                (
+                        [&] {
+                            if (!result) {
+                                return;
+                            }
+                            constexpr auto member = Base::all_members_[Is];
+                            if constexpr (UpsertGrammar<T>::template is_unlisted_auto_update<SetCols...>(member)) {
+                                if (auto r = stmt.bind_timepoint(param_index++, now); !r) {
+                                    result = std::unexpected(r.error());
+                                }
+                            }
+                        }(),
+                        ...);
+            }(typename Base::field_indices_t{});
+            return result;
+        }
+```
+
+NOTE: confirm the exact timepoint-bind call used by conditional UPDATE (`bind_timepoint` vs other). Verify and copy the real call:
+
+```bash
+grep -n "bind.*now\|bind_timepoint\|now)" src/orm/statements/update.cppm | head
+```
+
+Also add a `static consteval std::size_t placeholders_count()` to `InsertStatement` returning `field_count_ - 1` (non-PK count) if no equivalent exists.
+
+- [ ] **Step 4: Build (proxies not wired yet — expect proxy errors only).** This task's execute methods compile standalone; the proxy `.on_conflict()` arrives in Task 5. To unit-test the execute paths now, temporarily call them directly:
+
+```cpp
+// Temporary direct-call test (delete after Task 5 wires the proxy):
+TYPED_TEST(UpsertTest, DirectExecuteNothing) {
+    auto conn = storm::QuerySet<Person, TypeParam>::get_default_connection();
+    storm::orm::statements::InsertStatement<Person, TypeParam> stmt{conn};
+    Person const a{.name = "Zed", .age = 1, .department = "X"};
+    auto r = stmt.template execute_upsert_nothing<^^Person::name>(a);
+    ASSERT_TRUE(r.has_value());
+    EXPECT_TRUE(r.value().has_value());
+}
+```
+
+Run: `cmake --build --preset ninja-debug 2>&1 | tail -20 && ctest --preset ninja-debug -R "UpsertTest.DirectExecuteNothing" --output-on-failure`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/orm/statements/insert.cppm tests/crud/test_upsert.cpp
+git commit -m "feat(upsert): execute_upsert_nothing/update paths on InsertStatement (#205)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Proxy chain — `on_conflict()` → `update()` / `nothing()`
+
+**Files:**
+- Modify: `src/orm/statements/insert.cppm`
+- Test: `tests/crud/test_upsert.cpp`
+
+**Interfaces:**
+- Consumes: Task 4 execute paths; concepts from Task 3.
+- Produces (public): `SingleQuery::on_conflict<Target...>()` and `VoidQuery::on_conflict<Target...>()` → `ConflictTarget`; `ConflictTarget::update<SetCols...>()` → terminal `expected<int64_t>`; `ConflictTarget::nothing()` → terminal `expected<optional<int64_t>>`. Each terminal proxy has `.execute()`, `.to_sql()`, `.sql()`.
+
+- [ ] **Step 1: Write the failing test** — the two TYPED_TEST cases from Task 4 Step 1 (`DoNothingSkipsOnConflict`, `DoUpdateOverwritesListedColumn`) are the failing tests for this task. They already use the proxy chain. Also add `.sql()` goldens:
+
+```cpp
+TYPED_TEST(UpsertTest, SqlGoldenNothing) {
+    storm::QuerySet<Person, TypeParam> qs;
+    Person const a{.name = "Q", .age = 1, .department = "X"};
+    const std::string sql = qs.insert(a).template on_conflict<^^Person::name>().nothing().sql();
+    EXPECT_NE(sql.find("ON CONFLICT (name) DO NOTHING"), std::string::npos) << sql;
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cmake --build --preset ninja-debug 2>&1 | tail -25`
+Expected: FAIL — `on_conflict` not a member of `SingleQuery`.
+
+- [ ] **Step 3: Add proxies to `InsertStatement`.** Define the terminal proxies and `ConflictTarget`, then add `on_conflict` to `SingleQuery`/`VoidQuery`. If `insert.cppm` trips the 600-line hook, wrap these in `namespace detail { ... }` (pattern #438) and alias.
+
+```cpp
+        // DO UPDATE terminal proxy.
+        template <std::meta::info... Target> struct ConflictTargetProxy; // fwd
+
+        template <std::meta::info... Target, std::meta::info... SetCols>
+        struct UpdateUpsertQuery {
+            InsertStatement stmt;
+            const T&        obj;
+            [[nodiscard]] auto execute() -> std::expected<std::int64_t, Error> {
+                return stmt.template execute_upsert_update<Target..., SetCols...>(obj);
+            }
+            [[nodiscard]] auto to_sql() -> std::expected<std::string, Error> {
+                const std::string sql = UpsertGrammar<T>::template update_sql<Target...>(
+                        UpsertGrammar<T>::template build_excluded_set_clause<SetCols...>());
+                return stmt.to_sql_with(sql, obj); // thin wrapper over to_sql_impl + bind_single (+auto_update)
+            }
+            [[nodiscard]] auto sql() -> std::string {
+                return UpsertGrammar<T>::template update_sql<Target...>(
+                        UpsertGrammar<T>::template build_excluded_set_clause<SetCols...>());
+            }
+        };
+
+        // DO NOTHING terminal proxy.
+        template <std::meta::info... Target>
+        struct NothingUpsertQuery {
+            InsertStatement stmt;
+            const T&        obj;
+            [[nodiscard]] auto execute() -> std::expected<std::optional<std::int64_t>, Error> {
+                return stmt.template execute_upsert_nothing<Target...>(obj);
+            }
+            [[nodiscard]] auto to_sql() -> std::expected<std::string, Error> {
+                return stmt.to_sql_with(UpsertGrammar<T>::template nothing_sql<Target...>(), obj);
+            }
+            [[nodiscard]] auto sql() -> std::string {
+                return UpsertGrammar<T>::template nothing_sql<Target...>();
+            }
+        };
+
+        // Intermediate: carries the conflict target, offers update<>/nothing().
+        template <std::meta::info... Target>
+        struct ConflictTarget {
+            InsertStatement stmt;
+            const T&        obj;
+            template <std::meta::info... SetCols>
+                requires UpsertSettable<T, SetCols...>
+            [[nodiscard]] auto update() -> UpdateUpsertQuery<Target..., SetCols...> {
+                return {std::move(stmt), obj};
+            }
+            [[nodiscard]] auto nothing() -> NothingUpsertQuery<Target...> {
+                return {std::move(stmt), obj};
+            }
+        };
+```
+
+Add to `SingleQuery` AND `VoidQuery` (both hold `InsertStatement stmt; const T& obj;`):
+
+```cpp
+            template <std::meta::info... Target>
+                requires ConflictTargetUnique<T, Target...>
+            [[nodiscard]] auto on_conflict() -> ConflictTarget<Target...> {
+                return {std::move(stmt), obj};
+            }
+```
+
+Add the `to_sql_with` helper to `InsertStatement` (private), generalizing `to_sql_impl` to bind non-PK + auto_update tail:
+
+```cpp
+        template <std::meta::info... SetCols>
+        [[nodiscard]] auto to_sql_with(const std::string& sql, const T& obj)
+                -> std::expected<std::string, Error> {
+            return to_sql_impl(sql, [&](Statement& s) -> std::expected<void, Error> {
+                if (auto b = bind_single(s, obj); !b) {
+                    return std::unexpected(b.error());
+                }
+                return bind_upsert_auto_updates<SetCols...>(s, obj);
+            });
+        }
+```
+
+(For `NothingUpsertQuery::to_sql`, SetCols is empty — auto_update tail is empty too, so the bind is just non-PK fields.)
+
+- [ ] **Step 4: Build, run all upsert tests, verify pass**
+
+Run: `cmake --build --preset ninja-debug 2>&1 | tail -20 && ctest --preset ninja-debug -R "UpsertTest|UpsertGrammarTest" --output-on-failure`
+Expected: ALL upsert tests PASS. Delete the temporary `DirectExecuteNothing` test from Task 4.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/orm/statements/insert.cppm tests/crud/test_upsert.cpp
+git commit -m "feat(upsert): on_conflict/update/nothing proxy chain (#205)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Coverage tests — FK, composite target, auto_update, errors
+
+**Files:**
+- Modify: `tests/crud/test_upsert.cpp`
+
+**Interfaces:** Consumes the full public API from Tasks 1-5. Per the testing checklist in the spec.
+
+- [ ] **Step 1: Write the additional tests:**
+
+```cpp
+// Composite conflict target via UniqueIndex<name, department>.
+TYPED_TEST(UpsertTest, CompositeConflictTarget) {
+    storm::QuerySet<Person, TypeParam> qs;
+    Person const a{.name = "Cara", .age = 20, .department = "Eng"};
+    auto first = qs.insert(a).template on_conflict<^^Person::name, ^^Person::department>()
+                         .template update<^^Person::age>().execute();
+    ASSERT_TRUE(first.has_value());
+    Person const upd{.name = "Cara", .age = 21, .department = "Eng"};
+    auto second = qs.insert(upd).template on_conflict<^^Person::name, ^^Person::department>()
+                          .template update<^^Person::age>().execute();
+    ASSERT_TRUE(second.has_value());
+    EXPECT_EQ(second.value(), first.value());
+}
+
+// DO UPDATE with multiple SET columns.
+TYPED_TEST(UpsertTest, DoUpdateMultipleColumns) {
+    storm::QuerySet<Person, TypeParam> qs;
+    Person const a{.name = "Dan", .age = 10, .salary = 100.0, .department = "Eng"};
+    (void)qs.insert(a).template on_conflict<^^Person::name>()
+            .template update<^^Person::age, ^^Person::salary>().execute();
+    Person const upd{.name = "Dan", .age = 11, .salary = 200.0, .department = "Eng"};
+    auto r = qs.insert(upd).template on_conflict<^^Person::name>()
+                     .template update<^^Person::age, ^^Person::salary>().execute();
+    ASSERT_TRUE(r.has_value());
+    auto row = qs.where(storm::orm::where::f<^^Person::name>() == std::string("Dan")).select().execute();
+    ASSERT_TRUE(row.has_value());
+    EXPECT_EQ(row.value().begin()->age, 11);
+    EXPECT_DOUBLE_EQ(row.value().begin()->salary, 200.0);
+}
+
+// to_sql() inlines the bound params (debug helper).
+TYPED_TEST(UpsertTest, ToSqlInlinesParams) {
+    storm::QuerySet<Person, TypeParam> qs;
+    Person const a{.name = "Eve", .age = 5, .department = "X"};
+    auto r = qs.insert(a).template on_conflict<^^Person::name>().nothing().to_sql();
+    ASSERT_TRUE(r.has_value());
+    EXPECT_NE(r.value().find("ON CONFLICT (name) DO NOTHING"), std::string::npos) << r.value();
+}
+```
+
+If a model with an `auto_update` time_point + `unique` field exists in `shared/models.h`, add a test asserting the timestamp is refreshed after a DO UPDATE upsert. Verify:
+
+```bash
+grep -n "auto_update\|time_point" shared/models.h
+```
+
+If none has BOTH, note it: an auto_update-on-upsert test needs such a model; either reuse an existing timestamp model that also has a unique field, or skip with a `// TODO(follow-up)` ONLY if no suitable model exists (document in the PR).
+
+- [ ] **Step 2: Run, verify pass**
+
+Run: `cmake --build --preset ninja-debug 2>&1 | tail -20 && ctest --preset ninja-debug -R UpsertTest --output-on-failure`
+Expected: ALL PASS.
+
+- [ ] **Step 3: Error-path test via mock backend** — follow `tests/errors/` pattern. Add a prepare-failure case (mock returns error from `prepare_cached`) asserting `execute()` returns `std::unexpected`. Locate the pattern:
+
+```bash
+grep -rln "mock\|MockConn\|prepare.*error" tests/errors/ | head
+```
+
+Mirror an existing insert error test, swapping in the `.on_conflict<>().nothing().execute()` call.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/crud/test_upsert.cpp
+git commit -m "test(upsert): composite target, multi-col, auto_update, to_sql, errors (#205)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Documentation
+
+**Files:**
+- Create: `docs/guide/features/UPSERT.md`
+- Modify: `docs/README.md`, `CLAUDE.md`
+
+- [ ] **Step 1: Write `docs/guide/features/UPSERT.md`** — both patterns, the return-type table from the spec, and the get-or-create caveat (DO NOTHING returns `nullopt` on conflict, NOT the existing id; use DO UPDATE if you need the pk every time). Include the two SQL examples. Match the structure of a sibling like `docs/guide/features/JOIN_OPERATIONS.md`.
+
+- [ ] **Step 2: Link from `docs/README.md`** — add UPSERT.md under the features list (mirror how REFERENTIAL_INTEGRITY.md is linked).
+
+- [ ] **Step 3: Add a QuerySet API row to `CLAUDE.md`** — under the QuerySet API section, document:
+
+```cpp
+// Upsert (#205) — single-row INSERT ... ON CONFLICT (target) DO UPDATE / DO NOTHING.
+// Conflict target must be a unique field / UniqueIndex (compile-time checked).
+qs.insert(p).on_conflict<^^Person::name>().update<^^Person::age>().execute();   // expected<int64_t>
+qs.insert(p).on_conflict<^^Person::name>().nothing().execute();                 // expected<optional<int64_t>> (nullopt = skipped)
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/guide/features/UPSERT.md docs/README.md CLAUDE.md
+git commit -m "docs(upsert): UPSERT.md + README/CLAUDE API references (#205)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: Sanitizers, benchmarks, full suite, PR
+
+**Files:** none (verification + PR).
+
+- [ ] **Step 1: Full test suite (SQLite + PG)**
+
+Run: `ctest --preset ninja-debug --output-on-failure 2>&1 | tail -30`
+Expected: all pass (PG skips gracefully if not running; if running, the upsert TYPED_TESTs must pass on PG too).
+
+- [ ] **Step 2: Sanitizers (rule #7)**
+
+```bash
+cmake --preset ninja-asan-ubsan && cmake --build --preset ninja-asan-ubsan && ctest --preset ninja-asan-ubsan -R "Upsert" --output-on-failure
+cmake --preset ninja-tsan && cmake --build --preset ninja-tsan && ctest --preset ninja-tsan -R "Upsert" --output-on-failure
+```
+
+Expected: no new ASAN/UBSAN/TSAN violations.
+
+- [ ] **Step 3: Benchmark guard (rule #6)** — upsert adds NO code to existing INSERT hot paths (new methods are separate). Confirm the plain-insert benchmark is unchanged:
+
+```bash
+cmake --preset ninja-release && cmake --build --preset ninja-release
+./build/release/benchmarks/storm_bench --benchmark_filter='Storm/INSERT/.*' --benchmark_repetitions=5
+```
+
+Expected: INSERT numbers within noise of develop (revert any regression — there should be none, since `execute_single_optimized` is untouched).
+
+- [ ] **Step 4: Update the issue's Definition of Done** — `gh issue view 205`, check off the delivered acceptance criteria with `gh issue edit 205 --body "..."` (`- [x]`). MySQL criterion → mark as "clear error / out of scope (compile-time backend syntax is SQLite/PG only)".
+
+- [ ] **Step 5: Push + PR + auto-merge**
+
+```bash
+git push -u origin feature/205-upsert-on-conflict
+gh pr create --base develop --title "feat(upsert): ON CONFLICT DO UPDATE / DO NOTHING (#205)" \
+  --body "Closes #205
+
+Single-row upsert via insert proxy chain. See docs/superpowers/specs/2026-06-22-upsert-design.md.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+sleep 30
+```
+
+Then `/sonarcloud-status`; if zero new issues, `gh pr checks <PR#> --watch`; once SonarCloud gate + all CI jobs green, `gh pr merge <PR#> --squash --auto`.
+
+- [ ] **Step 6: After merge** — `gh issue close 205`, `git -C <main repo> checkout develop && git pull`, `git worktree remove .claude/worktrees/feature-205-upsert`.

--- a/docs/superpowers/specs/2026-06-22-upsert-design.md
+++ b/docs/superpowers/specs/2026-06-22-upsert-design.md
@@ -1,0 +1,200 @@
+# Upsert support (`ON CONFLICT`) — Design
+
+**Issue**: #205
+**Date**: 2026-06-22
+**Status**: Approved (brainstorming) → ready for implementation plan
+
+## Goal
+
+Add single-row upsert (`INSERT ... ON CONFLICT ...`) to the `QuerySet` insert
+proxy, covering the two real-world patterns:
+
+- **DO UPDATE** — overwrite listed columns with the attempted-insert values.
+- **DO NOTHING** — get-or-create; skip the insert when a conflicting row exists.
+
+Both SQLite (3.35+) and PostgreSQL share identical syntax, so there is no
+backend divergence. MySQL (`ON DUPLICATE KEY UPDATE`) is out of scope.
+
+## Out of scope (follow-up issues)
+
+- **Bulk upsert** — `qs.insert(span).on_conflict<>()...`. The `DO NOTHING` +
+  RETURNING-vector gap problem (skipped rows leave holes in the id vector) and
+  the chunked-transaction path make this a separate, larger effort.
+- **SET-expression DSL** — `SET count = count + 1`, literals, arbitrary
+  expressions. v1 only emits `col = excluded.col`.
+- **Auto conflict-target detection** — inferring the unique column. v1 requires
+  an explicit target.
+
+## API Surface
+
+The upsert chain hangs off the existing single-row insert proxies
+(`SingleQuery` for `ReturnId::Yes`, `VoidQuery` for `ReturnId::No`). The upsert
+path itself does **not** carry `ReturnId` — the return type is determined by the
+terminal verb, not a template flag.
+
+```cpp
+// DO UPDATE — overwrite listed columns; always returns the touched row's id
+int64_t id = QuerySet<User>()
+    .insert(user)
+    .on_conflict<^^User::email>()          // → ConflictTarget proxy
+    .update<^^User::name, ^^User::age>()   // → UpdateUpsertQuery
+    .execute();                            // std::expected<int64_t, Error>
+
+// DO NOTHING — get-or-create; nullopt = conflict skipped (row already existed)
+std::optional<int64_t> r = QuerySet<User>()
+    .insert(user)
+    .on_conflict<^^User::email>()
+    .nothing()                             // → NothingUpsertQuery
+    .execute();                            // std::expected<std::optional<int64_t>, Error>
+```
+
+### Return-type rationale (`ReturnId` dropped on the upsert path)
+
+`ReturnId::Yes/No` ("do I want the pk back?") and `DO UPDATE`/`DO NOTHING`
+("what happens on conflict?") are independent axes. But the only useful reason
+to call `.nothing()` is get-or-create, which *needs* the id — and `.update()`
+always touches a row, so it always has an id. The `ReturnId::No` + upsert
+combination is fire-and-forget you can't observe: practically useless. So the
+upsert chain omits `ReturnId` entirely and the verb picks the return shape:
+
+| verb            | conflict effect | return type                              |
+| --------------- | --------------- | ---------------------------------------- |
+| `.update<...>()`| overwrite row   | `std::expected<int64_t, Error>`          |
+| `.nothing()`    | may skip        | `std::expected<std::optional<int64_t>, Error>` |
+
+Plain `insert()` keeps `ReturnId::Yes/No` unchanged (fire-and-forget bulk loads
+still want it). Only the upsert chain drops it.
+
+### Proxy chain
+
+- `on_conflict<Target...>()` — added to **both** `SingleQuery` and `VoidQuery`.
+  Returns a `ConflictTarget` proxy holding the moved `InsertStatement`, the
+  `obj` reference (`[[clang::lifetimebound]]`), and the target columns as NTTPs.
+- `ConflictTarget::update<SetCols...>()` → `UpdateUpsertQuery`
+  (`.execute()` / `.to_sql()` / `.sql()`).
+- `ConflictTarget::nothing()` → `NothingUpsertQuery`
+  (`.execute()` / `.to_sql()` / `.sql()`).
+
+## Compile-time validation
+
+Two `requires` constraints, fired at the call sites (CLAUDE.md rule #11 — use
+`requires`, never `throw` in `consteval`):
+
+- **`ConflictTargetUnique<T, Target...>`** — every `Target` is a non-static data
+  member of `T`, and the set is either:
+  - a single field carrying `FieldAttr::unique`, **or**
+  - an exact column-set match for some `UniqueIndex<...>` in `Indexes<T>`.
+
+  Rejects targets with no DB-level unique constraint, which would otherwise be a
+  runtime `ON CONFLICT` error from SQLite/PG. (The PK is a valid implicit unique
+  target too; included.)
+
+- **`UpsertSettable<T, SetCols...>`** — reuses
+  `UpdateGrammar::is_settable_member` (non-static data member, not the PK). The
+  conflict-target columns may appear in the SET list but need not.
+
+## SQL generation
+
+A new `UpsertGrammar<T>` module mirrors `UpdateGrammar<T>`: all `consteval`,
+deriving purely from reflection over `T` (via `Base = BaseStatement<T>`). It
+appends the conflict clause onto the existing compile-time INSERT SQL
+(`InsertStatement::build_insert_sql_array_impl<true>()` — the RETURNING variant),
+reusing the table/column/placeholder machinery rather than re-spelling it.
+RETURNING is **always** emitted (both verbs need it).
+
+```sql
+-- .on_conflict<email>().update<name, age>()
+INSERT INTO users (name, email, age) VALUES (?, ?, ?)
+ON CONFLICT (email) DO UPDATE SET name=excluded.name, age=excluded.age
+RETURNING id
+
+-- .on_conflict<email>().nothing()
+INSERT INTO users (name, email, age) VALUES (?, ?, ?)
+ON CONFLICT (email) DO NOTHING
+RETURNING id
+```
+
+- **SET clause** — a variant of `build_conditional_set_clause` emitting
+  `col=excluded.col`. FK columns use the `_id` column-name writer (#422):
+  `owner_id=excluded.owner_id`. These take **no bind params**.
+  `auto_update` timestamp fields (#209) are auto-appended to the SET list and
+  **do** bind `now()` at execution — consistent with conditional UPDATE, so an
+  upserted-via-DO-UPDATE row gets a fresh `updated_at`.
+- **Conflict target** — `(col1, col2, ...)` via the `_id`-aware column-name
+  writer (so an FK conflict target renders `owner_id`).
+- The clause text is a compile-time constant per `<Target..., SetCols...>`
+  instantiation (`ConstexprString` → `static inline const std::string`), the
+  same caching pattern as `insert_returning_sql_string`.
+- **Bind order is unchanged** — the same non-PK INSERT binders run; only the
+  trailing `auto_update` `now()`-stamps are appended (exactly as conditional
+  UPDATE does). `excluded.col` SET targets bind nothing.
+
+## Execution & return semantics
+
+Two new single-row paths on `InsertStatement`, modeled on
+`execute_single_optimized` (prepare_cached → bind non-PK + auto_update now() →
+`step_raw()`):
+
+```cpp
+execute_upsert_update(obj)  -> std::expected<int64_t, Error>
+execute_upsert_nothing(obj) -> std::expected<std::optional<int64_t>, Error>
+```
+
+- **`execute_upsert_update`** — `DO UPDATE` always touches a row:
+  - `ROW_AVAILABLE` → `extract_int64(0)` (inserted or updated row id).
+  - `NO_MORE_ROWS` → defensive `Error` (should not occur with DO UPDATE).
+  - error rc → `std::unexpected(Error{...})`.
+- **`execute_upsert_nothing`** — `DO NOTHING` may skip:
+  - `ROW_AVAILABLE` → `std::optional{extract_int64(0)}` (newly inserted).
+  - `NO_MORE_ROWS` → `std::nullopt` (conflict skipped — no id available;
+    `DO NOTHING` returns no row, so the *existing* row's id is not retrievable
+    here. Callers who need the existing id every time should use `.update()`).
+  - error rc → `std::unexpected(Error{...})`.
+
+No `ReturnId::No` / void path on the upsert chain (removed by construction — it
+is the one practically useless combination).
+
+`.to_sql()` (params inlined, for debugging) and `.sql()` (raw template) reuse
+the existing `to_sql_impl` / static-string helpers in `InsertStatement`.
+
+## Testing
+
+`TYPED_TEST` over `DatabaseTypes` (SQLite + PostgreSQL — both share the syntax).
+
+- DO UPDATE: single column, multiple columns; assert the row is overwritten and
+  the returned id matches the conflicting row.
+- DO NOTHING: insert-new (assert id present) vs conflict-skip (assert `nullopt`);
+  assert the existing row is untouched.
+- FK column in SET list → `owner_id=excluded.owner_id`.
+- FK column as conflict target → `ON CONFLICT (owner_id)`.
+- `auto_update` field stamped fresh on a DO UPDATE upsert.
+- Composite conflict target via `UniqueIndex<a, b>`.
+- `.to_sql()` / `.sql()` golden strings (both verbs).
+- Error path via the mock backend (prepare/step failure), following the
+  `test_orm_mock_errors.cpp` pattern.
+- **Compile-fail tests** (where the harness supports them): non-unique conflict
+  target; PK in the SET list.
+
+TDD order (CLAUDE.md rule #9): write tests → run (new tests MUST fail) →
+implement → run (all pass).
+
+## Documentation
+
+- New `docs/guide/features/UPSERT.md` with both patterns, the return-type table,
+  and the get-or-create caveat (DO NOTHING does not return the existing id).
+- Link from `docs/README.md` and add an upsert row to the QuerySet API section
+  in `CLAUDE.md`.
+- Update the `storm-docs-writer` agent surface if it enumerates features.
+
+## Module / file layout
+
+- `src/orm/statements/upsert_grammar.cppm` — new `UpsertGrammar<T>` (mirrors
+  `update_grammar.cppm`): `consteval` conflict-target + `excluded.col` SET-clause
+  builders, and the per-instantiation upsert SQL string.
+- `src/orm/statements/insert.cppm` — add `on_conflict<>()` to `SingleQuery` /
+  `VoidQuery`; add `ConflictTarget`, `UpdateUpsertQuery`, `NothingUpsertQuery`
+  proxies; add `execute_upsert_update` / `execute_upsert_nothing`. (Watch the
+  600-line hook limit; if it pushes over, the proxies may move to a sibling
+  `namespace detail` like the UpdateStatement proxies did in #438.)
+- Both `.cppm` files are GLOB-discovered — no CMake changes.
+```

--- a/src/orm/schema.cppm
+++ b/src/orm/schema.cppm
@@ -999,6 +999,7 @@ export namespace storm::orm::schema {
             auto result = create_fk_parents(conn, done).and_then([&conn] {
                 return conn->execute(with_if_not_exists(create_table_sql<dialect>()));
             });
+            result      = result.and_then([&conn] { return create_indexes_if_not_exist(conn); });
 
             // Auto-generated junction tables for many_to_many fields — one per
             // auto-junction field (#203 Phase 1; #392 several relations). Each junction

--- a/src/orm/statements/field_names.cppm
+++ b/src/orm/statements/field_names.cppm
@@ -85,6 +85,20 @@ export namespace storm::orm::statements {
         static consteval auto build_non_pk_field_names_list() {
             return build_field_names_list_impl<true>();
         }
+
+        // "?, ?, ..." placeholders for the SQL VALUES clause, one per non-PK field
+        // (skips the primary key for auto-increment). Shared by InsertStatement's
+        // VALUES clause and UpsertGrammar's re-derived INSERT prefix (#205).
+        static consteval auto build_placeholders() {
+            ConstexprString<utilities::buffer_size::SQL_SMALL> result;
+            for_each_field_name<true>([&](std::size_t /*i*/, bool needs_comma) {
+                if (needs_comma) {
+                    result.append(", ");
+                }
+                result.append("?");
+            });
+            return result;
+        }
     };
 
 } // namespace storm::orm::statements

--- a/src/orm/statements/insert.cppm
+++ b/src/orm/statements/insert.cppm
@@ -38,26 +38,9 @@ export namespace storm::orm::statements {
         using Error      = typename ConnType::Error;
         using Statement  = typename ConnType::Statement;
 
-        // Pre-compute placeholders for SQL VALUES clause (excluding PK for auto-increment)
-        static consteval auto build_placeholders() {
-            ConstexprString<utilities::buffer_size::SQL_SMALL> result;
-            bool                                               first = true;
-            for (std::size_t i = 0; i < Base::field_count_; ++i) {
-                // Skip primary key
-                if (Base::all_members_[i] == Base::primary_key_) {
-                    continue;
-                }
-                if (!first) {
-                    result += ", ";
-                }
-                result += "?";
-                first = false;
-            }
-            return result;
-        }
-
-        // Pre-computed placeholders (excludes PK for auto-increment)
-        static constexpr auto placeholders_ = build_placeholders();
+        // Pre-computed placeholders (excludes PK for auto-increment). Shared with
+        // UpsertGrammar via FieldNameGrammar<Base>::build_placeholders() (#205).
+        static constexpr auto placeholders_ = FieldNameGrammar<Base>::build_placeholders();
 
         // Compile-time SQL size calculation
         static consteval auto calculate_insert_sql_size() -> std::size_t {

--- a/src/orm/statements/insert.cppm
+++ b/src/orm/statements/insert.cppm
@@ -82,7 +82,7 @@ export namespace storm::orm::statements {
             using Error = typename ConnType::Error;
             InsertStatement<T, ConnType> stmt;
             const T&                     obj;
-            [[nodiscard]] auto           execute() -> std::expected<std::optional<std::int64_t>, Error> {
+            [[nodiscard]] auto execute() -> std::expected<std::optional<std::int64_t>, Error> { // NOSONAR(cpp:S1659)
                 return stmt.template execute_upsert_nothing<Target...>(obj);
             }
             [[nodiscard]] auto to_sql() -> std::expected<std::string, Error> {

--- a/src/orm/statements/insert.cppm
+++ b/src/orm/statements/insert.cppm
@@ -11,6 +11,7 @@ import std;
 
 import storm_orm_statements_base;
 import storm_orm_statements_field_names;
+import storm_orm_statements_upsert_grammar;
 import storm_orm_utilities;
 import storm_orm_transaction;
 import storm_db_concept;
@@ -34,6 +35,7 @@ export namespace storm::orm::statements {
     template <typename T, storm::db::DatabaseConnection ConnType> class InsertStatement : private BaseStatement<T> {
         friend class BaseStatement<T>; // Allow BaseStatement to access protected/private members
         using Base       = BaseStatement<T>;
+        using Grammar    = UpsertGrammar<T>;
         using Connection = ConnType;
         using Error      = typename ConnType::Error;
         using Statement  = typename ConnType::Statement;
@@ -416,6 +418,64 @@ export namespace storm::orm::statements {
             return std::unexpected(Error{rc, stmt->get_error_message()});
         }
 
+        // Non-PK field count — the number of VALUES placeholders in a plain INSERT.
+        // Used by the DO UPDATE upsert path to find where the auto_update now() tail
+        // starts binding (right after the VALUES params).
+        static consteval auto placeholders_count() -> std::size_t {
+            return Base::field_count_ - 1;
+        }
+
+        // Upsert DO NOTHING — RETURNING yields the new id, or no row when skipped.
+        template <std::meta::info... Target>
+        [[nodiscard]] auto execute_upsert_nothing(const T& obj) -> std::expected<std::optional<std::int64_t>, Error> {
+            const std::string& sql      = Grammar::template nothing_sql<Target...>();
+            auto               prepared = prepare_and_bind(sql, obj);
+            if (!prepared) {
+                return std::unexpected(prepared.error());
+            }
+            Statement*                  stmt = *prepared;
+            const int                   rc   = stmt->step_raw();
+            std::optional<std::int64_t> out;
+            if (rc == Statement::ROW_AVAILABLE) {
+                out = stmt->extract_int64(0);
+            }
+            stmt->reset();
+            if (rc == Statement::ROW_AVAILABLE || rc == Statement::NO_MORE_ROWS) {
+                return out; // value() set when a row came back, nullopt when skipped
+            }
+            return std::unexpected(Error{rc, stmt->get_error_message()});
+        }
+
+        // Upsert DO UPDATE — always touches a row, so RETURNING always yields the id.
+        // The SET clause is "col=excluded.col, ..." for SetCols, plus an auto_update
+        // tail (#209) for any auto_update column not already listed.
+        template <std::meta::info... Target, std::meta::info... SetCols>
+        [[nodiscard]] auto execute_upsert_update(const T& obj) -> std::expected<std::int64_t, Error> {
+            const std::string sql =
+                    Grammar::template update_sql<Target...>(Grammar::template build_excluded_set_clause<SetCols...>());
+            auto stmt_result = conn_->prepare_cached(sql);
+            if (!stmt_result) {
+                return std::unexpected(stmt_result.error());
+            }
+            Statement* stmt = *stmt_result;
+            // (1) bind VALUES params (non-PK fields, same as plain INSERT).
+            if (auto bind_result = bind_all_fields(*stmt, obj); !bind_result) {
+                return std::unexpected(bind_result.error());
+            }
+            // (2) bind the trailing auto_update now() params (excluded.col targets bind nothing).
+            if (auto bind_result = bind_upsert_auto_updates<SetCols...>(stmt); !bind_result) {
+                return std::unexpected(bind_result.error());
+            }
+            const int rc = stmt->step_raw();
+            if (rc == Statement::ROW_AVAILABLE) {
+                std::int64_t id = stmt->extract_int64(0);
+                stmt->reset();
+                return id;
+            }
+            stmt->reset();
+            return std::unexpected(Error{rc, stmt->get_error_message()});
+        }
+
       protected: // Changed to protected so BaseStatement can access
         // Bind non-PK fields for INSERT (skips primary key for auto-increment)
         [[nodiscard]] auto bind_all_fields(Statement& stmt, const T& obj) noexcept -> std::expected<void, Error> {
@@ -533,6 +593,38 @@ export namespace storm::orm::statements {
         }
 
       private:
+        // Bind now() for each unlisted auto_update column (#209), in declaration order,
+        // starting right after the VALUES placeholders (excluded.col SET targets need
+        // no params; only the trailing "col=?" auto_update tail does). Mirrors
+        // UpdateStatement::bind_unlisted_auto_updates (update.cppm).
+        template <std::meta::info... SetCols>
+        [[nodiscard]] auto bind_upsert_auto_updates(Statement* stmt) noexcept -> std::expected<void, Error> {
+            int        param_index = static_cast<int>(placeholders_count()) + 1; // 1-based, after VALUES
+            const auto now         = Base::batch_now();
+            return bind_upsert_auto_updates_impl<SetCols...>(stmt, param_index, now, typename Base::field_indices_t{});
+        }
+
+        template <std::meta::info... SetCols, std::size_t... Is>
+        [[nodiscard]] auto bind_upsert_auto_updates_impl(
+                Statement*                            stmt,
+                int&                                  param_index,
+                std::chrono::system_clock::time_point now,
+                std::index_sequence<Is...> /*unused*/
+        ) noexcept -> std::expected<void, Error> {
+            std::expected<void, Error> result{};
+            (
+                    [&] {
+                        if constexpr (Grammar::template is_unlisted_auto_update<SetCols...>(Base::all_members_[Is])) {
+                            if (result.has_value()) {
+                                result = Base::template bind_one<ConnType>(stmt, param_index, now);
+                            }
+                        }
+                    }(),
+                    ...
+            );
+            return result;
+        }
+
         // Prepare (L3-cached) the given INSERT SQL and bind the object's non-PK
         // fields. Both single-row execute paths share this so the prepare +
         // bind + error-check sequence lives in one place.

--- a/src/orm/statements/insert.cppm
+++ b/src/orm/statements/insert.cppm
@@ -31,6 +31,97 @@ export namespace storm::orm::statements {
         std::optional<std::size_t> batch_size = std::nullopt; // nullopt = automatic (999/field_count)
     };
 
+    template <typename T, storm::db::DatabaseConnection ConnType> class InsertStatement;
+
+    // Upsert proxy chain (#205): lifted OUT of InsertStatement so their sql()/execute()/to_sql()
+    // methods don't count toward InsertStatement's method total (cpp:S1448 — mirrors the
+    // UpdateStatement proxy split in #438). on_conflict<Target...>() returns a ConflictTarget,
+    // whose update<SetCols...>()/nothing() are the two terminal upsert proxies.
+    //
+    // ConflictTargetTag<Target...> carries the conflict-target columns as a TYPE (not a pack)
+    // so UpdateUpsertQuery can be a class template with exactly one variadic NTTP pack
+    // (SetCols...). A class template cannot declare two `std::meta::info...` packs — both
+    // would need independent deduction/specification, which the language does not support —
+    // so Target... must be wrapped before it reaches a second pack's scope.
+    template <std::meta::info... Target> struct ConflictTargetTag {};
+
+    namespace detail {
+
+        // DO UPDATE terminal proxy. TargetTag is a ConflictTargetTag<Target...> instantiation.
+        template <typename T, storm::db::DatabaseConnection ConnType, typename TargetTag, std::meta::info... SetCols>
+        struct UpdateUpsertQuery;
+
+        template <
+                typename T,
+                storm::db::DatabaseConnection ConnType,
+                std::meta::info... Target,
+                std::meta::info... SetCols>
+        struct UpdateUpsertQuery<T, ConnType, ConflictTargetTag<Target...>, SetCols...> {
+            using Error = typename ConnType::Error;
+            InsertStatement<T, ConnType> stmt;
+            const T&                     obj;
+            [[nodiscard]] auto           execute() -> std::expected<std::int64_t, Error> {
+                return stmt.template upsert_update_runner<Target...>().template run<SetCols...>(obj);
+            }
+            [[nodiscard]] auto to_sql() -> std::expected<std::string, Error> {
+                const std::string sql = UpsertGrammar<T>::template update_sql<Target...>(
+                        UpsertGrammar<T>::template build_excluded_set_clause<SetCols...>()
+                );
+                return stmt.template to_sql_with<SetCols...>(sql, obj);
+            }
+            [[nodiscard]] auto sql() -> std::string {
+                return UpsertGrammar<T>::template update_sql<Target...>(
+                        UpsertGrammar<T>::template build_excluded_set_clause<SetCols...>()
+                );
+            }
+        };
+
+        // DO NOTHING terminal proxy.
+        template <typename T, storm::db::DatabaseConnection ConnType, std::meta::info... Target>
+        struct NothingUpsertQuery {
+            using Error = typename ConnType::Error;
+            InsertStatement<T, ConnType> stmt;
+            const T&                     obj;
+            [[nodiscard]] auto           execute() -> std::expected<std::optional<std::int64_t>, Error> {
+                return stmt.template execute_upsert_nothing<Target...>(obj);
+            }
+            [[nodiscard]] auto to_sql() -> std::expected<std::string, Error> {
+                return stmt.template to_sql_with<>(UpsertGrammar<T>::template nothing_sql<Target...>(), obj);
+            }
+            [[nodiscard]] auto sql() -> std::string {
+                return UpsertGrammar<T>::template nothing_sql<Target...>();
+            }
+        };
+
+        // Intermediate: carries the conflict target, offers update<>/nothing().
+        template <typename T, storm::db::DatabaseConnection ConnType, std::meta::info... Target> struct ConflictTarget {
+            InsertStatement<T, ConnType> stmt;
+            const T&                     obj;
+            template <std::meta::info... SetCols>
+                requires UpsertSettable<T, SetCols...>
+            [[nodiscard]] auto update() -> UpdateUpsertQuery<T, ConnType, ConflictTargetTag<Target...>, SetCols...> {
+                return {std::move(stmt), obj};
+            }
+            [[nodiscard]] auto nothing() -> NothingUpsertQuery<T, ConnType, Target...> {
+                return {std::move(stmt), obj};
+            }
+        };
+
+        // Shared upsert entry point (#205) for the single-row query proxies (SingleQuery/
+        // VoidQuery): INSERT ... ON CONFLICT (Target...) DO {UPDATE|NOTHING}. CRTP base so
+        // both proxies offer on_conflict() without duplicating the method body — the derived
+        // proxy supplies `stmt`/`obj` via Derived's own members.
+        template <typename T, storm::db::DatabaseConnection ConnType, typename Derived> struct OnConflictMixin {
+            template <std::meta::info... Target>
+                requires ConflictTargetUnique<T, Target...>
+            [[nodiscard]] auto on_conflict() -> ConflictTarget<T, ConnType, Target...> {
+                auto* self = static_cast<Derived*>(this);
+                return {std::move(self->stmt), self->obj};
+            }
+        };
+
+    } // namespace detail
+
     // Statement class for ORM insert operations
     template <typename T, storm::db::DatabaseConnection ConnType> class InsertStatement : private BaseStatement<T> {
         friend class BaseStatement<T>; // Allow BaseStatement to access protected/private members
@@ -209,7 +300,7 @@ export namespace storm::orm::statements {
       public:
         explicit InsertStatement(std::shared_ptr<ConnType> conn) : conn_(std::move(conn)) {}
 
-        struct SingleQuery {
+        struct SingleQuery : detail::OnConflictMixin<T, ConnType, SingleQuery> {
             InsertStatement    stmt;
             const T&           obj;
             [[nodiscard]] auto execute() -> std::expected<std::int64_t, Error> {
@@ -223,7 +314,7 @@ export namespace storm::orm::statements {
             }
         };
 
-        struct VoidQuery {
+        struct VoidQuery : detail::OnConflictMixin<T, ConnType, VoidQuery> {
             InsertStatement    stmt;
             const T&           obj;
             [[nodiscard]] auto execute() -> std::expected<void, Error> {
@@ -270,9 +361,9 @@ export namespace storm::orm::statements {
 
         template <ReturnId R = ReturnId::Yes> [[nodiscard]] auto query(const T& obj [[clang::lifetimebound]]) {
             if constexpr (R == ReturnId::Yes) {
-                return SingleQuery{std::move(*this), obj};
+                return SingleQuery{{}, std::move(*this), obj};
             } else {
-                return VoidQuery{std::move(*this), obj};
+                return VoidQuery{{}, std::move(*this), obj};
             }
         }
         // LIFETIME CONTRACT (issue #357, finding B): the returned BulkQuery holds a
@@ -324,6 +415,20 @@ export namespace storm::orm::statements {
             }
             return to_sql_impl(get_bulk_insert_returning_sql(objects.size()), [&](Statement& s) {
                 return bind_bulk(s, objects);
+            });
+        }
+
+        // Returns SQL string with bound parameters inlined for an upsert (DO UPDATE/DO NOTHING)
+        // statement (for debugging). Generalizes to_sql_impl to bind the non-PK VALUES fields
+        // plus the auto_update now() tail (#209) for any auto_update column not in SetCols —
+        // empty SetCols (the DO NOTHING proxy) binds just the non-PK fields.
+        template <std::meta::info... SetCols>
+        [[nodiscard]] auto to_sql_with(const std::string& sql, const T& obj) -> std::expected<std::string, Error> {
+            return to_sql_impl(sql, [&](Statement& s) -> std::expected<void, Error> {
+                if (auto bound = bind_single(s, obj); !bound) {
+                    return std::unexpected(bound.error());
+                }
+                return bind_upsert_auto_updates<SetCols...>(&s);
             });
         }
 
@@ -449,31 +554,52 @@ export namespace storm::orm::statements {
         // Upsert DO UPDATE — always touches a row, so RETURNING always yields the id.
         // The SET clause is "col=excluded.col, ..." for SetCols, plus an auto_update
         // tail (#209) for any auto_update column not already listed.
-        template <std::meta::info... Target, std::meta::info... SetCols>
-        [[nodiscard]] auto execute_upsert_update(const T& obj) -> std::expected<std::int64_t, Error> {
-            const std::string sql =
-                    Grammar::template update_sql<Target...>(Grammar::template build_excluded_set_clause<SetCols...>());
-            auto stmt_result = conn_->prepare_cached(sql);
-            if (!stmt_result) {
-                return std::unexpected(stmt_result.error());
-            }
-            Statement* stmt = *stmt_result;
-            // (1) bind VALUES params (non-PK fields, same as plain INSERT).
-            if (auto bind_result = bind_all_fields(*stmt, obj); !bind_result) {
-                return std::unexpected(bind_result.error());
-            }
-            // (2) bind the trailing auto_update now() params (excluded.col targets bind nothing).
-            if (auto bind_result = bind_upsert_auto_updates<SetCols...>(stmt); !bind_result) {
-                return std::unexpected(bind_result.error());
-            }
-            const int rc = stmt->step_raw();
-            if (rc == Statement::ROW_AVAILABLE) {
-                std::int64_t id = stmt->extract_int64(0);
+        //
+        // NOTE (#205, found while wiring the on_conflict() proxy in Task 5): a SINGLE
+        // function template cannot take two variadic NTTP packs — `template <info...
+        // Target, info... SetCols>` compiles, but ALL explicitly-supplied arguments bind
+        // to the first pack and the second is silently always empty (verified: GCC/Clang
+        // both do this — no diagnostic). The original two-pack signature here was never
+        // caught because Task 4 shipped it with zero call sites. Splitting into Target
+        // (this function's pack) + SetCols (the nested run<>() pack) mirrors the proven
+        // ConflictTarget<Target...>::update<SetCols...>() shape and resolves both packs
+        // unambiguously.
+        template <std::meta::info... Target> struct UpsertUpdateRunner {
+            InsertStatement* self;
+            template <std::meta::info... SetCols>
+            [[nodiscard]] auto run(const T& obj) -> std::expected<std::int64_t, Error> {
+                const std::string sql = Grammar::template update_sql<Target...>(
+                        Grammar::template build_excluded_set_clause<SetCols...>()
+                );
+                auto stmt_result = self->conn_->prepare_cached(sql);
+                if (!stmt_result) {
+                    return std::unexpected(stmt_result.error());
+                }
+                Statement* stmt = *stmt_result;
+                // (1) bind VALUES params (non-PK fields, same as plain INSERT).
+                if (auto bind_result = self->bind_all_fields(*stmt, obj); !bind_result) {
+                    return std::unexpected(bind_result.error());
+                }
+                // (2) bind the trailing auto_update now() params (excluded.col targets bind nothing).
+                if (auto bind_result = self->template bind_upsert_auto_updates<SetCols...>(stmt); !bind_result) {
+                    return std::unexpected(bind_result.error());
+                }
+                const int rc = stmt->step_raw();
+                if (rc == Statement::ROW_AVAILABLE) {
+                    std::int64_t id = stmt->extract_int64(0);
+                    stmt->reset();
+                    return id;
+                }
                 stmt->reset();
-                return id;
+                return std::unexpected(Error{rc, stmt->get_error_message()});
             }
-            stmt->reset();
-            return std::unexpected(Error{rc, stmt->get_error_message()});
+        };
+
+        // Entry point: fixes Target... via UpsertUpdateRunner; callers then supply
+        // SetCols... via run<>(). Used by the detail::UpdateUpsertQuery proxy.
+        template <std::meta::info... Target>
+        [[nodiscard]] auto upsert_update_runner() -> UpsertUpdateRunner<Target...> {
+            return {this};
         }
 
       protected: // Changed to protected so BaseStatement can access

--- a/src/orm/statements/upsert_grammar.cppm
+++ b/src/orm/statements/upsert_grammar.cppm
@@ -12,6 +12,7 @@ export module storm_orm_statements_upsert_grammar;
 import std;
 
 import storm_orm_statements_base;
+import storm_orm_statements_field_names;
 import storm_orm_utilities;
 
 export namespace storm::orm::statements {
@@ -80,6 +81,52 @@ export namespace storm::orm::statements {
                 }
             }
             return result;
+        }
+
+        // INSERT INTO <table> (<non-pk cols>) VALUES (<placeholders>) — the same
+        // prefix InsertStatement builds, re-derived here from reflection so this
+        // module stays connection-free (it has no ConnType to reach InsertStatement
+        // through). Placeholders come from FieldNameGrammar<Base>::build_placeholders(),
+        // the single shared source of that text (#205).
+        static consteval auto build_insert_prefix() {
+            ConstexprString<utilities::buffer_size::SQL_LARGE> result;
+            result.append("INSERT INTO ");
+            result.append(Base::table_name_);
+            result.append(" (");
+            result.append(FieldNameGrammar<Base>::build_non_pk_field_names_list());
+            result.append(") VALUES (");
+            result.append(FieldNameGrammar<Base>::build_placeholders());
+            result.append(")");
+            return result;
+        }
+
+        // Full "INSERT ... ON CONFLICT (...) DO NOTHING RETURNING <pk>" statement.
+        template <std::meta::info... Target> static auto nothing_sql() -> const std::string& {
+            static const std::string sql = [] {
+                std::string out(build_insert_prefix());
+                out += " ON CONFLICT ";
+                out += std::string(build_conflict_target<Target...>());
+                out += " DO NOTHING RETURNING ";
+                out += std::string(Base::pk_name_);
+                return out;
+            }();
+            return sql;
+        }
+
+        // Full "INSERT ... ON CONFLICT (...) DO UPDATE SET <set_clause> RETURNING <pk>"
+        // statement. The SET clause is passed in as a precomputed value (built by
+        // build_excluded_set_clause<SetCols...>()) because Target... and SetCols...
+        // cannot share one template parameter list.
+        template <std::meta::info... Target, std::size_t N>
+        static auto update_sql(const ConstexprString<N>& set_clause) -> std::string {
+            std::string out(build_insert_prefix());
+            out += " ON CONFLICT ";
+            out += std::string(build_conflict_target<Target...>());
+            out += " DO UPDATE SET ";
+            out += std::string(set_clause);
+            out += " RETURNING ";
+            out += std::string(Base::pk_name_);
+            return out;
         }
     };
 

--- a/src/orm/statements/upsert_grammar.cppm
+++ b/src/orm/statements/upsert_grammar.cppm
@@ -1,0 +1,86 @@
+module;
+
+// Compile-time UPSERT (ON CONFLICT) SQL grammar (#205): the consteval helpers
+// that spell the conflict-target list and the `excluded.col` DO UPDATE SET
+// clause, split out of InsertStatement to keep that class cohesive. Stateless
+// and connection-free — every member derives purely from reflection over T.
+
+#include <meta>
+
+export module storm_orm_statements_upsert_grammar;
+
+import std;
+
+import storm_orm_statements_base;
+import storm_orm_utilities;
+
+export namespace storm::orm::statements {
+
+    using storm::orm::utilities::ConstexprString;
+
+    template <typename T> struct UpsertGrammar {
+        using Base = BaseStatement<T>;
+
+        // Append ", " before every element after the first.
+        template <typename Buf> static consteval auto append_separator(Buf& buf, bool& first) -> void {
+            if (!first) {
+                buf.append(", ");
+            }
+            first = false;
+        }
+
+        // (col1, col2, ...) — conflict-target column list, FK "_id"-aware (#422).
+        template <std::meta::info... Target> static consteval auto build_conflict_target() {
+            ConstexprString<utilities::buffer_size::SQL_SMALL> result;
+            result.append("(");
+            bool first = true;
+            (
+                    [&] {
+                        append_separator(result, first);
+                        meta::append_column_name(result, Target);
+                    }(),
+                    ...
+            );
+            result.append(")");
+            return result;
+        }
+
+        // Each SET target must be a non-static data member of T and not the PK.
+        template <std::meta::info Member> static consteval auto is_settable_member() -> bool {
+            return std::meta::is_nonstatic_data_member(Member) && Member != Base::primary_key_;
+        }
+
+        // True when `member` carries auto_update (#209) and is NOT in the explicit pack.
+        template <std::meta::info... SetCols>
+        static consteval auto is_unlisted_auto_update(std::meta::info member) -> bool {
+            return meta::is_auto_update(member) && ((member != SetCols) && ...);
+        }
+
+        // "col=excluded.col, ..." for the explicit SetCols pack, then any
+        // auto_update field of T not already listed, appended as "col=?" (bound
+        // now() at execution). The column ORDER of the auto_update tail is the
+        // canonical bind order used by the execute path.
+        template <std::meta::info... SetCols> static consteval auto build_excluded_set_clause() {
+            ConstexprString<utilities::buffer_size::SQL_MEDIUM> result;
+            bool                                                first = true;
+            (
+                    [&] {
+                        append_separator(result, first);
+                        meta::append_column_name(result, SetCols);
+                        result.append("=excluded.");
+                        meta::append_column_name(result, SetCols);
+                    }(),
+                    ...
+            );
+            for (const auto& member : Base::all_members_) {
+                if (is_unlisted_auto_update<SetCols...>(member)) {
+                    append_separator(result, first);
+                    result.append(std::meta::identifier_of(member));
+                    result.append("=?");
+                }
+            }
+            return result;
+        }
+    };
+
+} // namespace storm::orm::statements

--- a/src/orm/statements/upsert_grammar.cppm
+++ b/src/orm/statements/upsert_grammar.cppm
@@ -14,6 +14,8 @@ import std;
 import storm_orm_statements_base;
 import storm_orm_statements_field_names;
 import storm_orm_utilities;
+import storm_orm_indexes;
+import storm_orm_field_attr;
 
 export namespace storm::orm::statements {
 
@@ -129,5 +131,45 @@ export namespace storm::orm::statements {
             return out;
         }
     };
+
+    // True if the Target... column set exactly matches some UniqueIndex<...> in Indexes<T>.
+    template <typename T, std::meta::info... Target> consteval auto target_matches_unique_index() -> bool {
+        constexpr std::array targets{Target...};
+        bool                 matched = false;
+        [&]<typename... Idx>(std::tuple<Idx...>*) {
+            (
+                    [&] {
+                        if constexpr (Idx::unique) {
+                            if (Idx::fields.size() == targets.size()) {
+                                bool all = true;
+                                for (std::size_t i = 0; i < targets.size(); ++i) {
+                                    if (Idx::fields[i] != targets[i]) {
+                                        all = false;
+                                    }
+                                }
+                                if (all) {
+                                    matched = true;
+                                }
+                            }
+                        }
+                    }(),
+                    ...
+            );
+        }(static_cast<storm::indexes_t<T>*>(nullptr));
+        return matched;
+    }
+
+    // A valid conflict target: every Target is a data member of T, AND either a
+    // single FieldAttr::unique field, or the PK, or a matching UniqueIndex<...>.
+    template <typename T, std::meta::info... Target>
+    concept ConflictTargetUnique =
+            ((std::meta::is_nonstatic_data_member(Target)) && ...) &&
+            ((sizeof...(Target) == 1 &&
+              ((storm::meta::is_unique(Target) || Target == BaseStatement<T>::primary_key_) && ...)) ||
+             target_matches_unique_index<T, Target...>());
+
+    // A valid SET target: a non-static data member of T that is not the PK.
+    template <typename T, std::meta::info... SetCols>
+    concept UpsertSettable = (UpsertGrammar<T>::template is_settable_member<SetCols>() && ...);
 
 } // namespace storm::orm::statements

--- a/src/orm/statements/upsert_grammar.cppm
+++ b/src/orm/statements/upsert_grammar.cppm
@@ -132,6 +132,22 @@ export namespace storm::orm::statements {
         }
     };
 
+    // True if the two field lists are identical element-wise. Conflict-target
+    // columns must be supplied in the same declared order as the matching
+    // UniqueIndex. This is a v1 simplification; set-comparison (order-insensitive
+    // matching) can be added later if needed.
+    consteval auto fields_equal_ordered(const auto& lhs, const auto& rhs) -> bool {
+        if (lhs.size() != rhs.size()) {
+            return false;
+        }
+        for (std::size_t i = 0; i < lhs.size(); ++i) {
+            if (lhs[i] != rhs[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     // True if the Target... column set exactly matches some UniqueIndex<...> in Indexes<T>.
     template <typename T, std::meta::info... Target> consteval auto target_matches_unique_index() -> bool {
         constexpr std::array targets{Target...};
@@ -140,19 +156,8 @@ export namespace storm::orm::statements {
             (
                     [&] {
                         if constexpr (Idx::unique) {
-                            if (Idx::fields.size() == targets.size()) {
-                                bool all = true;
-                                // Conflict-target columns must be supplied in the same declared order as
-                                // the matching UniqueIndex. This is a v1 simplification; set-comparison
-                                // (order-insensitive matching) can be added later if needed.
-                                for (std::size_t i = 0; i < targets.size(); ++i) {
-                                    if (Idx::fields[i] != targets[i]) {
-                                        all = false;
-                                    }
-                                }
-                                if (all) {
-                                    matched = true;
-                                }
+                            if (fields_equal_ordered(Idx::fields, targets)) {
+                                matched = true;
                             }
                         }
                     }(),

--- a/src/orm/statements/upsert_grammar.cppm
+++ b/src/orm/statements/upsert_grammar.cppm
@@ -142,6 +142,9 @@ export namespace storm::orm::statements {
                         if constexpr (Idx::unique) {
                             if (Idx::fields.size() == targets.size()) {
                                 bool all = true;
+                                // Conflict-target columns must be supplied in the same declared order as
+                                // the matching UniqueIndex. This is a v1 simplification; set-comparison
+                                // (order-insensitive matching) can be added later if needed.
                                 for (std::size_t i = 0; i < targets.size(); ++i) {
                                     if (Idx::fields[i] != targets[i]) {
                                         all = false;

--- a/src/orm/statements/upsert_grammar.cppm
+++ b/src/orm/statements/upsert_grammar.cppm
@@ -163,13 +163,12 @@ export namespace storm::orm::statements {
     }
 
     // A valid conflict target: every Target is a data member of T, AND either a
-    // single FieldAttr::unique field, or the PK, or a matching UniqueIndex<...>.
+    // single FieldAttr::unique field or a matching UniqueIndex<...>. INSERT
+    // omits the primary key, so it cannot form a useful conflict target.
     template <typename T, std::meta::info... Target>
-    concept ConflictTargetUnique =
-            ((std::meta::is_nonstatic_data_member(Target)) && ...) &&
-            ((sizeof...(Target) == 1 &&
-              ((storm::meta::is_unique(Target) || Target == BaseStatement<T>::primary_key_) && ...)) ||
-             target_matches_unique_index<T, Target...>());
+    concept ConflictTargetUnique = ((std::meta::is_nonstatic_data_member(Target)) && ...) &&
+                                   ((sizeof...(Target) == 1 && (storm::meta::is_unique(Target) && ...)) ||
+                                    target_matches_unique_index<T, Target...>());
 
     // A valid SET target: a non-static data member of T that is not the PK.
     template <typename T, std::meta::info... SetCols>

--- a/src/storm.cppm
+++ b/src/storm.cppm
@@ -17,6 +17,7 @@ export import storm_db_postgresql;
 export import storm_db_pool;
 export import storm_orm_statements_base;
 export import storm_orm_statements_insert;
+export import storm_orm_statements_upsert_grammar;
 export import storm_orm_statements_select;
 export import storm_orm_statements_join;
 export import storm_orm_statements_setop;

--- a/tests/crud/test_upsert.cpp
+++ b/tests/crud/test_upsert.cpp
@@ -1,0 +1,27 @@
+#include <gtest/gtest.h>
+#include "test_db_helpers.h"
+#include <sqlite3.h>
+
+import storm;
+import std;
+
+#include "test_models.h" // NOSONAR cpp:S954
+#include "test_seed_helpers.h"
+
+namespace {
+    using storm::orm::statements::UpsertGrammar;
+}
+
+// Grammar emits a single-column conflict target via the FK-aware writer.
+TEST(UpsertGrammarTest, ConflictTargetSingleColumn) {
+    constexpr auto    target = UpsertGrammar<Person>::build_conflict_target<^^Person::name>();
+    const std::string s(target);
+    EXPECT_EQ(s, "(name)");
+}
+
+// Grammar emits col=excluded.col for each listed SET column.
+TEST(UpsertGrammarTest, ExcludedSetClauseMultipleColumns) {
+    constexpr auto    set = UpsertGrammar<Person>::build_excluded_set_clause<^^Person::age, ^^Person::salary>();
+    const std::string s(set);
+    EXPECT_EQ(s, "age=excluded.age, salary=excluded.salary");
+}

--- a/tests/crud/test_upsert.cpp
+++ b/tests/crud/test_upsert.cpp
@@ -8,6 +8,30 @@ import std;
 #include "test_models.h" // NOSONAR cpp:S954
 #include "test_seed_helpers.h"
 
+struct CompositeUpsertRecord {
+    [[= storm::FieldAttr::primary]] int id{};
+    std::string                         name;
+    std::string                         department;
+    int                                 age{};
+};
+
+template <> struct storm::Indexes<CompositeUpsertRecord> {
+    using type = std::tuple<storm::UniqueIndex<^^CompositeUpsertRecord::name, ^^CompositeUpsertRecord::department>>;
+};
+
+struct TimestampedUpsertRecord {
+    [[= storm::FieldAttr::primary]] int                                       id{};
+    [[= storm::FieldAttr::unique]] std::string                                name;
+    [[= storm::FieldAttr::auto_create]] std::chrono::system_clock::time_point created_at{};
+    [[= storm::FieldAttr::auto_update]] std::chrono::system_clock::time_point updated_at{};
+};
+
+struct UniqueOwnerRecord {
+    [[= storm::FieldAttr::primary]] int                    id{};
+    [[= storm::FieldAttr::unique]][[= storm::fk<>]] Person owner;
+    std::string                                            label;
+};
+
 namespace {
     using storm::orm::statements::UpsertGrammar;
 }
@@ -24,6 +48,13 @@ TEST(UpsertGrammarTest, ExcludedSetClauseMultipleColumns) {
     constexpr auto    set = UpsertGrammar<Person>::build_excluded_set_clause<^^Person::age, ^^Person::salary>();
     const std::string s(set);
     EXPECT_EQ(s, "age=excluded.age, salary=excluded.salary");
+}
+
+TEST(UpsertGrammarTest, ForeignKeyColumnsUseIdSuffix) {
+    constexpr auto target = UpsertGrammar<UniqueOwnerRecord>::build_conflict_target<^^UniqueOwnerRecord::owner>();
+    constexpr auto set    = UpsertGrammar<UniqueOwnerRecord>::build_excluded_set_clause<^^UniqueOwnerRecord::owner>();
+    EXPECT_EQ(std::string(target), "(owner_id)");
+    EXPECT_EQ(std::string(set), "owner_id=excluded.owner_id");
 }
 
 // Full DO NOTHING statement for Person conflicting on name.
@@ -49,6 +80,8 @@ static_assert(storm::orm::statements::ConflictTargetUnique<Person, ^^Person::nam
 static_assert(storm::orm::statements::ConflictTargetUnique<Person, ^^Person::name, ^^Person::department>);
 // Negative: a non-unique column is NOT a valid conflict target.
 static_assert(!storm::orm::statements::ConflictTargetUnique<Person, ^^Person::age>);
+// Negative: inserts omit the PK, so it cannot be a conflict target.
+static_assert(!storm::orm::statements::ConflictTargetUnique<Person, ^^Person::id>);
 // Negative: the PK is NOT settable.
 static_assert(!storm::orm::statements::UpsertSettable<Person, ^^Person::id>);
 // Positive: a normal column IS settable.
@@ -60,6 +93,9 @@ TEST(UpsertGrammarTest, ConstraintsCompile) {
 
 template <typename ConnType> class UpsertTest : public StormTestFixture<Person, ConnType> {};
 TYPED_TEST_SUITE(UpsertTest, DatabaseTypes);
+
+template <typename ConnType> class CompositeUpsertTest : public StormTestFixture<CompositeUpsertRecord, ConnType> {};
+TYPED_TEST_SUITE(CompositeUpsertTest, DatabaseTypes);
 
 // Seeds the initial "Zed" row via the DO NOTHING proxy and returns its id.
 // Shared by both conflict tests below so each only adds its own conflicting insert.
@@ -114,4 +150,93 @@ TYPED_TEST(UpsertTest, SqlGoldenNothing) {
     Person const                       row{.name = "Q", .age = 1, .department = "X"};
     const std::string                  sql = qs.insert(row).template on_conflict<^^Person::name>().nothing().sql();
     EXPECT_NE(sql.find("ON CONFLICT (name) DO NOTHING"), std::string::npos) << sql;
+}
+
+// Composite conflict target via UniqueIndex<name, department>.
+TYPED_TEST(CompositeUpsertTest, CompositeConflictTarget) {
+    storm::QuerySet<CompositeUpsertRecord, TypeParam> qs;
+    CompositeUpsertRecord const                       rec{.name = "Cara", .department = "Eng", .age = 20};
+    auto                                              first = qs.insert(rec)
+                         .template on_conflict<^^CompositeUpsertRecord::name, ^^CompositeUpsertRecord::department>()
+                         .template update<^^CompositeUpsertRecord::age>()
+                         .execute();
+    ASSERT_TRUE(first.has_value()) << first.error().message();
+    CompositeUpsertRecord const upd{.name = "Cara", .department = "Eng", .age = 21};
+    auto                        second = qs.insert(upd)
+                          .template on_conflict<^^CompositeUpsertRecord::name, ^^CompositeUpsertRecord::department>()
+                          .template update<^^CompositeUpsertRecord::age>()
+                          .execute();
+    ASSERT_TRUE(second.has_value()) << second.error().message();
+    EXPECT_EQ(second.value(), first.value());
+}
+
+// DO UPDATE with multiple SET columns.
+TYPED_TEST(UpsertTest, DoUpdateMultipleColumns) {
+    storm::QuerySet<Person, TypeParam> qs;
+    Person const                       rec{.name = "Dan", .age = 10, .salary = 100.0, .department = "Eng"};
+    auto                               first = qs.insert(rec)
+                         .template on_conflict<^^Person::name>()
+                         .template update<^^Person::age, ^^Person::salary>()
+                         .execute();
+    ASSERT_TRUE(first.has_value()) << first.error().message();
+    Person const upd{.name = "Dan", .age = 11, .salary = 200.0, .department = "Eng"};
+    auto         r = qs.insert(upd)
+                     .template on_conflict<^^Person::name>()
+                     .template update<^^Person::age, ^^Person::salary>()
+                     .execute();
+    ASSERT_TRUE(r.has_value()) << r.error().message();
+    EXPECT_EQ(r.value(), first.value());
+    auto row = qs.where(storm::orm::where::f<^^Person::name>() == std::string("Dan")).select().execute();
+    ASSERT_TRUE(row.has_value());
+    EXPECT_EQ(row.value().begin()->age, 11);
+    EXPECT_DOUBLE_EQ(row.value().begin()->salary, 200.0);
+}
+
+// to_sql() inlines the bound params (debug helper).
+TYPED_TEST(UpsertTest, ToSqlInlinesParams) {
+    storm::QuerySet<Person, TypeParam> qs;
+    Person const                       rec{.name = "Eve", .age = 5, .department = "X"};
+    auto                               r = qs.insert(rec).template on_conflict<^^Person::name>().nothing().to_sql();
+    ASSERT_TRUE(r.has_value());
+    EXPECT_NE(r.value().find("ON CONFLICT (name) DO NOTHING"), std::string::npos) << r.value();
+}
+
+// auto_update (#209) is re-stamped on a DO UPDATE upsert. The unique name
+// forces the second insert to hit the existing row; the auto_update updated_at
+// column is bound now() afresh, so the stored value advances. Timestamps are
+// bind-time-only (no write-back), so re-SELECT to read.
+template <typename ConnType> class UpsertTimestampTest : public StormTestFixture<TimestampedUpsertRecord, ConnType> {};
+TYPED_TEST_SUITE(UpsertTimestampTest, DatabaseTypes);
+
+TYPED_TEST(UpsertTimestampTest, DoUpdateRefreshesAutoUpdateTimestamp) {
+    using storm::orm::where::f;
+    storm::QuerySet<TimestampedUpsertRecord, TypeParam> qs;
+
+    TimestampedUpsertRecord const seed{.name = "record"};
+    auto                          inserted = qs.insert(seed)
+                            .template on_conflict<^^TimestampedUpsertRecord::name>()
+                            .template update<^^TimestampedUpsertRecord::name>()
+                            .execute();
+    ASSERT_TRUE(inserted.has_value());
+
+    auto before = qs.where(f<^^TimestampedUpsertRecord::name>() == "record").select().execute();
+    ASSERT_TRUE(before.has_value());
+    ASSERT_EQ(before.value().size(), 1U);
+    const auto first_stamp = before.value().begin()->updated_at;
+
+    // Sleep one second: the stored format has 1s resolution (tp_to_string), so a
+    // sub-second gap would round to the same string and falsely fail the advance check.
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+
+    TimestampedUpsertRecord const conflicting{.name = "record"};
+    auto                          updated = qs.insert(conflicting)
+                           .template on_conflict<^^TimestampedUpsertRecord::name>()
+                           .template update<^^TimestampedUpsertRecord::name>()
+                           .execute();
+    ASSERT_TRUE(updated.has_value());
+
+    auto after = qs.where(f<^^TimestampedUpsertRecord::name>() == "record").select().execute();
+    ASSERT_TRUE(after.has_value());
+    ASSERT_EQ(after.value().size(), 1U);
+    EXPECT_GT(after.value().begin()->updated_at, first_stamp); // updated_at advanced
 }

--- a/tests/crud/test_upsert.cpp
+++ b/tests/crud/test_upsert.cpp
@@ -42,3 +42,18 @@ TEST(UpsertGrammarTest, FullSqlDoUpdate) {
     EXPECT_NE(sql.find("ON CONFLICT (name) DO UPDATE SET age=excluded.age"), std::string::npos) << sql;
     EXPECT_TRUE(sql.ends_with("RETURNING id")) << sql;
 }
+
+// Positive: a single unique field IS a valid conflict target.
+static_assert(storm::orm::statements::ConflictTargetUnique<Person, ^^Person::name>);
+// Positive: the UniqueIndex<name, department> column set IS valid.
+static_assert(storm::orm::statements::ConflictTargetUnique<Person, ^^Person::name, ^^Person::department>);
+// Negative: a non-unique column is NOT a valid conflict target.
+static_assert(!storm::orm::statements::ConflictTargetUnique<Person, ^^Person::age>);
+// Negative: the PK is NOT settable.
+static_assert(!storm::orm::statements::UpsertSettable<Person, ^^Person::id>);
+// Positive: a normal column IS settable.
+static_assert(storm::orm::statements::UpsertSettable<Person, ^^Person::age>);
+
+TEST(UpsertGrammarTest, ConstraintsCompile) {
+    SUCCEED();
+}

--- a/tests/crud/test_upsert.cpp
+++ b/tests/crud/test_upsert.cpp
@@ -57,3 +57,17 @@ static_assert(storm::orm::statements::UpsertSettable<Person, ^^Person::age>);
 TEST(UpsertGrammarTest, ConstraintsCompile) {
     SUCCEED();
 }
+
+template <typename ConnType> class UpsertTest : public StormTestFixture<Person, ConnType> {};
+TYPED_TEST_SUITE(UpsertTest, DatabaseTypes);
+
+// Temporary direct-call test (delete after Task 5 wires the on_conflict() proxy):
+// exercises execute_upsert_nothing() directly since the fluent proxy isn't wired yet.
+TYPED_TEST(UpsertTest, DirectExecuteNothing) {
+    auto conn = storm::QuerySet<Person, TypeParam>::get_default_connection();
+    storm::orm::statements::InsertStatement<Person, TypeParam> stmt{conn};
+    Person const                                               obj{.name = "Zed", .age = 1, .department = "X"};
+    auto r = stmt.template execute_upsert_nothing<^^Person::name>(obj);
+    ASSERT_TRUE(r.has_value());
+    EXPECT_TRUE(r.value().has_value());
+}

--- a/tests/crud/test_upsert.cpp
+++ b/tests/crud/test_upsert.cpp
@@ -61,13 +61,57 @@ TEST(UpsertGrammarTest, ConstraintsCompile) {
 template <typename ConnType> class UpsertTest : public StormTestFixture<Person, ConnType> {};
 TYPED_TEST_SUITE(UpsertTest, DatabaseTypes);
 
-// Temporary direct-call test (delete after Task 5 wires the on_conflict() proxy):
-// exercises execute_upsert_nothing() directly since the fluent proxy isn't wired yet.
-TYPED_TEST(UpsertTest, DirectExecuteNothing) {
-    auto conn = storm::QuerySet<Person, TypeParam>::get_default_connection();
-    storm::orm::statements::InsertStatement<Person, TypeParam> stmt{conn};
-    Person const                                               obj{.name = "Zed", .age = 1, .department = "X"};
-    auto r = stmt.template execute_upsert_nothing<^^Person::name>(obj);
-    ASSERT_TRUE(r.has_value());
-    EXPECT_TRUE(r.value().has_value());
+// Seeds the initial "Zed" row via the DO NOTHING proxy and returns its id.
+// Shared by both conflict tests below so each only adds its own conflicting insert.
+template <typename ConnType> auto seed_zed(storm::QuerySet<Person, ConnType>& qs) -> std::int64_t {
+    Person const first{.name = "Zed", .age = 1, .department = "X"};
+    auto         first_id = qs.insert(first).template on_conflict<^^Person::name>().nothing().execute();
+    EXPECT_TRUE(first_id.has_value());
+    EXPECT_TRUE(first_id.value().has_value());
+    return first_id.value().value();
+}
+
+// DO NOTHING via the fluent proxy: first insert lands, the conflicting second
+// insert is skipped (no row touched), leaving the original row untouched.
+TYPED_TEST(UpsertTest, DoNothingSkipsOnConflict) {
+    using storm::orm::where::f;
+    storm::QuerySet<Person, TypeParam> qs;
+    seed_zed(qs);
+
+    Person const conflicting{.name = "Zed", .age = 99, .department = "Y"};
+    auto         second = qs.insert(conflicting).template on_conflict<^^Person::name>().nothing().execute();
+    ASSERT_TRUE(second.has_value());
+    EXPECT_FALSE(second.value().has_value()); // skipped — no row touched
+
+    auto rows = qs.where(f<^^Person::name>() == "Zed").select().execute();
+    ASSERT_TRUE(rows.has_value());
+    ASSERT_EQ(rows.value().size(), 1U);
+    EXPECT_EQ(rows.value().begin()->age, 1); // untouched by the conflicting insert
+}
+
+// DO UPDATE via the fluent proxy: the conflicting insert overwrites the listed
+// column (age) on the existing row.
+TYPED_TEST(UpsertTest, DoUpdateOverwritesListedColumn) {
+    using storm::orm::where::f;
+    storm::QuerySet<Person, TypeParam> qs;
+    const std::int64_t                 first_id = seed_zed(qs);
+
+    Person const conflicting{.name = "Zed", .age = 99, .department = "Y"};
+    auto         updated_id =
+            qs.insert(conflicting).template on_conflict<^^Person::name>().template update<^^Person::age>().execute();
+    ASSERT_TRUE(updated_id.has_value());
+    EXPECT_EQ(updated_id.value(), first_id);
+
+    auto rows = qs.where(f<^^Person::name>() == "Zed").select().execute();
+    ASSERT_TRUE(rows.has_value());
+    ASSERT_EQ(rows.value().size(), 1U);
+    EXPECT_EQ(rows.value().begin()->age, 99); // overwritten by the conflicting insert
+}
+
+// .sql() golden — DO NOTHING shape via the fluent proxy.
+TYPED_TEST(UpsertTest, SqlGoldenNothing) {
+    storm::QuerySet<Person, TypeParam> qs;
+    Person const                       row{.name = "Q", .age = 1, .department = "X"};
+    const std::string                  sql = qs.insert(row).template on_conflict<^^Person::name>().nothing().sql();
+    EXPECT_NE(sql.find("ON CONFLICT (name) DO NOTHING"), std::string::npos) << sql;
 }

--- a/tests/crud/test_upsert.cpp
+++ b/tests/crud/test_upsert.cpp
@@ -25,3 +25,20 @@ TEST(UpsertGrammarTest, ExcludedSetClauseMultipleColumns) {
     const std::string s(set);
     EXPECT_EQ(s, "age=excluded.age, salary=excluded.salary");
 }
+
+// Full DO NOTHING statement for Person conflicting on name.
+TEST(UpsertGrammarTest, FullSqlDoNothing) {
+    const std::string& sql = UpsertGrammar<Person>::nothing_sql<^^Person::name>();
+    EXPECT_TRUE(sql.starts_with("INSERT INTO Person ")) << sql;
+    EXPECT_NE(sql.find("ON CONFLICT (name) DO NOTHING"), std::string::npos) << sql;
+    EXPECT_TRUE(sql.ends_with("RETURNING id")) << sql;
+}
+
+// Full DO UPDATE statement, conflict on name, set age.
+TEST(UpsertGrammarTest, FullSqlDoUpdate) {
+    const std::string sql = UpsertGrammar<Person>::update_sql<^^Person::name>(
+            UpsertGrammar<Person>::build_excluded_set_clause<^^Person::age>()
+    );
+    EXPECT_NE(sql.find("ON CONFLICT (name) DO UPDATE SET age=excluded.age"), std::string::npos) << sql;
+    EXPECT_TRUE(sql.ends_with("RETURNING id")) << sql;
+}

--- a/tests/mock_sqlite/test_orm_mock_errors.cpp
+++ b/tests/mock_sqlite/test_orm_mock_errors.cpp
@@ -60,6 +60,14 @@ namespace {
         std::optional<int>                           age;
     };
 
+    // Test model with an auto_update timestamp (#209), used to cover the upsert
+    // DO UPDATE auto_update-tail bind-error branch (#205).
+    struct MockPersonAutoUpdate {
+        [[= storm::FieldAttr::primary]] std::int64_t                              id{};
+        std::string                                                               name;
+        [[= storm::FieldAttr::auto_update]] std::chrono::system_clock::time_point updated_at{};
+    };
+
     /**
      * @brief Test fixture for ORM mock error tests
      *
@@ -143,8 +151,9 @@ namespace {
     }
 
     // ============================================================================
-    // UPSERT Error Tests (#205) — execute_upsert_nothing() called directly since
-    // the on_conflict() fluent proxy isn't wired up yet (Task 5).
+    // UPSERT Error Tests (#205) — execute_upsert_nothing() called directly to
+    // inject mock bind/step errors; the on_conflict() proxy chain (Task 5) only
+    // runs against a real connection, so it can't hit these error paths.
     // ============================================================================
 
     TEST_F(ORMMockErrorTest, UpsertNothingFailsOnBindError) {
@@ -174,6 +183,68 @@ namespace {
 
         ASSERT_FALSE(result.has_value());
         EXPECT_EQ(result.error().code(), SQLITE_IOERR);
+    }
+
+    TEST_F(ORMMockErrorTest, UpsertUpdateFailsOnPrepareError) {
+        MockSqlite3Config::prepare_returns(SQLITE_ERROR);
+
+        auto conn = QuerySet<MockPerson>::get_default_connection();
+        storm::orm::statements::InsertStatement<MockPerson, storm::db::sqlite::Connection> stmt{conn};
+        MockPerson const person{.id = 0, .name = "Alice", .age = 30};
+
+        auto result = stmt.template upsert_update_runner<^^MockPerson::name>().template run<^^MockPerson::age>(person);
+
+        ASSERT_FALSE(result.has_value());
+        EXPECT_EQ(result.error().code(), SQLITE_ERROR);
+    }
+
+    TEST_F(ORMMockErrorTest, UpsertUpdateFailsOnBindError) {
+        // Fail bind_text (used for the "name" VALUES field) so bind_all_fields() errors out.
+        MockSqlite3Config::bind_text_returns(SQLITE_NOMEM);
+
+        auto conn = QuerySet<MockPerson>::get_default_connection();
+        storm::orm::statements::InsertStatement<MockPerson, storm::db::sqlite::Connection> stmt{conn};
+        MockPerson const person{.id = 0, .name = "Alice", .age = 30};
+
+        auto result = stmt.template upsert_update_runner<^^MockPerson::name>().template run<^^MockPerson::age>(person);
+
+        ASSERT_FALSE(result.has_value());
+        EXPECT_EQ(result.error().code(), SQLITE_NOMEM);
+    }
+
+    TEST_F(ORMMockErrorTest, UpsertUpdateFailsOnStepError) {
+        // Let prepare and binding succeed, but fail on step with a real DB error.
+        MockSqlite3Config::step_returns(SQLITE_IOERR);
+
+        auto conn = QuerySet<MockPerson>::get_default_connection();
+        storm::orm::statements::InsertStatement<MockPerson, storm::db::sqlite::Connection> stmt{conn};
+        MockPerson const person{.id = 0, .name = "Alice", .age = 30};
+
+        auto result = stmt.template upsert_update_runner<^^MockPerson::name>().template run<^^MockPerson::age>(person);
+
+        ASSERT_FALSE(result.has_value());
+        EXPECT_EQ(result.error().code(), SQLITE_IOERR);
+    }
+
+    TEST_F(ORMMockErrorTest, UpsertUpdateFailsOnAutoUpdateBindError) {
+        // A system_clock::time_point binds via bind_text (tp_to_string), NOT bind_int64.
+        // For MockPersonAutoUpdate{id(PK), name, updated_at}, the DO UPDATE binds, in order:
+        // VALUES name -> text #1, VALUES updated_at -> text #2; then SetCols=name leaves
+        // updated_at unlisted, so the auto_update tail (#209) re-binds it -> text #3.
+        // Fail only text #3 to isolate bind_upsert_auto_updates' error branch from
+        // bind_all_fields'.
+        MockSqlite3Config::bind_text_fails_on_call(3, SQLITE_NOMEM);
+
+        (void)QuerySet<MockPersonAutoUpdate>::set_default_connection(":memory:");
+        auto conn = QuerySet<MockPersonAutoUpdate>::get_default_connection();
+        storm::orm::statements::InsertStatement<MockPersonAutoUpdate, storm::db::sqlite::Connection> stmt{conn};
+        MockPersonAutoUpdate const person{.id = 0, .name = "Alice"};
+
+        auto result = stmt.template upsert_update_runner<^^MockPersonAutoUpdate::id>()
+                              .template run<^^MockPersonAutoUpdate::name>(person);
+
+        ASSERT_FALSE(result.has_value());
+        EXPECT_EQ(result.error().code(), SQLITE_NOMEM);
     }
 
     // ============================================================================

--- a/tests/mock_sqlite/test_orm_mock_errors.cpp
+++ b/tests/mock_sqlite/test_orm_mock_errors.cpp
@@ -170,6 +170,22 @@ namespace {
         EXPECT_EQ(result.error().code(), SQLITE_NOMEM);
     }
 
+    TEST_F(ORMMockErrorTest, UpsertToSqlFailsOnBindError) {
+        // Fail bind_text so the bind step inside to_sql_with() errors out.
+        MockSqlite3Config::bind_text_returns(SQLITE_NOMEM);
+
+        auto conn = QuerySet<MockPerson>::get_default_connection();
+        storm::orm::statements::InsertStatement<MockPerson, storm::db::sqlite::Connection> stmt{conn};
+        MockPerson const person{.id = 0, .name = "Alice", .age = 30};
+
+        auto result = stmt.template to_sql_with<>(
+                storm::orm::statements::UpsertGrammar<MockPerson>::template nothing_sql<^^MockPerson::name>(), person
+        );
+
+        ASSERT_FALSE(result.has_value());
+        EXPECT_EQ(result.error().code(), SQLITE_NOMEM);
+    }
+
     TEST_F(ORMMockErrorTest, UpsertNothingFailsOnStepError) {
         // Let prepare and binding succeed, but fail on step with a real DB error
         // (neither ROW_AVAILABLE nor NO_MORE_ROWS).

--- a/tests/mock_sqlite/test_orm_mock_errors.cpp
+++ b/tests/mock_sqlite/test_orm_mock_errors.cpp
@@ -143,6 +143,40 @@ namespace {
     }
 
     // ============================================================================
+    // UPSERT Error Tests (#205) — execute_upsert_nothing() called directly since
+    // the on_conflict() fluent proxy isn't wired up yet (Task 5).
+    // ============================================================================
+
+    TEST_F(ORMMockErrorTest, UpsertNothingFailsOnBindError) {
+        // Fail bind_text (used for the "name" field) so prepare_and_bind() errors out.
+        MockSqlite3Config::bind_text_returns(SQLITE_NOMEM);
+
+        auto conn = QuerySet<MockPerson>::get_default_connection();
+        storm::orm::statements::InsertStatement<MockPerson, storm::db::sqlite::Connection> stmt{conn};
+        MockPerson const person{.id = 0, .name = "Alice", .age = 30};
+
+        auto result = stmt.template execute_upsert_nothing<^^MockPerson::name>(person);
+
+        ASSERT_FALSE(result.has_value());
+        EXPECT_EQ(result.error().code(), SQLITE_NOMEM);
+    }
+
+    TEST_F(ORMMockErrorTest, UpsertNothingFailsOnStepError) {
+        // Let prepare and binding succeed, but fail on step with a real DB error
+        // (neither ROW_AVAILABLE nor NO_MORE_ROWS).
+        MockSqlite3Config::step_returns(SQLITE_IOERR);
+
+        auto conn = QuerySet<MockPerson>::get_default_connection();
+        storm::orm::statements::InsertStatement<MockPerson, storm::db::sqlite::Connection> stmt{conn};
+        MockPerson const person{.id = 0, .name = "Alice", .age = 30};
+
+        auto result = stmt.template execute_upsert_nothing<^^MockPerson::name>(person);
+
+        ASSERT_FALSE(result.has_value());
+        EXPECT_EQ(result.error().code(), SQLITE_IOERR);
+    }
+
+    // ============================================================================
     // SELECT Error Tests
     // ============================================================================
 


### PR DESCRIPTION
Closes #205

Single-row upsert via insert proxy chain: `qs.insert(obj).on_conflict<^^T::field...>().update<^^T::col...>()` / `.nothing()`. Conflict target is compile-time checked (unique field or matching UniqueIndex); `update<>()` returns `expected<int64_t>`, `nothing()` returns `expected<optional<int64_t>>` (nullopt = conflict skipped). See docs/superpowers/specs/2026-06-22-upsert-design.md.

Also: `create_table` now creates declared unique indexes (composite conflict targets need them), and the PK is rejected as a conflict target (inserts omit it — it can never conflict).

Verified: 2453/2453 tests (SQLite+PG), 100% coverage, ASAN+UBSAN and TSAN clean, INSERT bench unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)