### PR TITLE
docs(agents): document upsert (#205/#458) in dev/reviewer/test agent files

### DIFF
--- a/.claude/agents/dev.md
+++ b/.claude/agents/dev.md
@@ -21,6 +21,7 @@ When implementing features:
    - `SMALL_THRESHOLD=10`: always bulk SQL for very small batches
    - `FALLBACK_BATCH_SIZE=50`: safe minimum constant in the adaptive algorithm
 6. Use `TransactionGuard` (`storm::begin(conn)`) for transaction management — cooperative with batch ops (#415)
+   - Upsert (#205/#458): single-row `insert(p).on_conflict<Target...>().update<Cols...>(proto)` / `.nothing()`. The `on_conflict<Target...>()` proxy lives on the insert statement (`insert.cppm`); `ConflictTarget`/`.update()`/`.nothing()` grammar in `storm_orm_statements_upsert_grammar`. Conflict target must be a single `FieldAttr::unique` field or a matching `UniqueIndex<...>` (compile-time checked via `target_matches_unique_index`). `DO UPDATE` → `std::expected<int64_t, Error>`; `DO NOTHING` → `std::expected<std::optional<int64_t>, Error>` (nullopt when the row already existed). Unlisted `auto_update` cols are still auto-stamped in the SET list
 7. Cache SQL strings using static methods like `get_insert_sql()`
 8. Handle `SQLITE_MAX_VARIABLE_NUMBER` (999) in all batch operations
 
@@ -31,7 +32,7 @@ When implementing features:
 - `storm_db_sqlite` / `storm_db_postgresql` implement concepts
 - `storm_orm_utilities`, `storm_orm_transaction` — no storm imports
 - `storm_orm_statements_base` uses db_concept + utilities
-- Statement modules (insert, erase, update, select, etc.) use statements_base
+- Statement modules (insert, erase, update, select, upsert, etc.) use statements_base
 - `storm_orm_queryset` at the top, imports all statement modules
 
 **Concept-Based Abstraction**: All database operations work through `DatabaseConnection` and `DatabaseStatement` concepts — SQLite-specific code stays in `storm_db_sqlite`.

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -34,6 +34,7 @@ You are a senior C++ code reviewer specializing in the Storm ORM project, with d
 
 ### 4. BaseStatement Consolidation
 - New statement classes inherit from `BaseStatement<T>`
+- Upsert (#205/#458): `insert(p).on_conflict<Target...>().update<Cols...>(proto)`/`.nothing()`. Conflict target MUST be a single `FieldAttr::unique` field or matching `UniqueIndex<...>` (compile-time checked). Verify return types: `DO UPDATE` → `std::expected<int64_t, Error>`, `DO NOTHING` → `std::expected<std::optional<int64_t>, Error>` (nullopt when the row already existed). Empty-WHERE refusal does not apply (single-row, INSERT-driven)
 - Batch transactions use `TransactionGuard` (`storm::begin(conn)`), not raw BEGIN/COMMIT
 - SQL string caching via static methods like `get_insert_sql()`
 - Minimize code duplication through shared binding helpers

--- a/.claude/agents/test.md
+++ b/.claude/agents/test.md
@@ -99,6 +99,7 @@ When tests fail, systematically check:
 
 ### 5. Common Storm-Specific Issues
 - Batch operation adaptive thresholds (999/field_count for bulk SQL; FALLBACK_BATCH_SIZE=50 is a minimum constant, not the primary cutoff)
+- Upsert (#205/#458) `on_conflict<Target...>().update<Cols...>()`/`.nothing()`: test both DO UPDATE (`std::expected<int64_t, Error>`) and DO NOTHING (`std::expected<std::optional<int64_t>, Error>`, nullopt on existing row); conflict on a `FieldAttr::unique` field vs a `UniqueIndex<...>`; insert-new vs conflict paths; unlisted `auto_update` cols still stamped; cross-backend via TYPED_TEST
 - Transaction management in BaseStatement utilities
 - SQL generation with runtime std::format
 - Statement caching and prepared statement lifecycle


### PR DESCRIPTION
## Summary

The upsert feature merged in #458 without updating the `.claude/agents/*.md` files, violating CLAUDE.md rule 8 ("code + docs + agent files commit together"). This backfills the agent-file coverage.

- **dev.md** — add `upsert` to the statement-module list; add an Implementation Practices catalog line covering `on_conflict<Target...>().update<Cols...>()`/`.nothing()`, the compile-time conflict-target check, and the `std::expected<int64_t>` vs `std::expected<std::optional<int64_t>>` return-type split.
- **reviewer.md** — add an upsert review-checklist item (unique-target requirement, return types, empty-WHERE refusal N/A).
- **test.md** — add an upsert test-coverage item (both DO UPDATE/DO NOTHING paths, unique-field vs UniqueIndex target, insert-new vs conflict, auto_update stamping, cross-backend).

Docs-only; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)