### PR TITLE
fix(indexes): nested-typedef opt-in replaces multi-GMF Indexes<Person> specialization (#464)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -371,6 +371,7 @@ See [docs/guide/reference/FIELD_TYPES.md](docs/guide/reference/FIELD_TYPES.md).
 - **std::function errors**: Use abstract base classes
 - **C headers / macros**: `<cassert>` (the `assert` macro) and POSIX headers (`<csignal>`, `<sys/*.h>`) must stay textual `#include` — `import std;` cannot deliver macros or POSIX extensions
 - **Template alias can't be specialized**: `template<T> using X = Y<T>;` doesn't allow `template<> struct X<Foo>`. Use a real class template in a dedicated module to avoid circular deps.
+- **No explicit specializations in multi-GMF headers**: an explicit specialization of a module-owned template (e.g. `Indexes<Person>`) in a header included by several module TUs' GMFs breaks with "reference to 'type' is ambiguous" once the import graph offers a second BMI path (#464). Use the nested-typedef opt-in (`using storm_indexes = std::tuple<...>;` inside the model) instead. See [COMPILER_ISSUES.md §11](docs/internals/compiler/COMPILER_ISSUES.md).
 - **`if constexpr` in consteval loops**: `if constexpr(f(arr[i]))` fails even in `consteval` — loop variable `i` isn't a core constant expression. Use plain `if` (both branches must compile, but that's fine in consteval).
 - **Compile-time errors: use `requires`, not `throw`**: `throw "msg"` in `consteval` produces a poor error message. Instead define a concept and constrain the template — the error fires at the call site with a clear constraint violation:
   ```cpp

--- a/benchmarks/query_benchmark.cppm
+++ b/benchmarks/query_benchmark.cppm
@@ -17,7 +17,7 @@ module;
 #include <sqlite3.h>
 #include <plf_hive/plf_hive.h>
 
-// `<tuple>` is needed by models.hpp (Indexes<Person>::type) before
+// `<tuple>` is needed by models.hpp (Person::storm_indexes) before
 // reflection-annotated structs are visible. Annotations are blind across BMI
 // boundaries (clang-p2996 #262, see feedback_cpp26_module_reflection_annotations),
 // so model types must be textually visible in the consumer's GMF for any

--- a/benchmarks/registry.cppm
+++ b/benchmarks/registry.cppm
@@ -13,7 +13,7 @@
 module;
 
 // shared/models.h (pulled in by models.hpp) uses std::tuple for the
-// Indexes<Person>::type typedef — needs to be visible textually before that
+// Person::storm_indexes typedef — needs to be visible textually before that
 // header expands inside the GMF.
 #include <tuple>
 

--- a/docs/internals/compiler/COMPILER_ISSUES.md
+++ b/docs/internals/compiler/COMPILER_ISSUES.md
@@ -268,6 +268,52 @@ Found in #388: the `FKFieldOf<T, Member>` concept (base.cppm) constrains
 `join<^^T::field>()` and must work with FK reflections produced by the benchmark
 registry module (`storm_benchmark_registry::resolve_fk_field`).
 
+### 11. Explicit Specialization in a Multi-GMF Header — Ambiguous Member Lookup
+
+**Problem**: An explicit specialization of a module-owned class template (e.g.
+`template <> struct storm::Indexes<Person>`), placed in a header that is
+textually included in **several module TUs' global module fragments** plus a
+plain TU that imports those modules, can make member lookup ambiguous:
+
+```
+src/orm/indexes.cppm:27:27: error: reference to 'type' is ambiguous
+shared/models.h:41:11: note: candidate found by name lookup is 'storm::Indexes<Person>::type'
+  (identical note repeated once per TU that carries the header)
+```
+
+Each GMF inclusion produces its own copy of the specialization; clang-p2996
+should merge them as one entity but fails when the specialization's members
+carry reflection NTTPs (`Index<^^Person::department, ...>` — same family as
+cross-BMI reflection-equality issues, see §10). The failure is **latent**: it
+only fires once the import graph gives the consumer TU more than one BMI path
+to the primary template. Found in #464: `storm_bench`'s `register.cpp` (textual
+`shared/models.h` + imports of 3 bench modules whose GMFs also include it)
+compiled fine until #458 added a second import path to `storm_orm_indexes`
+(`storm → insert → upsert_grammar → indexes`), then broke deterministically.
+
+**Solution**: For model headers consumed by multiple module TUs, do not
+explicitly specialize the trait. Declare the index list as a nested typedef
+inside the model instead — the constrained partial specialization in
+`indexes.cppm` (single owner, exactly one visible declaration) picks it up:
+
+```cpp
+// ❌ Explicit specialization — one copy per including TU, fragile merging
+template <> struct storm::Indexes<Person> {
+    using type = std::tuple<storm::Index<^^Person::department, ^^Person::age>>;
+};
+
+// ✅ Nested-typedef opt-in — merged as part of Person itself
+struct Person {
+    // ... fields ...
+    using storm_indexes = std::tuple<storm::Index<^^Person::department, ^^Person::age>>;
+};
+```
+
+Explicit specializations remain fine in single-TU contexts (test files,
+`tools/storm_schema`). Note: CI does **not** cover this — the `ninja-release`
+CI job is disabled (§ clang-scan-deps crash, issue #262), so `storm_bench`
+compiles only locally; a green CI is no evidence against a bench-only breakage.
+
 ## Debugging Tips
 
 1. **Clean build**: `rm -rf build/ && cmake --preset ninja-debug`

--- a/shared/models.h
+++ b/shared/models.h
@@ -34,12 +34,13 @@ struct Person {
     std::optional<int> score;
     std::optional<std::string> nickname;
     std::vector<uint8_t> avatar;
-};
 
-// Composite indexes for Person — specialize the trait after struct definition
-template <> struct storm::Indexes<Person> {
-    using type = std::tuple<storm::Index<^^Person::department, ^^Person::age>,
-                            storm::UniqueIndex<^^Person::name, ^^Person::department>>;
+    // Composite indexes — nested-typedef opt-in (issue #464). This header is
+    // textually included in several module TUs; an explicit Indexes<Person>
+    // specialization would exist once per TU and trip clang-p2996's cross-BMI
+    // declaration merging (ambiguous Indexes<Person>::type).
+    using storm_indexes = std::tuple<storm::Index<^^Person::department, ^^Person::age>,
+                                     storm::UniqueIndex<^^Person::name, ^^Person::department>>;
 };
 
 // Shared simple record — covers batch/transaction/update/reset tests needing {id, name, value}.

--- a/src/orm/indexes.cppm
+++ b/src/orm/indexes.cppm
@@ -24,6 +24,15 @@ export namespace storm {
         using type = std::tuple<>;
     };
 
+    // Nested-typedef opt-in — models declare `using storm_indexes = std::tuple<...>;`
+    // inside the struct instead of specializing Indexes<T>. Required when the model
+    // header is textually included in multiple module TUs (see issue #464).
+    template <typename T>
+        requires requires { typename T::storm_indexes; }
+    struct Indexes<T> {
+        using type = typename T::storm_indexes;
+    };
+
     template <typename T> using indexes_t = typename Indexes<T>::type;
 
 } // namespace storm

--- a/tests/test_models.h
+++ b/tests/test_models.h
@@ -13,8 +13,8 @@
  *   #include "test_models.h"  // AFTER import
  */
 
-// Shared model structs (Person, SimpleRecord, Message, ExtendedTypes, Task, Color,
-// Indexes<Person>, PEOPLE_25, MESSAGES_8) — also used by benchmarks.
+// Shared model structs (Person incl. its storm_indexes typedef, SimpleRecord,
+// Message, ExtendedTypes, Task, Color, PEOPLE_25, MESSAGES_8) — also used by benchmarks.
 #include "../shared/models.h"
 
 #include <gtest/gtest.h>


### PR DESCRIPTION
Closes #464

## Problem

`storm_bench` release build broke locally on `develop` with `reference to 'type' is ambiguous` at `src/orm/indexes.cppm:27` — the explicit specialization `storm::Indexes<Person>` in `shared/models.h` is textually included in 4 bench TUs (`register.cpp` + the GMFs of `storm_benchmark_registry`/`_crud`/`_query`), and clang-p2996 stopped merging the copies.

## Root cause (bisect-verified, corrects the issue's framing)

- **Not toolchain divergence**: CI never builds `storm_bench` (the `ninja-release` CI job is disabled — clang-scan-deps crash, #262), so "CI green" was vacuous.
- **Source regression trigger**: `b984a95` good → `9a437f0` (upsert #458) bad, same compiler binary. #458 added a second BMI path to `storm_orm_indexes` (`storm → insert → upsert_grammar → indexes`), which perturbed cross-BMI declaration merging of the reflection-NTTP-carrying specialization (same family as clang-p2996 #262 / COMPILER_ISSUES §10).

## Fix

- `Person` declares `using storm_indexes = std::tuple<Index<...>, UniqueIndex<...>>;` (merged as part of `Person` itself).
- `indexes.cppm` gains a constrained partial specialization (`requires requires { typename T::storm_indexes; }`) — exactly one visible declaration, single owner.
- Explicit specializations remain valid in single-TU contexts (test files, `tools/storm_schema`) and take precedence.
- Documented as COMPILER_ISSUES.md §11 + CLAUDE.md known-issues bullet.

## Verification

- `storm_bench` release build: red on `develop` → green with fix (same compiler).
- Full `ctest --preset ninja-debug`: 2453/2453 pass (SQLite + PostgreSQL); schema/index SQL unchanged.
- Bench smoke run OK; pre-commit hook (format, tidy, release build, tests, 100% coverage) green on a commit touching `benchmarks/`.
- `storm-code-reviewer`: approved, no blocking findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0117qc572gByYWvQ2siEnWSK