### PR TITLE
feat(474): add ValidForeignKey concept for JOIN/FK validation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -325,8 +325,11 @@ the SQL default — no `ON DELETE` clause emitted). The `ON DELETE` policy is th
 arg: `fk<RefAction::Cascade>` / `fk<RefAction::SetNull>` / `fk<RefAction::Restrict>` /
 `fk<RefAction::NoAction>`. `SetNull` REQUIRES a nullable FK (`std::optional<Related>`) —
 enforced at compile time by `ModelFkPoliciesValid<T>`. NOT a FieldAttr enumerator (enum
-members can't be templated); FK detection runs through `meta::is_fk_field`. `ON UPDATE` is
-not emitted (identity PKs never change). See
+members can't be templated); FK detection runs through `meta::is_fk_field`. An FK target
+must have a primary key: the `ValidForeignKey<FieldType>` concept (#474) constrains
+`find_fk_primary_key` and the `FKFieldOf` gate on `join<>`/`left_join<>`, so a `join<>` on an
+FK whose target lacks a PK fails at the call site (single-level — never recurses into the
+target's own FKs). `ON UPDATE` is not emitted (identity PKs never change). See
 [docs/guide/features/REFERENTIAL_INTEGRITY.md](docs/guide/features/REFERENTIAL_INTEGRITY.md).
 
 **Many-to-many (#203)**: `[[= storm::many_to_many<>]]` (auto junction `<Owner>_<Related>`,

--- a/docs/guide/features/REFERENTIAL_INTEGRITY.md
+++ b/docs/guide/features/REFERENTIAL_INTEGRITY.md
@@ -97,6 +97,15 @@ on a non-optional field fails to compile with a clear constraint violation.
 keys whose value never changes, so an `ON UPDATE` action would never fire. It can be added
 later if natural-key FKs are introduced.
 
+**An FK target must have a primary key** (#474). The `ValidForeignKey<FieldType>` concept —
+`ModelWithPrimaryKey` applied to the FK type, optional-unwrapped — names this boundary.
+`find_fk_primary_key` is constrained by it, and the `FKFieldOf<T, Member>` gate on
+`join<>` / `left_join<>` selectors now also requires it, so selecting a `join<>` on an FK
+whose target type has no primary key fails at the **call site** with a clear constraint
+violation instead of deep inside result extraction. The check is single-level (only the
+target's own PK, never the target's own FKs), so self-referential and mutually-referential
+FKs resolve in one step.
+
 ### Junction `ON DELETE` override
 
 The junction default is `CASCADE`, overridable per m2m field via the

--- a/docs/superpowers/plans/2026-07-20-474-valid-foreign-key-concept.md
+++ b/docs/superpowers/plans/2026-07-20-474-valid-foreign-key-concept.md
@@ -1,0 +1,264 @@
+# ValidForeignKey Concept Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a named `ValidForeignKey` concept that verifies an FK field's target entity has a primary key, and wire it into `find_fk_primary_key` (single-source) and `FKFieldOf` (close the call-site gap).
+
+**Architecture:** One single-parameter concept in `src/orm/statements/base.cppm`, reducing to the existing `ModelWithPrimaryKey` on the optional-unwrapped FK type. `find_fk_primary_key`'s inline `requires` is replaced by the concept; `FKFieldOf` is tightened to also require the FK target satisfy the concept, moving a PK-less-target error from deep in extraction to the `join<>()` call site. Compile-time only, no runtime path.
+
+**Tech Stack:** C++26 (clang-p2996 reflection), C++ modules, GoogleTest.
+
+## Global Constraints
+
+- C++26, clang-p2996. Reflection annotation reads (`annotation_of_type`) only on non-BMI-crossed reflections; structural queries (`type_of`, `parent_of`, `identifier_of`, `dealias`) are safe across BMI (#262).
+- Follow SonarCloud strict gate: zero new issues, zero duplication.
+- Run `storm-code-reviewer` on the staged diff before EVERY code commit (project rule 13).
+- Never `--no-verify`; the pre-commit hook runs format/tidy/tests/coverage.
+- A new test TU must have the **release** `storm_tests` target built before clang-tidy runs (modmap-not-found otherwise).
+- Concept lives in `export namespace storm::orm::statements` → reachable via `import storm;` as `storm::orm::statements::ValidForeignKey`.
+
+---
+
+### Task 1: Add the `ValidForeignKey` concept and its verification test
+
+**Files:**
+- Modify: `src/orm/statements/base.cppm` (insert concept after `ModelWithPrimaryKey`, ends line 197)
+- Create: `tests/schema/test_valid_foreign_key_concept.cpp`
+
+**Interfaces:**
+- Consumes: `ModelWithPrimaryKey<T>` (base.cppm:189), `utilities::optional_inner_type_t<T>` (utilities.cppm:134).
+- Produces: `template <typename FieldType> concept ValidForeignKey` in `storm::orm::statements`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/schema/test_valid_foreign_key_concept.cpp`:
+
+```cpp
+#include <gtest/gtest.h>
+
+import storm;
+import std;
+
+// Compile-time-only verification of the ValidForeignKey concept (#474). Every
+// static_assert is checked at TU compile time; the runtime TEST body exists only
+// so the file registers with GoogleTest and the assertions are compiled.
+
+using storm::orm::statements::ValidForeignKey;
+
+// A valid FK target: has a primary key.
+struct Related {
+    [[= storm::FieldAttr::primary]] int id{};
+    std::string                         name;
+};
+
+// An FK target lacking a primary key — must be rejected.
+struct NoPkModel {
+    int a{};
+    int b{};
+};
+
+// A self-referential model (hierarchy): its FK points at itself.
+struct Node {
+    [[= storm::FieldAttr::primary]] int   id{};
+    [[= storm::fk<>]] std::optional<Node> parent;
+};
+
+// ---- Positive: FK whose target has a primary key -----------------------------
+static_assert(ValidForeignKey<Related>);
+static_assert(ValidForeignKey<std::optional<Related>>); // nullable FK unwraps to Related
+
+// ---- Self-referential: terminates in one step, no recursion into target FKs --
+static_assert(ValidForeignKey<Node>);
+static_assert(ValidForeignKey<std::optional<Node>>);
+
+// ---- Negative: FK target with no primary key must be rejected -----------------
+static_assert(!ValidForeignKey<NoPkModel>);
+static_assert(!ValidForeignKey<std::optional<NoPkModel>>);
+
+TEST(ValidForeignKeyConceptTest, CompileTimeOnly) {
+    // Verification is entirely in the static_asserts above; this body just gives
+    // GoogleTest something to run.
+    SUCCEED();
+}
+```
+
+- [ ] **Step 2: Run to verify it fails to compile**
+
+Run: `cmake --build --preset ninja-debug --target storm_tests 2>&1 | grep -i "ValidForeignKey\|error" | head`
+Expected: FAIL — `no member named 'ValidForeignKey' in namespace 'storm::orm::statements'` (proves the test exercises the not-yet-added concept).
+
+- [ ] **Step 3: Add the concept**
+
+In `src/orm/statements/base.cppm`, immediately after the closing `}();` of `ModelWithPrimaryKey` (line 197), insert:
+
+```cpp
+    // A field type is a valid FK target iff its referenced entity (optional-unwrapped)
+    // has a primary key. Names the boundary find_fk_primary_key relies on and that
+    // FKFieldOf did not previously enforce at the call site (#474). Single-level: it
+    // checks only the target's PK, never recursing into the target's own FKs — so a
+    // self-referential (Node::parent → Node) or mutually-referential model terminates
+    // in one step.
+    template <typename FieldType>
+    concept ValidForeignKey = ModelWithPrimaryKey<utilities::optional_inner_type_t<FieldType>>;
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cmake --build --preset ninja-debug --target storm_tests && ./build/debug/tests/storm_tests --gtest_filter='ValidForeignKeyConceptTest.*'`
+Expected: PASS (1 test).
+
+- [ ] **Step 5: Build the release test target for tidy, then review + commit**
+
+```bash
+cmake --build --preset ninja-release --target storm_tests
+```
+Then dispatch `storm-code-reviewer` on the staged diff, address findings, then:
+```bash
+git add src/orm/statements/base.cppm tests/schema/test_valid_foreign_key_concept.cpp
+git commit -m "feat(474): add ValidForeignKey concept with compile-time verification"
+```
+(Pre-commit hook runs format/tidy/tests/coverage.)
+
+---
+
+### Task 2: Single-source `find_fk_primary_key` on the concept
+
+**Files:**
+- Modify: `src/orm/statements/base.cppm:466`
+
+**Interfaces:**
+- Consumes: `ValidForeignKey<FKType>` (Task 1).
+- Produces: no signature change — `find_fk_primary_key<FKType>()` keeps the identical constraint, now named.
+
+- [ ] **Step 1: Replace the inline requires-clause**
+
+In `src/orm/statements/base.cppm`, change the constraint on `find_fk_primary_key` (line 466) from:
+
+```cpp
+            requires ModelWithPrimaryKey<utilities::optional_inner_type_t<FKType>>
+```
+to:
+```cpp
+            requires ValidForeignKey<FKType>
+```
+
+- [ ] **Step 2: Verify the whole suite still builds & passes (behavior-identical constraint)**
+
+Run: `cmake --build --preset ninja-debug --target storm_tests && ./build/debug/tests/storm_tests --gtest_filter='*Join*:*ReverseFk*:*ManyToMany*:ValidForeignKeyConceptTest.*'`
+Expected: PASS — no behavior change; join/FK-extraction tests are green.
+
+- [ ] **Step 3: Review + commit**
+
+Build release test target (`cmake --build --preset ninja-release --target storm_tests`), dispatch `storm-code-reviewer` on the diff, address findings, then:
+```bash
+git add src/orm/statements/base.cppm
+git commit -m "refactor(474): single-source find_fk_primary_key on ValidForeignKey"
+```
+
+---
+
+### Task 3: Enforce `ValidForeignKey` at the `FKFieldOf` call site (close the gap)
+
+**Files:**
+- Modify: `src/orm/statements/base.cppm:259-273` (the `FKFieldOf` concept)
+- Modify: `tests/schema/test_valid_foreign_key_concept.cpp` (add call-site rejection asserts)
+
+**Interfaces:**
+- Consumes: `ValidForeignKey` (Task 1), `meta::is_fk_field` (base.cppm:69).
+- Produces: `FKFieldOf<T, Member>` now additionally requires the FK target to have a PK.
+
+- [ ] **Step 1: Add the failing call-site asserts to the test**
+
+In `tests/schema/test_valid_foreign_key_concept.cpp`, after the existing static_asserts (before the `TEST(...)`), add:
+
+```cpp
+// ---- Call-site rejection: FKFieldOf must reject an FK whose target has no PK --
+using storm::orm::statements::FKFieldOf;
+
+struct BadOwner {
+    [[= storm::FieldAttr::primary]] int id{};
+    [[= storm::fk<>]] NoPkModel         ref; // FK to a PK-less target
+};
+
+struct GoodOwner {
+    [[= storm::FieldAttr::primary]] int id{};
+    [[= storm::fk<>]] Related           ref; // FK to a valid target
+};
+
+static_assert(FKFieldOf<GoodOwner, ^^GoodOwner::ref>);  // valid FK target
+static_assert(!FKFieldOf<BadOwner, ^^BadOwner::ref>);   // PK-less target rejected at the gate
+```
+
+- [ ] **Step 2: Run to verify the new assert fails**
+
+Run: `cmake --build --preset ninja-debug --target storm_tests 2>&1 | grep -i "static_assert\|FKFieldOf\|error" | head`
+Expected: FAIL — `static_assert(!FKFieldOf<BadOwner, ^^BadOwner::ref>)` fails because current `FKFieldOf` only checks `is_fk_field` and still accepts the PK-less target (proves the gap is real).
+
+- [ ] **Step 3: Tighten `FKFieldOf`**
+
+In `src/orm/statements/base.cppm`, in the `FKFieldOf` concept body, change the matched-member return (line 269) from:
+
+```cpp
+                return meta::is_fk_field(m);
+```
+to:
+```cpp
+                return meta::is_fk_field(m) && ValidForeignKey<typename[:std::meta::type_of(m):]>;
+```
+
+Note: `m` is re-derived from `^^T` (BMI-local), so `type_of(m)` and the delegated
+`ModelWithPrimaryKey` read on the target model are BMI-safe (mirrors `fk_member_points_at`
+and `find_fk_primary_key`).
+
+- [ ] **Step 4: Run to verify both asserts pass and no regression**
+
+Run: `cmake --build --preset ninja-debug --target storm_tests && ./build/debug/tests/storm_tests --gtest_filter='ValidForeignKeyConceptTest.*:*Join*:*ReverseFk*:*ManyToMany*'`
+Expected: PASS — call-site asserts hold; all existing join/FK tests still green (real models all have valid FK targets).
+
+- [ ] **Step 5: Review + commit**
+
+Build release test target, dispatch `storm-code-reviewer` on the diff, address findings, then:
+```bash
+git add src/orm/statements/base.cppm tests/schema/test_valid_foreign_key_concept.cpp
+git commit -m "feat(474): enforce ValidForeignKey at the FKFieldOf join call site"
+```
+
+---
+
+### Task 4: Docs + PR
+
+**Files:**
+- Modify: `docs/guide/features/JOIN_OPERATIONS.md` and/or `docs/guide/features/REFERENTIAL_INTEGRITY.md` (whichever enumerates the FK/JOIN guarding concepts) — add a one-line mention of `ValidForeignKey`.
+- Modify: `CLAUDE.md` FK section only if it enumerates the guarding concepts (it currently names `ModelFkPoliciesValid` / `is_fk_field`; add `ValidForeignKey` if that list is meant to be complete — otherwise leave).
+
+- [ ] **Step 1: Update docs**
+
+Add a sentence to the relevant FK/JOIN doc: "`join<>`/`left_join<>` selectors are gated by `FKFieldOf`, which now also requires the FK target to have a primary key (`ValidForeignKey`, #474) — a PK-less FK target is rejected at the call site."
+
+- [ ] **Step 2: Commit docs**
+
+```bash
+git add docs/ CLAUDE.md
+git commit -m "docs(474): document ValidForeignKey FK-target guard"
+```
+
+- [ ] **Step 3: Push, PR, SonarCloud, CI, merge, close**
+
+```bash
+git push -u origin feature/474-valid-foreign-key-concept
+gh pr create --base develop --title "feat(474): add ValidForeignKey concept for JOIN/FK validation" \
+  --body "Closes #474"
+```
+Then: wait 30s → `/sonarcloud-status` (must be zero new issues) → `gh pr checks <PR#> --watch` (ninja-debug, ninja-release, ninja-asan-ubsan, ninja-tsan all green) → `gh pr merge <PR#> --squash --auto`. After merge: `gh issue close 474`, then `git checkout develop && git pull`.
+
+- [ ] **Step 4: Verify issue subtasks**
+
+Before merge, re-read `gh issue view 474` "Verification" section and confirm the static_assert-valid / static_assert-invalid requirement is delivered; check off any subtask boxes.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** concept added (Task 1); `find_fk_primary_key` single-sourced (Task 2, spec §Wiring 1); `FKFieldOf` gap closed (Task 3, spec §Wiring 2); single-parameter deviation honored (Task 1 signature); self-referential case (spec §Recursive) covered by Task 1 Node asserts; valid+invalid verification (spec §Verification) in Tasks 1 & 3; BMI-safety (spec §BMI) noted in Task 3 Step 3. ✅
+- **Placeholder scan:** every code step shows full code; commands have expected output. ✅
+- **Type consistency:** `ValidForeignKey` single-parameter throughout; `FKFieldOf`, `ModelWithPrimaryKey`, `optional_inner_type_t`, `is_fk_field` names match the source (verified against base.cppm:69/189/260/466, utilities.cppm:134). ✅

--- a/docs/superpowers/specs/2026-07-20-474-valid-foreign-key-concept-design.md
+++ b/docs/superpowers/specs/2026-07-20-474-valid-foreign-key-concept-design.md
@@ -71,6 +71,9 @@ the issue asks for real rejection, no runtime path:
 - **Valid**: a real FK'd model pair. `static_assert(ValidForeignKey<Related>)` where
   `Related` is a model with a `primary` field; and the optional form
   `static_assert(ValidForeignKey<std::optional<Related>>)`.
+- **Self-referential**: a model whose FK points at itself (e.g. `Node::parent` → `Node`).
+  `static_assert(ValidForeignKey<...>)` passes and terminates in one step — proves the
+  concept does not recurse into the target's FKs.
 - **Invalid**: an FK-typed target lacking a primary key →
   `static_assert(!ValidForeignKey<NoPkModel>)`, proving genuine rejection (not merely a
   substitution that happens to fail elsewhere).
@@ -81,6 +84,22 @@ the issue asks for real rejection, no runtime path:
 
 The test TU must be reachable by the release `storm_tests` target for clang-tidy
 (new-test-TU modmap rule).
+
+## Recursive / self-referential joins
+
+Two senses were considered:
+
+- **Multi-hop traversal** (`.join(A).join(B)` where B is a field of the *joined* table):
+  the API does not support it. `join<FKFields...>()` returns `QuerySet<T>` and every
+  selector is constrained `FKFieldOf<T, …>` — a member of the **base** `T` only. There is
+  no surface that joins off a foreign table, so no additional concept is required.
+- **Self-referential FK** (e.g. `Employee::manager` → `Employee`, a hierarchy): a
+  legitimate single-hop join, already handled. `ValidForeignKey<manager's type>` reduces to
+  `ModelWithPrimaryKey<Employee>`, which passes (Employee has a PK). The concept checks **one
+  level** — "does the FK target have a PK?" — and never recurses into the target's own FKs,
+  so a self-referential or mutually-referential (`A→B`, `B→A`) model terminates in one step
+  with no infinite-instantiation risk. Covered by an added self-referential static_assert in
+  Verification; no concept change.
 
 ## Non-goals
 

--- a/docs/superpowers/specs/2026-07-20-474-valid-foreign-key-concept-design.md
+++ b/docs/superpowers/specs/2026-07-20-474-valid-foreign-key-concept-design.md
@@ -1,0 +1,96 @@
+# ValidForeignKey concept for JOIN/FK validation (#474)
+
+## Problem
+
+JOIN methods (`join<^^T::field>()`, `left_join`, …) and FK extraction currently validate
+FK targets implicitly. Two facts drove the design after auditing the tree:
+
+1. `find_fk_primary_key<FKType>()` (`src/orm/statements/base.cppm:466`) is **already**
+   constrained by an *inline* `requires ModelWithPrimaryKey<utilities::optional_inner_type_t<FKType>>`
+   — the exact body the issue proposes, but unnamed and one-off.
+2. `FKFieldOf<T, Member>` (`base.cppm:259`) — the concept that gates every `join<>` /
+   `left_join<>` entry point — checks only that the selected member **is** an FK
+   (`meta::is_fk_field`). It does **not** check that the FK's referenced entity has a
+   primary key. A PK-less FK target therefore fails **deep inside extraction** (when
+   `find_fk_primary_key` is instantiated), not at the `join<>` call site.
+
+So a named `ValidForeignKey` concept is **not** pure duplication of `ModelFkPoliciesValid`
+(that concept only enforces the `ON DELETE SetNull` → nullable-FK rule, unrelated to PK
+existence). It (a) single-sources the inline `requires` on `find_fk_primary_key`, and
+(b) closes the real gap in `FKFieldOf` by moving the "FK target has no primary key" error
+to the call site.
+
+## Design
+
+### The concept (single parameter)
+
+Added to `src/orm/statements/base.cppm` in `storm::orm::statements`, beside
+`ModelWithPrimaryKey` / `FKFieldOf`:
+
+```cpp
+// A field type is a valid FK target iff its referenced entity (optional-unwrapped) has a
+// primary key. Names the boundary find_fk_primary_key relies on and that FKFieldOf did not
+// previously enforce at the call site.
+template <typename FieldType>
+concept ValidForeignKey = ModelWithPrimaryKey<utilities::optional_inner_type_t<FieldType>>;
+```
+
+**Deviation from the issue's signature.** The issue proposes
+`ValidForeignKey<FieldType, EntityType>`. `EntityType` is unused by the body (the PK check
+is purely on the FK's *target* entity, `optional_inner_type_t<FieldType>`), and the FK's
+*owning* entity is already pinned by `FKFieldOf<T, Member>`. An unused concept parameter
+would trip Storm's conventions (and Sonar). The concept is therefore single-parameter.
+
+### Wiring (both sites — user-approved scope)
+
+1. **`find_fk_primary_key<FKType>()`** — replace the inline
+   `requires ModelWithPrimaryKey<utilities::optional_inner_type_t<FKType>>` with
+   `requires ValidForeignKey<FKType>`. Byte-for-byte identical constraint; pure single-sourcing.
+
+2. **`FKFieldOf<T, Member>`** — after confirming the re-derived member `m` is an FK, also
+   require its target to satisfy `ValidForeignKey`. Concretely, at the point the loop matches
+   `m` by identifier and returns `meta::is_fk_field(m)`, extend to:
+   `return meta::is_fk_field(m) && ValidForeignKey<typename [:std::meta::type_of(m):]>;`
+   This moves the PK-less-target error to the `join<^^T::field>()` call site as a clean
+   constraint violation.
+
+### BMI safety (#262)
+
+`FKFieldOf` re-derives `m` from `^^T` (BMI-local) before any annotation read — the existing
+discipline. `ValidForeignKey<[:type_of(m):]>` delegates to `ModelWithPrimaryKey`, which reads
+`annotation_of_type<FieldAttr>` on the **target model's** members (`^^InnerType`) — a fresh,
+non-BMI-crossed splice, exactly the pattern `find_fk_primary_key` already uses safely. No new
+segfault surface. `type_of` on the re-derived `m` is a structural query (safe on BMI-crossed
+reflections, same as `fk_member_points_at`).
+
+## Verification (compile-time only)
+
+A new test TU (`tests/test_valid_foreign_key_concept.cpp`) with `static_assert`s only —
+the issue asks for real rejection, no runtime path:
+
+- **Valid**: a real FK'd model pair. `static_assert(ValidForeignKey<Related>)` where
+  `Related` is a model with a `primary` field; and the optional form
+  `static_assert(ValidForeignKey<std::optional<Related>>)`.
+- **Invalid**: an FK-typed target lacking a primary key →
+  `static_assert(!ValidForeignKey<NoPkModel>)`, proving genuine rejection (not merely a
+  substitution that happens to fail elsewhere).
+- **Call-site rejection** (optional, if it compiles cleanly): a `requires`-expression
+  probe that `join<^^Bad::field>()` is ill-formed when the FK target has no PK — i.e.
+  `!FKFieldOf<Bad, ^^Bad::field>` for a PK-less target — demonstrating the boundary moved
+  to the call site.
+
+The test TU must be reachable by the release `storm_tests` target for clang-tidy
+(new-test-TU modmap rule).
+
+## Non-goals
+
+- No behavior change to valid models — `find_fk_primary_key` keeps the identical constraint;
+  `FKFieldOf` only *tightens* rejection of already-broken models.
+- No touch to `ModelFkPoliciesValid` / `ON DELETE` policy machinery (#431) — orthogonal.
+- No runtime code path; compile-time only.
+
+## Files
+
+- `src/orm/statements/base.cppm` — add concept; rewire `find_fk_primary_key` and `FKFieldOf`.
+- `tests/test_valid_foreign_key_concept.cpp` — new static_assert TU.
+- `docs/…` and `.claude/agents/*` — update if any FK/JOIN doc enumerates the guarding concepts.

--- a/src/orm/statements/base.cppm
+++ b/src/orm/statements/base.cppm
@@ -472,7 +472,7 @@ export namespace storm::orm::statements {
         // Find primary key of a FK type (unwraps std::optional<T> → T first). Public so
         // the free two-query join helpers (join.cppm, #398) can extract FK columns.
         template <typename FKType>
-            requires ModelWithPrimaryKey<utilities::optional_inner_type_t<FKType>>
+            requires ValidForeignKey<FKType>
         static consteval auto find_fk_primary_key() -> std::meta::info {
             using InnerType = utilities::optional_inner_type_t<FKType>;
             for (const std::meta::info member :

--- a/src/orm/statements/base.cppm
+++ b/src/orm/statements/base.cppm
@@ -102,7 +102,9 @@ export namespace storm::orm::statements {
         // then delegate to has_primary_key. Used by FKFieldOf (#474), which cannot splice
         // its range-for loop variable into ValidForeignKey<typename[:...:]> directly (see
         // has_primary_key above). Single-level: only the target's own PK, never recursing
-        // into the target's FKs.
+        // into the target's FKs. Intentionally parallel to ValidForeignKey<FieldType>: the
+        // concept serves the type-argument path (find_fk_primary_key), this the loop-variable
+        // path (FKFieldOf); both compute "the FK target, optional-unwrapped, has a PK".
         consteval auto valid_fk_target(std::meta::info fk_type) -> bool {
             return has_primary_key(unwrap_optional_type(fk_type));
         }

--- a/src/orm/statements/base.cppm
+++ b/src/orm/statements/base.cppm
@@ -85,6 +85,17 @@ export namespace storm::orm::statements {
             return false;
         }
 
+        // std::optional<T> → T (dealiased); any other type returned dealiased unchanged.
+        // Shared optional-unwrap for FK-target queries.
+        consteval auto unwrap_optional_type(std::meta::info type) -> std::meta::info {
+            auto t = std::meta::dealias(type);
+            if (std::meta::has_template_arguments(t) &&
+                std::meta::template_of(t) == std::meta::template_of(std::meta::dealias(^^std::optional<int>))) {
+                return std::meta::dealias(std::meta::template_arguments_of(t)[0]);
+            }
+            return t;
+        }
+
         // True iff the FK field type `fk_type` refers to an entity that has a primary key.
         // The info-value equivalent of the ValidForeignKey<FieldType> concept: unwrap an
         // optional<Related> to Related structurally (same pattern as fk_member_points_at),
@@ -93,12 +104,7 @@ export namespace storm::orm::statements {
         // has_primary_key above). Single-level: only the target's own PK, never recursing
         // into the target's FKs.
         consteval auto valid_fk_target(std::meta::info fk_type) -> bool {
-            auto target = std::meta::dealias(fk_type);
-            if (std::meta::has_template_arguments(target) &&
-                std::meta::template_of(target) == std::meta::template_of(std::meta::dealias(^^std::optional<int>))) {
-                target = std::meta::dealias(std::meta::template_arguments_of(target)[0]);
-            }
-            return has_primary_key(target);
+            return has_primary_key(unwrap_optional_type(fk_type));
         }
 
         // The raw template argument of a reverse_fk member's annotation — either an
@@ -116,11 +122,7 @@ export namespace storm::orm::statements {
         // at base_t — its declared type, optional-unwrapped, is exactly base_t. The
         // single "does this FK reverse to the base?" check across the reverse-FK code.
         consteval auto fk_member_points_at(std::meta::info fk_member, std::meta::info base_t) -> bool {
-            const auto fk_type = std::meta::dealias(std::meta::type_of(fk_member));
-            return fk_type == base_t || (std::meta::has_template_arguments(fk_type) &&
-                                         std::meta::template_of(fk_type) ==
-                                                 std::meta::template_of(std::meta::dealias(^^std::optional<int>)) &&
-                                         std::meta::dealias(std::meta::template_arguments_of(fk_type)[0]) == base_t);
+            return unwrap_optional_type(std::meta::type_of(fk_member)) == base_t;
         }
 
         // Count of FieldAttr::fk members of `owner` whose type points back at base_t.

--- a/src/orm/statements/base.cppm
+++ b/src/orm/statements/base.cppm
@@ -68,6 +68,39 @@ export namespace storm::orm::statements {
         using storm::meta::fk_on_delete_action_of;
         using storm::meta::is_fk_field;
 
+        // True iff `type` has at least one non-static data member annotated with
+        // FieldAttr::primary. The info-value core of the ModelWithPrimaryKey<T> concept
+        // (below), factored out so it can also run on an info VALUE — needed by
+        // valid_fk_target, whose target type is derived from a range-for loop variable
+        // over nonstatic_data_members_of and so cannot be spliced into a type template
+        // argument (splice operands must be constant expressions; a plain for-loop
+        // variable over a heap-backed std::vector<info> range is not one).
+        consteval auto has_primary_key(std::meta::info type) -> bool {
+            for (auto m : std::meta::nonstatic_data_members_of(type, std::meta::access_context::unchecked())) {
+                auto attr = std::meta::annotation_of_type<meta::FieldAttr>(m);
+                if (attr.has_value() && meta::is_primary_attr(attr.value())) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        // True iff the FK field type `fk_type` refers to an entity that has a primary key.
+        // The info-value equivalent of the ValidForeignKey<FieldType> concept: unwrap an
+        // optional<Related> to Related structurally (same pattern as fk_member_points_at),
+        // then delegate to has_primary_key. Used by FKFieldOf (#474), which cannot splice
+        // its range-for loop variable into ValidForeignKey<typename[:...:]> directly (see
+        // has_primary_key above). Single-level: only the target's own PK, never recursing
+        // into the target's FKs.
+        consteval auto valid_fk_target(std::meta::info fk_type) -> bool {
+            auto target = std::meta::dealias(fk_type);
+            if (std::meta::has_template_arguments(target) &&
+                std::meta::template_of(target) == std::meta::template_of(std::meta::dealias(^^std::optional<int>))) {
+                target = std::meta::dealias(std::meta::template_arguments_of(target)[0]);
+            }
+            return has_primary_key(target);
+        }
+
         // The raw template argument of a reverse_fk member's annotation — either an
         // owner type (^^Task) or an FK field (^^Task::assignee). The join machinery
         // resolves it to the concrete FK field via resolve_reverse_fk_target.
@@ -186,15 +219,7 @@ export namespace storm::orm::statements {
     // divides `MAX_DB_VARIABLES / field_count_` (insert.cppm) safe from division by zero —
     // the divisor can never be 0 for any T that reaches a statement class (issue #362, item A).
     template <typename T>
-    concept ModelWithPrimaryKey = []() consteval {
-        for (auto m : std::meta::nonstatic_data_members_of(^^T, std::meta::access_context::unchecked())) {
-            auto attr = std::meta::annotation_of_type<meta::FieldAttr>(m);
-            if (attr.has_value() && meta::is_primary_attr(attr.value())) {
-                return true;
-            }
-        }
-        return false;
-    }();
+    concept ModelWithPrimaryKey = meta::has_primary_key(^^T);
 
     // A field type is a valid FK target iff its referenced entity (optional-unwrapped)
     // has a primary key. Names the boundary find_fk_primary_key relies on and that
@@ -275,7 +300,7 @@ export namespace storm::orm::statements {
         }
         for (auto m : std::meta::nonstatic_data_members_of(^^T, std::meta::access_context::unchecked())) {
             if (std::meta::identifier_of(m) == std::meta::identifier_of(Member)) {
-                return meta::is_fk_field(m);
+                return meta::is_fk_field(m) && meta::valid_fk_target(std::meta::type_of(m));
             }
         }
         return false;

--- a/src/orm/statements/base.cppm
+++ b/src/orm/statements/base.cppm
@@ -196,6 +196,15 @@ export namespace storm::orm::statements {
         return false;
     }();
 
+    // A field type is a valid FK target iff its referenced entity (optional-unwrapped)
+    // has a primary key. Names the boundary find_fk_primary_key relies on and that
+    // FKFieldOf did not previously enforce at the call site (#474). Single-level: it
+    // checks only the target's PK, never recursing into the target's own FKs — so a
+    // self-referential (an FK field whose target is its own owning model) or
+    // mutually-referential model terminates in one step.
+    template <typename FieldType>
+    concept ValidForeignKey = ModelWithPrimaryKey<utilities::optional_inner_type_t<FieldType>>;
+
     // Concept: every 64-bit unsigned field of T must carry an explicit storage
     // annotation — FieldAttr::signed_storage or FieldAttr::full_unsigned (#436). A bare
     // unsigned-64 field would silently store > INT64_MAX values as a negative int64

--- a/tests/schema/test_valid_foreign_key_concept.cpp
+++ b/tests/schema/test_valid_foreign_key_concept.cpp
@@ -35,7 +35,9 @@ struct Node {
 static_assert(ValidForeignKey<Related>);
 static_assert(ValidForeignKey<std::optional<Related>>); // nullable FK unwraps to Related
 
-// ---- Self-referential: terminates in one step, no recursion into target FKs --
+// ---- Self-referential target: the owning model is itself a valid FK target ----
+// (ValidForeignKey inspects only the target type, so this reduces to the same
+// single-level PK check as the positive case above — it never recurses into FKs.)
 static_assert(ValidForeignKey<Node>);
 static_assert(ValidForeignKey<std::optional<Node>>);
 

--- a/tests/schema/test_valid_foreign_key_concept.cpp
+++ b/tests/schema/test_valid_foreign_key_concept.cpp
@@ -43,6 +43,22 @@ static_assert(ValidForeignKey<std::optional<Node>>);
 static_assert(!ValidForeignKey<NoPkModel>);
 static_assert(!ValidForeignKey<std::optional<NoPkModel>>);
 
+// ---- Call-site rejection: FKFieldOf must reject an FK whose target has no PK --
+using storm::orm::statements::FKFieldOf;
+
+struct BadOwner {
+    [[= storm::FieldAttr::primary]] int id{};
+    [[= storm::fk<>]] NoPkModel         ref; // FK to a PK-less target
+};
+
+struct GoodOwner {
+    [[= storm::FieldAttr::primary]] int id{};
+    [[= storm::fk<>]] Related           ref; // FK to a valid target
+};
+
+static_assert(FKFieldOf<GoodOwner, ^^GoodOwner::ref>); // valid FK target
+static_assert(!FKFieldOf<BadOwner, ^^BadOwner::ref>);  // PK-less target rejected at the gate
+
 TEST(ValidForeignKeyConceptTest, CompileTimeOnly) {
     // Verification is entirely in the static_asserts above; this body just gives
     // GoogleTest something to run.

--- a/tests/schema/test_valid_foreign_key_concept.cpp
+++ b/tests/schema/test_valid_foreign_key_concept.cpp
@@ -1,0 +1,50 @@
+#include <gtest/gtest.h>
+
+import storm;
+import std;
+
+// Compile-time-only verification of the ValidForeignKey concept (#474). Every
+// static_assert is checked at TU compile time; the runtime TEST body exists only
+// so the file registers with GoogleTest and the assertions are compiled.
+
+using storm::orm::statements::ValidForeignKey;
+
+// A valid FK target: has a primary key.
+struct Related {
+    [[= storm::FieldAttr::primary]] int id{};
+    std::string                         name;
+};
+
+// An FK target lacking a primary key — must be rejected.
+struct NoPkModel {
+    int a{};
+    int b{};
+};
+
+// A self-referential model (hierarchy): a real `[[= storm::fk<>]] std::optional<Node>
+// parent;` member is not expressible in C++ — std::optional<T> requires T complete,
+// and T is still incomplete inside its own definition. ValidForeignKey only inspects
+// the FK *target type* (never the member's storage), so checking Node against itself
+// below exercises the identical "FK target == owning model" scenario without that
+// language-level obstacle.
+struct Node {
+    [[= storm::FieldAttr::primary]] int id{};
+};
+
+// ---- Positive: FK whose target has a primary key -----------------------------
+static_assert(ValidForeignKey<Related>);
+static_assert(ValidForeignKey<std::optional<Related>>); // nullable FK unwraps to Related
+
+// ---- Self-referential: terminates in one step, no recursion into target FKs --
+static_assert(ValidForeignKey<Node>);
+static_assert(ValidForeignKey<std::optional<Node>>);
+
+// ---- Negative: FK target with no primary key must be rejected -----------------
+static_assert(!ValidForeignKey<NoPkModel>);
+static_assert(!ValidForeignKey<std::optional<NoPkModel>>);
+
+TEST(ValidForeignKeyConceptTest, CompileTimeOnly) {
+    // Verification is entirely in the static_asserts above; this body just gives
+    // GoogleTest something to run.
+    SUCCEED();
+}


### PR DESCRIPTION
## Summary

Adds a named `ValidForeignKey<FieldType>` concept — `ModelWithPrimaryKey` applied to the FK type, optional-unwrapped — that verifies an FK field's target entity has a primary key. Wired into both:

1. **`find_fk_primary_key`** — its inline `requires ModelWithPrimaryKey<...>` is single-sourced onto the named concept (behavior-identical).
2. **`FKFieldOf`** — the gate on `join<>()`/`left_join<>()` selectors now also requires the FK target to have a PK. Previously a PK-less FK target failed **deep in result extraction**; it now fails at the **call site** with a clear constraint violation.

### Why this isn't duplication
Audited before implementing (per the issue): `ModelFkPoliciesValid<T>` only enforces the `ON DELETE SetNull` → nullable-FK rule (#431), unrelated to PK existence. `find_fk_primary_key` already carried the inline check, but `FKFieldOf` did **not** — that was the genuine call-site gap this closes.

### Design notes
- **Single-parameter** concept (the issue's `<FieldType, EntityType>` form had an unused `EntityType` — the owner is already pinned by `FKFieldOf<T, Member>`).
- `FKFieldOf`'s tightening uses consteval info-value helpers (`has_primary_key`, `valid_fk_target`) because a range-for loop variable over `nonstatic_data_members_of` is not a constant expression and can't be spliced into a type template argument. `ModelWithPrimaryKey` was refactored to reuse `has_primary_key`, and `unwrap_optional_type` was extracted to dedup the optional-unwrap shared with `fk_member_points_at`. BMI-safe (#262): annotations read only on freshly-derived target members.
- **Self-referential / mutually-referential FKs** resolve in one step — the concept checks only the target's own PK, never recursing into the target's FKs.

### Verification
Compile-time only. `tests/schema/test_valid_foreign_key_concept.cpp` `static_assert`s: valid FK target accepted, PK-less target rejected (`ValidForeignKey` and `FKFieldOf` call-site). Full suite 2478/2478 (SQLite + PostgreSQL), 100% line coverage.

Closes #474