### PR TITLE
feat(475): NumericAggregateable concept for aggregate functions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -441,6 +441,10 @@ qs.min<^^Person::age>().execute();             // std::optional<double> — null
 qs.max<^^Person::age>().execute();             // std::optional<double> — nullopt over empty set (#416)
 // MIN/MAX/AVG of no rows have NO value → std::nullopt, distinguishable from a real 0.
 // GROUP BY MIN/MAX/AVG tuple columns are std::optional<double> too (NULL within a group).
+// sum/avg/min/max require a NumericAggregateable target field (#475): arithmetic and
+// not bool, one level of std::optional<> unwrapped (nullable numeric columns are fine).
+// A string/BLOB/enum/UUID/temporal/bool field is a COMPILE ERROR, not a silent coercion.
+// count()/count_distinct() are unconstrained — COUNT is type-agnostic.
 
 // GROUP BY with aggregates → .select()
 qs.group_by<^^Person::department>().count().execute();

--- a/docs/superpowers/specs/2026-07-20-475-aggregateable-concept-design.md
+++ b/docs/superpowers/specs/2026-07-20-475-aggregateable-concept-design.md
@@ -1,0 +1,83 @@
+# #475 — NumericAggregateable concept for aggregate functions
+
+## Problem
+
+Split from #206. `sum()`, `avg()`, `min()`, `max()` on `AggregateStatement`,
+`GroupByBuilder`, and `QuerySet` currently accept **any** field type as their
+aggregate target. The target field's type flows only into (a) the generated SQL
+text via `std::meta::identifier_of` and (b) `op_has_floating_field` (a
+floating-point check). The result type (`OpResult`) is always numeric —
+`int64_t` / `double` / `std::optional<double>` — and extraction dispatches on
+that *destination* type, never the source column. Consequently
+`min<^^Person::name>()` (a `std::string` field) or `sum<^^Person::avatar>()`
+(a BLOB) **compiles today and silently coerces** via SQLite, instead of failing
+with a clear message.
+
+## Premise verification (per issue instruction)
+
+- Confirmed: no numeric aggregate meaningfully consumes a string/BLOB. `OpResult`
+  for SUM/AVG/MIN/MAX is numeric in every branch.
+- Confirmed: `COUNT` / `COUNT(DISTINCT)` legitimately count rows of **any** type
+  and must stay unconstrained.
+- Therefore the issue's illustrative `Aggregateable = arithmetic || string`
+  concept has **no honest call site** and is dropped. Only
+  `NumericAggregateable` is defined and applied. (User-confirmed.)
+
+## Concept
+
+In `src/orm/statements/aggregate.cppm`, `storm::orm::statements` namespace:
+
+```cpp
+template <typename T>
+concept NumericAggregateable = std::is_arithmetic_v<T> && !std::is_same_v<T, bool>;
+```
+
+`bool` is excluded: it is arithmetic in C++, but SUM/AVG/MIN/MAX over a boolean
+column is a modelling mistake, not a real query.
+
+To constrain a variadic `std::meta::info... FieldInfos` pack, a fold helper:
+
+```cpp
+template <std::meta::info... FieldInfos>
+concept AllNumericAggregateable =
+    (NumericAggregateable<std::remove_cvref_t<typename [:std::meta::type_of(FieldInfos):]>> && ...);
+```
+
+An empty pack is vacuously true — but the numeric aggregate methods always take
+at least one field in practice, and `count()` (which allows an empty pack for
+`COUNT(*)`) is never constrained by this concept.
+
+## Where applied
+
+`requires AllNumericAggregateable<FieldInfos...>` on the four numeric aggregate
+methods at all three call surfaces:
+
+- `AggregateStatement::sum/avg/min/max` (chaining) — `aggregate.cppm`
+- `GroupByBuilder::sum/avg/min/max` — `aggregate.cppm`
+- `QuerySet::sum/avg/min/max` — `queryset.cppm`
+
+`count`, `count_distinct` stay unconstrained (any field type is valid to count).
+
+## Verification (compile-time only)
+
+New TU `tests/query/test_aggregateable_concept.cpp`:
+
+- Positive `static_assert(NumericAggregateable<int/int64_t/double/float/...>)`.
+- Negative `static_assert(!NumericAggregateable<std::string>)`,
+  `!NumericAggregateable<bool>`, `!NumericAggregateable<std::vector<uint8_t>>`,
+  `!NumericAggregateable<Color>` (enum).
+- Method-level rejection via the #472 variable-template wrapper trick so the
+  constraint failure SFINAE-soft-fails instead of hard-erroring: assert that
+  `qs.min<^^Person::name>()` etc. are **not** instantiable while
+  `qs.min<^^Person::age>()` is.
+- A `TEST(...) { SUCCEED(); }` body to register the TU with GTest.
+
+Existing aggregate tests (all numeric fields) must still compile and pass —
+they double as the positive integration check.
+
+## Non-goals
+
+- No runtime behavior change; numeric aggregates over numeric fields are
+  byte-identical.
+- `Aggregateable` (arithmetic||string) concept — dropped (no call site).
+- No change to `count` / `count_distinct`.

--- a/src/orm/queryset.cppm
+++ b/src/orm/queryset.cppm
@@ -381,7 +381,9 @@ export namespace storm {
         //        queryset.where(age > 30).sum<^^Person::age>().execute()
         //        queryset.join<FK>().sum<^^Person::salary>().execute()
         // Returns statement by value - connection-level prepare_cached() handles SQL caching
-        template <std::meta::info... FieldInfos> [[nodiscard]] auto sum() {
+        template <std::meta::info... FieldInfos>
+            requires orm::statements::AllNumericAggregateable<FieldInfos...>
+        [[nodiscard]] auto sum() {
             using StmtType = orm::statements::AggregateStatement<
                     T,
                     ConnType,
@@ -410,7 +412,9 @@ export namespace storm {
         // Usage: queryset.avg<^^Person::salary>().execute()
         //        queryset.where(department == "Engineering").avg<^^Person::salary>().execute()
         // Returns statement by value - connection-level prepare_cached() handles SQL caching
-        template <std::meta::info... FieldInfos> [[nodiscard]] auto avg() {
+        template <std::meta::info... FieldInfos>
+            requires orm::statements::AllNumericAggregateable<FieldInfos...>
+        [[nodiscard]] auto avg() {
             using StmtType = orm::statements::AggregateStatement<
                     T,
                     ConnType,
@@ -424,7 +428,9 @@ export namespace storm {
         // Usage: queryset.min<^^Person::age>().execute()
         //        queryset.where(active == true).min<^^Person::age>().execute()
         // Returns statement by value - connection-level prepare_cached() handles SQL caching
-        template <std::meta::info... FieldInfos> [[nodiscard]] auto min() {
+        template <std::meta::info... FieldInfos>
+            requires orm::statements::AllNumericAggregateable<FieldInfos...>
+        [[nodiscard]] auto min() {
             using StmtType = orm::statements::AggregateStatement<
                     T,
                     ConnType,
@@ -438,7 +444,9 @@ export namespace storm {
         // Usage: queryset.max<^^Person::age>().execute()
         //        queryset.where(department == "Sales").max<^^Person::salary>().execute()
         // Returns statement by value - connection-level prepare_cached() handles SQL caching
-        template <std::meta::info... FieldInfos> [[nodiscard]] auto max() {
+        template <std::meta::info... FieldInfos>
+            requires orm::statements::AllNumericAggregateable<FieldInfos...>
+        [[nodiscard]] auto max() {
             using StmtType = orm::statements::AggregateStatement<
                     T,
                     ConnType,

--- a/src/orm/statements/aggregate.cppm
+++ b/src/orm/statements/aggregate.cppm
@@ -265,7 +265,10 @@ export namespace storm::orm::statements {
         [[nodiscard]] auto having(orm::where::ExpressionVariantPtr expr)
             requires HasGroupBy
         {
-            return AggregateStatement<T, ConnType, GroupFields, Ops...>{make_params(std::move(expr))};
+            AggregateParams<ConnType> params{
+                    conn_, where_expr_, join_stmt_, limit_, offset_, order_by_wrapper_, std::move(expr)
+            };
+            return AggregateStatement<T, ConnType, GroupFields, Ops...>{std::move(params)};
         }
 
         // Chaining methods (only for non-GROUP BY queries building aggregates).
@@ -703,10 +706,6 @@ export namespace storm::orm::statements {
 
         auto make_params() -> AggregateParams<ConnType> {
             return {conn_, where_expr_, join_stmt_, limit_, offset_, order_by_wrapper_, having_expr_};
-        }
-
-        auto make_params(orm::where::ExpressionVariantPtr having) -> AggregateParams<ConnType> {
-            return {conn_, where_expr_, join_stmt_, limit_, offset_, order_by_wrapper_, std::move(having)};
         }
 
         std::shared_ptr<ConnType>           conn_;

--- a/src/orm/statements/aggregate.cppm
+++ b/src/orm/statements/aggregate.cppm
@@ -23,6 +23,31 @@ export namespace storm::orm::statements {
 
     using storm::orm::utilities::ConstexprString;
 
+    // True for an arithmetic-but-not-bool scalar. SUM/AVG/MIN/MAX always yield a
+    // numeric result (int64_t / double / std::optional<double>), so a text, BLOB,
+    // enum, or struct target would silently coerce rather than fail. bool is
+    // excluded — aggregating a boolean column is a modelling mistake.
+    template <typename T> constexpr bool is_numeric_scalar_v = std::is_arithmetic_v<T> && !std::is_same_v<T, bool>;
+
+    // A field type valid as the target of a numeric aggregate. Unwraps one level
+    // of std::optional (a nullable numeric column, e.g. std::optional<int>, is a
+    // legitimate SUM/AVG target — NULLs are simply skipped by SQL). Routed through
+    // a constexpr bool because a concept body cannot use ?: / unwrap directly.
+    template <typename T>
+    constexpr bool is_numeric_aggregateable_v =
+            utilities::is_optional_v<T> ? is_numeric_scalar_v<utilities::optional_inner_type_t<T>>
+                                        : is_numeric_scalar_v<T>;
+
+    template <typename T>
+    concept NumericAggregateable = is_numeric_aggregateable_v<T>;
+
+    // Every field in the pack is a NumericAggregateable column. Used as the
+    // requires-clause on the numeric aggregate methods, which take the target
+    // fields as a std::meta::info pack (SUM(a + b) over several fields).
+    template <std::meta::info... FieldInfos>
+    concept AllNumericAggregateable =
+            (NumericAggregateable<std::remove_cvref_t<typename[:std::meta::type_of(FieldInfos):]>> && ...);
+
     // Aggregate function types
     enum class AggregateType : std::uint8_t { SUM, COUNT, AVG, MIN, MAX, COUNT_DISTINCT };
 
@@ -243,38 +268,36 @@ export namespace storm::orm::statements {
             return AggregateStatement<T, ConnType, GroupFields, Ops...>{make_params(std::move(expr))};
         }
 
-        // Chaining methods (only for non-GROUP BY queries building aggregates)
-        template <std::meta::info... FieldInfos> [[nodiscard]] auto sum() {
-            return AggregateStatement<T, ConnType, GroupFields, Ops..., AggregateOp<AggregateType::SUM, FieldInfos...>>{
-                    make_params()
-            };
+        // Chaining methods (only for non-GROUP BY queries building aggregates).
+        // sum/avg/min/max share one body — chain_op<Type>() — differing only by
+        // AggregateType; the numeric methods gate their target fields through
+        // AllNumericAggregateable, count() accepts any field (COUNT is type-agnostic).
+        template <std::meta::info... FieldInfos>
+            requires AllNumericAggregateable<FieldInfos...>
+        [[nodiscard]] auto sum() {
+            return chain_op<AggregateType::SUM, FieldInfos...>();
         }
 
         template <std::meta::info... FieldInfos> [[nodiscard]] auto count() {
-            return AggregateStatement<
-                    T,
-                    ConnType,
-                    GroupFields,
-                    Ops...,
-                    AggregateOp<AggregateType::COUNT, FieldInfos...>>{make_params()};
+            return chain_op<AggregateType::COUNT, FieldInfos...>();
         }
 
-        template <std::meta::info... FieldInfos> [[nodiscard]] auto avg() {
-            return AggregateStatement<T, ConnType, GroupFields, Ops..., AggregateOp<AggregateType::AVG, FieldInfos...>>{
-                    make_params()
-            };
+        template <std::meta::info... FieldInfos>
+            requires AllNumericAggregateable<FieldInfos...>
+        [[nodiscard]] auto avg() {
+            return chain_op<AggregateType::AVG, FieldInfos...>();
         }
 
-        template <std::meta::info... FieldInfos> [[nodiscard]] auto min() {
-            return AggregateStatement<T, ConnType, GroupFields, Ops..., AggregateOp<AggregateType::MIN, FieldInfos...>>{
-                    make_params()
-            };
+        template <std::meta::info... FieldInfos>
+            requires AllNumericAggregateable<FieldInfos...>
+        [[nodiscard]] auto min() {
+            return chain_op<AggregateType::MIN, FieldInfos...>();
         }
 
-        template <std::meta::info... FieldInfos> [[nodiscard]] auto max() {
-            return AggregateStatement<T, ConnType, GroupFields, Ops..., AggregateOp<AggregateType::MAX, FieldInfos...>>{
-                    make_params()
-            };
+        template <std::meta::info... FieldInfos>
+            requires AllNumericAggregateable<FieldInfos...>
+        [[nodiscard]] auto max() {
+            return chain_op<AggregateType::MAX, FieldInfos...>();
         }
 
         // Return the SQL that would be executed (for testing/debugging). Assembles
@@ -670,6 +693,14 @@ export namespace storm::orm::statements {
             return prepare_bind_extract(sql);
         }
 
+        // Shared body for the chaining aggregate methods: append one AggregateOp
+        // of the given AggregateType and return the extended statement.
+        template <AggregateType AType, std::meta::info... FieldInfos> [[nodiscard]] auto chain_op() {
+            return AggregateStatement<T, ConnType, GroupFields, Ops..., AggregateOp<AType, FieldInfos...>>{
+                    make_params()
+            };
+        }
+
         auto make_params() -> AggregateParams<ConnType> {
             return {conn_, where_expr_, join_stmt_, limit_, offset_, order_by_wrapper_, having_expr_};
         }
@@ -709,33 +740,48 @@ export namespace storm::orm::statements {
             return GroupByBuilder<T, ConnType, GroupFieldInfos...>{std::move(p)};
         }
 
+        // count/count_distinct accept any field type (COUNT is type-agnostic);
+        // sum/avg/min/max gate their target fields through AllNumericAggregateable.
+        // All delegate to grouped_op<Type>(), which appends one AggregateOp.
         template <std::meta::info... FieldInfos> [[nodiscard]] auto count() {
-            return AggregateStatement<T, ConnType, GBFields, AggregateOp<AggregateType::COUNT, FieldInfos...>>{params_};
+            return grouped_op<AggregateType::COUNT, FieldInfos...>();
         }
 
         template <std::meta::info... FieldInfos> [[nodiscard]] auto count_distinct() {
-            return AggregateStatement<T, ConnType, GBFields, AggregateOp<AggregateType::COUNT_DISTINCT, FieldInfos...>>{
-                    params_
-            };
+            return grouped_op<AggregateType::COUNT_DISTINCT, FieldInfos...>();
         }
 
-        template <std::meta::info... FieldInfos> [[nodiscard]] auto sum() {
-            return AggregateStatement<T, ConnType, GBFields, AggregateOp<AggregateType::SUM, FieldInfos...>>{params_};
+        template <std::meta::info... FieldInfos>
+            requires AllNumericAggregateable<FieldInfos...>
+        [[nodiscard]] auto sum() {
+            return grouped_op<AggregateType::SUM, FieldInfos...>();
         }
 
-        template <std::meta::info... FieldInfos> [[nodiscard]] auto avg() {
-            return AggregateStatement<T, ConnType, GBFields, AggregateOp<AggregateType::AVG, FieldInfos...>>{params_};
+        template <std::meta::info... FieldInfos>
+            requires AllNumericAggregateable<FieldInfos...>
+        [[nodiscard]] auto avg() {
+            return grouped_op<AggregateType::AVG, FieldInfos...>();
         }
 
-        template <std::meta::info... FieldInfos> [[nodiscard]] auto min() {
-            return AggregateStatement<T, ConnType, GBFields, AggregateOp<AggregateType::MIN, FieldInfos...>>{params_};
+        template <std::meta::info... FieldInfos>
+            requires AllNumericAggregateable<FieldInfos...>
+        [[nodiscard]] auto min() {
+            return grouped_op<AggregateType::MIN, FieldInfos...>();
         }
 
-        template <std::meta::info... FieldInfos> [[nodiscard]] auto max() {
-            return AggregateStatement<T, ConnType, GBFields, AggregateOp<AggregateType::MAX, FieldInfos...>>{params_};
+        template <std::meta::info... FieldInfos>
+            requires AllNumericAggregateable<FieldInfos...>
+        [[nodiscard]] auto max() {
+            return grouped_op<AggregateType::MAX, FieldInfos...>();
         }
 
       private:
+        // Shared body: append one AggregateOp of the given type to the GROUP BY
+        // aggregate statement.
+        template <AggregateType AType, std::meta::info... FieldInfos> [[nodiscard]] auto grouped_op() {
+            return AggregateStatement<T, ConnType, GBFields, AggregateOp<AType, FieldInfos...>>{params_};
+        }
+
         AggregateParams<ConnType> params_;
     };
 

--- a/tests/query/test_aggregateable_concept.cpp
+++ b/tests/query/test_aggregateable_concept.cpp
@@ -1,0 +1,103 @@
+#include <gtest/gtest.h>
+#include <plf_hive/plf_hive.h>
+#include "test_db_helpers.h"
+
+import storm;
+import storm_orm_statements_aggregate;
+import std;
+
+#include "test_models.h" // NOSONAR cpp:S954
+
+// Compile-time-only verification of the NumericAggregateable concept (#475).
+// Every static_assert below is checked at TU compile time; the runtime TEST body
+// only exists so the file registers with GoogleTest and the assertions compile.
+
+using storm::orm::statements::NumericAggregateable;
+
+// ---- Positive: arithmetic (non-bool) field types are numeric-aggregateable ---
+
+static_assert(NumericAggregateable<int>);
+static_assert(NumericAggregateable<short>);
+static_assert(NumericAggregateable<unsigned int>);
+static_assert(NumericAggregateable<std::int64_t>);
+static_assert(NumericAggregateable<long>);
+static_assert(NumericAggregateable<long long>);
+static_assert(NumericAggregateable<std::uint64_t>);
+static_assert(NumericAggregateable<double>);
+static_assert(NumericAggregateable<float>);
+static_assert(NumericAggregateable<signed char>);
+static_assert(NumericAggregateable<char>);
+
+// A nullable numeric column (std::optional<Numeric>) is a legitimate target —
+// SQL simply skips NULLs. One level of optional is unwrapped.
+static_assert(NumericAggregateable<std::optional<int>>);
+static_assert(NumericAggregateable<std::optional<double>>);
+static_assert(NumericAggregateable<std::optional<std::int64_t>>);
+
+// ---- Negative: bool, text, BLOB, enum, and unrelated types are rejected ------
+
+// bool is arithmetic in C++, but SUM/AVG/MIN/MAX over a boolean column is a
+// modelling mistake, not a real query — deliberately excluded.
+static_assert(!NumericAggregateable<bool>);
+static_assert(!NumericAggregateable<std::string>);
+static_assert(!NumericAggregateable<std::string_view>);
+static_assert(!NumericAggregateable<std::vector<std::uint8_t>>);
+static_assert(!NumericAggregateable<Color>); // enum, from test_models.h
+static_assert(!NumericAggregateable<void*>);
+static_assert(!NumericAggregateable<std::optional<std::string>>); // optional of non-numeric
+static_assert(!NumericAggregateable<std::optional<bool>>);        // optional of bool
+
+// Temporal / UUID columns are storable & WHERE-filterable but NOT numeric —
+// SUM/AVG/MIN/MAX over them is meaningless, so they are rejected (incl. optional).
+static_assert(!NumericAggregateable<storm::orm::utilities::UUID>);
+static_assert(!NumericAggregateable<std::chrono::system_clock::time_point>);
+static_assert(!NumericAggregateable<std::chrono::year_month_day>);
+static_assert(!NumericAggregateable<std::optional<storm::orm::utilities::UUID>>);
+static_assert(!NumericAggregateable<std::optional<std::chrono::system_clock::time_point>>);
+
+// Iterable / container field types (BLOBs and m2m/reverse-fk relation members
+// such as std::vector<Model> / plf::hive<Model>) are never a numeric aggregate
+// target — a container is not arithmetic, and the optional unwrap does not reach
+// into element types. Rejected regardless of element type.
+static_assert(!NumericAggregateable<std::vector<int>>);
+static_assert(!NumericAggregateable<std::vector<double>>);
+static_assert(!NumericAggregateable<plf::hive<int>>);
+static_assert(!NumericAggregateable<std::array<int, 3>>);
+
+// ---- Method-level rejection ---------------------------------------------------
+// A numeric aggregate over a non-numeric field must NOT be instantiable. The
+// variable template makes the requires-clause failure SFINAE-soft rather than a
+// hard error (the #472 wrapper trick).
+
+template <typename QS>
+concept min_name_ok = requires(QS qs) { qs.template min<^^Person::name>(); };
+template <typename QS>
+concept min_age_ok = requires(QS qs) { qs.template min<^^Person::age>(); };
+template <typename QS>
+concept sum_avatar_ok = requires(QS qs) { qs.template sum<^^Person::avatar>(); };
+template <typename QS>
+concept sum_salary_ok = requires(QS qs) { qs.template sum<^^Person::salary>(); };
+template <typename QS>
+concept max_active_ok = requires(QS qs) { qs.template max<^^Person::is_active>(); };
+
+using PersonQS = storm::QuerySet<Person>;
+
+// Numeric targets are accepted.
+static_assert(min_age_ok<PersonQS>);
+static_assert(sum_salary_ok<PersonQS>);
+
+// Non-numeric targets are rejected.
+static_assert(!min_name_ok<PersonQS>);   // std::string
+static_assert(!sum_avatar_ok<PersonQS>); // std::vector<uint8_t> (BLOB)
+static_assert(!max_active_ok<PersonQS>); // bool
+
+// count / count_distinct stay unconstrained — any field type is countable.
+template <typename QS>
+concept count_distinct_name_ok = requires(QS qs) { qs.template count_distinct<^^Person::name>(); };
+static_assert(count_distinct_name_ok<PersonQS>);
+
+TEST(AggregateableConceptTest, CompileTimeOnly) {
+    // The verification is entirely in the static_asserts above; this body just
+    // gives GoogleTest something to run.
+    SUCCEED();
+}


### PR DESCRIPTION
## Summary

Adds a compile-time `NumericAggregateable` concept (split from #206) that constrains the target field type of `sum()`/`avg()`/`min()`/`max()`. Previously **any** field type — string, BLOB, enum, UUID, temporal, bool, or a container relation member — compiled as a numeric aggregate target and silently coerced via SQLite. It is now a **compile error** with a clear constraint violation.

## Concept

```cpp
template <typename T>
constexpr bool is_numeric_scalar_v = std::is_arithmetic_v<T> && !std::is_same_v<T, bool>;

// one level of std::optional<> unwrapped — a nullable numeric column is a valid target
template <typename T>
concept NumericAggregateable = /* is_numeric_scalar_v, optional-unwrapped */;
```

- **`bool` excluded**: aggregating a boolean column is a modelling mistake, not a real query.
- **`std::optional<Numeric>` accepted**: nullable numeric columns (e.g. `std::optional<int>`) are legitimate SUM/AVG targets — SQL skips NULLs. This preserved the existing `sum<^^Person::score>()` tests.

## Design note (diverges from the issue's illustrative sketch)

The issue sketched two concepts (`Aggregateable = arithmetic||string` and `NumericAggregateable = arithmetic`). Verifying against the code: SUM/AVG/MIN/MAX all produce numeric results (`int64_t`/`double`/`optional<double>`) — none meaningfully handle strings — while `COUNT`/`COUNT(DISTINCT)` count rows of any type. So `Aggregateable = arithmetic||string` had no honest call site and was dropped. Only `NumericAggregateable` is defined and applied.

## Applied to

`requires AllNumericAggregateable<FieldInfos...>` on `sum`/`avg`/`min`/`max` at all three call surfaces:
- `AggregateStatement` chaining methods
- `GroupByBuilder`
- `QuerySet`

`count`/`count_distinct` stay **unconstrained** (COUNT is type-agnostic).

Also dedups the near-identical aggregate method bodies into shared `chain_op<Type>()` / `grouped_op<Type>()` helpers (behavior-preserving — a code-quality hook flagged the duplication).

## Verification

Compile-time-only `tests/query/test_aggregateable_concept.cpp`:
- Positive: `int`, `int64_t`, `double`, `float`, …, and `std::optional<Numeric>`.
- Negative: `bool`, `std::string`, BLOB, enum, `void*`, UUID, temporal, containers (`std::vector<T>`, `plf::hive<T>`, `std::array`), and `std::optional<non-numeric>`.
- Method-level SFINAE-soft rejection: `qs.min<^^Person::name>()` / `sum<avatar>` / `max<is_active>` are not instantiable; numeric targets and `count_distinct<name>` are.

Compile-time-only, no runtime change — no benchmarking needed. Full pre-commit hook (format, tidy, tests, coverage 100%) passed.

Closes #475

🤖 Generated with [Claude Code](https://claude.com/claude-code)