### PR TITLE
feat(477): add dialect-support concepts (SupportsPgDialect, SupportsLimitAll, TransactionCapable)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -373,6 +373,20 @@ concepts (`ModelWithPrimaryKey`, `ModelStorageAnnotated`, `ModelFkPoliciesValid`
 *policy*, `Entity` checks *reflectability*. Structural only: a `union` also satisfies `Entity`, so
 full model-ness is guaranteed by the semantic concepts together with it, not by `Entity` alone.
 
+**Dialect-support concepts (#477)**: named backend-capability gates in `src/db/concept.cppm`
+(`namespace storm::db`), replacing ad-hoc `if constexpr (requires { ConnType::trait; })` probes.
+`SupportsPgDialect<ConnType>` (present iff the backend declares `uses_pg_dialect`) IS the
+SQLite/PG dialect switch — true for PG, false for SQLite — used at `schema.cppm` (the `Dialect`
+enum) and `base.cppm` (`append_order_by` NULLS FIRST/LAST). `SupportsLimitAll<ConnType>` is an
+EXISTENCE probe true for BOTH backends; `append_limit_offset` still reads the bool VALUE to pick
+`LIMIT ALL` (PG) vs `LIMIT -1` (SQLite). `TransactionCapable<ConnType>` names the
+`in_transaction()`/`enter_transaction()`/`leave_transaction()`/`execute()`/`Error` surface that
+`TransactionGuard` (#415) calls, and now constrains `TransactionGuard` + `storm::begin`/`storm::transaction`,
+so a mis-typed connection fails at the `begin()` call site. NOT added: `SupportsRightJoin`
+(`right_join()` was removed in #397 — no call site) and `SupportsReturning`/`SupportsStrictTables`
+(declared on the connections but never read). Each backend static-asserts these next to its
+`Connection` definition.
+
 See [docs/guide/reference/FIELD_TYPES.md](docs/guide/reference/FIELD_TYPES.md).
 
 ## Known Compiler Issues

--- a/docs/superpowers/specs/2026-07-21-477-dialect-support-concepts-design.md
+++ b/docs/superpowers/specs/2026-07-21-477-dialect-support-concepts-design.md
@@ -1,0 +1,118 @@
+# #477 — Dialect-support concepts (design)
+
+## Problem
+
+Backend-dialect capability checks are done ad-hoc through anonymous
+`if constexpr (requires { ConnType::some_trait; })` probes rather than through
+named concepts. This makes the gating harder to read and gives no clear
+compile-time error when a backend lacks a capability.
+
+## Premise verification (issue is partly stale)
+
+The issue sketches `SupportsRightJoin` and `TransactionCapable`. Checking the
+current tree:
+
+- **`right_join()` was removed in #397** (replaced by reverse-FK, #398).
+  `tests/schema/test_fk_fields.cpp` even static-asserts `!has_right_join<QuerySet<Task>>`.
+  A `SupportsRightJoin` concept would therefore gate **nothing** — dead code the
+  day it lands (and a likely SonarCloud unused-symbol flag). **Skipped.**
+- **Dialect capabilities already exist** as `static constexpr bool` members on
+  the connection types:
+  - `postgresql::Connection`: `supports_limit_all`, `supports_returning`, `uses_pg_dialect`
+  - `sqlite::Connection`: `supports_limit_all`, `supports_returning`, `supports_strict_tables`
+- Only **two** of these are actually consumed today:
+  - `uses_pg_dialect` — `schema.cppm:991`, `base.cppm:938`
+  - `supports_limit_all` — `base.cppm:959`
+  `supports_returning` and `supports_strict_tables` are **declared but never
+  read** anywhere. Concepts for them would be speculative (same dead-concept
+  trap as `SupportsRightJoin`). **Skipped.**
+- **Transactions already work** (#415): `TransactionGuard::begin()` /
+  `storm::begin()` / `storm::transaction()` call
+  `in_transaction()`/`enter_transaction()`/`leave_transaction()`/`execute()` and
+  the `Error` alias — but `TransactionGuard` is **unconstrained**. There is no
+  named concept expressing that contract.
+
+## Scope (approved: "Real traits + TransactionCapable")
+
+Add named concepts for the dialect traits that genuinely exist AND are consumed,
+plus a `TransactionCapable` concept, and refactor the ad-hoc sites to use them.
+
+### New concepts (in `src/db/concept.cppm`, `namespace storm::db`)
+
+```cpp
+// A connection whose backend uses the PostgreSQL SQL dialect.
+template <typename ConnType>
+concept SupportsPgDialect = requires {
+    { ConnType::uses_pg_dialect } -> std::convertible_to<bool>;
+};
+
+// A connection whose backend spells "unlimited rows" as LIMIT ALL (PG) rather
+// than LIMIT -1 (SQLite). The concept captures the EXISTENCE probe; call sites
+// still read the bool VALUE to pick the spelling.
+template <typename ConnType>
+concept SupportsLimitAll = requires {
+    { ConnType::supports_limit_all } -> std::convertible_to<bool>;
+};
+
+// A connection that can run an RAII transaction (storm::begin / TransactionGuard).
+// Captures exactly what TransactionGuard calls.
+template <typename ConnType>
+concept TransactionCapable = requires(ConnType& conn, std::string_view sql) {
+    typename ConnType::Error;
+    { conn.in_transaction() } -> std::convertible_to<bool>;
+    conn.enter_transaction();
+    conn.leave_transaction();
+    { conn.execute(sql) } -> std::same_as<std::expected<void, typename ConnType::Error>>;
+};
+```
+
+`SupportsPgDialect`/`SupportsLimitAll` model *presence of a trait*, not its
+truth. `SupportsPgDialect<sqlite::Connection>` is **false** (SQLite declares no
+`uses_pg_dialect` member) and **true** for PG — so it doubles as the dialect
+switch the ad-hoc `requires { ... }` probe was already performing.
+`SupportsLimitAll` is **true for BOTH** backends (both declare the member); its
+call site still reads the value to choose `LIMIT ALL` vs `LIMIT -1`. This
+matches the existing two-level `if constexpr` (existence, then value) exactly —
+no behavior change.
+
+### Refactored call sites (behavior-preserving)
+
+| File | Before | After |
+|---|---|---|
+| `schema.cppm:991` | `requires { ConnType::uses_pg_dialect; }` | `db::SupportsPgDialect<ConnType>` |
+| `base.cppm:938` | `requires { ConnTypeForDialect::uses_pg_dialect; }` | `db::SupportsPgDialect<ConnTypeForDialect>` |
+| `base.cppm:959` | `requires { ConnTypeForDialect::supports_limit_all; }` | `db::SupportsLimitAll<ConnTypeForDialect>` |
+
+The `base.cppm` sites default `ConnTypeForDialect = void`; `void` satisfies
+neither concept, so the SQLite-compatible fallback branch is preserved.
+
+### `TransactionCapable` constraint
+
+Constrain `TransactionGuard<ConnType>` and the `storm::begin` / `storm::transaction`
+free functions on `TransactionCapable<ConnType>`. This turns a mis-typed
+connection into a clear constraint violation at the `begin()` call site instead
+of a deep error inside the guard body. No behavior change for the real
+connections (both satisfy it).
+
+## Verification
+
+Compile-time only, per the issue:
+
+- `static_assert` near each connection definition (or in the test TU):
+  - `SupportsPgDialect<postgresql::Connection>` / `!SupportsPgDialect<sqlite::Connection>`
+  - `SupportsLimitAll<sqlite::Connection>` && `SupportsLimitAll<postgresql::Connection>`
+  - `TransactionCapable<sqlite::Connection>` && `TransactionCapable<postgresql::Connection>`
+  - Negative gates: `!SupportsPgDialect<int>`, `!TransactionCapable<int>`
+- New `tests/schema/test_dialect_concepts.cpp` (auto-discovered by GLOB), a
+  runnable GTest TU whose real content is the static_asserts (mirrors
+  `test_entity_concept.cpp`).
+
+TDD: write the test TU first, confirm it fails to compile (concepts undefined),
+then add the concepts + refactor, then it passes.
+
+## Explicitly out of scope
+
+- `SupportsRightJoin` — no call site (right_join removed in #397).
+- `SupportsReturning`, `SupportsStrictTables` — declared but unused; adding
+  concepts would be dead code.
+- Any new dialect capability or backend feature.

--- a/src/db/concept.cppm
+++ b/src/db/concept.cppm
@@ -95,6 +95,43 @@ export namespace storm::db {
         { conn.cache_stats() } -> std::same_as<CacheStats>;
     };
 
+    // ── Dialect-support concepts (Issue #477) ────────────────────────────────
+    // Named gates for backend-dialect capability checks that were previously
+    // done ad-hoc via anonymous `if constexpr (requires { ConnType::trait; })`
+    // probes. Each models PRESENCE of a static trait, not its truth.
+
+    // A connection whose backend uses the PostgreSQL SQL dialect. PG declares
+    // `uses_pg_dialect`; SQLite does not — so this concept IS the dialect switch
+    // (true for PG, false for SQLite), used to pick PG-specific SQL (NULLS
+    // FIRST/LAST ordering, LIMIT ALL, the schema-generation Dialect enum).
+    template <typename ConnType>
+    concept SupportsPgDialect = requires {
+        { ConnType::uses_pg_dialect } -> std::convertible_to<bool>;
+    };
+
+    // A connection that declares how it spells "unlimited rows" after OFFSET:
+    // PG uses `LIMIT ALL`, SQLite uses `LIMIT -1`. Both backends declare the
+    // trait, so this concept is an EXISTENCE probe — call sites still read the
+    // bool VALUE to choose the spelling; a backend that declares neither falls
+    // back to the SQLite-compatible form.
+    template <typename ConnType>
+    concept SupportsLimitAll = requires {
+        { ConnType::supports_limit_all } -> std::convertible_to<bool>;
+    };
+
+    // A connection that can run an RAII transaction (storm::begin /
+    // TransactionGuard, #415). Captures exactly the surface TransactionGuard
+    // calls, so a mis-typed connection fails at the begin() call site with a
+    // clear constraint violation instead of deep inside the guard body.
+    template <typename ConnType>
+    concept TransactionCapable = requires(ConnType& conn, std::string_view sql) {
+        typename ConnType::Error;
+        { conn.in_transaction() } -> std::convertible_to<bool>;
+        conn.enter_transaction();
+        conn.leave_transaction();
+        { conn.execute(sql) } -> std::same_as<std::expected<void, typename ConnType::Error>>;
+    };
+
     // Database statement concept.
     // Issue #206: covers the full bind/extract/control surface actually used by
     // orm/utilities.cppm and orm/statements/extract.cppm, not just the minimal

--- a/src/db/postgresql_connection.cppm
+++ b/src/db/postgresql_connection.cppm
@@ -341,4 +341,10 @@ export namespace storm::db::postgresql {
     static_assert(storm::db::DatabaseStatement<Statement>);
     static_assert(storm::db::DatabaseError<Error>);
 
+    // Dialect-support concepts (#477). PostgreSQL uses the PG dialect, declares
+    // supports_limit_all, and is transaction-capable.
+    static_assert(storm::db::SupportsPgDialect<Connection>);
+    static_assert(storm::db::SupportsLimitAll<Connection>);
+    static_assert(storm::db::TransactionCapable<Connection>);
+
 } // namespace storm::db::postgresql

--- a/src/db/sqlite.cppm
+++ b/src/db/sqlite.cppm
@@ -524,4 +524,10 @@ export namespace storm::db::sqlite {
     static_assert(storm::db::DatabaseStatement<Statement>);
     static_assert(storm::db::DatabaseError<Error>);
 
+    // Dialect-support concepts (#477). SQLite uses its own dialect (no
+    // uses_pg_dialect), declares supports_limit_all, and is transaction-capable.
+    static_assert(!storm::db::SupportsPgDialect<Connection>);
+    static_assert(storm::db::SupportsLimitAll<Connection>);
+    static_assert(storm::db::TransactionCapable<Connection>);
+
 } // namespace storm::db::sqlite

--- a/src/orm/schema.cppm
+++ b/src/orm/schema.cppm
@@ -988,7 +988,7 @@ export namespace storm::orm::schema {
         [[nodiscard]] static auto
         create_table_if_not_exists(std::shared_ptr<ConnType> conn, std::set<std::string, std::less<>>& done)
                 -> std::expected<void, typename ConnType::Error> {
-            constexpr Dialect dialect = requires { ConnType::uses_pg_dialect; } ? Dialect::PostgreSQL : Dialect::SQLite;
+            constexpr Dialect dialect = db::SupportsPgDialect<ConnType> ? Dialect::PostgreSQL : Dialect::SQLite;
 
             // Already created in this call tree — break FK cycles and avoid redundant DDL.
             if (!done.insert(std::string(Base::table_name_)).second) {

--- a/src/orm/statements/base.cppm
+++ b/src/orm/statements/base.cppm
@@ -935,7 +935,7 @@ export namespace storm::orm::statements {
         append_order_by(std::string& sql, const std::optional<OrderByWrapper>& order_by_wrapper) {
             if (order_by_wrapper.has_value() && !order_by_wrapper->empty()) {
                 const auto& order_sql = order_by_wrapper->get_order_by_sql();
-                if constexpr (requires { ConnTypeForDialect::uses_pg_dialect; }) {
+                if constexpr (db::SupportsPgDialect<ConnTypeForDialect>) {
                     std::string adapted = order_sql; // LCOV_EXCL_LINE — PG-only
                     adapt_order_by_for_pg(adapted);  // LCOV_EXCL_LINE — PG-only
                     sql += adapted;                  // LCOV_EXCL_LINE — PG-only
@@ -956,7 +956,7 @@ export namespace storm::orm::statements {
                 sql += std::to_string(limit.value());
             } else if (offset.has_value()) {
                 // Need LIMIT when using OFFSET
-                if constexpr (requires { ConnTypeForDialect::supports_limit_all; }) {
+                if constexpr (db::SupportsLimitAll<ConnTypeForDialect>) {
                     if constexpr (ConnTypeForDialect::supports_limit_all) {
                         sql += " LIMIT ALL";
                     } else {

--- a/src/orm/transaction.cppm
+++ b/src/orm/transaction.cppm
@@ -5,6 +5,7 @@ module;
 export module storm_orm_transaction;
 
 import std;
+import storm_db_concept;
 
 export namespace storm::orm::utilities {
 
@@ -24,7 +25,7 @@ export namespace storm::orm::utilities {
     // Destructor automatically ROLLBACKs if commit() was not called.
     // ============================================================================
 
-    template <typename ConnType> class TransactionGuard {
+    template <db::TransactionCapable ConnType> class TransactionGuard {
         using Error = typename ConnType::Error;
 
         std::shared_ptr<ConnType> conn_;

--- a/src/storm.cppm
+++ b/src/storm.cppm
@@ -41,7 +41,7 @@ export namespace storm {
     // resolving the nested-BEGIN bug (#9).
     template <typename ConnType> using TransactionGuard = orm::utilities::TransactionGuard<ConnType>;
 
-    template <typename ConnType>
+    template <db::TransactionCapable ConnType>
     [[nodiscard]] auto begin(std::shared_ptr<ConnType> conn)
             -> std::expected<TransactionGuard<ConnType>, typename ConnType::Error> {
         return orm::utilities::TransactionGuard<ConnType>::begin(std::move(conn));
@@ -51,7 +51,7 @@ export namespace storm {
     // std::expected<T, Error>; on a value the scope COMMITs and forwards it, on a
     // std::unexpected (or a throw) the guard ROLLBACKs and the error propagates.
     // A thin convenience layer over storm::begin — same cooperative nesting (#9).
-    template <typename ConnType, typename Body>
+    template <db::TransactionCapable ConnType, typename Body>
     [[nodiscard]] auto transaction(std::shared_ptr<ConnType> conn, Body&& body)
             -> std::invoke_result_t<Body&, TransactionGuard<ConnType>&> {
         using Ret = std::invoke_result_t<Body&, TransactionGuard<ConnType>&>;

--- a/tests/schema/test_dialect_concepts.cpp
+++ b/tests/schema/test_dialect_concepts.cpp
@@ -1,0 +1,47 @@
+#include <gtest/gtest.h>
+
+import storm;
+import std;
+
+// ── #477: dialect-support concepts are compile-time backend-capability gates ──
+// These name the ad-hoc `if constexpr (requires { ConnType::trait; })` probes
+// used for dialect selection, plus the previously-unconstrained transaction
+// contract. Verification is compile-time only (the issue: "static_assert per
+// backend"). Each backend's own definition also static-asserts these (see
+// sqlite.cppm / postgresql_connection.cppm); this TU adds the CROSS-BACKEND
+// contrast and the NEGATIVE gates a non-connection type is rejected. It stays a
+// runnable GTest target so the suite reports it.
+
+using SqliteConn = storm::db::sqlite::Connection;
+using PgConn     = storm::db::postgresql::Connection;
+
+// SupportsPgDialect IS the dialect switch: PG declares uses_pg_dialect, SQLite
+// does not — so the two backends must disagree, and a non-connection is out.
+static_assert(storm::db::SupportsPgDialect<PgConn>);
+static_assert(!storm::db::SupportsPgDialect<SqliteConn>);
+static_assert(!storm::db::SupportsPgDialect<int>);
+
+// SupportsLimitAll is an EXISTENCE probe — true for BOTH backends (both declare
+// the member); call sites read the bool VALUE to pick "LIMIT ALL" vs "LIMIT -1".
+static_assert(storm::db::SupportsLimitAll<PgConn>);
+static_assert(storm::db::SupportsLimitAll<SqliteConn>);
+static_assert(!storm::db::SupportsLimitAll<int>);
+
+// TransactionCapable holds for real connections and rejects a non-connection.
+static_assert(storm::db::TransactionCapable<PgConn>);
+static_assert(storm::db::TransactionCapable<SqliteConn>);
+static_assert(!storm::db::TransactionCapable<int>);
+
+// The TransactionCapable constraint is load-bearing: storm::begin is callable
+// for a real connection type and NOT for a non-connection. The probe is wrapped
+// in a variable template so the failed-constraint case is a dependent SFINAE
+// soft-fail rather than a hard error at namespace scope.
+template <class C> constexpr bool begin_callable = requires(std::shared_ptr<C> conn) { storm::begin(conn); };
+static_assert(begin_callable<SqliteConn>);
+static_assert(!begin_callable<int>);
+
+TEST(DialectConcepts, CompileTimeOnly) {
+    // The static_asserts above are the real test; this keeps the TU a runnable
+    // GTest target so the suite reports it.
+    SUCCEED();
+}


### PR DESCRIPTION
## Summary

Splits out of #206 (low-priority "backend-specific" bucket). Names the backend-dialect capability checks that were previously done ad-hoc via anonymous \`if constexpr (requires { ConnType::trait; })\` probes, so dialect-specific code paths gate through named concepts with clear compile-time errors.

Three concepts in \`src/db/concept.cppm\` (\`namespace storm::db\`):

- **\`SupportsPgDialect<ConnType>\`** — present iff the backend declares \`uses_pg_dialect\`; IS the SQLite/PG dialect switch (true for PG, false for SQLite). Refactors the \`Dialect\`-enum site in \`schema.cppm\` and the NULLS FIRST/LAST site in \`base.cppm::append_order_by\`.
- **\`SupportsLimitAll<ConnType>\`** — existence probe (true for **both** backends); \`base.cppm::append_limit_offset\` still reads the bool VALUE to pick \`LIMIT ALL\` (PG) vs \`LIMIT -1\` (SQLite). Two-level \`if constexpr\` (existence → value) preserved byte-identically.
- **\`TransactionCapable<ConnType>\`** — names the \`in_transaction()\`/\`enter_transaction()\`/\`leave_transaction()\`/\`execute()\`/\`Error\` surface \`TransactionGuard\` (#415) calls; now constrains \`TransactionGuard\` plus \`storm::begin\`/\`storm::transaction\`, so a mis-typed connection fails at the \`begin()\` call site instead of deep inside the guard body.

## Premise verification (issue is partly stale)

The issue sketched \`SupportsRightJoin\` and \`TransactionCapable\`. Checking current code:

- **\`SupportsRightJoin\` NOT added** — \`right_join()\` was removed in #397 (replaced by reverse-FK, #398); \`test_fk_fields.cpp\` even static-asserts \`!has_right_join<QuerySet<Task>>\`. A concept for it would gate nothing (dead code + likely SonarCloud unused-symbol flag).
- **\`SupportsReturning\` / \`SupportsStrictTables\` NOT added** — declared on the connections but never read anywhere; concepts for them would be equally speculative.

## Verification (compile-time only, per the issue)

- Co-located \`static_assert\`s next to each \`Connection\` definition (\`sqlite.cppm\`, \`postgresql_connection.cppm\`) — a dropped trait fails at the connection.
- New \`tests/schema/test_dialect_concepts.cpp\`: cross-backend contrast (\`SupportsPgDialect\` disagrees; \`SupportsLimitAll\` agrees), negative gates (\`!...<int>\`), and a load-bearing \`storm::begin\` SFINAE check.

All checks green locally: clang-format, clang-tidy, 2480 tests (100%, incl. PG mock), 100% coverage.

Closes #477

🤖 Generated with [Claude Code](https://claude.com/claude-code)