### PR TITLE
ci(tidy-sweep): sync container image digest with ci.yml

### DIFF
--- a/.github/workflows/clang-tidy-sweep.yml
+++ b/.github/workflows/clang-tidy-sweep.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-24.04
     container:
       # Same pinned storm-ci image as ci.yml — keep digests in sync when bumping.
-      image: ghcr.io/spiritecosse/storm-ci@sha256:68eaac686d20d926e7f7cd4c8582d540e7377d4392443f748299c771d346de63
+      image: ghcr.io/spiritecosse/storm-ci@sha256:3a5a0f5db4011de96c0f178d8a6c75ae8af10f55d7e526e10c30076ddfbf8678
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
Fixes the weekly clang-tidy sweep job, which has failed on every Monday since 2026-06-01 with a CMake configuration error. The sweep's container image digest drifted out of sync with `ci.yml`.

**Root cause:** On 2026-05-31 (PR #342), `ci.yml` bumped its `storm-ci` image from `68eaac…` → `3a5a0f…` (the `import std;` rebuild), which ships a clang-p2996 whose libc++ module layout matches `cmake/libcxx.cmake`'s symlink logic. The sweep workflow was left pinned to the old stale image where that symlink never fires, so configure fails before clang-tidy runs.

**Fix:** Bump sweep to `3a5a0f…` to match `ci.yml`, restoring the workflow's own documented invariant: "Same pinned storm-ci image as ci.yml — keep digests in sync when bumping."

🤖 Generated with [Claude Code](https://claude.com/claude-code)