### PR TITLE
docs: sync docs/ and benchmarks/README.md with current src/ behavior

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -19,7 +19,7 @@ The unified benchmark system is a **100% compile-time C++ solution** that loads 
 - ✅ **Batch INSERT/UPDATE/DELETE** - YAML profiles (`batch_standard`, `batch_*_edge`) drive size sweeps via gbench `Arg()`
 - ✅ **Range / Complexity sweeps** - `dataset_standard` / `dataset_small` map to gbench `Range()` + `Complexity(oN)`
 
-> **CLI**: This benchmark binary is a Google Benchmark executable. Use `--benchmark_filter`, `--benchmark_repetitions`, `--benchmark_min_time`, `--benchmark_format=json`, etc. The pre–#235 flags `--filter`, `--iterations`, `--scale-test`, `-c <category>` are gone — older sections of this document that still show them refer to the migrated equivalents `--benchmark_filter='Storm/<category>/.*'` and `--benchmark_repetitions=N`.
+> **CLI**: This benchmark binary is a Google Benchmark executable. Use `--benchmark_filter`, `--benchmark_repetitions`, `--benchmark_min_time`, `--benchmark_format=json`, etc. — see [Usage](#-usage) below. The pre–#235 flags `--filter`, `--iterations`, `--scale-test`, `-c <category>`, `--quick`/`--thorough`, `--disk`/`--db=` no longer exist.
 
 ## 🚀 Quick Start
 
@@ -246,7 +246,6 @@ namespace storm::benchmark::sizes {
 **⚠️ CRITICAL: ONLY use Release builds for benchmarks!**
 
 ```bash
-# Release build (MANDATORY for accurate performance measurements)
 cmake --preset ninja-release -DENABLE_BENCH=ON
 cmake --build --preset ninja-release
 ```
@@ -259,1357 +258,83 @@ cmake --build --preset ninja-release
 
 **DO NOT use debug builds for benchmarking!**
 
-> **Note:** This is the new unified benchmark system. The old Python-based benchmark system (`bench.py`, `scripts/bench/`) has been deprecated. All benchmark functionality is now available through the `storm_bench` executable with compile-time dispatch and zero runtime overhead.
-
-### Show Help
-
-```bash
-./build/release/benchmarks/storm_bench --help
-```
-
-**Output:**
-```
-Storm ORM Benchmark System
-
-Usage: ./build/release/benchmarks/storm_bench [options]
-
-Options:
-  --filter=<pattern>      Run only tests with EXACT name match
-  -c, --category=<name>   Run tests matching category prefix (SELECT matches SELECT*)
-  --scale-test            Test performance with increasing sizes (substring match)
-  --iterations=<n>        Override iterations for all tests (default: use JSON values)
-  --quick                 Quick validation mode (~3-5 min, 0.3x iterations)
-  --thorough              Thorough regression mode (~15-20 min, 1.5x iterations)
-  --disk                  Use disk-based database (default: in-memory)
-  --db=<path>             Use specific database file path
-  --list, -l              List all available tests (combine with -c to filter)
-  --help, -h              Show this help message
-
-Modes:
-  (default)               Use JSON-defined iterations (~10 min for all tests)
-  --quick                 0.3x iterations for fast development feedback
-  --thorough              1.5x iterations for pre-commit validation
-
-Examples:
-  ./build/release/benchmarks/storm_bench --quick                          # Fast validation (~3-5 min)
-  ./build/release/benchmarks/storm_bench --quick -c SELECT                # Quick SELECT tests only
-  ./build/release/benchmarks/storm_bench --thorough                       # Thorough regression test
-  ./build/release/benchmarks/storm_bench -c SELECT                        # Run SELECT* categories
-  ./build/release/benchmarks/storm_bench -c SELECT --list                 # Preview SELECT tests
-  ./build/release/benchmarks/storm_bench --filter=insert_batch_100        # Run only insert_batch_100
-  ./build/release/benchmarks/storm_bench --filter=insert_batch --scale-test  # Test all batch sizes
-  ./build/release/benchmarks/storm_bench --iterations=5000                # Override all iterations
-  ./build/release/benchmarks/storm_bench --list
-```
-
-### Benchmark Modes
-
-The benchmark system supports three modes for different use cases:
-
-| Mode | Flag | Runtime | Iterations | Use Case |
-|------|------|---------|------------|----------|
-| **Default** | (none) | ~10 min | Per-test from JSON | Standard benchmarking |
-| **Quick** | `--quick` | ~3-5 min | 0.3x JSON values | Fast development validation |
-| **Thorough** | `--thorough` | ~15-20 min | 1.5x JSON values | Pre-commit regression testing |
-
-**Quick Mode** - Use during development for fast feedback:
-```bash
-./build/release/benchmarks/storm_bench --quick                 # All tests, ~3-5 min
-./build/release/benchmarks/storm_bench --quick -c SELECT       # Just SELECT tests, ~30 sec
-./build/release/benchmarks/storm_bench --quick --filter=insert_single  # Single test
-```
-
-**Thorough Mode** - Use before commits for comprehensive validation:
-```bash
-./build/release/benchmarks/storm_bench --thorough              # All tests, ~15-20 min
-./build/release/benchmarks/storm_bench --thorough -c INSERT    # Thorough INSERT tests
-```
-
-**Mode Interactions:**
-- `--iterations=N` always overrides mode multipliers
-- `--quick` and `--thorough` are mutually exclusive (error if both specified)
-- Without any mode flag, uses JSON-defined per-test iteration counts
+`storm_bench` is a stock Google Benchmark executable — all flags are gbench's own
+(`--benchmark_filter`, `--benchmark_repetitions`, `--benchmark_min_time`,
+`--benchmark_format`, `--benchmark_list_tests`, `--help`, etc.). See
+[Google Benchmark's user guide](https://github.com/google/benchmark/blob/main/docs/user_guide.md)
+for the full flag reference.
 
 ### List Available Tests
 
 ```bash
-./build/release/benchmarks/storm_bench --list
+./build/release/benchmarks/storm_bench --benchmark_list_tests=true
 ```
 
-**Output:**
-```
-=== Available Benchmark Tests ===
-Total: 28 tests
+Lists every registered gbench name, e.g. `Storm/WHERE/where_int_comparison_gt/N:10000`,
+`Raw/INSERT/insert/N:1000`. Combine with `--benchmark_filter` to preview a subset:
 
-Test Name                      Category         Operation
-────────────────────────────────────────────────────────────
-where_int_comparison_gt        WHERE            where
-where_bool_equality            WHERE            where
-where_double_comparison        WHERE            where
-where_int_less_than            WHERE            where
-insert_single                  INSERT           insert
-insert_batch_10                INSERT           insert
-insert_batch_100               INSERT           insert
-...
-update_pk_single               UPDATE_PK        update_pk
-update_pk_batch_10             UPDATE_PK        update_pk
-update_pk_batch_100            UPDATE_PK        update_pk
-...
+```bash
+./build/release/benchmarks/storm_bench --benchmark_filter='Storm/SELECT/.*' --benchmark_list_tests=true
 ```
 
 ### Run All Benchmarks
 
 ```bash
-# Run all tests defined in benchmark_tests.yaml (auto-converted to JSON at build time)
+# Run every test defined in benchmark_tests.yaml (auto-converted to JSON at build time)
 ./build/release/benchmarks/storm_bench
 ```
 
-**Output:**
-```
-Inserting test data...
-✅ Inserted 10,000 test records
-=== Running All Benchmark Tests (Compile-Time Dispatch) ===
-Total tests: 28
-Iterations per test: 1000
-Using compile-time JSON parsing with nested C++ structs
-
-
-=== where_int_comparison_gt ===
-Field: age, Operator: >, Value: 30
-Iterations: 1000
-Total operations: 7800000
-Duration: 2543274 μs
-Throughput: 3.06691 M ops/sec
-✅ Benchmark complete!
-
-=== where_bool_equality ===
-Field: is_active, Operator: ==, Value: 0
-Iterations: 1000
-Total operations: 5000000
-Duration: 1687314 μs
-Throughput: 2.96329 M ops/sec
-✅ Benchmark complete!
-
-...
-
-✅ All tests completed with COMPILE-TIME dispatch!
-✅ Zero runtime string parsing overhead!
-✅ Each test has its own specialized function!
-✅ Tests loaded from JSON at compile time!
-```
-
-### Run Batch INSERT Benchmarks
-
-**✅ NEW FEATURE!** Benchmark batch insert operations with various batch sizes:
+Each registered test runs as a normal gbench benchmark: gbench itself controls repetition
+count, minimum run time, and statistical aggregation (mean/median/stddev/CV) — see
+`--benchmark_repetitions`, `--benchmark_min_time`. There is no custom `--quick`/`--thorough`
+mode; use gbench's own knobs to trade off runtime vs. precision, e.g.:
 
 ```bash
-# Run all INSERT benchmarks (single + batch)
-./build/release/benchmarks/storm_bench --filter="insert"
-
-# Run only batch INSERT benchmarks
-./build/release/benchmarks/storm_bench --filter="insert_batch"
-
-# Run specific batch size
-./build/release/benchmarks/storm_bench --filter="insert_batch_100"
-```
-
-**Available batch sizes:**
-- `insert_single` - Single row inserts (1 row per operation)
-- `insert_batch_10` - Batch inserts with 10 rows per batch
-- `insert_batch_100` - Batch inserts with 100 rows per batch
-- `insert_batch_500` - Batch inserts with 500 rows per batch
-- `insert_batch_1000` - Batch inserts with 1000 rows per batch
-
-**What's tested:**
-- **Storm ORM**: Uses `QuerySet::insert(std::span<const T>)` with automatic transaction management and chunked bulk SQL
-- **Raw SQLite**: Manual prepared statement binding + BEGIN/COMMIT transaction wrapping using chunked bulk SQL
-- **Fair comparison**: Both versions use the SAME chunked bulk SQL strategy for batches exceeding SQLite's 999-variable limit
-
-### Batch INSERT Performance Characteristics
-
-**Three INSERT Strategies (matching Storm ORM):**
-
-Both Storm ORM and the Raw SQLite benchmark use **identical strategies** for fair comparison:
-
-| Strategy | Batch Size | SQL Pattern | Transaction |
-|----------|------------|-------------|-------------|
-| **1. Single INSERT** | 1 row | `INSERT INTO ... VALUES (?, ?, ...)` | None |
-| **2. Bulk VALUES** | 2-249 rows | `INSERT INTO ... VALUES (...), (...), ...` | None (single statement) |
-| **3. Chunked Bulk** | 250+ rows | Multiple bulk INSERTs (249 rows each) | None (each chunk is atomic) |
-
-**Threshold Calculation:**
-- SQLite limit: 999 variables per statement
-- Person model has 4 non-PK fields → max chunk size = 999 / 4 = **249 rows**
-- Batches exceeding 249 rows split into multiple bulk INSERT statements
-- Each chunk: `INSERT INTO ... VALUES (...), (...), ... (up to 249 rows)`
-- **Note:** INSERT doesn't need transaction wrapping because each bulk INSERT is already atomic
-
-**Chunking Boundary Performance:**
-
-Tests verify smooth performance across the chunking boundary (249 rows for 4-field models):
-
-| Batch Size | Chunks | Efficiency | Notes |
-|------------|--------|------------|-------|
-| 248 | 1 | **~109%** | ✅ Storm FASTER |
-| 249 | 1 | **~109%** | ✅ Storm FASTER |
-| 250 | 2 | **~111%** | ✅ Storm FASTER - no cliff! |
-
-SQL caching and compile-time generation eliminate the chunking overhead entirely. Storm maintains >100% efficiency across the boundary.
-
-**Single INSERT Performance (verified 2026-02-06, 10,000 iterations, Release build):**
-
-| Operation | Storm ORM | Raw SQLite | Efficiency | Notes |
-|-----------|-----------|------------|------------|-------|
-| **Single INSERT** | 0.70-0.73 M/s | 0.71-0.73 M/s | **~97%** | ✅ **Only ~3% overhead** - excellent for full ORM abstraction! |
-
-**Batch INSERT Performance (verified 2026-02-06, fair chunked bulk SQL comparison, Release build):**
-
-| Batch Size | Storm ORM | Raw SQLite | Efficiency | Chunks | Notes |
-|------------|-----------|------------|------------|--------|-------|
-| 10 | 2.81-3.02 M/s | 2.93-3.14 M/s | **~98%** | 1 | ✅ Near parity |
-| 100 | 4.78-5.48 M/s | 4.17-5.03 M/s | **~111%** | 1 | ✅ Storm FASTER - SQL caching |
-| 500 | 5.16-6.17 M/s | 4.82-5.43 M/s | **~114%** | 3 (249×2+2) | ✅ Storm FASTER |
-| **1000** | 4.84-6.24 M/s | 5.25-5.46 M/s | **~115%** | 5 (249×4+4) | ✅ **Storm FASTER - SQL caching** |
-| 5000 | 6.03-6.39 M/s | 5.52-5.69 M/s | **~111%** | 21 (249×20+20) | ✅ Storm FASTER |
-| 10000 | 5.55-6.48 M/s | 4.63-5.61 M/s | **~116%** | 41 (249×40+40) | ✅ Storm FASTER |
-| 50000 | 6.09-6.28 M/s | 5.52-5.94 M/s | **~110%** | 201 (249×200+200) | ✅ Storm FASTER |
-| 100000 | 6.04-6.15 M/s | 5.75-6.06 M/s | **~102%** | 402 (249×401+151) | ✅ Storm FASTER |
-
-**🎯 What Fixed the Benchmark (2025-12-06 Update)**
-
-**Critical Issue Identified and Resolved:**
-
-**❌ UNFAIR COMPARISON** - Raw SQLite benchmark was NOT using the same strategy as Storm ORM for large batches!
-
-**The Problem:**
-- For `batch_1000`, Storm uses **chunked bulk SQL** (5 chunks of 249 rows each)
-- Raw SQLite was using **1000 individual INSERT statements** with transaction
-- This made Storm appear 3x faster (296% efficiency) - completely misleading!
-
-**The Root Cause:** The old raw-SQLite benchmark switched to individual INSERTs for batches above the bulk sweet-spot (~124 rows), while Storm kept using chunked bulk SQL. The two paths weren't comparing the same algorithm.
-
-**The Fix:**
-1. ✅ **Implemented chunked bulk SQL** in raw SQLite benchmark for large batches (>124 rows)
-2. ✅ **Added statement caching** - prepare statements ONCE, reuse across iterations
-3. ✅ **Fair apples-to-apples comparison** - Both Storm and raw SQLite now use identical strategy
-
-**Result:**
-- **Before fix**: 296% efficiency (Storm 3x faster than raw SQLite) - UNFAIR
-- **After fix**: 99-100% efficiency (near parity) - FAIR COMPARISON!
-
-**Key Findings:**
-
-1. **Single INSERT: ~97% efficiency (only ~3% overhead!)**
-   - **Optimizations applied:**
-     - `statement_cache_.reserve(32)` prevents rehashing → safe raw pointer caching
-     - `[[unlikely]]` hints on error paths → better branch prediction
-     - Simple imperative style → no lambda overhead
-     - Direct pointer access → no hash lookup on every call
-   - The remaining ~3% overhead comes from:
-     - `std::expected` error handling
-     - Additional function call layer (QuerySet → InsertStatement)
-   - **This is excellent** for a full ORM providing type safety, automatic ID retrieval, and clean interface!
-
-2. **Batch Operations: 98-116% efficiency (Storm consistently FASTER!)**
-   - Storm ORM achieves **98-116% efficiency** across all batch sizes
-   - SQL caching and compile-time generation give Storm an edge over hand-written raw SQLite
-
-3. **Why Storm beats raw SQLite for batches?**
-   - **SQL String Caching** - Thread-local cache avoids regenerating SQL every iteration
-   - **Compile-Time SQL Generation** - Pre-computed SQL with optimized string handling
-   - **Statement Preparation Optimization** - Connection-level caching reduces overhead
-   - **BulkSQLCache** - Eliminates SQL string construction for repeated batch sizes
-
-4. **Consistent 5.5-6.5 M ops/sec for large batches** - Performance plateaus around 6 M/s for batches ≥500, with Storm consistently outperforming raw SQLite
-
-5. **Storm's overhead is only ~3% for single INSERT**, demonstrating that the ORM abstraction layer is extremely efficient! For batch operations, Storm is actually **faster** than raw SQLite thanks to aggressive caching.
-
-### Run Batch UPDATE Benchmarks
-
-**✅ NEW FEATURE!** Benchmark update-by-primary-key operations with various batch sizes:
-
-```bash
-# Run all UPDATE benchmarks (single + batch)
-./build/release/benchmarks/storm_bench --filter="update_pk" --scale-test
-
-# Run only single UPDATE benchmark
-./build/release/benchmarks/storm_bench --filter="update_pk_single"
-
-# Run specific batch size
-./build/release/benchmarks/storm_bench --filter="update_pk_batch_100"
-```
-
-**Available batch sizes:**
-- `update_pk_single` - Single row updates (1 row per operation)
-- `update_pk_batch_10` - Batch updates with 10 rows per batch
-- `update_pk_batch_100` - Batch updates with 100 rows per batch
-- `update_pk_batch_198` - Just under chunking boundary
-- `update_pk_batch_199` - Exactly at chunking boundary
-- `update_pk_batch_200` - Just over chunking boundary
-- `update_pk_batch_500` to `update_pk_batch_100000` - Large batch sizes
-
-**What's tested:**
-- **Storm ORM**: Uses `QuerySet::update(obj)` for single and `QuerySet::update(span)` for batch with automatic transaction management
-- **Raw SQLite**: Manual `UPDATE ... SET ... WHERE id=?` with transaction wrapping for batches
-- **Fair comparison**: Both versions use the SAME strategy (individual UPDATEs within transaction for batches)
-
-### Batch UPDATE Performance Characteristics
-
-**Two UPDATE Strategies (matching Storm ORM):**
-
-Both Storm ORM and the Raw SQLite benchmark use **identical strategies** for fair comparison:
-
-| Strategy | Batch Size | SQL Pattern | Transaction |
-|----------|------------|-------------|-------------|
-| **1. Single UPDATE** | 1 row | `UPDATE ... SET ... WHERE id = ?` | None |
-| **2. Batch UPDATE** | 2+ rows | Individual UPDATEs in loop | One transaction wrapping all |
-
-**Note:** Unlike INSERT and DELETE, there's no multi-row UPDATE syntax in SQLite. All batch updates execute individual UPDATE statements within a single transaction for atomicity.
-
-**Architecture: CRTP Base Class**
-
-CRUD benchmarks share data setup via CRTP through `DataBenchmarkBase` (in `base.cppm`). The `CrudBenchmark<Model, test>` fixture in `crud_benchmark.cppm` dispatches `insert` / `insert_no_return` / `update_pk` / `delete_pk` from the `BenchmarkTest` NTTP, mirroring how `QueryBenchmark` handles SELECT-family operations.
-
-**Chunking Boundary for UPDATE:**
-- UPDATE binds 5 parameters per row (4 data fields + 1 PK for WHERE clause)
-- Max rows per transaction: 999 / 5 = **199 rows**
-- Compare to INSERT: 999 / 4 = **249 rows**
-
-**✅ Chunking Boundary Performance (verified 2026-02-06, thorough mode):**
-
-| Batch Size | Efficiency | Notes |
-|------------|------------|-------|
-| 198 | **~100%** | Just under boundary |
-| 199 | **~103%** | Exactly at max_bulk |
-| 200 | **~102%** | Just over boundary |
-
-**Note:** Unlike INSERT (which uses bulk SQL), UPDATE always executes individual statements within a transaction. The "chunking boundary" is less significant for UPDATE since there's no multi-row UPDATE syntax in SQLite.
-
-**Single UPDATE Performance (verified 2026-02-06, Release build):**
-
-| Operation | Storm ORM | Raw SQLite | Efficiency | Notes |
-|-----------|-----------|------------|------------|-------|
-| **Single UPDATE** | ~1.80 M/s | ~1.83 M/s | **~98%** | ✅ Excellent for full ORM! |
-
-**Batch UPDATE Performance (verified 2026-02-06, Release build):**
-
-| Batch Size | Storm ORM | Raw SQLite | Efficiency | Notes |
-|------------|-----------|------------|------------|-------|
-| 10 | ~2.76 M/s | ~2.38 M/s | **~116%** | ✅ Storm FASTER! |
-| 100 | ~2.98 M/s | ~2.84 M/s | **~105%** | ✅ Storm FASTER! |
-| 500 | ~2.56 M/s | ~2.59 M/s | **~99%** | ✅ Excellent |
-| 1000 | ~2.76 M/s | ~2.78 M/s | **~99%** | ✅ Excellent |
-| 5000 | ~3.58 M/s | ~3.54 M/s | **~101%** | ✅ Storm FASTER! |
-| 10000 | ~3.62 M/s | ~3.55 M/s | **~102%** | ✅ Storm FASTER! |
-| 50000 | ~3.35 M/s | ~3.30 M/s | **~101%** | ✅ Storm FASTER! |
-| 100000 | ~3.24 M/s | ~3.21 M/s | **~101%** | ✅ Storm FASTER! |
-
-**Key Optimizations Applied:**
-
-1. **RAII TransactionGuard** - Clean transaction management with automatic rollback
-2. **Statement Pointer Caching** - Cached `sqlite3_stmt*` avoids hash lookup per row
-3. **Inline Binding** - `inline_bind_all_fields()` with compile-time type dispatch
-4. **Zero-Overhead Abstraction** - TransactionGuard fully inlined by compiler
-5. **CRTP Pattern** - Zero-overhead abstraction for shared functionality
-
-**TransactionGuard Pattern (Python context manager style):**
-```cpp
-// ❌ OLD: Verbose flat code with manual rollback
-auto begin_result = conn_->execute("BEGIN TRANSACTION");
-if (!begin_result) return std::unexpected(begin_result.error());
-for (const auto& obj : objects) {
-    if (!bind_result) { (void)conn_->execute("ROLLBACK"); return ...; }
-    if (!exec_result) { (void)conn_->execute("ROLLBACK"); return ...; }
-}
-auto commit_result = conn_->execute("COMMIT");
-if (!commit_result) { (void)conn_->execute("ROLLBACK"); return ...; }
-
-// ✅ NEW: Clean RAII style (zero overhead - fully inlined)
-auto txn = TransactionGuard<ConnType>::begin(*conn_);
-if (!txn) return std::unexpected(txn.error());
-for (const auto& obj : objects) {
-    if (!bind_result) return std::unexpected(bind_result.error());  // Auto-rollback
-    if (!exec_result) return std::unexpected(exec_result.error());  // Auto-rollback
-}
-return txn->commit();
-```
-
-### Run Batch DELETE Benchmarks
-
-**✅ NEW FEATURE!** Benchmark delete-by-primary-key operations with various batch sizes:
-
-```bash
-# Run all DELETE benchmarks (single + batch)
-./build/release/benchmarks/storm_bench --filter="delete_pk" --scale-test
-
-# Run only single DELETE benchmark
-./build/release/benchmarks/storm_bench --filter="delete_pk_single"
-
-# Run specific batch size
-./build/release/benchmarks/storm_bench --filter="delete_pk_batch_100"
-```
-
-**Available batch sizes:**
-- `delete_pk_single` - Single row deletes (1 row per operation)
-- `delete_pk_batch_10` - Batch deletes with 10 rows per batch
-- `delete_pk_batch_100` - Batch deletes with 100 rows per batch
-- `delete_pk_batch_500` - Batch deletes with 500 rows per batch
-- `delete_pk_batch_1000` to `delete_pk_batch_100000` - Large batch sizes
-
-**What's tested:**
-- **Storm ORM**: Uses `QuerySet::erase(span)` with automatic strategy selection (bulk IN clause vs individual deletes in transaction)
-- **Raw SQLite**: Manual `DELETE FROM ... WHERE id=?` with transaction wrapping for batches
-- **Fair comparison**: Both versions tested with same batch sizes
-
-### Batch DELETE Performance Characteristics
-
-**Three DELETE Strategies (matching Storm ORM):**
-
-Both Storm ORM and the Raw SQLite benchmark use **identical strategies** for fair comparison:
-
-| Strategy | Batch Size | SQL Pattern | Transaction |
-|----------|------------|-------------|-------------|
-| **1. Single DELETE** | 1 row | `DELETE FROM ... WHERE id = ?` | None |
-| **2. Bulk IN Clause** | 2-799 rows | `DELETE FROM ... WHERE id IN (?, ?, ...)` | None |
-| **3. Chunked IN Clause** | 800+ rows | Multiple `IN (?, ?, ...)` queries (799 each) | One transaction wrapping all chunks |
-
-**Threshold Calculation:**
-- SQLite limit: 999 variables per statement
-- DELETE uses 1 variable per row (just the primary key)
-- Safe threshold: 80% of 999 = **799 rows** per IN clause
-- For batches > 799: Split into chunks of 799, wrapped in single transaction
-
-**Example for 1000 rows:**
-```sql
-BEGIN TRANSACTION;
-DELETE FROM Person WHERE id IN (?, ?, ..., ?);  -- 799 placeholders
-DELETE FROM Person WHERE id IN (?, ?, ..., ?);  -- 201 placeholders
-COMMIT;
-```
-
-**Single DELETE Performance (verified 2026-02-06, Release build):**
-
-| Operation | Storm ORM | Raw SQLite | Efficiency | Notes |
-|-----------|-----------|------------|------------|-------|
-| **Single DELETE** | ~3.86 M/s | ~3.86 M/s | **~100.0%** | ✅ Parity with raw! |
-
-**Batch DELETE Performance (verified 2026-02-06, fair comparison, Release build):**
-
-| Batch Size | Storm ORM | Raw SQLite | Efficiency | Strategy | Notes |
-|------------|-----------|------------|------------|----------|-------|
-| 10 | ~0.91 M/s | ~0.92 M/s | **~98.2%** | IN clause | ✅ Near parity |
-| 100 | ~1.32 M/s | ~1.29 M/s | **~102.2%** | IN clause | ✅ Storm FASTER! |
-| 500 | ~1.44 M/s | ~1.50 M/s | **~96.3%** | IN clause | ✅ Above 95% target |
-| 1000 | ~1.92 M/s | ~1.87 M/s | **~102.7%** | Chunked (2 queries) | ✅ Storm FASTER! |
-| 5000 | ~1.89 M/s | ~1.85 M/s | **~101.9%** | Chunked (7 queries) | ✅ Storm FASTER! |
-| 10000 | ~1.85 M/s | ~1.77 M/s | **~104.6%** | Chunked (13 queries) | ✅ Storm FASTER! |
-| 50000 | ~1.74 M/s | ~1.71 M/s | **~101.9%** | Chunked (63 queries) | ✅ Storm FASTER! |
-| 100000 | ~1.70 M/s | ~1.71 M/s | **~99.4%** | Chunked (126 queries) | ✅ Near parity |
-
-**Key Optimizations Applied (2026-02-06 Update):**
-
-1. **RAII TransactionGuard** - Clean transaction management with automatic rollback on early return
-   - Similar to Python's `with transaction():` context manager
-   - Zero overhead - fully inlined by compiler
-
-2. **Chunked IN Clause for Large Batches** - Instead of 1000 individual DELETEs, uses chunked IN clauses
-   - `DELETE WHERE id IN (?, ?, ...)` with up to 799 IDs per chunk
-
-3. **Statement Caching** - Uses `prepare_cached()` for all DELETE statements
-   - Prepared statements reused across iterations
-   - SQL strings cached per chunk size via thread-local `BulkSQLCache`
-
-4. **Thread-Local Bulk SQL Cache** - Eliminates repeated string allocation for bulk DELETE SQL
-   - Same pattern used by INSERT for bulk VALUES SQL generation
-   - Returns cached `const std::string&` instead of constructing new string each call
-
-5. **Fair Benchmark Comparison** - Both Storm and Raw SQLite use identical strategies
-   - Same threshold calculations (799 rows = 80% of SQLite limit)
-   - Same chunking logic for large batches
-   - Pre-prepared BEGIN/COMMIT statements for raw SQLite
-
-**Why Results Show ~98-105% Efficiency:**
-- Both Storm and Raw SQLite use the **exact same strategy**
-- Thread-local SQL caching eliminates allocation overhead in bulk paths
-- Statement caching eliminates SQL parsing overhead
-- Chunked IN clause is optimal for SQLite's query planner
-
-### Run SELECT Benchmarks
-
-**✅ Benchmark SELECT operations** with various configurations:
-
-```bash
-# Run all SELECT benchmarks
-./build/release/benchmarks/storm_bench --filter="select" --scale-test
-
-# Run simple SELECT (no WHERE, no JOIN)
-./build/release/benchmarks/storm_bench --filter="select_1000"
-
-# Run SELECT with JOIN
-./build/release/benchmarks/storm_bench --filter="select_join" --scale-test
-
-# Run SELECT with WHERE + JOIN
-./build/release/benchmarks/storm_bench --filter="select_where_join" --scale-test
-```
-
-**Available SELECT tests:**
-- `select_1000` / `select_5000` / `select_10000` - Simple SELECT (all rows)
-- `select_join_100` to `select_join_100000` - SELECT with INNER JOIN
-- `select_where_join_100` to `select_where_join_100000` - SELECT with WHERE + INNER JOIN
-- `select_left_join_100` to `select_left_join_100000` - SELECT with LEFT JOIN
-- `select_left_join_where_100` / `select_left_join_where_10000` - SELECT with LEFT JOIN + WHERE
-- `select_multi_fk_join_100` to `select_multi_fk_join_100000` - SELECT with multiple FK JOINs (sender + receiver)
-
-**What's tested:**
-- **Storm ORM**: Uses `QuerySet::select()` with automatic statement caching
-- **Raw SQLite**: Manual `SELECT` with prepared statements
-- **Fair comparison**: Both use statement caching and identical query patterns
-
-### SELECT Performance Characteristics
-
-**Six SELECT Configurations:**
-
-| Configuration | SQL Pattern | Use Case |
-|--------------|-------------|----------|
-| **Simple SELECT** | `SELECT * FROM table` | Fetch all rows |
-| **SELECT + INNER JOIN** | `SELECT ... FROM t INNER JOIN r ON ...` | Fetch with related data |
-| **SELECT + WHERE + INNER JOIN** | `SELECT ... FROM t INNER JOIN r ON ... WHERE ...` | Filtered fetch with related data |
-| **SELECT + LEFT JOIN** | `SELECT ... FROM t LEFT JOIN r ON ...` | Fetch with optional related data |
-| **SELECT + LEFT JOIN + WHERE** | `SELECT ... FROM t LEFT JOIN r ON ... WHERE ...` | Filtered LEFT JOIN |
-| **SELECT + Multi-FK JOIN** | `SELECT ... FROM t JOIN r1 ON ... JOIN r2 ON ...` | Multiple foreign key JOINs |
-
-**Simple SELECT Performance (verified 2026-01-03, Release build):**
-
-| Dataset Size | Storm ORM | Raw SQLite | Efficiency | Notes |
-|--------------|-----------|------------|------------|-------|
-| 1000 | ~10.0 M/s | ~10.5 M/s | **~96%** | ✅ Near parity |
-| 5000 | ~9.3 M/s | ~9.7 M/s | **~96%** | ✅ Near parity |
-| 10000 | ~9.1 M/s | ~9.4 M/s | **~96%** | ✅ Near parity |
-
-**SELECT + JOIN Performance (verified 2026-01-03, Release build):**
-
-| Dataset Size | Storm ORM | Raw SQLite | Efficiency | Notes |
-|--------------|-----------|------------|------------|-------|
-| 1000 | ~7.8 M/s | ~7.6 M/s | **~103%** | ✅ Storm FASTER! |
-| 5000 | ~7.7 M/s | ~7.5 M/s | **~103%** | ✅ Storm FASTER! |
-| 10000 | ~7.6 M/s | ~7.5 M/s | **~102%** | ✅ Storm FASTER! |
-
-**SELECT + WHERE + JOIN Performance (verified 2026-01-03, Release build):**
-
-| Dataset Size | Storm ORM | Raw SQLite | Efficiency | Notes |
-|--------------|-----------|------------|------------|-------|
-| 1000 | ~6.8 M/s | ~6.6 M/s | **~103%** | ✅ Storm FASTER! |
-| 5000 | ~7.0 M/s | ~6.9 M/s | **~101%** | ✅ Near parity |
-| 10000 | ~6.5 M/s | ~6.9 M/s | **~95%** | ✅ Good |
-
-**SELECT WHERE (no JOIN) Performance (verified 2026-02-06, Release build):**
-
-| Test | Storm ORM | Raw SQLite | Efficiency | Notes |
-|------|-----------|------------|------------|-------|
-| WHERE age > 30 | ~9.3 M/s | ~9.6 M/s | **~97%** | ✅ Near parity |
-| WHERE LIKE prefix | ~2.8 M/s | ~2.9 M/s | **~98%** | ✅ Near parity |
-| WHERE LIKE contains | ~8.0 M/s | ~8.3 M/s | **~96%** | ✅ Near parity |
-| WHERE BETWEEN | ~7.8 M/s | ~7.9 M/s | **~99%** | ✅ Near parity |
-| WHERE IN (3 values) | ~1.7 M/s | ~1.7 M/s | **~100%** | ✅ Near parity |
-| WHERE AND | ~8.3 M/s | ~8.8 M/s | **~94%** | ✅ Good |
-| WHERE OR | ~6.1 M/s | ~6.3 M/s | **~97%** | ✅ Near parity |
-
-**SELECT + LEFT JOIN Performance (verified 2026-01-14, Release build):**
-
-| Dataset Size | Storm ORM | Raw SQLite | Efficiency | Notes |
-|--------------|-----------|------------|------------|-------|
-| 100 | ~7.3 M/s | ~7.3 M/s | **~100%** | ✅ Near parity |
-| 1000 | ~7.1 M/s | ~7.2 M/s | **~99%** | ✅ Near parity |
-| 10000 | ~7.0 M/s | ~7.1 M/s | **~99%** | ✅ Near parity |
-
-**SELECT + Multi-FK JOIN Performance (verified 2026-01-14, Release build):**
-
-| Dataset Size | Storm ORM | Raw SQLite | Efficiency | Notes |
-|--------------|-----------|------------|------------|-------|
-| 100 | ~4.9 M/s | ~5.5 M/s | **~88%** | ✅ Good for double JOIN |
-| 1000 | ~4.7 M/s | ~5.3 M/s | **~89%** | ✅ Good for double JOIN |
-| 10000 | ~4.5 M/s | ~5.1 M/s | **~88%** | ✅ Good for double JOIN |
-
-**Key Findings:**
-
-1. **Simple SELECT: ~96% efficiency**
-   - Statement caching eliminates SQL parsing overhead
-   - Raw pointer caching in extraction loops
-   - Compile-time SQL generation matches raw performance
-
-2. **SELECT + INNER JOIN: 102-103% efficiency (Storm is FASTER!)**
-   - Statement pointer caching avoids connection cache hash lookup
-   - Type-erased JOIN extraction pattern is highly optimized
-   - SQL string caching avoids repeated concatenation
-
-3. **SELECT + WHERE + JOIN: 95-103% efficiency**
-   - Parameter binding adds minimal overhead
-   - Larger datasets show slightly more overhead due to increased row extraction
-
-4. **WHERE Operators: 94-100% efficiency**
-   - **Basic operators (>, <, =)**: ~97% - Near parity with raw SQLite
-   - **LIKE patterns**: 96-98% - Near parity with raw SQLite
-   - **IN clauses**: ~100% - Parity with raw SQLite
-   - **BETWEEN**: ~99% - Near parity with raw SQLite
-   - **AND/OR combinations**: 94-97% - Good efficiency for complex expressions
-
-5. **SELECT + LEFT JOIN: 99-101% efficiency**
-   - LEFT JOIN has near-identical performance to INNER JOIN
-   - Same compile-time SQL generation and statement caching optimizations apply
-
-6. **SELECT + Multi-FK JOIN: ~88% efficiency**
-   - Double JOIN (sender + receiver) has more overhead due to:
-     - Two JOIN clauses in SQL
-     - More columns to extract per row
-     - More complex SQL generation
-   - Still excellent for a multi-table JOIN operation
-
-7. **Why JOIN operations show >100% efficiency:**
-   - **Statement pointer caching**: Direct pointer reuse vs hash lookup every call
-   - **SQL string caching**: Thread-local cache avoids regenerating SQL
-   - **Optimized row extraction**: Raw pointer caching in hot loops
-
-### Run DISTINCT Benchmarks
-
-**✅ NEW FEATURE!** Benchmark SELECT DISTINCT operations with various configurations:
-
-```bash
-# Run all DISTINCT benchmarks
-./build/release/benchmarks/storm_bench --filter="distinct" --scale-test
-
-# Run only simple DISTINCT benchmarks
-./build/release/benchmarks/storm_bench --filter="distinct_simple" --scale-test
-
-# Run DISTINCT with WHERE
-./build/release/benchmarks/storm_bench --filter="distinct_where" --scale-test
-
-# Run DISTINCT with JOIN
-./build/release/benchmarks/storm_bench --filter="distinct_join" --scale-test
-
-# Run specific test
-./build/release/benchmarks/storm_bench --filter="distinct_simple_1000"
-```
-
-**Available DISTINCT tests:**
-- `distinct_simple_1000` / `distinct_simple_10000` - Simple DISTINCT on age field
-- `distinct_where_1000` / `distinct_where_10000` - DISTINCT with WHERE clause (salary >= 50000)
-- `distinct_join_1000` / `distinct_join_10000` - DISTINCT with INNER JOIN
-- `distinct_where_join_1000` / `distinct_where_join_10000` - DISTINCT with WHERE + JOIN
-
-**What's tested:**
-- **Storm ORM**: Uses `QuerySet::distinct<Field>().execute()` with automatic SQL generation
-- **Raw SQLite**: Manual `SELECT DISTINCT field FROM table` with prepared statements
-- **Fair comparison**: Both versions use prepared statement caching and identical query patterns
-
-### DISTINCT Performance Characteristics
-
-**Four DISTINCT Configurations:**
-
-| Configuration | SQL Pattern | Use Case |
-|--------------|-------------|----------|
-| **Simple DISTINCT** | `SELECT DISTINCT field FROM table` | Unique values from single table |
-| **DISTINCT + WHERE** | `SELECT DISTINCT field FROM table WHERE ...` | Filtered unique values |
-| **DISTINCT + JOIN** | `SELECT DISTINCT t.field FROM t JOIN r ON ...` | Unique values with related data |
-| **DISTINCT + WHERE + JOIN** | `SELECT DISTINCT t.field FROM t JOIN r ON ... WHERE ...` | Filtered unique values with JOIN |
-
-**DISTINCT Performance (verified 2025-01-01, Release build):**
-
-| Test | Storm ORM | Raw SQLite | Efficiency | Notes |
-|------|-----------|------------|------------|-------|
-| **distinct_simple_1000** | ~1.37 M/s | ~1.36 M/s | **~100%** | ✅ Near parity |
-| **distinct_simple_10000** | ~0.15 M/s | ~0.15 M/s | **~100%** | ✅ Near parity |
-| **distinct_where_1000** | ~1.12 M/s | ~1.12 M/s | **~100%** | ✅ Near parity |
-| **distinct_where_10000** | ~0.12 M/s | ~0.12 M/s | **~99%** | ✅ Near parity |
-| **distinct_join_1000** | ~6.57 M/s | ~6.21 M/s | **~106%** | ✅ Storm FASTER! |
-| **distinct_join_10000** | ~6.52 M/s | ~3.92 M/s | **~166%** | ✅ Storm FASTER! |
-| **distinct_where_join_1000** | ~6.00 M/s | ~5.63 M/s | **~107%** | ✅ Storm FASTER! |
-| **distinct_where_join_10000** | ~6.16 M/s | ~3.84 M/s | **~160%** | ✅ Storm FASTER! |
-
-**Key Findings:**
-
-1. **Simple DISTINCT: ~100% efficiency**
-   - Statement caching eliminates SQL parsing overhead
-   - Compile-time SQL generation matches raw performance
-
-2. **DISTINCT + WHERE: ~99-100% efficiency**
-   - Parameter binding adds minimal overhead
-   - Expression caching skips SQL rebuilding on repeated queries
-
-3. **DISTINCT + JOIN: 106-166% efficiency (Storm is FASTER!)**
-   - Statement pointer caching avoids connection cache hash lookup
-   - SQL string caching avoids repeated concatenation
-   - Storm's caching architecture outperforms naive raw SQLite usage
-
-4. **Why JOIN operations show >100% efficiency:**
-   - **Statement pointer caching**: Direct pointer reuse vs hash lookup every call
-   - **SQL string caching**: Thread-local cache avoids regenerating SQL
-   - **Optimized row extraction**: Raw pointer caching in hot loops
-
-**Architecture:**
-```cpp
-// All SELECT-family operations (including DISTINCT) are driven by a single
-// QueryBenchmark<Model, test> class; features dispatch at compile time via
-// if constexpr on test.distinct.enabled / test.where.enabled / etc.
-template <typename Model, auto const& test>
-class QueryBenchmark : public DataBenchmarkBase<QueryBenchmark<Model, test>, Model, 1> {
-    // Builds a fully configured QuerySet (JOIN → WHERE → ORDER BY → LIMIT)
-    // and stores the terminal (.select() / .execute() / aggregate / distinct / group_by).
-    static auto build_qs();
-    auto prepare(int n) -> void; // populate dataset of size n, rebuild terminal
-    auto run_once() -> void;     // one Storm-only execution — gbench owns the loop
-};
-// Raw SQLite anchors live in benchmarks/anchors_raw.cpp (the `storm_anchors`
-// binary), not on QueryBenchmark itself.
-```
-
-### Run Multi-Field DISTINCT Benchmarks
-
-**✅ NEW FEATURE!** Benchmark SELECT DISTINCT on multiple fields:
-
-```bash
-# Run multi-field DISTINCT benchmarks
-./build/release/benchmarks/storm_bench -c DISTINCT_MULTI
-
-# Run DISTINCT + ORDER BY benchmarks
-./build/release/benchmarks/storm_bench -c DISTINCT_ORDER
-
-# Run specific test
-./build/release/benchmarks/storm_bench --filter=distinct_multi_field_2_1000
-```
-
-**Available Multi-Field DISTINCT tests:**
-- `distinct_multi_field_2` - DISTINCT on 2 fields (name, age)
-- `distinct_multi_field_3` - DISTINCT on 3 fields (name, age, is_active)
-- `distinct_order_by_asc_1000` / `distinct_order_by_asc_10000` - DISTINCT + ORDER BY ASC
-- `distinct_order_by_desc_1000` / `distinct_order_by_desc_10000` - DISTINCT + ORDER BY DESC
-
-**What's tested:**
-- **Storm ORM**: Uses `QuerySet::distinct<Field1, Field2>().execute()` for multi-field
-- **Raw SQLite**: Manual `SELECT DISTINCT field1, field2 FROM table` with prepared statements
-- **Fair comparison**: Both versions use statement caching and identical query patterns
-
-### Multi-Field DISTINCT Performance Characteristics
-
-**Multi-Field DISTINCT Performance (verified 2026-02-06, Release build):**
-
-| Test | Storm ORM | Raw SQLite | Efficiency | Notes |
-|------|-----------|------------|------------|-------|
-| **distinct_multi_field_2** | ~3.4 M/s | ~3.5 M/s | **~98%** | ✅ 2 fields (name, age) |
-| **distinct_multi_field_3** | ~3.3 M/s | ~3.3 M/s | **~101%** | ✅ 3 fields (name, age, is_active) |
-
-**DISTINCT + ORDER BY Performance (verified 2026-01-14, Release build):**
-
-| Test | Storm ORM | Raw SQLite | Efficiency | Notes |
-|------|-----------|------------|------------|-------|
-| **distinct_order_by_asc_1000** | ~0.71 M/s | ~0.73 M/s | **~97%** | ORDER BY age ASC |
-| **distinct_order_by_asc_10000** | ~0.07 M/s | ~0.07 M/s | **~100%** | Near parity |
-| **distinct_order_by_desc_1000** | ~1.27 M/s | ~1.31 M/s | **~97%** | ORDER BY age DESC |
-| **distinct_order_by_desc_10000** | ~0.13 M/s | ~0.14 M/s | **~92%** | Good efficiency |
-
-**Key Findings:**
-
-1. **Multi-Field DISTINCT: 98-101% efficiency**
-   - Near parity with raw SQLite after benchmark fairness fix
-   - Performance is consistent across 2 and 3 fields
-   - Both Storm and raw SQLite extract typed columns into tuples
-
-2. **DISTINCT + ORDER BY: 92-100% efficiency**
-   - ORDER BY clause is handled at compile-time
-   - Near-parity performance with raw SQLite
-   - Larger datasets show better efficiency due to amortized overhead
-
-3. **Why multi-field DISTINCT now shows near-parity:**
-   - **Fair benchmark**: Both Storm and raw SQLite extract typed columns into `std::tuple<T1, T2, ...>`
-   - **Statement caching**: Prepared statements reused across iterations
-   - **Compile-time SQL generation**: Zero runtime SQL building overhead
-
-### Why `values()` Has No Separate Benchmark
-
-`values()` (column projection without DISTINCT) shares the same `ProjectionStatement` class as `distinct()` — the only difference is a `ProjectionMode` enum resolved via `if constexpr` at compile time. The compiler generates identical machine code for both modes except for the SQL string literal (`"SELECT "` vs `"SELECT DISTINCT "`). The query execution loop, statement caching, column extraction, and all hot paths are shared. Benchmarking `values()` separately would measure SQLite's query engine difference between `SELECT` and `SELECT DISTINCT`, not any ORM overhead.
-
-### Run LIMIT/OFFSET Benchmarks
-
-**✅ NEW FEATURE!** Benchmark SELECT with LIMIT and OFFSET clauses:
-
-```bash
-# Run all LIMIT benchmarks
-./build/release/benchmarks/storm_bench -c SELECT_LIMIT
-
-# Run all LIMIT+OFFSET pagination benchmarks
-./build/release/benchmarks/storm_bench -c SELECT_LIMIT_OFFSET
-
-# Run WHERE + LIMIT benchmarks
-./build/release/benchmarks/storm_bench -c SELECT_WHERE_LIMIT
-
-# Run JOIN + LIMIT benchmarks
-./build/release/benchmarks/storm_bench -c SELECT_JOIN_LIMIT
-
-# Run specific test
-./build/release/benchmarks/storm_bench --filter=select_limit_100
-```
-
-**Available LIMIT/OFFSET tests:**
-- `select_limit_10` / `select_limit_50` / `select_limit_100` / `select_limit_500` / `select_limit_1000` - Simple LIMIT
-- `select_offset_100` / `select_offset_500` - OFFSET only (with LIMIT -1)
-- `select_limit_offset_page1` / `select_limit_offset_page10` / `select_limit_offset_page50` / `select_limit_offset_deep` - Pagination scenarios
-- `select_where_limit_100` / `select_where_limit_500` - WHERE + LIMIT
-- `select_join_limit_100` / `select_join_limit_500` - JOIN + LIMIT
-- `select_join_limit_offset_page1` / `select_join_limit_offset_page50` - JOIN + pagination
-
-**What's tested:**
-- **Storm ORM**: Uses `QuerySet::limit(n).offset(m).select()` with automatic SQL generation
-- **Raw SQLite**: Manual `SELECT ... LIMIT n OFFSET m` with prepared statements
-- **Fair comparison**: Both versions use prepared statement caching and identical query patterns
-
-### LIMIT/OFFSET Performance Characteristics
-
-**Six LIMIT/OFFSET Configurations:**
-
-| Configuration | SQL Pattern | Use Case |
-|--------------|-------------|----------|
-| **Simple LIMIT** | `SELECT * FROM table LIMIT n` | First N rows |
-| **OFFSET only** | `SELECT * FROM table LIMIT -1 OFFSET n` | Skip N rows |
-| **LIMIT + OFFSET** | `SELECT * FROM table LIMIT n OFFSET m` | Pagination |
-| **WHERE + LIMIT** | `SELECT * FROM table WHERE ... LIMIT n` | Filtered first N |
-| **JOIN + LIMIT** | `SELECT ... FROM t JOIN r LIMIT n` | JOIN with limit |
-| **JOIN + LIMIT + OFFSET** | `SELECT ... FROM t JOIN r LIMIT n OFFSET m` | JOIN pagination |
-
-**LIMIT Performance (verified 2026-01-13, Release build):**
-
-| Test | Storm ORM | Raw SQLite | Efficiency | Notes |
-|------|-----------|------------|------------|-------|
-| **select_limit_10** | ~6.8 M/s | ~7.4 M/s | **~92%** | ✅ Good |
-| **select_limit_100** | ~6.6 M/s | ~6.8 M/s | **~96%** | ✅ Near parity |
-| **select_limit_500** | ~6.5 M/s | ~6.7 M/s | **~96%** | ✅ Near parity |
-| **select_limit_1000** | ~6.3 M/s | ~7.0 M/s | **~89%** | ✅ Good |
-
-**LIMIT + OFFSET Pagination Performance:**
-
-| Test | Storm ORM | Raw SQLite | Efficiency | Notes |
-|------|-----------|------------|------------|-------|
-| **select_limit_offset_page1** | ~6.6 M/s | ~6.9 M/s | **~95%** | ✅ Near parity |
-| **select_limit_offset_page10** | ~6.6 M/s | ~6.7 M/s | **~98%** | ✅ Near parity |
-| **select_limit_offset_page50** | ~6.6 M/s | ~6.8 M/s | **~97%** | ✅ Near parity |
-| **select_limit_offset_deep** | ~6.5 M/s | ~6.5 M/s | **~99%** | ✅ Near parity |
-
-**JOIN + LIMIT Performance:**
-
-| Test | Storm ORM | Raw SQLite | Efficiency | Notes |
-|------|-----------|------------|------------|-------|
-| **select_join_limit_100** | ~7.2 M/s | ~6.9 M/s | **~105%** | ✅ Storm FASTER! |
-| **select_join_limit_500** | ~7.0 M/s | ~6.8 M/s | **~104%** | ✅ Storm FASTER! |
-| **select_join_limit_offset_page1** | ~7.0 M/s | ~6.8 M/s | **~103%** | ✅ Storm FASTER! |
-| **select_join_limit_offset_page50** | ~7.0 M/s | ~6.7 M/s | **~104%** | ✅ Storm FASTER! |
-
-**Key Findings:**
-
-1. **Simple LIMIT: 89-96% efficiency**
-   - Statement caching eliminates SQL parsing overhead
-   - LIMIT clause is a static SQL component (no parameter binding)
-
-2. **LIMIT + OFFSET pagination: 95-99% efficiency**
-   - Deep pagination (high OFFSET values) shows better efficiency
-   - Consistent performance across different page depths
-
-3. **JOIN + LIMIT: 103-105% efficiency (Storm is FASTER!)**
-   - Statement pointer caching avoids connection cache hash lookup
-   - SQL string caching avoids repeated SQL concatenation
-   - JOIN operations benefit most from Storm's caching architecture
-
-4. **Why JOIN operations with LIMIT show >100% efficiency:**
-   - **Statement pointer caching**: Direct pointer reuse vs hash lookup every call
-   - **SQL string caching**: Thread-local cache avoids regenerating SQL
-   - **Compile-time SQL generation**: Zero runtime SQL string building
-
-### Run ORDER BY Benchmarks
-
-**✅ NEW FEATURE!** Benchmark SELECT with ORDER BY clause:
-
-```bash
-# Run all ORDER BY benchmarks
-./build/release/benchmarks/storm_bench -c ORDER_BY
-
-# Run ORDER BY with WHERE benchmarks
-./build/release/benchmarks/storm_bench -c ORDER_BY_WHERE
-
-# Run ORDER BY with LIMIT (Top-N queries)
-./build/release/benchmarks/storm_bench -c ORDER_BY_LIMIT
-
-# Run specific test
-./build/release/benchmarks/storm_bench --filter=order_by_single_asc
-```
-
-**Available ORDER BY tests:**
-- `order_by_single_asc` - Single field ascending (ORDER BY age ASC)
-- `order_by_single_desc` - Single field descending (ORDER BY salary DESC)
-- `order_by_with_where` - ORDER BY with WHERE clause (WHERE age > 30 ORDER BY salary DESC)
-- `order_by_with_limit_10` / `order_by_with_limit_100` - Top-N query pattern (ORDER BY salary DESC LIMIT N)
-
-**What's tested:**
-- **Storm ORM**: Uses `QuerySet::order_by<Field>().select()` with automatic SQL generation
-- **Raw SQLite**: Manual `SELECT ... ORDER BY field ASC/DESC` with prepared statements
-- **Fair comparison**: Both versions use prepared statement caching and identical query patterns
-
-### ORDER BY Performance Characteristics
-
-**Four ORDER BY Configurations:**
-
-| Configuration | SQL Pattern | Use Case |
-|--------------|-------------|----------|
-| **ORDER BY ASC** | `SELECT * FROM table ORDER BY field ASC` | Sort ascending |
-| **ORDER BY DESC** | `SELECT * FROM table ORDER BY field DESC` | Sort descending |
-| **ORDER BY + WHERE** | `SELECT * FROM table WHERE ... ORDER BY field` | Filtered sorting |
-| **ORDER BY + LIMIT** | `SELECT * FROM table ORDER BY field LIMIT n` | Top-N queries |
-
-**ORDER BY Performance (verified 2026-01-13, Release build):**
-
-| Test | Storm ORM | Raw SQLite | Efficiency | Notes |
-|------|-----------|------------|------------|-------|
-| **order_by_single_asc** | ~5.1 M/s | ~5.2 M/s | **~98.7%** | ✅ Near parity |
-| **order_by_single_desc** | ~4.2 M/s | ~4.2 M/s | **~99.1%** | ✅ Near parity |
-| **order_by_with_where** | ~4.5 M/s | ~4.6 M/s | **~98.4%** | ✅ Near parity |
-| **order_by_with_limit_10** | ~10 K/s | ~10 K/s | **~101.5%** | ✅ Storm FASTER! |
-| **order_by_with_limit_100** | ~70 K/s | ~73 K/s | **~96.5%** | ✅ Near parity |
-
-**Key Findings:**
-
-1. **ORDER BY ASC/DESC: 98-99% efficiency**
-   - Statement caching eliminates SQL parsing overhead
-   - ORDER BY clause is a static SQL component
-   - Compile-time SQL generation matches raw performance
-
-2. **ORDER BY + WHERE: ~98% efficiency**
-   - Parameter binding adds minimal overhead
-   - Combined queries show excellent performance
-
-3. **ORDER BY + LIMIT (Top-N): 96-101% efficiency**
-   - Top-N queries are highly optimized
-   - Small result sets benefit from Storm's caching
-   - Statement pointer caching provides performance gains
-
-4. **Why Top-N queries show good efficiency:**
-   - **Compile-time ORDER BY direction**: No runtime direction checks
-   - **Statement pointer caching**: Direct pointer reuse for repeated queries
-   - **Optimized row extraction**: Only fetches limited rows
-
-### Run Multi-Field ORDER BY Benchmarks
-
-**✅ NEW FEATURE!** Benchmark SELECT with multi-field ORDER BY clause:
-
-```bash
-# Run all multi-field ORDER BY benchmarks
-./build/release/benchmarks/storm_bench -c ORDER_BY_MULTI
-
-# Run specific test
-./build/release/benchmarks/storm_bench --filter=order_by_multi_2_asc_10000
-```
-
-**Available Multi-Field ORDER BY tests:**
-- `order_by_multi_2_asc_1000` - 2-field ORDER BY ASC (name ASC, age ASC, 1K rows)
-- `order_by_multi_2_asc_10000` - 2-field ORDER BY ASC (age ASC, salary ASC, 10K rows)
-- `order_by_multi_2_desc_10000` - 2-field ORDER BY DESC (age DESC, salary DESC, 10K rows)
-- `order_by_multi_2_mixed_10000` - 2-field mixed directions (age ASC, salary DESC, 10K rows)
-- `order_by_multi_2_mixed_100000` - 2-field mixed directions (is_active DESC, salary ASC, 100K rows)
-
-**What's tested:**
-- **Storm ORM**: Uses variadic `QuerySet::order_by<Field1, Dir1, Field2, Dir2>().select()`
-- **Raw SQLite**: Manual `SELECT ... ORDER BY field1 ASC/DESC, field2 ASC/DESC`
-- **Fair comparison**: Both versions use prepared statement caching
-
-### Multi-Field ORDER BY Performance Characteristics
-
-**Multi-Field ORDER BY Configurations:**
-
-| Configuration | SQL Pattern | Use Case |
-|--------------|-------------|----------|
-| **2-field ASC** | `SELECT * FROM table ORDER BY f1 ASC, f2 ASC` | Multi-level sorting |
-| **2-field DESC** | `SELECT * FROM table ORDER BY f1 DESC, f2 DESC` | Reverse multi-level sorting |
-| **2-field Mixed** | `SELECT * FROM table ORDER BY f1 ASC, f2 DESC` | Complex sorting requirements |
-
-**Multi-Field ORDER BY Performance (verified 2026-01-14, Release build):**
-
-| Test | Storm ORM | Raw SQLite | Efficiency | Notes |
-|------|-----------|------------|------------|-------|
-| **order_by_multi_2_asc_1000** | ~5.8 M/s | ~5.9 M/s | **~98%** | ✅ Near parity |
-| **order_by_multi_2_asc_10000** | ~4.5 M/s | ~4.6 M/s | **~98%** | ✅ Near parity |
-| **order_by_multi_2_desc_10000** | ~3.9 M/s | ~4.0 M/s | **~95%** | ✅ Good efficiency |
-| **order_by_multi_2_mixed_10000** | ~4.1 M/s | ~4.1 M/s | **~98%** | ✅ Near parity |
-| **order_by_multi_2_mixed_100000** | ~2.6 M/s | ~2.7 M/s | **~99%** | ✅ Near parity |
-
-**Key findings:**
-
-1. **Multi-field ORDER BY: 95-99% efficiency**
-   - Multiple ORDER BY fields add minimal overhead
-   - Storm ORM uses variadic templates for compile-time SQL generation
-   - Direction combinations (ASC/DESC) handled at compile time
-
-2. **Why multi-field ORDER BY shows excellent performance:**
-   - **Compile-time SQL generation**: ORDER BY clause built at compile time
-   - **Variadic template support**: `order_by<Field1, Dir1, Field2, Dir2>()` expands efficiently
-   - **No runtime overhead**: Direction enum converted to bool at compile time
-
-### Run GROUP BY Benchmarks
-
-**✅ NEW FEATURE!** Benchmark SELECT with GROUP BY clause:
-
-```bash
-# Run all GROUP BY benchmarks
-./build/release/benchmarks/storm_bench -c GROUP_BY
-
-# Run multi-field GROUP BY benchmarks
-./build/release/benchmarks/storm_bench -c GROUP_BY_MULTI
-
-# Run GROUP BY + WHERE benchmarks
-./build/release/benchmarks/storm_bench -c GROUP_BY_WHERE
-
-# Run specific test
-./build/release/benchmarks/storm_bench --filter=group_by_single_age
-```
-
-**Available GROUP BY tests:**
-- `group_by_single_age` - Single field grouping (GROUP BY age, 10K rows)
-- `group_by_single_is_active` - Boolean field grouping (GROUP BY is_active, 10K rows)
-- `group_by_single_100k` - Large dataset grouping (GROUP BY age, 100K rows)
-- `group_by_with_where_gt` - GROUP BY + WHERE (GROUP BY age WHERE salary > 50000)
-- `group_by_with_where_lt` - GROUP BY + WHERE (GROUP BY is_active WHERE age < 40)
-- `group_by_multi_2_age_is_active_1000` - 2-field GROUP BY (1K rows)
-- `group_by_multi_2_age_is_active_10000` - 2-field GROUP BY (10K rows)
-- `group_by_multi_2_is_active_age_10000` - 2-field GROUP BY reversed order (10K rows)
-
-**What's tested:**
-- **Storm ORM**: Uses `QuerySet::group_by<Field>().execute()` with automatic SQL generation
-- **Raw SQLite**: Manual `SELECT ... GROUP BY field` with prepared statements
-- **Fair comparison**: Both versions use prepared statement caching
-
-### GROUP BY Performance Characteristics
-
-**Three GROUP BY Configurations:**
-
-| Configuration | SQL Pattern | Use Case |
-|--------------|-------------|----------|
-| **Single-Field GROUP BY** | `SELECT * FROM table GROUP BY field` | Simple grouping |
-| **GROUP BY + WHERE** | `SELECT * FROM table WHERE ... GROUP BY field` | Filtered grouping |
-| **Multi-Field GROUP BY** | `SELECT * FROM table GROUP BY f1, f2` | Complex grouping |
-
-**Single-Field GROUP BY Performance (verified 2026-01-15, Release build):**
-
-| Test | Storm ORM | Raw SQLite | Notes |
-|------|-----------|------------|-------|
-| **group_by_single_age** | ~8.9 M/s | ~0.05 M/s | High efficiency due to caching |
-| **group_by_single_is_active** | ~9.9 M/s | ~0.002 M/s | Boolean grouping (2 groups) |
-| **group_by_single_100k** | ~8.7 M/s | ~0.005 M/s | Large dataset |
-
-**GROUP BY + WHERE Performance:**
-
-| Test | Storm ORM | Raw SQLite | Notes |
-|------|-----------|------------|-------|
-| **group_by_with_where_gt** | ~9.4 M/s | ~0.05 M/s | WHERE salary > 50000 |
-| **group_by_with_where_lt** | ~7.8 M/s | ~0.004 M/s | WHERE age < 40 |
-
-**Multi-Field GROUP BY Performance:**
-
-| Test | Storm ORM | Raw SQLite | Notes |
-|------|-----------|------------|-------|
-| **group_by_multi_2 (1K rows)** | ~9.8 M/s | ~0.41 M/s | 2-field grouping |
-| **group_by_multi_2 (10K rows)** | ~9.8 M/s | ~0.04 M/s | Larger dataset |
-| **group_by_multi_2 reversed** | ~9.7 M/s | ~0.03 M/s | Field order variation |
-
-**Key Findings:**
-
-1. **GROUP BY shows high efficiency**
-   - Storm ORM's statement caching provides significant speedup
-   - GROUP BY results are typically much smaller than source data
-   - Compile-time SQL generation optimizes query execution
-
-2. **Why GROUP BY shows such high performance ratios:**
-   - **Result set reduction**: GROUP BY dramatically reduces output rows
-   - **Statement caching**: Prepared statements reused across iterations
-   - **Raw SQLite overhead**: Benchmark raw version extracts full row data unnecessarily
-
-3. **Multi-field GROUP BY uses variadic templates:**
-   - Single `GroupByMultiFieldBenchmark<Model, Field1, Field2, ...>` class
-   - Fold expressions for SQL building and printing
-   - Easy to extend to 3+ fields by adding type aliases
-
-### Run GROUP BY + COUNT Benchmarks
-
-**✅ NEW FEATURE!** Benchmark GROUP BY with COUNT aggregate function:
-
-```bash
-# Run all GROUP BY + COUNT benchmarks
-./build/release/benchmarks/storm_bench -c GROUP_BY_COUNT
-
-# Run specific test
-./build/release/benchmarks/storm_bench --filter=group_by_with_count_age_1000
-```
-
-**Available GROUP BY + COUNT tests:**
-- `group_by_with_count_age_1000` - COUNT per age group (1K rows)
-- `group_by_with_count_age_10000` - COUNT per age group (10K rows)
-- `group_by_with_count_is_active_10000` - COUNT per boolean group (2 groups)
-- `group_by_with_count_age_100000` - COUNT per age group (100K rows)
-
-**What's tested:**
-- **Storm ORM**: Uses `qs.group_by<field>().count().execute()` returning `plf::hive<std::tuple<GroupKeyType, int64_t>>`
-- **Raw SQLite**: Manual `SELECT field, COUNT(*) FROM table GROUP BY field`
-- **Fair comparison**: Both count actual groups returned
-
-**GROUP BY + COUNT Performance (verified 2026-01-15, Release build):**
-
-| Test | Storm ORM | Raw SQLite | Efficiency | Notes |
-|------|-----------|------------|------------|-------|
-| **1K rows (age)** | ~0.66 M/s | ~0.67 M/s | **~99.2%** | Near parity |
-| **10K rows (age)** | ~0.06 M/s | ~0.06 M/s | **~99.7%** | Scales well |
-| **10K rows (is_active, 2 groups)** | ~0.06 M/s | ~0.06 M/s | **~100.1%** | Storm slightly faster |
-| **100K rows (age)** | ~0.006 M/s | ~0.006 M/s | **~99.7%** | Large dataset |
-
-**Key Findings:**
-
-1. **GROUP BY + COUNT achieves near-parity (98.9-100.1%)**
-   - Proper chaining: `group_by<field>().count().execute()`
-   - Both Storm and raw SQLite return same group count
-
-2. **Low throughput is expected:**
-   - Each operation scans entire dataset for grouping
-   - GROUP BY + COUNT is I/O bound, not CPU bound
-   - Efficiency metric (Storm vs raw) is the key measure
-
-### Run GROUP BY + SUM Benchmarks
-
-**✅ NEW FEATURE!** Benchmark GROUP BY with SUM aggregate function:
-
-```bash
-# Run all GROUP BY + SUM benchmarks
-./build/release/benchmarks/storm_bench -c GROUP_BY_SUM
-
-# Run specific test
-./build/release/benchmarks/storm_bench --filter=group_by_with_sum_age_salary_1000
-```
-
-**Available GROUP BY + SUM tests:**
-- `group_by_with_sum_age_salary_1000` - SUM(salary) per age group (1K rows)
-- `group_by_with_sum_age_salary_10000` - SUM(salary) per age group (10K rows)
-- `group_by_with_sum_is_active_salary_10000` - SUM(salary) per boolean group (2 groups)
-- `group_by_with_sum_age_salary_100000` - SUM(salary) per age group (100K rows)
-
-**What's tested:**
-- **Storm ORM**: Uses `qs.group_by<field>().sum<agg_field>().execute()` returning `plf::hive<std::tuple<GroupKeyType, double>>`
-- **Raw SQLite**: Manual `SELECT field, SUM(agg_field) FROM table GROUP BY field`
-- **Fair comparison**: Both count actual groups returned
-
-**GROUP BY + SUM Performance (verified 2026-01-15, Release build):**
-
-| Test | Storm ORM | Raw SQLite | Efficiency | Notes |
-|------|-----------|------------|------------|-------|
-| **1K rows (age, salary)** | ~0.51 M/s | ~0.51 M/s | **~99.4%** | Near parity |
-| **10K rows (age, salary)** | ~0.05 M/s | ~0.05 M/s | **~99.6%** | Scales well |
-| **10K rows (is_active, 2 groups)** | ~0.05 M/s | ~0.05 M/s | **~99.3%** | Boolean grouping |
-| **100K rows (age, salary)** | ~0.005 M/s | ~0.005 M/s | **~98.4%** | Large dataset |
-
-**Key Findings:**
-
-1. **GROUP BY + SUM achieves near-parity (98.4-99.6%)**
-   - Proper chaining: `group_by<field>().sum<agg_field>().execute()`
-   - Both Storm and raw SQLite return same group count
-
-2. **Low throughput is expected:**
-   - Each operation scans entire dataset for grouping and summing
-   - GROUP BY + SUM is I/O bound, not CPU bound
-   - Efficiency metric (Storm vs raw) is the key measure
-
-### Run WHERE Operator Benchmarks
-
-**✅ NEW FEATURE!** Benchmark advanced WHERE operators (LIKE, BETWEEN, IN, AND/OR):
-
-```bash
-# Run LIKE pattern matching benchmarks
-./build/release/benchmarks/storm_bench -c WHERE_LIKE
-
-# Run BETWEEN range query benchmarks
-./build/release/benchmarks/storm_bench -c WHERE_BETWEEN
-
-# Run IN set membership benchmarks
-./build/release/benchmarks/storm_bench -c WHERE_IN
-
-# Run AND/OR complex condition benchmarks
-./build/release/benchmarks/storm_bench -c WHERE_AND
-./build/release/benchmarks/storm_bench -c WHERE_OR
-
-# Run specific test
-./build/release/benchmarks/storm_bench --filter=where_like_prefix
-```
-
-**Available WHERE Operator tests:**
-- `where_like_prefix` - Pattern matching with prefix (name LIKE 'Person1%')
-- `where_like_contains` - Pattern matching with contains (name LIKE '%son%')
-- `where_between_int` - Range queries (age BETWEEN 25 AND 45)
-- `where_in_small` - Small IN set (age IN (25, 30, 35))
-- `where_and_simple` - AND combination (age > 30 AND salary > 50000)
-- `where_or_simple` - OR combination (age < 25 OR age > 60)
-
-**What's tested:**
-- **Storm ORM**: Uses `f<>().like()`, `f<>().between()`, `f<>().in()`, and `&&`/`||` operators
-- **Raw SQLite**: Manual SQL with LIKE, BETWEEN, IN clauses
-- **Fair comparison**: Both versions use prepared statement caching
-
-### WHERE Operator Performance Characteristics
-
-**Five WHERE Operator Configurations:**
-
-| Configuration | SQL Pattern | Use Case |
-|--------------|-------------|----------|
-| **LIKE prefix** | `SELECT * FROM table WHERE name LIKE 'pattern%'` | Fast prefix search |
-| **LIKE contains** | `SELECT * FROM table WHERE name LIKE '%pattern%'` | Full text search |
-| **BETWEEN** | `SELECT * FROM table WHERE field BETWEEN ? AND ?` | Range queries |
-| **IN** | `SELECT * FROM table WHERE field IN (?, ?, ...)` | Set membership |
-| **AND/OR** | `SELECT * FROM table WHERE cond1 AND/OR cond2` | Complex conditions |
-
-**WHERE Operator Performance (verified 2026-02-06, Release build):**
-
-| Test | Storm ORM | Raw SQLite | Efficiency | Notes |
-|------|-----------|------------|------------|-------|
-| **where_like_prefix** | ~2.8 M/s | ~2.9 M/s | **~98%** | ✅ Near parity |
-| **where_like_contains** | ~8.0 M/s | ~8.3 M/s | **~96%** | ✅ Near parity |
-| **where_between_int** | ~7.8 M/s | ~7.9 M/s | **~99%** | ✅ Near parity |
-| **where_in_small** | ~1.7 M/s | ~1.7 M/s | **~100%** | ✅ Parity |
-| **where_and_simple** | ~8.3 M/s | ~8.8 M/s | **~94%** | ✅ Good |
-| **where_or_simple** | ~6.1 M/s | ~6.3 M/s | **~97%** | ✅ Near parity |
-
-**🎯 What Fixed the Benchmark (2026-02-06 Update)**
-
-**Critical Issue Identified and Resolved:**
-
-**❌ UNFAIR COMPARISON** - Raw SQLite benchmark was NOT extracting column data like Storm ORM!
-
-**The Problem:**
-- Storm ORM performed full SELECT with object extraction into `plf::hive<Model>`
-- Raw SQLite was just counting rows with `total++` without extracting any data
-- This made Storm appear 55-91% efficient - completely misleading!
-
-**The Fix:**
-1. ✅ **Added proper column extraction** to raw SQLite - now extracts all 5 columns per row
-2. ✅ **Added `extract_row()` helper** to each benchmark class for type-safe extraction
-3. ✅ **Results stored in `plf::hive<Model>`** - same container as Storm ORM
-4. ✅ **Fair apples-to-apples comparison** - Both Storm and raw SQLite now do identical work
-
-**Result:**
-- **Before fix**: 55-91% efficiency (raw SQLite just counted rows) - UNFAIR
-- **After fix**: 94-100% efficiency (both extract full row data) - FAIR COMPARISON!
-
-**Key Findings:**
-
-1. **LIKE: 96-98% efficiency**
-   - Near parity with raw SQLite for both prefix and contains patterns
-   - Statement caching eliminates SQL parsing overhead
-
-2. **BETWEEN: ~99% efficiency**
-   - Near parity with raw SQLite
-   - Range queries are highly efficient with proper extraction
-
-3. **IN: ~100% efficiency**
-   - Parity with raw SQLite
-   - Set membership queries show excellent performance
-
-4. **AND/OR: 94-97% efficiency**
-   - Good efficiency for complex multi-condition expressions
-   - Expression tree traversal adds minimal overhead
-
-### Run Benchmarks by Filter (Test Name)
-
-**✅ IMPLEMENTED!** Filter tests by name with exact or substring matching:
-
-```bash
-# Exact match (default) - run ONLY tests with exact name match
-./build/release/benchmarks/storm_bench --filter=insert_batch_100
-# Runs only: insert_batch_100
-
-# Scale test mode - test performance degradation with increasing sizes
-./build/release/benchmarks/storm_bench --filter=insert_batch --scale-test
-# Runs: insert_batch_10, insert_batch_100, insert_batch_500, insert_batch_1000, etc.
-
-# Test specific progression
-./build/release/benchmarks/storm_bench --filter=insert_batch_100 --scale-test
-# Runs: insert_batch_100, insert_batch_1000, insert_batch_10000, insert_batch_100000
-
-# Run all WHERE tests with "where_int" in the name
-./build/release/benchmarks/storm_bench --filter=where_int --scale-test
-# Runs: where_int_comparison_gt, where_int_less_than
-```
-
-**Filter Modes:**
-- **Default (exact match)**: `--filter=<name>` runs only the test with that exact name
-- **Scale test mode**: `--filter=<pattern> --scale-test` uses substring matching to run all tests containing the pattern
-  - Perfect for testing performance degradation as batch sizes increase
-  - Example: `--filter=insert_batch --scale-test` runs all batch insert benchmarks
-
-**Output (with colors and comparison!):**
-```
-Inserting test data...
-✅ Inserted 10,000 test records
-=== Running Filtered Benchmark Tests ===
-Filter: "insert_single"
-Iterations per test: 100
-Using compile-time dispatch with runtime filtering
-
-
-=== insert_single ===                    (bold cyan)
-Operation: INSERT (single row)
-Iterations: 100                           (yellow)
-
-Storm ORM:                                 (bold)
-  Operations: 100                          (yellow)
-  Duration: 222.15 μs                      (magenta)
-  Throughput: 0.45 M ops/sec               (yellow)
-
-Raw SQLite:                                (bold)
-  Operations: 100                          (yellow)
-  Duration: 319.90 μs                      (magenta)
-  Throughput: 0.31 M ops/sec               (yellow)
-
-Efficiency: 144.0% (FASTER than raw SQLite)
-            ^^^^^^  (bold green = ≥95%, green = 85-95%, yellow = 70-85%, red = <70%)
-✅ Benchmark complete!                    (green)
-
-✅ Filtered tests completed!
-```
-
-**Performance-Based Color Coding:**
-
-**Throughput:**
-- **Bold Green** (≥5M ops/sec): Excellent performance
-- **Green** (1-5M ops/sec): Good performance
-- **Yellow** (<1M ops/sec): Needs optimization
-
-**Efficiency:**
-- **Bold Green** (≥95%): Excellent - near parity with raw SQLite
-- **Green** (85-95%): Good - acceptable overhead
-- **Yellow** (70-85%): Moderate - needs investigation
-- **Red** (<70%): Poor - significant overhead
-
-### Custom Iterations
-
-```bash
-# Run with custom iteration count
-./build/release/benchmarks/storm_bench --filter="insert_single" --iterations=5000
+# Fast smoke test — short min-time, no repetitions
+./build/release/benchmarks/storm_bench --benchmark_min_time=0.2s
+
+# High-confidence run for a regression decision
+./build/release/benchmarks/storm_bench --benchmark_repetitions=10 --benchmark_min_time=1s
 ```
 
 ### Run Benchmarks by Category
 
-**Current Status:** Specific category filtering is not yet implemented, but you can use `--filter` with `--scale-test` to match category names in test names:
+Every registered benchmark name follows `<Storm|Raw>/<CATEGORY>/<test_name>[/N:<size>]`, where
+`<CATEGORY>` is the YAML `category:` field (see [Size Profiles](#-size-profiles) below for the
+full category list). Filter with a regex anchored to that shape:
 
 ```bash
-# Filter WHERE tests (matches test names containing "where")
-./build/release/benchmarks/storm_bench --filter=where --scale-test
-
-# Filter INSERT tests (matches test names containing "insert")
-./build/release/benchmarks/storm_bench --filter=insert --scale-test
+./build/release/benchmarks/storm_bench --benchmark_filter='Storm/SELECT/.*'         # All SELECT-family tests
+./build/release/benchmarks/storm_bench --benchmark_filter='Storm/INSERT/.*'         # All INSERT tests
+./build/release/benchmarks/storm_bench --benchmark_filter='Storm/WHERE/.*'          # All WHERE-operator tests
+./build/release/benchmarks/storm_bench --benchmark_filter='.*/insert/N:100$'        # One specific size, both sides
+./build/release/benchmarks/storm_bench --benchmark_filter='Storm/SELECT_JOIN/.*'    # SELECT + INNER JOIN only
 ```
+
+Both `Storm/...` and `Raw/...` benchmarks (the raw-SQLite comparison side) match the same
+`--benchmark_filter` regex, so filtering by category naturally runs both sides together.
+
+### Custom Repetitions / Timing
+
+```bash
+# Override how many times gbench repeats each benchmark (for tighter stddev)
+./build/release/benchmarks/storm_bench --benchmark_repetitions=20
+
+# Machine-readable output for scripting / diffing
+./build/release/benchmarks/storm_bench --benchmark_format=json --benchmark_out=current.json
+```
+
+See `benchmarks/scripts/compare_against_baseline.sh` (documented above under
+[Regression detection](#-regression-detection)) for the supported comparison workflow — it
+wraps exactly this JSON output.
 
 ## 🔧 How It Works
 
-### 1. **Compile-Time JSON Parsing**
+### 1. Compile-Time YAML→JSON Test Definitions
 
-The system uses C++26 `#embed` to load JSON at compile time:
+`benchmarks/tests/benchmark_tests.yaml` is the human-friendly source of truth. It is converted
+to JSON at build time (`scripts/yaml_to_json.py`) and loaded into the binary at **compile time**
+via C++26 `#embed`:
 
 ```cpp
 // In parser.cppm (storm_benchmark_parser module)
@@ -1621,57 +346,44 @@ constexpr const char* BENCHMARK_JSON =
 constexpr auto BENCHMARK_TESTS = parse_benchmark_tests();
 ```
 
-### 2. **Template Metaprogramming Test Dispatch**
+### 2. Registration Bridges Compile-Time Data to Google Benchmark
 
-Each test is executed via template recursion with compile-time dispatch:
+`register.cpp` walks `BENCHMARK_TESTS` (the `#embed`-parsed array) at program startup and builds
+a `std::vector<RegisteredBenchmark>` — a POD-only table (`bench_register.h`) of `{name, setup,
+run, sized, args, range_lo, range_hi, range_multiplier}`. `main.cpp` (the actual gbench entry
+point) then calls `benchmark::RegisterBenchmark(name, ...)` once per entry, wiring each into
+gbench's own `Range()`/`Arg()`/`Complexity(benchmark::oN)` machinery so gbench drives repetition,
+timing, and dataset-size sweeps:
 
 ```cpp
-template<typename Model, size_t TestIndex, size_t TotalTests>
-struct TestExecutor {
-    static void execute(BenchmarkRunner& runner, int iterations, ...) {
-        constexpr auto& test = BENCHMARK_TESTS[TestIndex];
-        constexpr std::string_view operation = test.operation.view();
-
-        // CRUD operations keep dedicated classes (data-driven, not query-driven).
-        if constexpr (operation == "insert") {
-            run_insert_operation<Model, test>(runner, iterations);
-        } else if constexpr (operation == "update_pk") {
-            run_update_pk_operation<Model, test>(runner, iterations);
-        } else if constexpr (operation == "delete_pk") {
-            run_delete_pk_operation<Model, test>(runner, iterations);
-        } else {
-            // ALL SELECT-family operations — one unified class, feature dispatch
-            // happens inside QueryBenchmark via if constexpr on test.*.enabled.
-            registry::with_base_model<test>([&]<typename M>() {
-                runner.template dispatch_sized<test, IterKind::Dataset>(
-                    iterations, test.dataset_size,
-                    [](int size) { return QueryBenchmark<M, test>{size}; });
-            });
-        }
-
-        if constexpr (TestIndex + 1 < TotalTests)
-            TestExecutor<Model, TestIndex + 1, TotalTests>::execute(runner, iterations, ...);
+// main.cpp — one real gbench registration per compile-time-known test
+auto* bench_reg = benchmark::RegisterBenchmark(reg.name, [reg](benchmark::State& state) {
+    reg.setup(state.range(0));
+    for (auto _ : state) {
+        reg.run();
     }
-};
+    state.SetComplexityN(state.range(0));
+});
+if (reg.sized) {
+    bench_reg->RangeMultiplier(reg.range_multiplier)->Range(reg.range_lo, reg.range_hi)
+              ->Complexity(benchmark::oN)->ArgName("N");
+}
 ```
 
-**What this achieves:**
-- ✅ Zero runtime string parsing or dispatch
-- ✅ Each test gets its own specialized template instantiation
-- ✅ Compiler unrolls the loop completely
-- ✅ All field names and operators resolved at compile time
-- ✅ Maximum performance - no virtual dispatch, no function pointers
+Each test's operation dispatch (WHERE / JOIN / aggregate / INSERT / ...) is still resolved at
+**compile time** via `if constexpr` inside the fixture classes (`query_benchmark.cppm`,
+`crud_benchmark.cppm`) — so the per-test hot loop has zero runtime branching on operation type.
+What changed vs. the pre-#235 system is the *outer* layer: Google Benchmark now owns filtering,
+repetition, timing, and statistical aggregation instead of a custom runner.
 
-### 3. **Field Dispatch Using Reflection**
+### 3. Field Dispatch Using Reflection
 
-Field names are mapped to struct members at compile time using C++26 reflection:
+Field names in YAML are mapped to struct members at compile time using C++26 reflection:
 
 ```cpp
 template<typename Model>
 constexpr auto dispatch_field(std::string_view field_name) {
     constexpr auto members = members_of(^^Model);
-
-    // Find matching field at compile time
     template for (constexpr auto member : members) {
         constexpr auto name = display_name_of(member);
         if (field_name == name) {
@@ -1702,7 +414,7 @@ Edit `benchmarks/tests/benchmark_tests.yaml` (the human-friendly source of truth
     init_dataset_size: 10000
 ```
 
-**Option B: Size profile test** (auto-iterates over multiple sizes)
+**Option B: Size profile test** (auto-iterates over multiple sizes via gbench `Range()`/`Arg()`)
 
 ```yaml
   - name: select_custom
@@ -1713,17 +425,27 @@ Edit `benchmarks/tests/benchmark_tests.yaml` (the human-friendly source of truth
     size_profile: dataset_standard
 ```
 
-This will generate tests: `select_custom_100`, `select_custom_1000`, `select_custom_10000`, `select_custom_100000`
+This registers a single gbench benchmark (`Storm/SELECT_CUSTOM/select_custom`) with
+`Range(100, 100000)` — gbench itself expands the sweep and reports one row per size
+(`.../N:100`, `.../N:1000`, ...), rather than one YAML entry per size.
 
-> **Note:** The YAML file is automatically converted to JSON during build via `scripts/yaml_to_json.py`. The C++ parser reads the generated JSON using `#embed`.
+> **Note:** The YAML file is automatically converted to JSON during build via
+> `scripts/yaml_to_json.py`. The C++ parser reads the generated JSON using `#embed`.
 
 ### Step 2: Wire it into the right fixture
 
-If the operation fits the SELECT family (WHERE / JOIN / aggregates / DISTINCT / GROUP BY / etc.), `benchmarks/query_benchmark.cppm` already dispatches via `if constexpr` on the test's flags — you typically only edit YAML and the matching `if constexpr` branch in `QueryBenchmark::build_qs` / `run_once`.
+If the operation fits the SELECT family (WHERE / JOIN / aggregates / DISTINCT / GROUP BY / etc.),
+`benchmarks/query_benchmark.cppm` already dispatches via `if constexpr` on the test's flags — you
+typically only edit YAML and the matching `if constexpr` branch in `QueryBenchmark::build_qs` /
+`run_once`.
 
-CRUD operations (insert / update_pk / delete_pk) live in `benchmarks/crud_benchmark.cppm`. Adding a new CRUD-shaped operation means a new branch in `CrudBenchmark::run_once` plus a name match in `register.cpp::is_crud`.
+CRUD operations (insert / update_pk / delete_pk) live in `benchmarks/crud_benchmark.cppm`. Adding
+a new CRUD-shaped operation means a new branch in `CrudBenchmark::run_once` plus a name match in
+`register.cpp::is_crud`.
 
-For genuinely new operation families, add a fixture module alongside `query_benchmark.cppm` / `crud_benchmark.cppm`, import it from `register.cpp`, and have `register_all<>()` route the right tests to it.
+For genuinely new operation families, add a fixture module alongside `query_benchmark.cppm` /
+`crud_benchmark.cppm`, import it from `register.cpp`, and have `register_all<>()` route the right
+tests to it.
 
 ### Step 3: Rebuild and Run
 
@@ -1732,84 +454,13 @@ cmake --build --preset ninja-release
 ./build/release/benchmarks/storm_bench --benchmark_filter='Storm/<category>/<name>'
 ```
 
-Google Benchmark picks up the new entry automatically — `register.cpp` walks `BENCHMARK_TESTS` at startup and registers a `void(*)()` trampoline per test.
-
-## ⏱️ Accurate Timing
-
-The benchmark system uses **`std::chrono::steady_clock`** for timing, which provides:
-
-- **Monotonic timing**: Clock never goes backwards (immune to system time changes)
-- **Nanosecond precision**: Accurate timing even for fast operations
-- **Same as Google Benchmark**: Uses the same clock that Google Benchmark uses internally
-- **Better than `high_resolution_clock`**: More reliable on many platforms
-
-**Why not full Google Benchmark?**
-- Module system compatibility issues with the reflection compiler
-- We only need accurate timing, not the full benchmarking framework
-- Simpler integration without external dependencies breaking the build
-- Custom colored output and Storm-specific reporting
-
-## 📈 Statistical Analysis
-
-Each benchmark runs **5 times** and reports statistical metrics:
-
-- **Median**: Most stable metric, less affected by outliers
-- **Mean**: Average throughput with standard deviation (±)
-- **Range**: [min - max] shows variance between runs
-
-**Example output:**
-```
-Storm ORM:
-  Operations: 100
-  Median:  4.21 M ops/sec
-  Mean:    4.18 M ops/sec (±0.15)
-  Range:   [4.01 - 4.35]
-
-Raw SQLite:
-  Operations: 100
-  Median:  4.15 M ops/sec
-  Mean:    4.12 M ops/sec (±0.12)
-  Range:   [3.98 - 4.28]
-
-Efficiency: 101.4% (FASTER than raw SQLite)
-```
-
-**Why 5 runs?**
-- Enough samples for median/stddev calculation
-- Catches variance from system noise
-- Not too slow for development iteration
-
-## 💾 In-Memory vs Disk Benchmarks
-
-By default, benchmarks use **in-memory SQLite** (`:memory:`) because:
-
-| Aspect | In-Memory (default) | Disk (`--disk`) |
-|--------|---------------------|-----------------|
-| **Speed** | Fastest | Slower (I/O bound) |
-| **Reproducibility** | High (no disk variability) | Lower (depends on I/O) |
-| **Isolation** | No leftover files | Creates temp file (auto-cleaned) |
-| **Use case** | Development, CI/CD | Production-realistic testing |
-
-**When to use `--disk`:**
-- Testing real-world performance with disk I/O
-- Benchmarking with fsync/journaling overhead
-- Comparing WAL vs other journal modes
-
-**Example:**
-```bash
-# In-memory benchmark (default, fast)
-./build/release/benchmarks/storm_bench --filter=insert_single
-
-# Disk-based benchmark (realistic I/O)
-./build/release/benchmarks/storm_bench --filter=insert_single --disk
-
-# Specific database file
-./build/release/benchmarks/storm_bench --filter=insert_single --db=/tmp/bench.db
-```
+Google Benchmark picks up the new entry automatically — `register.cpp` walks `BENCHMARK_TESTS` at
+startup and registers a real gbench benchmark per test.
 
 ## 📊 Storm ORM vs Raw SQLite Comparison
 
-Every benchmark runs **two versions** of the same operation:
+Every applicable benchmark runs **two versions** of the same operation, registered as sibling
+gbench benchmarks (`Storm/<category>/<name>` and `Raw/<category>/<name>`):
 
 1. **Storm ORM**: Using the full ORM abstraction layer
 2. **Raw SQLite**: Direct SQLite API calls with manual object construction
@@ -1819,140 +470,70 @@ This provides an **apples-to-apples comparison** to measure the actual overhead 
 ### Fair Comparison Methodology
 
 **Both versions do the same work:**
-- **Prepare statement once** (outside loop - realistic production usage)
+- **Prepare statement once** (outside the timed loop — realistic production usage)
 - Execute the same SQL query with statement reuse
 - Bind the same parameters
 - Extract all column values from result rows
-- Construct C++ objects from the data
+- Construct C++ objects from the data, using the same container (`plf::hive`) Storm uses
 
-**Example - SELECT with WHERE:**
-```cpp
-// Storm ORM version (automatic statement caching)
-for (int i = 0; i < iterations; i++) {
-    auto results = qs.where(f<age>() > 30).select();
-}
+The `storm_anchors` binary (documented under [Live dashboard](#-live-dashboard) above) pins a
+small, intentional subset of these raw comparisons for release-time spot checks — see that
+section for the exact schema/row-shape fairness rules (#68) and the current pinned benchmark
+names.
 
-// Raw SQLite version (manual statement reuse)
-auto stmt = conn->prepare("SELECT * FROM Person WHERE age > ?");
-for (int i = 0; i < iterations; i++) {
-    stmt.reset();  // Reset for reuse
-    stmt.bind_int(1, 30);
-    while (stmt.step()) {
-        Person obj;
-        obj.id = stmt.extract_int(0);
-        obj.name = std::string(stmt.extract_text_view(1));
-        // ... extract all fields
-    }
-}
-```
-
-**Key Point:** Both versions use **prepared statement caching** to provide a realistic comparison. This is how you should use SQLite in production code!
-
-**What the efficiency % tells you:**
-- **≥100%**: Storm ORM is **faster** (statement caching, optimizations)
+**What the efficiency % tells you** (per CLAUDE.md's Performance Guidelines, target ≥95%):
+- **≥100%**: Storm ORM is **faster** (statement caching, compile-time SQL generation)
 - **90-99%**: Storm ORM has **minimal overhead** (excellent)
 - **70-89%**: Storm ORM has **acceptable overhead** (good)
-- **50-69%**: Storm ORM has **moderate overhead** (needs optimization)
-- **<50%**: Storm ORM has **significant overhead** (investigation needed)
+- **<70%**: investigate — see [docs/internals/performance/PERFORMANCE.md](../docs/internals/performance/PERFORMANCE.md)
 
-**Why Storm can be faster than raw SQLite:**
-- **Statement caching**: Prepared statements reused across calls
-- **SQL string caching**: Compile-time SQL generation, no runtime concatenation
-- **Inline optimizations**: Compiler can fully inline ORM templates
-- **Thread-local caching**: Per-thread statement pools eliminate contention
+**Why Storm can match or beat raw SQLite:**
+- **Statement caching**: prepared statements reused across calls (Connection-level, see
+  [STATEMENT_CACHING.md](../docs/internals/architecture/STATEMENT_CACHING.md))
+- **SQL string caching**: compile-time SQL generation, no runtime concatenation
+- **Inline optimizations**: compiler can fully inline ORM templates across module boundaries
+  (see [MODULE_SYSTEM.md](../docs/internals/architecture/MODULE_SYSTEM.md))
+- **Thread-local caching**: per-thread SQL caches eliminate contention
 
-## 🎨 Why Compile-Time Dispatch?
+For current, verified efficiency numbers (not stale point-in-time snapshots), run the relevant
+category locally — see [Run Benchmarks by Category](#run-benchmarks-by-category) — or check the
+per-PR regression-gate comment described under [Regression detection](#-regression-detection).
 
-**Advantages of compile-time JSON + template metaprogramming:**
+## 📝 YAML Test Schema
 
-1. ✅ **Zero Runtime Overhead** - No string parsing or dispatch at runtime
-2. ✅ **Maximum Performance** - Each test is a fully specialized template function
-3. ✅ **Type Safety** - All field names and operators checked at compile time
-4. ✅ **Easy Configuration** - Add tests via JSON without changing C++ code
-5. ✅ **Compiler Optimization** - Full inlining and optimization of each test
-6. ✅ **Compile-Time Errors** - Invalid field names caught during compilation
-7. ✅ **Self-Documenting** - JSON serves as both config and documentation
-8. ✅ **Colorized Output** - Performance-based color coding for easy analysis
+See `benchmarks/tests/benchmark_tests.yaml` for the full set of fields in use; the shape below
+covers the common ones (not every operation uses every field):
 
-## 📝 JSON Schema
+```yaml
+  - name: unique_test_identifier
+    category: WHERE               # groups the gbench name: Storm/<category>/<name>
+    description: "Human-readable description"
+    model: Person
+    operation: where               # dispatch key read by query_benchmark.cppm / crud_benchmark.cppm
+    iterations: 1000               # only meaningful where gbench doesn't own repetition
+    init_dataset_size: 10000       # rows pre-seeded before the timed loop
+    batch_size: 1                  # CRUD operations: rows per batch (size_profile can override)
+    size_profile: dataset_standard # OR explicit size — see Size Profiles above
 
-### Test Definition
+    # WHERE-family fields
+    where_field: age
+    where_op: ">"                  # >|<|>=|<=|==|!=|LIKE|BETWEEN|IN
+    where_value_int: 30
+    where_value_string: "pattern"
+    where_in_values: [25, 30, 35]
 
-```json
-{
-  "test_name": "unique_test_identifier",
-  "test_category": "WHERE|INSERT|SELECT|JOIN|DISTINCT|AGGREGATE|SELECT_LIMIT|SELECT_OFFSET|SELECT_LIMIT_OFFSET|ORDER_BY|ORDER_BY_WHERE|ORDER_BY_LIMIT|ORDER_BY_MULTI|WHERE_LIKE|WHERE_BETWEEN|WHERE_IN|WHERE_AND|WHERE_OR",
-  "description": "Human-readable description",
-  "model": "Person",
-  "operation": "where|insert|select|select_limit|select_offset|select_limit_offset|select_where_limit|select_join_limit|select_join_limit_offset|order_by_asc|order_by_desc|order_by_where|order_by_limit|order_by_multi_2_asc|order_by_multi_2_desc|order_by_multi_2_mixed|where_like|where_between|where_in|where_and|where_or",
-  "iterations": 1000,
-  "init_dataset_size": 10000,
-  "batch_size": 1,  // For batch operations (1 = single, >1 = batch)
+    # LIMIT/OFFSET
+    limit_value: 100
+    offset_value: 0
 
-  // For WHERE operations
-  "where_field": "age",
-  "where_op": ">|<|>=|<=|==|!=|LIKE|BETWEEN",
-  "where_value_int": 30,
-  "where_value_double": 50000.0,
-  "where_value_bool": true,
-  "where_value_string": "pattern",
-  "where_value_int2": 45,            // Second value for BETWEEN
-  "where_in_values": [25, 30, 35],   // Array for IN operator
-
-  // For complex AND/OR conditions
-  "where_field2": "salary",
-  "where_op2": ">",
-  "where_value2_int": 50000,
-
-  // For LIMIT/OFFSET operations
-  "limit_value": 100,   // Number of rows to return (0 = no LIMIT)
-  "offset_value": 0,    // Number of rows to skip (0 = no OFFSET)
-
-  // For ORDER BY operations
-  "order_by_field": "salary",      // Field name to order by
-  "order_by_direction": "DESC",    // "ASC" or "DESC" (default: ASC)
-
-  // For Multi-Field ORDER BY operations
-  "order_by_field2": "name",       // Second field for multi-field ORDER BY
-  "order_by_direction2": "ASC"     // Direction for second field
-}
+    # ORDER BY
+    order_by_field: salary
+    order_by_direction: DESC        # ASC|DESC
 ```
 
-**Parameters:**
-- `batch_size` (optional, default: 1): Number of rows per batch operation
-  - `1` = Single row operation
-  - `10, 50, 100, 500, 1000` = Predefined batch sizes (compile-time optimized)
-  - Other values default to 100
-
-## ✅ Implemented Features
-
-- [x] **Runtime filtering** by test name (substring matching)
-- [x] **Command-line arguments** (--filter, --iterations, --list, --help)
-- [x] **Test listing** (--list shows all available tests)
-- [x] **Custom iterations** (--iterations=N)
-- [x] **Help system** (--help)
-
-## 🚧 Current Limitations
-
-### Not Yet Implemented
-
-See [GitHub Issues (benchmarks)](https://github.com/spiritEcosse/storm/issues?q=is%3Aissue+is%3Aopen+label%3Abenchmarks) for planned improvements.
-
-### Design Trade-offs
-
-**Hybrid Dispatch Model (Current Implementation):**
-- ✅ **Pro:** Maximum performance - compile-time operation dispatch
-- ✅ **Pro:** Runtime flexibility - filter tests without rebuilding
-- ✅ **Pro:** Best of both worlds achieved!
-- ⚠️ **Trade-off:** Small runtime overhead for filtering (negligible - simple string match)
-- ❌ **Con:** Longer compile times (every test instantiates templates)
-- ❌ **Con:** Binary size increases with number of tests
-
-**Why This Works:**
-- Compile-time dispatch for operation types (where, insert, etc.) → zero overhead
-- Runtime filtering on test names → minimal overhead (simple string check)
-- All tests still get specialized template functions
-- No virtual dispatch or function pointers
+Valid `category` values are exactly the `category:` entries actually used in
+`benchmarks/tests/benchmark_tests.yaml` — grep that file rather than trusting a fixed enum here,
+since new categories are added as new operation families land.
 
 ## 🎯 Future Enhancements
 
@@ -1983,23 +564,11 @@ struct Person {
 };
 ```
 
-### Benchmark runs but shows 0 operations
+### Benchmark runs but shows 0 operations / 0 items processed
 
 **Cause:** Query returned no results or operation failed silently.
 
 **Solution:** Check that test data was inserted correctly and WHERE conditions match some rows.
-
----
-
-## 📚 Related Documentation
-
-- **Main benchmark guide:** [README.md](README.md)
-- **Performance guidelines:** [../docs/internals/performance/PERFORMANCE.md](../docs/internals/performance/PERFORMANCE.md)
-- **Storm ORM architecture:** [../docs/internals/architecture/](../docs/internals/architecture/)
-
----
-
-**This is the future of Storm ORM benchmarking: Pure C++26 with compile-time dispatch!** 🚀
 
 ## Profiling and Performance Debugging
 
@@ -2012,3 +581,7 @@ The custom `timing.hpp` / `timing_trace.hpp` macros from the pre-Google-Benchmar
 
 When you need ad-hoc per-call timing inside a Storm code path, drop a local `auto t = std::chrono::steady_clock::now(); ...; std::cerr << ...;` into the file under investigation and remove it before committing — there is no longer a project-wide tracing macro.
 
+## 📚 Related Documentation
+
+- **Performance guidelines:** [../docs/internals/performance/PERFORMANCE.md](../docs/internals/performance/PERFORMANCE.md)
+- **Storm ORM architecture:** [../docs/internals/architecture/](../docs/internals/architecture/)

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,7 @@ Documentation for users of Storm ORM — patterns, features, and field/migration
 - **[Batch Operations](guide/features/BATCH_OPERATIONS.md)** - Bulk INSERT/UPDATE/DELETE with smart thresholds
 - **[UPSERT Operations](guide/features/UPSERT.md)** - Single-row ON CONFLICT DO UPDATE / DO NOTHING
 - **[Referential Integrity](guide/features/REFERENTIAL_INTEGRITY.md)** - Always-on FK constraints, junction FOREIGN KEYs, SQLite PRAGMA
+- **[Indexes](guide/features/INDEXES.md)** - Single-column `indexed`/`unique` tags and composite `Index<>`/`UniqueIndex<>`
 - **[Connection Tuning](guide/features/CONNECTION_TUNING.md)** - SQLite busy_timeout default, optional WAL, pooled concurrency
 
 ### Reference

--- a/docs/guide/COOKBOOK.md
+++ b/docs/guide/COOKBOOK.md
@@ -96,6 +96,20 @@ for (auto& p : people) { p.salary *= 1.1; }
 qs.update(people).execute();
 ```
 
+## Upsert
+
+```cpp
+// INSERT ... ON CONFLICT (name) DO UPDATE — conflict target must be a
+// unique field / UniqueIndex (compile-time checked).
+qs.insert(p).on_conflict<^^Person::name>().update<^^Person::age>().execute();
+
+// INSERT ... ON CONFLICT (name) DO NOTHING
+qs.insert(p).on_conflict<^^Person::name>().nothing().execute();
+```
+
+See [reference/FIELD_TYPES.md](reference/FIELD_TYPES.md) and the QuerySet API section of
+[CLAUDE.md](../../CLAUDE.md) for details (#205).
+
 ## Automatic Timestamps
 
 ```cpp
@@ -157,6 +171,12 @@ if (lo && lo->has_value()) {
 
 // With WHERE
 auto active_count = qs.where(f<^^Person::is_active>() == true).count().execute();
+
+// COUNT(DISTINCT field) — counts distinct values, not distinct rows
+auto distinct_depts = qs.count_distinct<^^Person::department>().execute(); // expected<int64_t>
+auto active_distinct = qs.where(f<^^Person::is_active>() == true)
+    .count_distinct<^^Person::department>()
+    .execute();
 ```
 
 ## GROUP BY + HAVING
@@ -226,6 +246,35 @@ auto common = qs1.where(...).intersect_(qs2.where(...)).select().execute();
 auto diff   = qs1.where(...).except_(qs2.where(...)).select().execute();
 ```
 
+## Transactions
+
+```cpp
+auto conn = QuerySet<Person>::get_default_connection();
+
+// RAII guard — explicit commit; rollback on early return/throw/scope exit.
+auto txn = storm::begin(conn);
+if (!txn) return std::unexpected(txn.error());
+if (auto r = qs.insert(a).execute(); !r) return std::unexpected(r.error());
+if (auto r = qs.update(b).execute(); !r) return std::unexpected(r.error());
+return txn->commit();
+
+// Scope helper — commits on a returned value, rolls back on std::unexpected/throw.
+auto r = storm::transaction(conn, [&](auto& txn) -> std::expected<int, Error> {
+    if (auto x = qs.insert(a).execute(); !x) return std::unexpected(x.error());
+    return 42;
+});
+```
+
+Nesting is cooperative: `begin()` on an already-open connection returns a passive guard, so
+batch operations that open their own inner transaction never collide with an outer one (#415).
+Never issue a raw `conn->execute("BEGIN TRANSACTION")`.
+
+## Connection Tuning & Pooling
+
+SQLite connections take a `busy_timeout_ms` and `journal_mode` (WAL opt-in), applied once at
+`open()` — see [features/CONNECTION_TUNING.md](features/CONNECTION_TUNING.md) for pooled setups
+and WAL recommendations (#410).
+
 ## Thread Safety
 
 ```cpp
@@ -237,4 +286,10 @@ void worker() {
 }
 
 std::jthread t1(worker), t2(worker);
+
+// Check before use — has_default_connection() avoids the assert in
+// get_default_connection() when a thread might not have set one yet.
+if (!QuerySet<Person>::has_default_connection()) {
+    QuerySet<Person>::set_default_connection(":memory:");
+}
 ```

--- a/docs/guide/features/BATCH_OPERATIONS.md
+++ b/docs/guide/features/BATCH_OPERATIONS.md
@@ -149,7 +149,7 @@ std::vector<Person> people = {
 
 auto result = queryset.update(std::span<const Person>(people));
 if (!result) {
-    std::cerr << "Batch update failed: " << result.error().message << std::endl;
+    std::cerr << "Batch update failed: " << result.error().message() << std::endl;
 }
 ```
 

--- a/docs/guide/features/CONNECTION_TUNING.md
+++ b/docs/guide/features/CONNECTION_TUNING.md
@@ -22,8 +22,13 @@ struct Config {                 // storm::db::sqlite::Config
     JournalMode journal_mode             = JournalMode::Default; // #410: WAL opt-in
 };
 
-enum class JournalMode { Default, WAL };   // storm::db::sqlite::JournalMode
+enum class JournalMode { Default, WAL };   // storm::db::JournalMode
 ```
+
+`JournalMode` itself is deliberately declared **backend-neutral**, in `storm::db` (`src/db/concept.cppm`),
+so the generic `PoolConfig` can carry it without depending on the SQLite backend module. SQLite's
+`Config` and the examples below reach it via `using storm::db::JournalMode;` re-exposed from
+`storm::db::sqlite`.
 
 | Field | Default | Effect |
 |---|---|---|

--- a/docs/guide/features/CRUD_OPERATIONS.md
+++ b/docs/guide/features/CRUD_OPERATIONS.md
@@ -124,7 +124,7 @@ Updates all non-primary-key fields:
 Person person{1, "Alice", 26};  // ID = 1, new age
 auto result = queryset.update(person).execute();
 if (!result) {
-    std::cerr << "Update failed: " << result.error().message << std::endl;
+    std::cerr << "Update failed: " << result.error().message() << std::endl;
 }
 ```
 
@@ -362,8 +362,8 @@ if (result) {
     int64_t id = result.value();
 } else {
     // Error
-    std::cerr << "Error: " << result.error().message << std::endl;
-    std::cerr << "Code: " << result.error().code << std::endl;
+    std::cerr << "Error: " << result.error().message() << std::endl;
+    std::cerr << "Code: " << result.error().code() << std::endl;
 }
 ```
 

--- a/docs/guide/features/INDEXES.md
+++ b/docs/guide/features/INDEXES.md
@@ -1,0 +1,98 @@
+# Indexes
+
+Storm generates `CREATE INDEX` statements from model annotations — both single-column
+tags on individual fields and composite (multi-column) indexes declared separately.
+
+## Single-column indexes
+
+Two tag annotations request a single-column index:
+
+```cpp
+struct Person {
+    [[= storm::primary]] int id;
+    [[= storm::unique]] std::string email;    // CREATE UNIQUE INDEX
+    [[= storm::indexed]] std::string name;    // CREATE INDEX
+};
+```
+
+| Tag | Effect |
+|---|---|
+| `storm::unique` | `CREATE UNIQUE INDEX IF NOT EXISTS idx_<field> ON <table>(<field>)` |
+| `storm::indexed` | `CREATE INDEX IF NOT EXISTS idx_<field> ON <table>(<field>)` |
+
+Foreign-key fields (`[[= storm::fk<>]]`) are indexed automatically — no `indexed`/`unique`
+tag needed — because JOINs and cascade deletes both hit the FK column:
+
+```cpp
+struct Message {
+    [[= storm::primary]] int id;
+    [[= storm::fk<>]] Person sender;   // implicit CREATE INDEX idx_sender_id ON Message(sender_id)
+};
+```
+
+The primary key is never separately indexed (SQLite's `INTEGER PRIMARY KEY` already is one).
+`unique` and `indexed` are mutually exclusive with each other in the sense that `unique`
+already implies indexing — combining both on the same field is redundant, not an error, but
+prefer just `unique` when you need the uniqueness constraint.
+
+## Composite (multi-column) indexes
+
+A single-column tag can't express "unique on the *pair* of columns" — use `storm::Index<>` /
+`storm::UniqueIndex<>` for that, specifying the member list as `std::meta::info` NTTPs:
+
+```cpp
+struct Enrollment {
+    [[= storm::primary]] int id;
+    [[= storm::fk<>]] Student student;
+    [[= storm::fk<>]] Course  course;
+
+    using storm_indexes = std::tuple<
+        storm::UniqueIndex<^^Enrollment::student, ^^Enrollment::course>
+    >;
+};
+```
+
+```sql
+CREATE UNIQUE INDEX IF NOT EXISTS idx_Enrollment_student_id_course_id
+    ON Enrollment(student_id, course_id)
+```
+
+`storm::Index<^^A::x, ^^A::y>` (non-unique) and `storm::UniqueIndex<^^A::x, ^^A::y>` both
+accept any number of member selectors. FK members in the list resolve to their `_id` column
+name automatically (#422), same as everywhere else in Storm.
+
+### Declaring composite indexes: the nested-typedef form
+
+Declare the `storm_indexes` nested typedef **inside the model struct**, as shown above,
+rather than specializing `storm::Indexes<T>` externally:
+
+```cpp
+// ❌ Don't specialize Indexes<T> in a header included by multiple module TUs
+template <> struct storm::Indexes<Enrollment> {
+    using type = std::tuple<storm::UniqueIndex<^^Enrollment::student, ^^Enrollment::course>>;
+};
+
+// ✅ Nested typedef — safe everywhere
+struct Enrollment {
+    // ...
+    using storm_indexes = std::tuple<storm::UniqueIndex<^^Enrollment::student, ^^Enrollment::course>>;
+};
+```
+
+An explicit specialization of a module-owned template (`storm::Indexes<T>`) in a header
+included by several module TUs' Global Module Fragments breaks with "reference to 'type' is
+ambiguous" once the import graph offers a second BMI path (issue #464). The nested-typedef
+opt-in sidesteps this entirely — `storm::Indexes<T>` picks it up via a `requires { typename
+T::storm_indexes; }` constraint — and is the only supported way to declare composite indexes.
+A model with no `storm_indexes` typedef simply has no composite indexes (the default
+`Indexes<T>::type` is an empty `std::tuple<>`).
+
+## Where indexes are created
+
+All index SQL — single-column and composite — is generated at compile time and executed as
+part of `create_table()` / schema setup, alongside the table's `CREATE TABLE` statement. There
+is no separate "create indexes" step to call.
+
+See also:
+- [reference/FIELD_TYPES.md](../reference/FIELD_TYPES.md) — the full annotation reference
+- [REFERENTIAL_INTEGRITY.md](REFERENTIAL_INTEGRITY.md) — FK `ON DELETE` policies (a related but separate concern from FK indexing)

--- a/docs/guide/features/WHERE_CLAUSES.md
+++ b/docs/guide/features/WHERE_CLAUSES.md
@@ -151,6 +151,20 @@ auto results = QuerySet<Person>()
     .select();
 ```
 
+## IN
+
+The `in()` method takes a variadic list of values and matches any of them.
+
+```cpp
+// WHERE id IN (100, 200, 300)
+auto results = QuerySet<Person>()
+    .where(f<^^Person::id>().in(100, 200, 300))
+    .select();
+```
+
+Works on any comparable field type also supported by the comparison operators — int,
+`int64_t`, double, float, string, temporal (`year_month_day` / `time_point`), and UUID.
+
 ## COLLATE
 
 Collation for string comparisons (case-insensitive, etc).

--- a/docs/guide/reference/FIELD_TYPES.md
+++ b/docs/guide/reference/FIELD_TYPES.md
@@ -167,6 +167,21 @@ app layer, so it emits a real `CHECK` on SQLite — nothing to remember or bypas
 Out of scope (YAGNI): `min_length` (separate follow-up — `CHECK(length >= N)` passes on NULL,
 so it does *not* mean "required") and `check<"expr">` (raw-SQL escape hatch).
 
+### Single-column indexes (`unique` / `indexed`)
+
+```cpp
+struct Person {
+    [[= storm::primary]] int id;
+    [[= storm::unique]] std::string email;    // CREATE UNIQUE INDEX
+    [[= storm::indexed]] std::string name;    // CREATE INDEX
+};
+```
+
+`unique` adds a uniqueness constraint (`UNIQUE INDEX`); `indexed` adds a plain lookup index
+with no uniqueness constraint. Foreign-key fields (`fk<>`) are indexed automatically without
+either tag. See [features/INDEXES.md](../features/INDEXES.md) for full coverage, including
+composite (multi-column) indexes via `storm::Index<>` / `storm::UniqueIndex<>`.
+
 ## Optional Types (NULL Support)
 
 | C++ Type | SQLite Type | Binding Method | Extraction Method |
@@ -421,3 +436,46 @@ accept `int` and rely on `is_class_type` to gate).
 call site's extra `!is_relation_field(MemberInfo)` check, which excludes `many_to_many` /
 `reverse_fk` container members that are not persisted columns — that check is still ANDed alongside
 `ValidFieldInfo` at each selector site.
+
+## Foreign Key Target Validation (`ValidForeignKey`) (#474)
+
+`storm::orm::statements::ValidForeignKey<FieldType>` is the compile-time gate that an FK field's
+target has a primary key — a plain alias over the existing model concept, unwrapping one level of
+`std::optional` first (an FK field is often `std::optional<Related>`):
+
+```cpp
+template <typename FieldType>
+concept ValidForeignKey = ModelWithPrimaryKey<utilities::optional_inner_type_t<FieldType>>;
+```
+
+`join<>()` / `left_join<>()` and `find_fk_primary_key<FKType>()` `require` it, so calling
+`join<^^Message::sender>()` when `sender`'s target type has no primary key fails at the join call
+site instead of deep inside FK-column extraction. It is single-level only — it checks the target's
+own PK, never recursing into the target's FKs (a Base⟷Owner reference cycle would otherwise never
+terminate). Loop bodies that walk members at runtime (e.g. `FKFieldOf`) can't splice a loop variable
+into `ValidForeignKey<typename[:...:]>`, so `base.cppm` also carries an info-value twin,
+`valid_fk_target(std::meta::info fk_type) -> bool`, computing the same "target, optional-unwrapped,
+has a PK" check for that path.
+
+## Numeric Aggregate Validation (`NumericAggregateable`) (#475)
+
+`storm::orm::statements::NumericAggregateable<T>` is the compile-time gate on the target field(s)
+of `sum()` / `avg()` / `min()` / `max()` — true for an arithmetic, non-`bool` type, unwrapping one
+level of `std::optional` (a nullable numeric column, e.g. `std::optional<int>`, is a legitimate
+aggregate target; SQL simply skips NULLs):
+
+```cpp
+template <typename T>
+constexpr bool is_numeric_aggregateable_v =
+        utilities::is_optional_v<T> ? is_numeric_scalar_v<utilities::optional_inner_type_t<T>>
+                                    : is_numeric_scalar_v<T>;
+
+template <typename T>
+concept NumericAggregateable = is_numeric_aggregateable_v<T>;
+```
+
+`AllNumericAggregateable<FieldInfos...>` folds this over the whole field pack (multi-field
+aggregates sum/min/max several columns, e.g. `SUM(a + b)`) and is the `requires`-clause on
+`QuerySet::sum/avg/min/max`. A string/BLOB/enum/UUID/temporal/`bool` field is a **compile error**
+at the aggregate call site, not a silent coercion. `count()` / `count_distinct()` are unconstrained
+— `COUNT` is type-agnostic and accepts any column.

--- a/docs/internals/architecture/MODULE_SYSTEM.md
+++ b/docs/internals/architecture/MODULE_SYSTEM.md
@@ -166,38 +166,56 @@ export class SelectStatement {
 };
 ```
 
-### Step 3: Adding PostgreSQL Support
+### Step 3: The PostgreSQL Backend
 
-To add PostgreSQL support, create a new backend module with the same interface:
+Storm ships a PostgreSQL backend alongside SQLite (`src/db/postgresql.cppm`,
+`postgresql_connection.cppm`, `postgresql_error.cppm`, `postgresql_statement.cppm`), following the
+same-interface pattern described above — `Statement` exposes the same template hot-path
+methods (`step_raw`, `extract_int`, ...), just backed by `PGresult`/`PQgetvalue` instead of
+`sqlite3_stmt`/`sqlite3_column_*`. A future third backend (e.g. MySQL) would follow the identical
+recipe: a new backend module with the same `Statement`/`Connection` interface, gated by the
+concepts in `src/db/concept.cppm`.
+
+### Dialect-Support Concepts (#477)
+
+Because two backends now genuinely differ in SQL dialect, `src/db/concept.cppm` declares named
+capability gates instead of ad-hoc `if constexpr (requires { ConnType::trait; })` probes at each
+call site:
 
 ```cpp
-// src/db/postgresql.cppm
-export module storm_db_postgresql;
+// The dialect switch itself — true for PG, false for SQLite. Used to pick
+// PG-specific SQL (NULLS FIRST/LAST ordering, LIMIT ALL, the schema Dialect enum).
+template <typename ConnType>
+concept SupportsPgDialect = requires {
+    { ConnType::uses_pg_dialect } -> std::convertible_to<bool>;
+};
 
-export class Statement {
-    PGresult* result_;
-    int current_row_ = 0;
+// Existence probe: both backends declare `supports_limit_all`; call sites still
+// read the bool VALUE to pick the spelling (PG: LIMIT ALL, SQLite: LIMIT -1).
+template <typename ConnType>
+concept SupportsLimitAll = requires {
+    { ConnType::supports_limit_all } -> std::convertible_to<bool>;
+};
 
-    template <typename = void>
-    [[nodiscard]] __attribute__((always_inline)) auto step_raw() noexcept -> int {
-        if (current_row_ < PQntuples(result_)) {
-            ++current_row_;
-            return ROW_AVAILABLE;
-        }
-        return NO_MORE_ROWS;
-    }
-
-    template <typename = void>
-    [[nodiscard]] __attribute__((always_inline)) auto extract_int(int col) const noexcept -> int {
-        return std::atoi(PQgetvalue(result_, current_row_ - 1, col));
-    }
-
-    // ... same interface as SQLite
-
-    static constexpr int ROW_AVAILABLE = 1;
-    static constexpr int NO_MORE_ROWS  = 0;
+// The surface storm::begin / TransactionGuard (#415) needs to run an RAII
+// transaction — a mis-typed connection fails at the begin() call site.
+template <typename ConnType>
+concept TransactionCapable = requires(ConnType& conn, std::string_view sql) {
+    typename ConnType::Error;
+    { conn.in_transaction() } -> std::convertible_to<bool>;
+    conn.enter_transaction();
+    conn.leave_transaction();
+    { conn.execute(sql) } -> std::same_as<std::expected<void, typename ConnType::Error>>;
 };
 ```
+
+`SupportsPgDialect` gates the `Dialect` enum selection in `schema.cppm` and `append_order_by`'s
+NULLS FIRST/LAST behavior in `base.cppm`. `SupportsLimitAll` gates `append_limit_offset`.
+`TransactionCapable` constrains `TransactionGuard` and `storm::begin`/`storm::transaction`. Each
+backend `static_assert`s these next to its `Connection` definition. Two candidate concepts were
+considered and dropped: `SupportsRightJoin` (`right_join()` was removed — no call site) and
+`SupportsReturning`/`SupportsStrictTables` (declared on the connections but never read by any
+call site).
 
 ## Performance Results
 

--- a/docs/internals/architecture/OVERVIEW.md
+++ b/docs/internals/architecture/OVERVIEW.md
@@ -75,12 +75,22 @@ Extensive use of compile-time features:
 src/
 ├── storm.cppm                      # Main module
 ├── db/
-│   ├── concept.cppm                # Database concepts
-│   └── sqlite.cppm                 # SQLite implementation
+│   ├── concept.cppm                # Database concepts (incl. dialect-support concepts, #477)
+│   ├── pool.cppm                   # PoolConfig, connection pooling
+│   ├── sqlite.cppm                 # SQLite implementation
+│   ├── postgresql.cppm             # PostgreSQL implementation
+│   ├── postgresql_connection.cppm  # PostgreSQL connection management
+│   ├── postgresql_error.cppm       # PostgreSQL error mapping
+│   └── postgresql_statement.cppm   # PostgreSQL prepared statements
 └── orm/
     ├── queryset.cppm               # QuerySet interface
     ├── field_attr.cppm             # Free-standing flag annotation objects (leaf module, #387/#492)
     ├── relation_meta.cppm          # m2m/reverse-fk annotation types + is_relation_field (leaf module, #408)
+    ├── indexes.cppm                # Index, UniqueIndex, Indexes<T> trait
+    ├── schema.cppm                 # DDL/schema generation
+    ├── generator.cppm              # storm-schema CLI codegen support
+    ├── transaction.cppm            # TransactionGuard, storm::begin/transaction (#415)
+    ├── where.cppm                  # WHERE-clause expression builders
     ├── utilities.cppm              # ConstexprString, SQLCache
     └── statements/
         ├── base.cppm               # BaseStatement utilities
@@ -90,8 +100,13 @@ src/
         ├── select.cppm             # SelectStatement + JOIN
         ├── update.cppm             # UpdateStatement
         ├── update_grammar.cppm     # UpdateGrammar — UPDATE SQL builders (#434)
+        ├── upsert_grammar.cppm     # Upsert (ON CONFLICT) SQL builders (#205)
         ├── erase.cppm              # EraseStatement
-        └── join.cppm               # JoinStatement (SQL builder)
+        ├── join.cppm               # JoinStatement (SQL builder)
+        ├── aggregate.cppm          # COUNT/SUM/AVG/MIN/MAX (#475)
+        ├── distinct.cppm           # DISTINCT
+        ├── orderby.cppm            # ORDER BY
+        └── setop.cppm              # Set-op helpers (e.g. GROUP BY/HAVING support)
 ```
 
 ## Cross-Module Dependencies
@@ -99,12 +114,20 @@ src/
 ```
 storm (main module)
 ├── storm_db_concept
+├── storm_db_pool
 ├── storm_db_sqlite
+├── storm_db_postgresql{,_connection,_error,_statement}
 ├── storm_orm_field_attr
 ├── storm_orm_relation_meta
-├── storm_orm_statements_base
+├── storm_orm_indexes
+├── storm_orm_schema
+├── storm_orm_generator
+├── storm_orm_transaction
+├── storm_orm_where
 ├── storm_orm_utilities
-├── storm_orm_statements_{insert,update,erase,select,join}
+├── storm_orm_statements_base
+├── storm_orm_statements_{insert,update,update_grammar,upsert_grammar,erase,select,join}
+├── storm_orm_statements_{aggregate,distinct,orderby,setop,extract,field_names}
 └── storm_orm_queryset
 ```
 
@@ -198,7 +221,7 @@ concept DatabaseStatement = requires(T stmt) {
 ```
 
 **Benefits**:
-- Future PostgreSQL/MySQL support
+- PostgreSQL support shipped alongside SQLite (MySQL: future work)
 - No ORM code changes needed
 - Compile-time interface verification
 

--- a/docs/internals/building/COMMON_TASKS.md
+++ b/docs/internals/building/COMMON_TASKS.md
@@ -154,12 +154,17 @@ static auto get_cached_sql(size_t key) -> std::string {
 - Debug bottlenecks
 - Regression testing
 
-## Adding PostgreSQL Support
+## Adding a New Database Backend (e.g. MySQL)
 
-1. Create `src/db/postgresql.cppm` implementing concepts
-2. Add PostgreSQL-specific statement implementations
-3. Update `ConnectionManager` for multiple backends
-4. Ensure concepts properly abstract differences
+PostgreSQL support already ships this way (`src/db/postgresql.cppm`,
+`postgresql_connection.cppm`, `postgresql_error.cppm`, `postgresql_statement.cppm`),
+alongside SQLite. To add another backend:
+
+1. Create `src/db/<backend>.cppm` implementing the concepts in `src/db/concept.cppm`
+   (including the dialect-support concepts, e.g. `SupportsPgDialect`, `TransactionCapable`)
+2. Add backend-specific connection/statement/error modules, mirroring the PostgreSQL split
+3. Static-assert the dialect-support concepts next to the new `Connection` definition
+4. Ensure concepts properly abstract differences — no ORM-layer (`src/orm/`) code changes needed
 
 ## Performance Checklist
 

--- a/docs/internals/building/PRE_COMMIT.md
+++ b/docs/internals/building/PRE_COMMIT.md
@@ -4,6 +4,17 @@ Storm's pre-commit hook (`commit.sh`) runs format → clang-tidy → tests → c
 This page documents the **clang-tidy** stage in detail, because it has three
 modes with different scopes.
 
+## Self-healing on a fresh/stale worktree (#489)
+
+Before running clang-tidy, `commit.sh` configures and fully builds the release
+target set (BMIs + mock test binaries) — not just `--target storm` — so a fresh
+worktree doesn't fail with "module BMI not found" (clang-tidy on files that
+`import std;`/`import storm;` need the BMIs) or `storm_mock_tests_NOT_BUILT`
+later at the `ctest` stage. It similarly ensures `build/debug` is built before
+running `ctest`. Both guards are file-check-and-build: a no-op (fast) on an
+already-warm build directory, so this doesn't add cost on the common path — it
+only matters the first time you commit from a new worktree.
+
 ## The three clang-tidy modes
 
 | Mode | What it scans | Where it runs | Blocks on |

--- a/docs/internals/testing/MSAN_LIBC_FIX.md
+++ b/docs/internals/testing/MSAN_LIBC_FIX.md
@@ -5,7 +5,8 @@
 **Partially applied, not yet working.** The fix is tracked in
 `docs/development/fix_msan_libc_string.patch` (apply to `../clang-p2996/libcxx/include/string`).
 
-The `ninja-msan` CI job is marked `continue-on-error: true` until this is resolved.
+The `ninja-msan` job is removed from the CI matrix entirely (not
+`continue-on-error`) until this is resolved — see `.github/workflows/ci.yml`.
 
 ## Root cause
 

--- a/docs/internals/testing/SANITIZERS.md
+++ b/docs/internals/testing/SANITIZERS.md
@@ -12,6 +12,15 @@ Storm provides sanitizer-enabled CMake presets for catching memory, concurrency,
 
 > **Note**: ASAN, TSAN, and MSAN are mutually exclusive — they cannot be combined in a single build.
 
+> **MSAN is not run in CI.** Under `import std;` (#326), GTest's static `TEST()`
+> registration move-constructs `std::string` through the MSAN-instrumented std
+> module, and MSAN reports the SSO buffer as uninitialized — aborting the binary
+> before any test body runs. This is a false positive in clang-p2996's MSAN +
+> `import std;` combination, so the preset produces no signal; the matrix entry
+> was removed from `.github/workflows/ci.yml` (not merely `continue-on-error`).
+> It is kept as a local-only preset for future investigation. See
+> [MSAN_LIBC_FIX.md](MSAN_LIBC_FIX.md) and issue #326.
+
 ## Quick Start
 
 ```bash


### PR DESCRIPTION
## Summary
- Fixed structural drift between `docs/` and `src/` accumulated since the PostgreSQL backend and recent concept work (#474/#475/#477) shipped without matching docs — module tree, MSAN CI status, PostgreSQL "future work" framing, missing `ValidForeignKey`/`NumericAggregateable`/dialect-support-concepts coverage.
- Rewrote `benchmarks/README.md`'s Usage section (~1700 of 2015 lines) which described a pre-Google-Benchmark custom runner (fake `--quick`/`--thorough`/`-c`/`--filter`/`--disk` flags, stale dated perf tables) that no longer exists in `src/` — replaced with accurate `--benchmark_filter`/gbench-based usage.
- Added a missing `IN` section to `WHERE_CLAUSES.md`.
- Fixed a real bug in doc examples: `Error.message`/`Error.code` shown as data members instead of `.message()`/`.code()` methods — the sample code would not compile as written.
- Added `docs/guide/features/INDEXES.md` (previously undocumented: `storm::indexed`/`storm::unique` tags, composite `Index<>`/`UniqueIndex<>`, the #464 nested-typedef requirement).
- Minor completeness: `count_distinct()`/`has_default_connection()` examples in COOKBOOK.md, `JournalMode` namespace fix in CONNECTION_TUNING.md, #489 self-heal note in PRE_COMMIT.md.

No `src/` changes — doc-only.

## Test plan
- [x] Docs-only change — pre-commit hook confirmed no C++/cmake files, skipped format/tidy/tests/coverage
- [ ] CI (docs-only, should be a no-op / pass trivially)

🤖 Generated with [Claude Code](https://claude.com/claude-code)