### PR TITLE
feat(501): composite PK — UPDATE and DELETE by composite key

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -366,9 +366,35 @@ column. `calculate_column_defs_size` keeps FK columns on the FK-suffix budget fo
 (the regular suffix under-counts and `ConstexprString` truncates silently); `build_sql_impl` gained a
 whole-SQL `std::unreachable()` backstop, since the per-column one can't catch a sizing shortfall. Autoincrement on a composite key is **unrepresentable**,
 not just useless — SQLite rejects both spellings at parse time and PG's identity is single-column —
-hence the compile-time rejection. **Scope**: annotation + DDL only; INSERT/UPDATE/DELETE/JOIN by
-composite key and composite FKs are #501–#504, so a composite model reaching CRUD fails at a named
-concept. See [docs/guide/reference/FIELD_TYPES.md](docs/guide/reference/FIELD_TYPES.md).
+hence the compile-time rejection. **Scope**: annotation + DDL only; UPDATE/DELETE by composite key
+land in #501 (below), INSERT/JOIN and composite FKs in #502–#504.
+See [docs/guide/reference/FIELD_TYPES.md](docs/guide/reference/FIELD_TYPES.md).
+
+**Composite PK — UPDATE and DELETE (#501)**: the by-key `WHERE pk = ?` widens to
+`WHERE a = ? AND b = ?`, AND-joined in declaration order. Three things changed, each with its own
+failure mode. (1) **SQL text**: the clause writer/sizer pair `append_pk_where_clause` /
+`pk_where_clause_size` are free functions in `base.cppm` (NOT `BaseStatement` methods — that class is
+inherited by every statement type, and `SchemaStatement` already sits at the S1448 ceiling), taking
+the PK-member array as a parameter so `erase.cppm` and `update_grammar.cppm` share them without
+depending on each other. Parts go through `append_column_name` (#422), so an FK part emits
+`warehouse_id`. (2) **Bind arithmetic**: `bind_pk_values` binds all N parts via an index sequence
+(each part may be a DIFFERENT type — `int` + `std::string` is the canonical shape, so the dispatch is
+per-part at compile time) and threads `param_index` by REFERENCE, which is what removes the old
+`++param_index`-per-row stride assumption. In UPDATE the key follows the SET values, so it starts at
+N_set+1. (3) **SET-target gate**: `is_settable_member` in BOTH `update_grammar.cppm` and
+`upsert_grammar.cppm` now tests `Base::is_pk_member(M)` instead of `M != primary_key_` — the old test
+excluded only the FIRST part, leaving `SET b=? WHERE a=? AND b=?` (rewriting the key it matches on)
+legal. `bind_field_at_index` gained a **separate** `SkipAllPK` flag rather than widening `SkipPK`:
+INSERT passes `SkipPK` too, and composite INSERT is #502 — widening it would silently change INSERT's
+bind order as a side effect. Bulk DELETE uses a **row-value IN list**, `(a, b) IN ((?,?),(?,?))`
+(PG always, SQLite ≥ 3.15 vs the project's 3.35 floor); the per-column form `a IN (…) AND b IN (…)`
+is WRONG — it matches the parts' cross product and deletes unlisted keys. Chunking is now
+`MAX_CHUNK_ROWS = 799/N` since each row costs N parameters. The consteval DELETE grammar moved to a
+new `erase_grammar.cppm` leaf (mirroring `update_grammar.cppm`, #434) to keep `erase.cppm` under the
+file-size limit; its `append_row_placeholder_list` is shared by the consteval max-chunk builder AND
+the runtime per-count builder, so the two cannot drift into disagreeing placeholder counts.
+Single-PK SQL is byte-identical (regression-asserted), and single-PK UPDATE/DELETE benchmarks are
+within noise (≤1.4% deltas at cv 1.1–2.9%).
 
 **Foreign keys (#431)**: `[[= storm::fk<>]]` marks an FK field (bare = `RESTRICT`,
 the SQL default — no `ON DELETE` clause emitted). The `ON DELETE` policy is the template

--- a/docs/guide/reference/FIELD_TYPES.md
+++ b/docs/guide/reference/FIELD_TYPES.md
@@ -254,10 +254,35 @@ is the canonical association-table key, and the clause names the FK's actual col
 > `indexed` on a part is currently a no-op: the PK already indexes the parts, so the
 > per-column index is suppressed for every PK member, as it is for a single-column PK.
 
-> **Scope (#500)**: composite keys currently cover the annotation, the compile-time PK
-> machinery, and `CREATE TABLE` DDL. INSERT/UPDATE/DELETE/JOIN by composite key, and
-> composite foreign keys, land in #501–#504; until then a composite-PK model reaching a
-> CRUD path fails to compile at a named concept.
+### UPDATE and DELETE by composite key (#501)
+
+`update(obj)` and `erase(obj)` match on the **whole** key: the `WHERE pk = ?` of a
+single-PK model becomes `WHERE a = ? AND b = ?`, with every part bound in declaration
+order. A row matching only *some* parts is not touched.
+
+```cpp
+qs.erase(OrderItem{.order_id = 1, .product_id = 20}).execute();
+// DELETE FROM OrderItem WHERE order_id = ? AND product_id = ?
+
+qs.update(OrderItem{.order_id = 1, .product_id = 20, .quantity = 7}).execute();
+// UPDATE OrderItem SET quantity=? WHERE order_id = ? AND product_id = ?
+```
+
+- **No key part is ever a SET target.** The UPDATE (and upsert `DO UPDATE`) SET clause
+  excludes *every* PK member, so a statement can never rewrite part of the key it matches on.
+- **Batch DELETE uses a row-value `IN` list** — `WHERE (a, b) IN ((?,?),(?,?))`. This is
+  standard SQL (PostgreSQL always; SQLite since 3.15, well under this project's 3.35 floor).
+  The per-column form `a IN (…) AND b IN (…)` would match the *cross product* of the parts
+  and delete keys that were never listed, so it is not used.
+- **Batch chunking shrinks with key width.** Each row costs one bound parameter per PK
+  column, so an N-part key fits `799 / N` rows per chunk instead of 799. Single-PK models
+  keep the historical 799.
+- **Single-PK SQL is byte-identical** to what Storm emitted before composite support.
+
+> **Scope**: composite keys now cover the annotation, the compile-time PK machinery,
+> `CREATE TABLE` DDL (#500), and UPDATE/DELETE by key (#501). INSERT by composite key
+> (#502), upsert `ON CONFLICT` targets (#503), and composite foreign keys / JOIN (#504)
+> are still open.
 
 ## Optional Types (NULL Support)
 

--- a/scripts/run_clang_tidy.sh
+++ b/scripts/run_clang_tidy.sh
@@ -137,6 +137,7 @@ echo ""
 #   tests/test_models.h, tests/test_seed_helpers.h, tests/test_select_runner.h,
 #   tests/test_write_runner.h, tests/test_yaml_register.h,
 #   tests/query/test_aggregate_fixture.h, tests/query/test_m2m_models.h,
+#   tests/crud/test_composite_pk_models.h,
 #   tests/test_parser.hpp, tests/tools/storm_schema/models.h
 #
 #   benchmarks/bench_register.h — includes benchmark/benchmark.h which
@@ -168,6 +169,7 @@ is_known_unparseable() {
         tests/test_yaml_register.h) return 0 ;;
         tests/query/test_aggregate_fixture.h) return 0 ;;
         tests/query/test_m2m_models.h) return 0 ;;
+        tests/crud/test_composite_pk_models.h) return 0 ;;
         tests/test_parser.hpp) return 0 ;;
         tests/tools/storm_schema/models.h) return 0 ;;
         benchmarks/bench_register.h) return 0 ;;

--- a/src/orm/statements/base.cppm
+++ b/src/orm/statements/base.cppm
@@ -562,6 +562,47 @@ export namespace storm::orm::statements {
         }
     }
 
+    // ── Primary-key WHERE clause (#501) ──────────────────────────────────────────
+    // The by-key WHERE that UPDATE-by-object and DELETE-by-object share. For a single
+    // PK this emits exactly the "<pk> = ?" the two statements spelled inline before, so
+    // single-PK SQL stays byte-identical; for a composite key it AND-joins every part in
+    // declaration order — the same order pk_members binds in.
+    //
+    // Free function templates over the PK-member array rather than BaseStatement methods:
+    // SchemaStatement sits at the cpp:S1448 35-method ceiling and BaseStatement is the
+    // class both statements inherit, so anything added there is paid by every statement
+    // type. Taking the array as a parameter also lets erase.cppm and update_grammar.cppm
+    // call these without either one depending on the other.
+
+    // Byte length of "<a> = ? AND <b> = ?" for the given PK members. Exact — both callers
+    // size a ConstexprString with it, and ConstexprString truncates SILENTLY on overflow,
+    // so an under-count is a wrong-SQL bug with no diagnostic. Column names go through
+    // the canonical writer (#422) so an FK part is measured as "<name>_id".
+    template <std::size_t N>
+    consteval auto pk_where_clause_size(const std::array<std::meta::info, N>& pk_members) -> std::size_t {
+        constexpr std::size_t EQUALS_PLACEHOLDER = 4; // " = ?"
+        constexpr std::size_t AND_JOIN           = 5; // " AND "
+        std::size_t           size               = 0;
+        for (const std::meta::info member : pk_members) {
+            size += storm::meta::column_name_size(member) + EQUALS_PLACEHOLDER;
+        }
+        return size + (AND_JOIN * (N - 1));
+    }
+
+    // Append "<a> = ? AND <b> = ?" for the given PK members, in declaration order.
+    template <typename Buf, std::size_t N>
+    consteval auto append_pk_where_clause(Buf& buf, const std::array<std::meta::info, N>& pk_members) -> void {
+        bool first = true;
+        for (const std::meta::info member : pk_members) {
+            if (!first) {
+                buf.append(" AND ");
+            }
+            storm::meta::append_column_name(buf, member); // #422 — FK parts emit "<name>_id"
+            buf.append(" = ?");
+            first = false;
+        }
+    }
+
     // Shared reflection utilities for all statement types
     template <typename T>
         requires storm::meta::Entity<T> && ModelWithPrimaryKey<T> && ModelStorageAnnotated<T> &&
@@ -633,6 +674,26 @@ export namespace storm::orm::statements {
             return meta::is_fk_field(member);
         }
 
+      public:
+        // True when `member` is ANY part of the primary key (#501) — the widened form of
+        // the `member == primary_key_` test that the UPDATE and upsert SET-target gates
+        // used. On a composite model that old test excluded only the FIRST part, leaving
+        // every other part writable: `SET product_id=? WHERE order_id=? AND product_id=?`
+        // would rewrite part of the very key it matches on. Identical to the old test on a
+        // single-PK model (the array has one element). Public because UpdateGrammar and
+        // UpsertGrammar are separate types, not subclasses.
+        static consteval auto is_pk_member(std::meta::info member) -> bool {
+            // A CALLED consteval any_of lambda reports as uncovered against the 100%
+            // line-coverage gate; the plain loop does not.
+            for (const std::meta::info pk : primary_key_members_) { // NOLINT(readability-use-anyofallof)
+                if (pk == member) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+      protected:
         // Per-attribute predicates forward to the storm_orm_field_attr leaf (#421),
         // the single source of truth for each flag-annotation test.
         static consteval auto is_unique_field(std::meta::info member) -> bool {
@@ -801,6 +862,12 @@ export namespace storm::orm::statements {
         static constexpr auto primary_key_members_ = find_primary_key_members_impl();
         static constexpr bool has_composite_pk_    = primary_key_members_.size() > 1;
 
+        // How many columns the key spans, as a plain std::size_t (#501). Needed because
+        // primary_key_members_ is an array of std::meta::info — a consteval-only type
+        // that cannot be named at all in a runtime context, not even via .size(). The
+        // bind path advances param_index by this at runtime.
+        static constexpr std::size_t primary_key_column_count_ = primary_key_count();
+
       protected:
         // Index sequence utilities for compile-time field binding
         using field_indices_t = std::make_index_sequence<field_count_>;
@@ -830,13 +897,36 @@ export namespace storm::orm::statements {
             return result;
         }
 
+        // Does the caller's PK-skip policy exclude `member` from the bind order?
+        // SkipAllPK covers every part of a composite key (#501); plain SkipPK keeps the
+        // historical first-PK-only skip that INSERT relies on. The two coincide on a
+        // single-PK model.
+        template <bool SkipPK, bool SkipAllPK> static consteval auto skips_pk_column(std::meta::info member) -> bool {
+            if (!SkipPK) {
+                return false;
+            }
+            return SkipAllPK ? is_pk_member(member) : member == primary_key_;
+        }
+
         // Unified field binder: binds a single field at compile-time index.
         // SkipPK=true skips primary key fields (for INSERT/UPDATE non-PK binding).
         // IsUpdate=true marks the UPDATE path so auto_create fields bind the object's
         // stored value instead of now() (#209). `now` is read once per operation by the
         // caller and threaded in so every row in a batch shares the same timestamp.
         // Auto-increments param_index on successful bind.
-        template <typename ConnType, std::size_t Index, bool SkipPK = false, bool IsUpdate = false>
+        //
+        // SkipAllPK widens the skip from primary_key_ to EVERY primary-key member (#501),
+        // which is what UPDATE needs: its SET clause omits the whole composite key, so the
+        // bind order must too. Deliberately a SEPARATE flag rather than widening SkipPK
+        // itself — INSERT also passes SkipPK, and how a composite key is INSERTed is #502.
+        // Changing SkipPK here would silently alter the INSERT bind order as a side effect
+        // of a DELETE/UPDATE issue. No effect on single-PK models, where the two coincide.
+        template <
+                typename ConnType,
+                std::size_t Index,
+                bool        SkipPK    = false,
+                bool        IsUpdate  = false,
+                bool        SkipAllPK = false>
         [[nodiscard]] __attribute__((always_inline)) static constexpr auto bind_field_at_index(
                 typename ConnType::Statement*         stmt,
                 const T&                              obj,
@@ -854,8 +944,8 @@ export namespace storm::orm::statements {
                 );
             }
 
-            // Compile-time PK skip for INSERT/UPDATE non-PK paths
-            if constexpr (SkipPK && member == primary_key_) {
+            // Compile-time PK skip for INSERT/UPDATE non-PK paths.
+            if constexpr (skips_pk_column<SkipPK, SkipAllPK>(member)) {
                 return {};
             }
             // Auto-timestamp (#209): stamp now() for auto_update (always) and auto_create
@@ -972,9 +1062,13 @@ export namespace storm::orm::statements {
             return bind_bulk_objects_impl<true, ConnType, Statement, ContainerType, Is...>(stmt, objects, seq);
         }
 
-        // Common batch operation thresholds
+      public:
+        // Common batch operation thresholds. Public since #501: EraseGrammar derives the
+        // bulk-DELETE chunk size from it and is a separate type, not a subclass. It is a
+        // backend constant rather than model state, so exposing it leaks nothing.
         static constexpr std::size_t MAX_DB_VARIABLES = 999;
 
+      protected:
         // Adaptive threshold calculation based on batch size and field count
         // Returns the optimal threshold for deciding between bulk SQL and individual inserts
         static constexpr auto calculate_adaptive_threshold(std::size_t batch_size, std::size_t max_bulk_size)
@@ -1021,7 +1115,73 @@ export namespace storm::orm::statements {
             );
         }
 
-      protected:
+        // Bind every primary-key value of `obj`, in declaration order, starting at
+        // `param_index` and advancing it past the last part (#501). The bind order matches
+        // the column order append_pk_where_clause emits, which is what keeps the
+        // placeholders and the values aligned.
+        //
+        // The index sequence is over primary_key_members_ rather than a runtime loop
+        // because each part may be a DIFFERENT type (int + std::string is the canonical
+        // composite key), so the bind has to be dispatched per part at compile time. An FK
+        // part binds the referenced object's own PK value, matching how the "<name>_id"
+        // column is written.
+        // Each part's placeholder is `param_index + Is` — a compile-time offset from the
+        // start of the key, so no running counter is threaded through the fold. On a
+        // single-PK model this collapses to exactly one `bind(stmt, param_index, value)`
+        // call, identical to the hand-written bind it replaced.
+        template <typename ConnType, std::size_t... Is>
+        [[nodiscard]] __attribute__((always_inline)) static auto bind_pk_values_impl(
+                typename ConnType::Statement& stmt, const T& obj, int param_index, std::index_sequence<Is...> /*unused*/
+        ) noexcept -> std::expected<void, typename ConnType::Error> {
+            std::expected<void, typename ConnType::Error> result{};
+            ((result = bind_one_pk_part<ConnType, primary_key_members_[Is]>(
+                      stmt, obj, param_index + static_cast<int>(Is)
+              ),
+              result.has_value()) &&
+             ...);
+            return result;
+        }
+
+        // Bind one primary-key part at `index`. An FK part (the canonical
+        // association-table shape) stores the referenced row's key, so bind THAT, not the
+        // whole object — the same value the "<name>_id" column holds.
+        //
+        // Takes `index` BY VALUE and does not advance it: the caller computes each part's
+        // offset as a compile-time constant (see bind_pk_values_impl). Flat code, no
+        // lambda and no dead increment on the last part — this sits directly in the
+        // single-row UPDATE/DELETE hot path, where nested lambdas have cost ~3-4% before.
+        template <typename ConnType, std::meta::info Member>
+        [[nodiscard]] __attribute__((always_inline)) static auto
+        bind_one_pk_part(typename ConnType::Statement& stmt, const T& obj, int index) noexcept
+                -> std::expected<void, typename ConnType::Error> {
+            if constexpr (is_fk_field(Member)) {
+                using FKType = std::remove_cvref_t<decltype(obj.[:Member:])>;
+                return bind_value_by_type<ConnType>(stmt, index, obj.[:Member:].[:find_fk_primary_key<FKType>():]);
+            } else {
+                return bind_value_by_type<ConnType>(stmt, index, obj.[:Member:]);
+            }
+        }
+
+        // Bind the whole primary key of `obj` starting at `param_index`, advancing it past
+        // the key. The entry point erase.cppm and update.cppm call; single-PK models bind
+        // exactly one value, as before.
+        //
+        // The advance is a single add of a compile-time constant, applied once here rather
+        // than per-part inside the fold — on the single-PK path the caller never reads it
+        // back, so it folds away entirely.
+        template <typename ConnType>
+        [[nodiscard]] __attribute__((always_inline)) static auto
+        bind_pk_values(typename ConnType::Statement& stmt, const T& obj, int& param_index) noexcept
+                -> std::expected<void, typename ConnType::Error> {
+            auto result = bind_pk_values_impl<ConnType>(
+                    stmt, obj, param_index, std::make_index_sequence<primary_key_column_count_>{}
+            );
+            if (result.has_value()) {
+                param_index += static_cast<int>(primary_key_column_count_);
+            }
+            return result;
+        }
+
         // =====================================================================
         // COLUMN EXTRACTION HELPERS - Moved here from SelectStatement so that
         // constexpr access to all_members_[Index] happens in base.cppm context

--- a/src/orm/statements/erase.cppm
+++ b/src/orm/statements/erase.cppm
@@ -10,6 +10,7 @@ export module storm_orm_statements_erase;
 import std;
 
 import storm_orm_statements_base;
+import storm_orm_statements_erase_grammar;
 import storm_orm_utilities;
 import storm_orm_transaction;
 import storm_orm_where;
@@ -30,108 +31,29 @@ export namespace storm::orm::statements {
         using Error      = typename ConnType::Error;
         using Statement  = typename ConnType::Statement;
 
-        // Common prefix size: "DELETE FROM <table> WHERE <pk_name>". Both the
-        // single-row and the bulk DELETE size calculators used to spell this
-        // out; their only difference is the tail (" = ?" vs " IN (").
-        static consteval auto delete_prefix_size() -> std::size_t {
-            using utilities::sql_len::DELETE_FROM;
-            using utilities::sql_len::WHERE;
-            return DELETE_FROM + Base::table_name_.size() + WHERE + Base::pk_name_.size();
-        }
+        // Compile-time DELETE SQL grammar (#501): every "how the SQL is spelled" helper —
+        // the prefix, the AND-joined key clause, the row-value IN list and the chunk
+        // arithmetic — lives in EraseGrammar<T>. Split out to keep this file under the
+        // size threshold, mirroring UpdateGrammar (#434).
+        using Grammar = EraseGrammar<T>;
 
-        // Compile-time single DELETE SQL size calculation
-        static consteval auto calculate_single_delete_sql_size() -> std::size_t {
-            return delete_prefix_size() + 4 + 1; // " = ?" + null terminator
-        }
+        // Rows per chunk. Each row costs one bound parameter per PK column, so a
+        // composite key fits proportionally fewer rows under the same variable ceiling
+        // (#501); single-PK models keep the historical 799.
+        static constexpr std::size_t MAX_CHUNK_ROWS = Grammar::MAX_CHUNK_ROWS;
 
-        // Append the shared "DELETE FROM <table> WHERE <pk_name>" prefix.
-        // The single-row builder appends "= ?" after; the bulk builder appends
-        // " IN (". Centralising the prefix removes the textual duplicate the
-        // hook flagged.
-        template <typename Buf> static consteval auto append_delete_prefix(Buf& buf) -> void {
-            buf.append("DELETE FROM ");
-            buf.append(Base::table_name_);
-            buf.append(" WHERE ");
-            buf.append(Base::pk_name_);
-        }
-
-        // Build single DELETE SQL at compile-time using ConstexprString
-        static consteval auto build_single_delete_sql_array() {
-            constexpr std::size_t     sql_size = calculate_single_delete_sql_size() + utilities::sql_len::LARGE_BUFFER;
-            ConstexprString<sql_size> result;
-            append_delete_prefix(result);
-            result.append(" = ?");
-            return result;
-        }
-
-        // Pre-computed single DELETE SQL generated at compile-time
-        static inline const std::string single_delete_sql_string = std::string(build_single_delete_sql_array());
-
-        // Compile-time all-rows DELETE SQL (no WHERE clause)
-        static consteval auto build_delete_all_sql_array() {
-            using utilities::sql_len::DELETE_FROM;
-            constexpr std::size_t sql_size = DELETE_FROM + Base::table_name_.size() + utilities::sql_len::LARGE_BUFFER;
-            ConstexprString<sql_size> result;
-            result.append("DELETE FROM ");
-            result.append(Base::table_name_);
-            return result;
-        }
+        // Pre-computed single DELETE SQL generated at compile-time.
+        // Single PK  → "DELETE FROM t WHERE id = ?"          (byte-identical to pre-#501)
+        // Composite  → "DELETE FROM t WHERE a = ? AND b = ?"
+        static inline const std::string single_delete_sql_string =
+                std::string(Grammar::build_single_delete_sql_array());
 
         // Pre-computed all-rows DELETE SQL
-        static inline const std::string delete_all_sql_string = std::string(build_delete_all_sql_array());
+        static inline const std::string delete_all_sql_string = std::string(Grammar::build_delete_all_sql_array());
 
       private:
-        // Compile-time bulk DELETE prefix calculation
-        static consteval auto calculate_bulk_delete_prefix_size() -> std::size_t {
-            return delete_prefix_size() + utilities::sql_len::IN_OPEN + 1; // " IN (" + null terminator
-        }
-
-        // Build bulk DELETE prefix at compile-time using ConstexprString
-        static consteval auto build_bulk_delete_prefix() {
-            constexpr std::size_t prefix_size = calculate_bulk_delete_prefix_size() + utilities::sql_len::LARGE_BUFFER;
-            ConstexprString<prefix_size> result;
-            append_delete_prefix(result);
-            result.append(" IN (");
-            return result;
-        }
-
-        // Pre-computed bulk DELETE prefix generated at compile-time
-        static inline const std::string bulk_delete_prefix = std::string(build_bulk_delete_prefix());
-        static constexpr std::size_t    bulk_delete_prefix_size =
-                calculate_bulk_delete_prefix_size() - 1; // Exclude null terminator
-
-        // Maximum chunk size for IN clause (80% of SQLite limit for safety)
-        // Defined here so it can be used in compile-time SQL generation
-        static constexpr std::size_t MAX_CHUNK_SIZE = (Base::MAX_DB_VARIABLES * 4) / 5; // 799
-
-        // Compile-time max bulk DELETE SQL size calculation
-        static consteval auto calculate_max_bulk_delete_sql_size() -> std::size_t {
-            // prefix + (MAX_CHUNK_SIZE placeholders) + (MAX_CHUNK_SIZE-1 commas) + closing paren + null
-            return bulk_delete_prefix_size + MAX_CHUNK_SIZE + (MAX_CHUNK_SIZE - 1) + 1 + 1;
-        }
-
-        // Build max bulk DELETE SQL at compile-time (799 placeholders)
-        static consteval auto build_max_bulk_delete_sql() {
-            constexpr std::size_t     sql_size = calculate_max_bulk_delete_sql_size() + 50; // Safety buffer
-            ConstexprString<sql_size> result;
-
-            // Reuse bulk delete prefix
-            result.append(build_bulk_delete_prefix());
-
-            // Append 799 placeholders with commas
-            for (std::size_t i = 0; i < MAX_CHUNK_SIZE; ++i) {
-                if (i > 0) {
-                    result.append(",");
-                }
-                result.append("?");
-            }
-            result.append(")");
-
-            return result;
-        }
-
-        // Pre-computed max bulk DELETE SQL (799 placeholders) generated at compile-time
-        static inline const std::string max_bulk_delete_sql = std::string(build_max_bulk_delete_sql());
+        // Pre-computed max-chunk bulk DELETE SQL generated at compile-time
+        static inline const std::string max_bulk_delete_sql = std::string(Grammar::build_max_bulk_delete_sql());
 
         // Generate single DELETE SQL string (compile-time computed, runtime accessible)
         static auto get_single_delete_sql() -> const std::string& {
@@ -153,24 +75,9 @@ export namespace storm::orm::statements {
                 return *cached; // Return by reference - no copy
             }
 
-            // Calculate exact size needed
-            const std::size_t total_size =
-                    bulk_delete_prefix_size + count + (count - 1) + 1; // prefix + ?s + commas + )
-
-            std::string sql;
-            sql.reserve(total_size);
-            sql = bulk_delete_prefix;
-
-            for (std::size_t i = 0; i < count; ++i) {
-                if (i > 0) {
-                    sql += ",";
-                }
-                sql += "?";
-            }
-            sql += ")";
-
-            // Cache the result and return reference to it
-            cache.insert(count, std::move(sql));
+            // Built by the same grammar the consteval max-chunk builder uses, so the
+            // runtime and compile-time SQL for a given count cannot drift apart.
+            cache.insert(count, Grammar::bulk_delete_sql_for(count));
             return *cache.find(count); // Guaranteed to exist after insert
         }
 
@@ -258,8 +165,9 @@ export namespace storm::orm::statements {
             if (!stmt_result) {
                 return std::unexpected(stmt_result.error());
             }
-            auto* stmt = *stmt_result;
-            if (auto bind_result = bind_pk_at(*stmt, obj, 1); !bind_result) {
+            auto* stmt        = *stmt_result;
+            int   param_index = 1;
+            if (auto bind_result = bind_pk_at(*stmt, obj, param_index); !bind_result) {
                 return std::unexpected(bind_result.error());
             }
             return stmt->expanded_sql();
@@ -285,10 +193,11 @@ export namespace storm::orm::statements {
             // hot binder hierarchy for no real safety gain.
             int param_index = 1;
             for (const auto& obj : objects) {
+                // bind_pk_at advances param_index past the whole key (N parameters for an
+                // N-column PK), so no manual stride here.
                 if (auto result = bind_pk_at(*stmt, obj, param_index); !result) {
                     return std::unexpected(result.error());
                 }
-                ++param_index;
             }
             return stmt->expanded_sql();
         }
@@ -304,7 +213,7 @@ export namespace storm::orm::statements {
             }
 
             // Strategy 2: Bulk IN clause (2-799 rows) - no transaction needed
-            if (objects.size() <= MAX_CHUNK_SIZE) {
+            if (objects.size() <= MAX_CHUNK_ROWS) {
                 return execute_bulk(objects);
             }
 
@@ -395,7 +304,8 @@ export namespace storm::orm::statements {
             auto* stmt = *stmt_result;
 
             // Bind PK and execute (statement already reset by ready_delete_statement)
-            if (auto bind_result = bind_pk_at(*stmt, obj, 1); !bind_result) {
+            int param_index = 1;
+            if (auto bind_result = bind_pk_at(*stmt, obj, param_index); !bind_result) {
                 return std::unexpected(bind_result.error());
             }
 
@@ -435,7 +345,7 @@ export namespace storm::orm::statements {
             Statement* max_bulk_stmt = *max_bulk_result;
 
             // Calculate remainder size upfront
-            const std::size_t remainder_size = objects.size() % MAX_CHUNK_SIZE;
+            const std::size_t remainder_size = objects.size() % MAX_CHUNK_ROWS;
             Statement*        remainder_stmt = nullptr;
 
             // Cache remainder statement if needed (only one hash lookup per batch)
@@ -450,12 +360,12 @@ export namespace storm::orm::statements {
 
             // Process full chunks using local pointer (no hash lookups in loop)
             std::size_t offset = 0;
-            while (offset + MAX_CHUNK_SIZE <= objects.size()) {
-                auto chunk = objects.subspan(offset, MAX_CHUNK_SIZE);
+            while (offset + MAX_CHUNK_ROWS <= objects.size()) {
+                auto chunk = objects.subspan(offset, MAX_CHUNK_ROWS);
                 if (auto result = bind_pks_and_execute(*max_bulk_stmt, chunk); !result) {
                     return std::unexpected(result.error());
                 }
-                offset += MAX_CHUNK_SIZE;
+                offset += MAX_CHUNK_ROWS;
             }
 
             // Process remainder with pre-cached statement
@@ -476,13 +386,13 @@ export namespace storm::orm::statements {
             // Reset before binding - required for cached statement reuse
             stmt.reset();
 
-            // Bind all primary key values
+            // Bind all primary key values. bind_pk_at advances param_index past each
+            // object's whole key — N parameters per row for an N-column PK (#501).
             int param_index = 1;
             for (const auto& obj : objects) {
                 if (auto result = bind_pk_at(stmt, obj, param_index); !result) {
                     return std::unexpected(result.error());
                 }
-                ++param_index;
             }
 
             // Execute once with all parameters bound
@@ -509,14 +419,17 @@ export namespace storm::orm::statements {
             return stmt;
         }
 
-        // Bind primary key value at specific parameter index
-        [[nodiscard]] __attribute__((always_inline)) auto bind_pk_at(Statement& stmt, const T& obj, int index) noexcept
+        // Bind the object's whole primary key starting at `index`, advancing it past the
+        // key (#501). A single-PK model binds one value and advances by one, exactly as
+        // before; a composite key binds every part in declaration order — the same order
+        // the WHERE clause and the row-value placeholder group name them in.
+        //
+        // `index` is an in/out reference precisely so the callers below cannot get the
+        // stride wrong: the old `++param_index` per object silently assumed one parameter
+        // per row, which is the bug this issue exists to fix.
+        [[nodiscard]] __attribute__((always_inline)) auto bind_pk_at(Statement& stmt, const T& obj, int& index) noexcept
                 -> std::expected<void, Error> {
-            // Get primary key value using pre-computed reflection
-            auto pk_value = obj.[:Base::primary_key_:];
-
-            // Use shared binding utility
-            return Base::template bind_value_by_type<ConnType>(stmt, index, pk_value);
+            return Base::template bind_pk_values<ConnType>(stmt, obj, index);
         }
 
       private:

--- a/src/orm/statements/erase_grammar.cppm
+++ b/src/orm/statements/erase_grammar.cppm
@@ -1,0 +1,215 @@
+module;
+
+// Compile-time DELETE SQL grammar (#501): the consteval "how DELETE SQL is spelled"
+// helpers, split out of EraseStatement so that class stays cohesive and the file stays
+// under the size threshold — the same split update_grammar.cppm got in #434. Stateless
+// and connection-free: every member derives purely from reflection over the model type T
+// (via Base = BaseStatement<T>).
+//
+// The composite-PK widening (#501) lives here. Both DELETE shapes are written once in
+// terms of PK_COLUMNS, so a single-PK model produces byte-identical SQL to what
+// EraseStatement emitted before composite keys existed:
+//
+//   single row, 1 PK   DELETE FROM t WHERE id = ?
+//   single row, N PKs  DELETE FROM t WHERE a = ? AND b = ?
+//   bulk,       1 PK   DELETE FROM t WHERE id IN (?,?,?)
+//   bulk,       N PKs  DELETE FROM t WHERE (a, b) IN ((?,?),(?,?),(?,?))
+//
+// The bulk composite form is a row-value IN list. Row values are standard SQL:
+// PostgreSQL has always accepted them, SQLite since 3.15 — well under this project's
+// 3.35 floor. The per-column alternative "a IN (...) AND b IN (...)" is WRONG: it
+// matches the cross product of the parts, so it would delete keys never listed.
+
+#include <meta>
+
+export module storm_orm_statements_erase_grammar;
+
+import std;
+
+import storm_orm_field_attr; // column_name_size / append_column_name (#422)
+import storm_orm_statements_base;
+import storm_orm_utilities;
+
+export namespace storm::orm::statements {
+
+    using storm::orm::utilities::ConstexprString;
+
+    template <typename T> struct EraseGrammar {
+        using Base = BaseStatement<T>;
+
+        // Number of columns in the primary key: 1 for a single PK, N for a composite one.
+        // Every size and placeholder calculation below is expressed in terms of it, so the
+        // single-PK arithmetic falls out unchanged at PK_COLUMNS == 1.
+        static constexpr std::size_t PK_COLUMNS = Base::primary_key_members_.size();
+
+        // Common prefix: "DELETE FROM <table> WHERE ". The single-row and bulk builders
+        // differ only in what follows (the AND-joined key clause vs the IN opener).
+        static consteval auto delete_prefix_size() -> std::size_t {
+            using utilities::sql_len::DELETE_FROM;
+            using utilities::sql_len::WHERE;
+            return DELETE_FROM + Base::table_name_.size() + WHERE;
+        }
+
+        template <typename Buf> static consteval auto append_delete_prefix(Buf& buf) -> void {
+            buf.append("DELETE FROM ");
+            buf.append(Base::table_name_);
+            buf.append(" WHERE ");
+        }
+
+        // --- single-row DELETE ------------------------------------------------
+
+        // Exact size of "DELETE FROM <t> WHERE <a> = ? AND <b> = ?". Exactness matters:
+        // ConstexprString truncates SILENTLY on overflow, so an under-count would emit
+        // wrong SQL with no diagnostic.
+        static consteval auto calculate_single_delete_sql_size() -> std::size_t {
+            return delete_prefix_size() + pk_where_clause_size(Base::primary_key_members_) + 1; // + null terminator
+        }
+
+        static consteval auto build_single_delete_sql_array() {
+            constexpr std::size_t     sql_size = calculate_single_delete_sql_size() + utilities::sql_len::LARGE_BUFFER;
+            ConstexprString<sql_size> result;
+            append_delete_prefix(result);
+            append_pk_where_clause(result, Base::primary_key_members_);
+            return result;
+        }
+
+        // --- all-rows DELETE --------------------------------------------------
+
+        static consteval auto build_delete_all_sql_array() {
+            using utilities::sql_len::DELETE_FROM;
+            constexpr std::size_t sql_size = DELETE_FROM + Base::table_name_.size() + utilities::sql_len::LARGE_BUFFER;
+            ConstexprString<sql_size> result;
+            result.append("DELETE FROM ");
+            result.append(Base::table_name_);
+            return result;
+        }
+
+        // --- bulk DELETE: the IN opener ---------------------------------------
+
+        // "<pk> IN (" for a single PK, "(a, b) IN (" for a composite key.
+        static consteval auto in_opener_size() -> std::size_t {
+            std::size_t size = 0;
+            for (const std::meta::info member : Base::primary_key_members_) {
+                size += storm::meta::column_name_size(member);
+            }
+            if constexpr (PK_COLUMNS > 1) {
+                size += 2;                    // "()" around the row-value column list
+                size += 2 * (PK_COLUMNS - 1); // ", " between column names
+            }
+            return size + utilities::sql_len::IN_OPEN;
+        }
+
+        template <typename Buf> static consteval auto append_in_opener(Buf& buf) -> void {
+            if constexpr (PK_COLUMNS > 1) {
+                buf.append("(");
+            }
+            bool first = true;
+            for (const std::meta::info member : Base::primary_key_members_) {
+                if (!first) {
+                    buf.append(", ");
+                }
+                storm::meta::append_column_name(buf, member);
+                first = false;
+            }
+            if constexpr (PK_COLUMNS > 1) {
+                buf.append(")");
+            }
+            buf.append(" IN (");
+        }
+
+        static consteval auto calculate_bulk_delete_prefix_size() -> std::size_t {
+            return delete_prefix_size() + in_opener_size() + 1; // + null terminator
+        }
+
+        static consteval auto build_bulk_delete_prefix() {
+            constexpr std::size_t prefix_size = calculate_bulk_delete_prefix_size() + utilities::sql_len::LARGE_BUFFER;
+            ConstexprString<prefix_size> result;
+            append_delete_prefix(result);
+            append_in_opener(result);
+            return result;
+        }
+
+        // --- bulk DELETE: the per-row placeholder group -----------------------
+
+        // One row's placeholders: "?" for a single PK, "(?,?)" for a composite key.
+        static constexpr std::size_t ROW_PLACEHOLDER_SIZE =
+                PK_COLUMNS == 1 ? 1 : (2 + PK_COLUMNS + (PK_COLUMNS - 1)); // "(" + N "?" + N-1 "," + ")"
+
+        // Written once for BOTH the consteval max-chunk builder and the runtime
+        // per-count builder (ConstexprString and std::string both append). Keeping one
+        // definition is what stops the two from drifting into different SQL for the
+        // same model — the failure mode would be a prepared statement whose placeholder
+        // count disagrees with the bind loop.
+        template <typename Buf> static constexpr auto append_row_placeholder(Buf& buf) -> void {
+            if constexpr (PK_COLUMNS == 1) {
+                buf.append("?");
+            } else {
+                buf.append("(");
+                for (std::size_t col = 0; col < PK_COLUMNS; ++col) {
+                    if (col > 0) {
+                        buf.append(",");
+                    }
+                    buf.append("?");
+                }
+                buf.append(")");
+            }
+        }
+
+        // Append `count` comma-separated placeholder groups plus the closing paren —
+        // the tail of every bulk DELETE, compile-time or runtime. count == 0 yields an
+        // empty "IN ()", which no execution path can reach (both execute() and to_sql()
+        // return early on an empty span) but which keeps the size calculation above
+        // consistent with what is actually written.
+        template <typename Buf> static constexpr auto append_row_placeholder_list(Buf& buf, std::size_t count) -> void {
+            for (std::size_t i = 0; i < count; ++i) {
+                if (i > 0) {
+                    buf.append(",");
+                }
+                append_row_placeholder(buf);
+            }
+            buf.append(")");
+        }
+
+        // Exact size of `count` placeholder groups + separating commas + ")".
+        // count == 0 has no meaningful list — the unsigned `count - 1` would wrap — and no
+        // caller wants one: an empty batch is short-circuited before any SQL is built.
+        static constexpr auto row_placeholder_list_size(std::size_t count) -> std::size_t {
+            return count == 0 ? 1 : (count * ROW_PLACEHOLDER_SIZE) + (count - 1) + 1;
+        }
+
+        // The complete bulk DELETE SQL for `count` keys, built at runtime. Connection-free
+        // (the text is pure reflection), so it is also the seam the SQL-shape tests assert
+        // through — EraseStatement caches the result per count rather than carrying its own
+        // builder, which keeps that class off the cpp:S1448 method ceiling.
+        [[nodiscard]] static auto bulk_delete_sql_for(std::size_t count) -> std::string {
+            std::string sql;
+            sql.reserve((calculate_bulk_delete_prefix_size() - 1) + row_placeholder_list_size(count));
+            sql = std::string(build_bulk_delete_prefix());
+            append_row_placeholder_list(sql, count);
+            return sql;
+        }
+
+        // --- bulk DELETE: chunking -------------------------------------------
+
+        // 80% of the DB variable ceiling, for safety.
+        static constexpr std::size_t MAX_CHUNK_SIZE = (Base::MAX_DB_VARIABLES * 4) / 5; // 799
+
+        // Rows per chunk. Each row costs PK_COLUMNS bound parameters, not one, so a
+        // composite key fits proportionally fewer rows under the same variable ceiling
+        // (#501). Single-PK models keep the historical 799.
+        static constexpr std::size_t MAX_CHUNK_ROWS = MAX_CHUNK_SIZE / PK_COLUMNS;
+
+        static consteval auto calculate_max_bulk_delete_sql_size() -> std::size_t {
+            return (calculate_bulk_delete_prefix_size() - 1) + row_placeholder_list_size(MAX_CHUNK_ROWS) + 1;
+        }
+
+        static consteval auto build_max_bulk_delete_sql() {
+            constexpr std::size_t     sql_size = calculate_max_bulk_delete_sql_size() + 50; // Safety buffer
+            ConstexprString<sql_size> result;
+            result.append(build_bulk_delete_prefix());
+            append_row_placeholder_list(result, MAX_CHUNK_ROWS);
+            return result;
+        }
+    };
+
+} // namespace storm::orm::statements

--- a/src/orm/statements/update.cppm
+++ b/src/orm/statements/update.cppm
@@ -282,7 +282,10 @@ export namespace storm::orm::statements {
             return reset_bind_execute(stmt, obj);
         }
 
-        // Helper to unroll inline binding for all fields (skips PK, then binds PK last)
+        // Helper to unroll inline binding for all fields (skips PK, then binds PK last).
+        // The SET values occupy placeholders 1..N_set and the key follows, so for a
+        // composite key the WHERE parameters start at N_set+1 and run N_pk wide (#501) —
+        // bind_pk_values threads param_index through, so the offset is never recomputed.
         template <std::size_t... Is>
         [[nodiscard]] __attribute__((always_inline)) static auto
         inline_bind_all_fields(Statement* stmt, const T& obj, std::index_sequence<Is...> /*unused*/) noexcept
@@ -290,11 +293,21 @@ export namespace storm::orm::statements {
             int param_index = 1;
 
             // Bind all non-PK fields at compile time using unified binder.
-            // IsUpdate=true: auto_update stamps now(); auto_create binds the object's
-            // stored value (preserving created_at). One now() read shared across fields (#209).
+            // SkipAllPK=true skips EVERY primary-key member, matching the SET clause
+            // build_field_assignments emits (#501). IsUpdate=true: auto_update stamps
+            // now(); auto_create binds the object's stored value (preserving created_at).
+            // One now() read shared across fields (#209).
+            // Named rather than three bare `true`s at the call site — they are three
+            // different policies and their order is not guessable from the call.
+            constexpr bool SKIP_PK     = true; // the key is bound separately, after the SET values
+            constexpr bool IS_UPDATE   = true; // auto_create keeps its stored value
+            constexpr bool SKIP_ALL_PK = true; // every part of a composite key, not just the first
+
             std::expected<void, Error> result{};
             const auto                 now = Base::batch_now();
-            ((result = Base::template bind_field_at_index<ConnType, Is, true, true>(stmt, obj, param_index, now),
+            ((result = Base::template bind_field_at_index<ConnType, Is, SKIP_PK, IS_UPDATE, SKIP_ALL_PK>(
+                      stmt, obj, param_index, now
+              ),
               result.has_value()) &&
              ...);
 
@@ -302,9 +315,9 @@ export namespace storm::orm::statements {
                 return result;
             }
 
-            // Bind primary key last (PK is never a FK field by design)
-            auto pk_value = obj.[:Base::primary_key_:];
-            return Base::template bind_value_by_type<ConnType>(*stmt, param_index, pk_value);
+            // Bind the whole primary key last — one value per PK column, in declaration
+            // order, matching the AND-joined WHERE clause.
+            return Base::template bind_pk_values<ConnType>(*stmt, obj, param_index);
         }
 
         // Ultra-optimized single UPDATE - pre-cached statement, fully inlined binding.

--- a/src/orm/statements/update_grammar.cppm
+++ b/src/orm/statements/update_grammar.cppm
@@ -27,13 +27,16 @@ export namespace storm::orm::statements {
             // containers are not columns, so they must not appear in the SET clause.
             // Base::all_members_ already excludes them and matches the bind order used
             // by inline_bind_all_fields.
-            auto pk = Base::primary_key_;
-
+            //
+            // EVERY primary-key member is skipped, not just primary_key_ (#501): on a
+            // composite model the old `member != primary_key_` test left the other parts
+            // in the SET list, so the statement would rewrite part of the key it matches
+            // on. Identical to the old test for a single-PK model.
             ConstexprString<utilities::buffer_size::SQL_MEDIUM> result;
             bool                                                first = true;
 
             for (const auto& member : Base::all_members_) {
-                if (member != pk) {
+                if (!Base::is_pk_member(member)) {
                     if (!first) {
                         result.append(", ");
                     }
@@ -61,11 +64,16 @@ export namespace storm::orm::statements {
             std::unreachable(); // guarded by is_settable_member() at the call site
         }
 
-        // Each SET target must be a non-static data member of T, not the primary key,
-        // and not a relation container (#486) — m2m / reverse_fk members are not
-        // persisted columns, so setting them would emit a non-existent column.
+        // Each SET target must be a non-static data member of T, not ANY part of the
+        // primary key, and not a relation container (#486) — m2m / reverse_fk members are
+        // not persisted columns, so setting them would emit a non-existent column.
+        //
+        // The PK test is is_pk_member, not `Member != primary_key_` (#501): the latter
+        // excludes only the FIRST part, so on a composite model every other part stayed a
+        // legal SET target and `SET b=? WHERE a=? AND b=?` would rewrite the key being
+        // matched on. Unchanged for a single-PK model.
         template <std::meta::info Member> static consteval auto is_settable_member() -> bool {
-            return std::meta::is_nonstatic_data_member(Member) && Member != Base::primary_key_ &&
+            return std::meta::is_nonstatic_data_member(Member) && !Base::is_pk_member(Member) &&
                    !meta::is_relation_field(Member);
         }
 
@@ -84,6 +92,13 @@ export namespace storm::orm::statements {
         }
 
         // Is `member` an auto_update field NOT already present in the explicit pack?
+        //
+        // Unlike is_settable_member above, this does NOT exclude primary-key members, so
+        // an auto_update PK would be appended to the SET clause and stamped now() —
+        // rewriting the key the statement matches on. Pre-existing and narrow (it needs a
+        // time_point PK carrying auto_update, a shape no in-tree model has); tracked as
+        // #511, which also has to decide between silently excluding it and rejecting the
+        // model outright. Left alone here rather than widened as a side effect of #501.
         template <std::meta::info... Members>
         static consteval auto is_unlisted_auto_update(std::meta::info member) -> bool {
             return is_auto_update_field(member) && ((member != Members) && ...);
@@ -120,7 +135,10 @@ export namespace storm::orm::statements {
             return result;
         }
 
-        // Compile-time UPDATE SQL size calculation
+        // Compile-time UPDATE SQL size calculation. The key clause is "<a> = ? AND <b> = ?"
+        // — one column per PK part (#501), which for a single PK is the same " <pk> = ?"
+        // this used to hardcode. Exact: ConstexprString truncates SILENTLY on overflow, so
+        // an under-count would emit wrong SQL with no diagnostic.
         static consteval auto calculate_update_sql_size() -> std::size_t {
             using utilities::sql_len::SET;
             using utilities::sql_len::UPDATE;
@@ -131,13 +149,14 @@ export namespace storm::orm::statements {
             size += SET; // " SET "
             size += field_assignments_.len;
             size += WHERE; // " WHERE "
-            size += Base::pk_name_.size();
-            size += 4; // " = ?"
+            size += pk_where_clause_size(Base::primary_key_members_);
             size += 1; // null terminator
             return size;
         }
 
-        // Build UPDATE SQL at compile-time using ConstexprString
+        // Build UPDATE SQL at compile-time using ConstexprString.
+        // Single PK  → "UPDATE t SET a=?, b=? WHERE id = ?"   (byte-identical to pre-#501)
+        // Composite  → "UPDATE t SET c=? WHERE a = ? AND b = ?"
         static consteval auto build_update_sql_array() {
             constexpr std::size_t     sql_size = calculate_update_sql_size() + utilities::sql_len::LARGE_BUFFER;
             ConstexprString<sql_size> result;
@@ -147,8 +166,7 @@ export namespace storm::orm::statements {
             result.append(" SET ");
             result.append(std::string_view(field_assignments_.data.data(), field_assignments_.len));
             result.append(" WHERE ");
-            result.append(Base::pk_name_);
-            result.append(" = ?");
+            append_pk_where_clause(result, Base::primary_key_members_);
 
             return result;
         }

--- a/src/orm/statements/upsert_grammar.cppm
+++ b/src/orm/statements/upsert_grammar.cppm
@@ -48,11 +48,17 @@ export namespace storm::orm::statements {
             return result;
         }
 
-        // Each SET target must be a non-static data member of T, not the PK, and
-        // not a relation container (#486) — m2m / reverse_fk members are not
+        // Each SET target must be a non-static data member of T, not ANY part of the PK,
+        // and not a relation container (#486) — m2m / reverse_fk members are not
         // persisted columns, so "col=excluded.col" would reference a missing column.
+        //
+        // The PK test is is_pk_member, not `Member != primary_key_` (#501): the latter
+        // excludes only the FIRST part, leaving every other part of a composite key a
+        // legal DO UPDATE target. Unchanged for a single-PK model. (ON CONFLICT targeting
+        // a composite key is #503; keeping the key parts out of the SET list is the half
+        // that belongs here.)
         template <std::meta::info Member> static consteval auto is_settable_member() -> bool {
-            return std::meta::is_nonstatic_data_member(Member) && Member != Base::primary_key_ &&
+            return std::meta::is_nonstatic_data_member(Member) && !Base::is_pk_member(Member) &&
                    !meta::is_relation_field(Member);
         }
 

--- a/tests/crud/test_composite_pk_crud.cpp
+++ b/tests/crud/test_composite_pk_crud.cpp
@@ -1,0 +1,529 @@
+#include <gtest/gtest.h>
+#include <meta>
+
+#include "test_db_helpers.h"
+
+import storm;
+import std;
+
+#include "test_models.h" // NOSONAR cpp:S954 — Person, the FK target of StockEntry
+
+// Must follow test_models.h: StockEntry's FK part names Person.
+#include "test_composite_pk_models.h" // NOSONAR cpp:S954
+
+// ── #501: composite PK — UPDATE and DELETE executed on live backends ─────────
+// The companion of test_composite_pk_sql.cpp, which pins the compile-time gates
+// and the generated SQL text. This TU proves the widened WHERE clause and the
+// bind arithmetic behave against real SQLite and PostgreSQL: a full-key match
+// hits exactly one row, and a partial-key match hits none.
+//
+// INSERT by composite key is #502, so every fixture seeds through raw SQL — the
+// same approach #500's execution test used.
+
+// NOLINTBEGIN(readability-implicit-bool-conversion)
+
+namespace {
+
+    // Composite-PK fixture. The table is created from the generated DDL, since
+    // ensure_tables() drives the same schema path. Anchors the connection on
+    // Person but creates no Person table.
+    template <typename Model, typename ConnType> class CompositePkFixture : public StormTestFixture<Person, ConnType> {
+      public:
+        auto on_setup(const std::shared_ptr<ConnType>& conn) -> void override {
+            const std::string ddl = storm::test::is_postgresql<ConnType>()
+                                            ? storm::create_table_sql<Model, storm::orm::schema::Dialect::PostgreSQL>()
+                                            : storm::create_table_sql<Model>();
+            ASSERT_TRUE(conn->execute(ddl).has_value()) << ddl;
+        }
+
+        static auto seed(std::string_view sql) -> void {
+            const auto& conn = storm::QuerySet<Person, ConnType>::get_default_connection();
+            ASSERT_TRUE(conn->execute(std::string(sql)).has_value()) << sql;
+        }
+
+        static auto row_count() -> int {
+            storm::QuerySet<Model, ConnType> qs;
+            auto                             result = qs.count().execute();
+            return result.has_value() ? static_cast<int>(result.value()) : -1;
+        }
+
+        // The single row matching `filter`, or nullopt when the filter matches
+        // nothing. Every "did the right row change?" assertion below reads
+        // through this, so the key-matching check is written once.
+        static auto find_one(const auto& filter) -> std::optional<Model> {
+            storm::QuerySet<Model, ConnType> qs;
+            auto                             rows = qs.where(filter).select().execute();
+            if (!rows.has_value() || rows.value().empty()) {
+                return std::nullopt;
+            }
+            return *rows.value().begin();
+        }
+    };
+
+    // --- OrderLine: 2-part int key -------------------------------------------
+
+    template <typename ConnType> class OrderLineTest : public CompositePkFixture<OrderLine, ConnType> {
+      public:
+        auto on_after_setup(const std::shared_ptr<ConnType>& /*conn*/) -> void override {
+            this->seed(
+                    "INSERT INTO OrderLine (order_id, product_id, quantity, note) VALUES "
+                    "(1, 10, 5, 'a'), (1, 20, 7, 'b'), (2, 10, 9, 'c'), (2, 20, 11, 'd')"
+            );
+        }
+
+        // quantity of one key, or -1 when the row is gone.
+        static auto quantity_of(int order_id, int product_id) -> int {
+            using storm::orm::where::f;
+            auto row = OrderLineTest::find_one(
+                    f<^^OrderLine::order_id>() == order_id && f<^^OrderLine::product_id>() == product_id
+            );
+            return row ? row->quantity : -1;
+        }
+    };
+
+} // namespace
+
+TYPED_TEST_SUITE(OrderLineTest, DatabaseTypes);
+
+// --- DELETE: single row -----------------------------------------------------
+
+TYPED_TEST(OrderLineTest, DeleteSingleMatchesFullKeyOnly) {
+    storm::QuerySet<OrderLine, TypeParam> qs;
+    const OrderLine                       target{.order_id = 1, .product_id = 20};
+    ASSERT_TRUE(qs.erase(target).execute().has_value());
+
+    EXPECT_EQ(this->row_count(), 3);
+    EXPECT_EQ(this->quantity_of(1, 20), -1) << "the full-key row is deleted";
+    EXPECT_EQ(this->quantity_of(1, 10), 5) << "a row sharing only order_id survives";
+    EXPECT_EQ(this->quantity_of(2, 20), 11) << "a row sharing only product_id survives";
+}
+
+// The core failure this issue prevents: with a single-column WHERE, deleting
+// (1,20) would also take (1,10) — every row sharing the first key part.
+TYPED_TEST(OrderLineTest, DeletePartialKeyMatchDoesNotDelete) {
+    storm::QuerySet<OrderLine, TypeParam> qs;
+    // order_id matches rows of order 1, but no row of order 1 has product_id 99.
+    const OrderLine target{.order_id = 1, .product_id = 99};
+    ASSERT_TRUE(qs.erase(target).execute().has_value());
+    EXPECT_EQ(this->row_count(), 4) << "no row matches the FULL key, so nothing is deleted";
+}
+
+TYPED_TEST(OrderLineTest, DeleteNoMatchIsNotAnError) {
+    storm::QuerySet<OrderLine, TypeParam> qs;
+    const OrderLine                       target{.order_id = 77, .product_id = 88};
+    EXPECT_TRUE(qs.erase(target).execute().has_value());
+    EXPECT_EQ(this->row_count(), 4);
+}
+
+// --- DELETE: batch ----------------------------------------------------------
+
+TYPED_TEST(OrderLineTest, DeleteBatchMatchesEachFullKey) {
+    storm::QuerySet<OrderLine, TypeParam> qs;
+    const std::vector<OrderLine>          targets{
+                     {.order_id = 1, .product_id = 10},
+                     {.order_id = 2, .product_id = 20},
+    };
+    ASSERT_TRUE(qs.erase(std::span<const OrderLine>(targets)).execute().has_value());
+
+    // The listed keys CROSS: (1,10) and (2,20) are given, (1,20) and (2,10) are
+    // not. A per-column IN list — "order_id IN (1,2) AND product_id IN (10,20)"
+    // — would wrongly delete all four. Only a row-value list gets this right.
+    EXPECT_EQ(this->row_count(), 2) << "exactly the two listed keys, not their cross product";
+    EXPECT_EQ(this->quantity_of(1, 10), -1);
+    EXPECT_EQ(this->quantity_of(2, 20), -1);
+    EXPECT_EQ(this->quantity_of(1, 20), 7) << "an unlisted key survives";
+    EXPECT_EQ(this->quantity_of(2, 10), 9) << "an unlisted key survives";
+}
+
+TYPED_TEST(OrderLineTest, DeleteEmptyBatchIsANoOp) {
+    storm::QuerySet<OrderLine, TypeParam> qs;
+    const std::vector<OrderLine>          empty;
+    EXPECT_TRUE(qs.erase(std::span<const OrderLine>(empty)).execute().has_value());
+    EXPECT_EQ(this->row_count(), 4);
+}
+
+// --- UPDATE: single row -----------------------------------------------------
+
+TYPED_TEST(OrderLineTest, UpdateSingleMatchesFullKeyOnly) {
+    storm::QuerySet<OrderLine, TypeParam> qs;
+    const OrderLine                       updated{.order_id = 1, .product_id = 20, .quantity = 700, .note = "B"};
+    ASSERT_TRUE(qs.update(updated).execute().has_value());
+
+    EXPECT_EQ(this->quantity_of(1, 20), 700) << "the full-key row is updated";
+    EXPECT_EQ(this->quantity_of(1, 10), 5) << "a row sharing only order_id is untouched";
+    EXPECT_EQ(this->quantity_of(2, 20), 11) << "a row sharing only product_id is untouched";
+}
+
+TYPED_TEST(OrderLineTest, UpdatePartialKeyMatchUpdatesNothing) {
+    storm::QuerySet<OrderLine, TypeParam> qs;
+    const OrderLine                       updated{.order_id = 1, .product_id = 99, .quantity = 700};
+    ASSERT_TRUE(qs.update(updated).execute().has_value());
+
+    EXPECT_EQ(this->quantity_of(1, 10), 5);
+    EXPECT_EQ(this->quantity_of(1, 20), 7);
+    EXPECT_EQ(this->row_count(), 4) << "UPDATE never inserts";
+}
+
+// The bind offsets are what this asserts: the two SET values occupy
+// placeholders 1-2, so the key values must land at 3-4. Binding the key at a
+// stale offset would either write the wrong row or fail outright.
+TYPED_TEST(OrderLineTest, UpdateBindsEveryKeyPartAtTheRightOffset) {
+    storm::QuerySet<OrderLine, TypeParam> qs;
+    const OrderLine                       updated{.order_id = 2, .product_id = 10, .quantity = 42, .note = "z"};
+    ASSERT_TRUE(qs.update(updated).execute().has_value());
+
+    EXPECT_EQ(this->quantity_of(2, 10), 42) << "the SET values and the key both landed correctly";
+    EXPECT_EQ(this->quantity_of(2, 20), 11) << "the second key part was bound, not defaulted";
+    EXPECT_EQ(this->quantity_of(1, 10), 5) << "the first key part was bound, not defaulted";
+}
+
+// --- UPDATE: batch ----------------------------------------------------------
+
+TYPED_TEST(OrderLineTest, UpdateBatchAppliesPerKey) {
+    storm::QuerySet<OrderLine, TypeParam> qs;
+    const std::vector<OrderLine>          updates{
+                     {.order_id = 1, .product_id = 10, .quantity = 100, .note = "x"},
+                     {.order_id = 2, .product_id = 20, .quantity = 200, .note = "y"},
+    };
+    ASSERT_TRUE(qs.update(std::span<const OrderLine>(updates)).execute().has_value());
+
+    EXPECT_EQ(this->quantity_of(1, 10), 100);
+    EXPECT_EQ(this->quantity_of(2, 20), 200);
+    EXPECT_EQ(this->quantity_of(1, 20), 7) << "an unlisted key is untouched";
+    EXPECT_EQ(this->quantity_of(2, 10), 9) << "an unlisted key is untouched";
+}
+
+TYPED_TEST(OrderLineTest, UpdateEmptyBatchIsANoOp) {
+    storm::QuerySet<OrderLine, TypeParam> qs;
+    const std::vector<OrderLine>          empty;
+    EXPECT_TRUE(qs.update(std::span<const OrderLine>(empty)).execute().has_value());
+    EXPECT_EQ(this->quantity_of(1, 10), 5);
+}
+
+// ── Mixed-type key parts (int + std::string) ─────────────────────────────────
+
+namespace {
+    template <typename ConnType> class InventoryTest : public CompositePkFixture<Inventory, ConnType> {
+      public:
+        auto on_after_setup(const std::shared_ptr<ConnType>& /*conn*/) -> void override {
+            this->seed(
+                    "INSERT INTO Inventory (warehouse, sku, on_hand) VALUES "
+                    "(1, 'apple', 5), (1, 'pear', 7), (2, 'apple', 9)"
+            );
+        }
+
+        static auto on_hand_of(int warehouse, std::string_view sku) -> int {
+            using storm::orm::where::f;
+            auto row = InventoryTest::find_one(
+                    f<^^Inventory::warehouse>() == warehouse && f<^^Inventory::sku>() == std::string(sku)
+            );
+            return row ? row->on_hand : -1;
+        }
+    };
+} // namespace
+
+TYPED_TEST_SUITE(InventoryTest, DatabaseTypes);
+
+TYPED_TEST(InventoryTest, DeleteWithTextKeyPart) {
+    storm::QuerySet<Inventory, TypeParam> qs;
+    const Inventory                       target{.warehouse = 1, .sku = "apple"};
+    ASSERT_TRUE(qs.erase(target).execute().has_value());
+
+    EXPECT_EQ(this->on_hand_of(1, "apple"), -1);
+    EXPECT_EQ(this->on_hand_of(1, "pear"), 7) << "same warehouse, different sku survives";
+    EXPECT_EQ(this->on_hand_of(2, "apple"), 9) << "same sku, different warehouse survives";
+}
+
+TYPED_TEST(InventoryTest, UpdateWithTextKeyPart) {
+    storm::QuerySet<Inventory, TypeParam> qs;
+    const Inventory                       updated{.warehouse = 2, .sku = "apple", .on_hand = 900};
+    ASSERT_TRUE(qs.update(updated).execute().has_value());
+
+    EXPECT_EQ(this->on_hand_of(2, "apple"), 900);
+    EXPECT_EQ(this->on_hand_of(1, "apple"), 5) << "the text part alone must not match";
+}
+
+TYPED_TEST(InventoryTest, DeleteBatchWithTextKeyPart) {
+    storm::QuerySet<Inventory, TypeParam> qs;
+    const std::vector<Inventory>          targets{
+                     {.warehouse = 1, .sku = "pear"},
+                     {.warehouse = 2, .sku = "apple"},
+    };
+    ASSERT_TRUE(qs.erase(std::span<const Inventory>(targets)).execute().has_value());
+
+    EXPECT_EQ(this->on_hand_of(1, "apple"), 5) << "unlisted key survives";
+    EXPECT_EQ(this->on_hand_of(1, "pear"), -1);
+    EXPECT_EQ(this->on_hand_of(2, "apple"), -1);
+}
+
+// ── Three-part key ───────────────────────────────────────────────────────────
+
+namespace {
+    template <typename ConnType> class LedgerTest : public CompositePkFixture<Ledger, ConnType> {
+      public:
+        auto on_after_setup(const std::shared_ptr<ConnType>& /*conn*/) -> void override {
+            this->seed(
+                    "INSERT INTO Ledger (region, account, period, balance) VALUES "
+                    "(1, 'cash', 202601, 10.5), (1, 'cash', 202602, 20.5), (1, 'debt', 202601, 30.5)"
+            );
+        }
+
+        static auto balance_of(int region, std::string_view account, std::int64_t period) -> double {
+            using storm::orm::where::f;
+            auto row = LedgerTest::find_one(
+                    f<^^Ledger::region>() == region && f<^^Ledger::account>() == std::string(account) &&
+                    f<^^Ledger::period>() == period
+            );
+            return row ? row->balance : -1.0;
+        }
+    };
+} // namespace
+
+TYPED_TEST_SUITE(LedgerTest, DatabaseTypes);
+
+// Two of the three parts match — the row must NOT be touched. This is the case
+// a 2-of-3 AND-join would get wrong.
+TYPED_TEST(LedgerTest, DeleteRequiresAllThreeParts) {
+    storm::QuerySet<Ledger, TypeParam> qs;
+    const Ledger                       target{.region = 1, .account = "cash", .period = 209912};
+    ASSERT_TRUE(qs.erase(target).execute().has_value());
+
+    EXPECT_DOUBLE_EQ(this->balance_of(1, "cash", 202601), 10.5) << "no row matches all three parts";
+    EXPECT_DOUBLE_EQ(this->balance_of(1, "cash", 202602), 20.5);
+    EXPECT_DOUBLE_EQ(this->balance_of(1, "debt", 202601), 30.5);
+}
+
+TYPED_TEST(LedgerTest, DeleteThreePartKey) {
+    storm::QuerySet<Ledger, TypeParam> qs;
+    const Ledger                       target{.region = 1, .account = "cash", .period = 202602};
+    ASSERT_TRUE(qs.erase(target).execute().has_value());
+
+    EXPECT_DOUBLE_EQ(this->balance_of(1, "cash", 202602), -1.0);
+    EXPECT_DOUBLE_EQ(this->balance_of(1, "cash", 202601), 10.5);
+    EXPECT_DOUBLE_EQ(this->balance_of(1, "debt", 202601), 30.5);
+}
+
+TYPED_TEST(LedgerTest, UpdateThreePartKey) {
+    storm::QuerySet<Ledger, TypeParam> qs;
+    const Ledger                       updated{.region = 1, .account = "debt", .period = 202601, .balance = 99.5};
+    ASSERT_TRUE(qs.update(updated).execute().has_value());
+
+    EXPECT_DOUBLE_EQ(this->balance_of(1, "debt", 202601), 99.5);
+    EXPECT_DOUBLE_EQ(this->balance_of(1, "cash", 202601), 10.5) << "differs in one part — untouched";
+}
+
+TYPED_TEST(LedgerTest, DeleteBatchThreePartKey) {
+    storm::QuerySet<Ledger, TypeParam> qs;
+    const std::vector<Ledger>          targets{
+                     {.region = 1, .account = "cash", .period = 202601},
+                     {.region = 1, .account = "debt", .period = 202601},
+    };
+    ASSERT_TRUE(qs.erase(std::span<const Ledger>(targets)).execute().has_value());
+
+    EXPECT_DOUBLE_EQ(this->balance_of(1, "cash", 202601), -1.0);
+    EXPECT_DOUBLE_EQ(this->balance_of(1, "debt", 202601), -1.0);
+    EXPECT_DOUBLE_EQ(this->balance_of(1, "cash", 202602), 20.5) << "unlisted key survives";
+}
+
+// ── FK key parts: the association-table shape ────────────────────────────────
+// An FK part binds the REFERENCED row's key, not the whole object, and names the
+// "<name>_id" column. Executing it is the only way to catch a mismatch between
+// the two — a bare-member column name fails at prepare time, and binding the
+// wrong value silently hits the wrong row.
+
+namespace {
+    template <typename ConnType> class StockEntryTest : public CompositePkFixture<StockEntry, ConnType> {
+      public:
+        // The FK target table must exist before the referencing table.
+        auto on_setup(const std::shared_ptr<ConnType>& conn) -> void override {
+            ASSERT_TRUE((storm::test::ensure_tables<ConnType, Person>(conn))) << "Failed to create Person";
+            CompositePkFixture<StockEntry, ConnType>::on_setup(conn);
+        }
+
+        auto on_after_setup(const std::shared_ptr<ConnType>& /*conn*/) -> void override {
+            storm::QuerySet<Person, ConnType> people;
+            for (int i = 1; i <= 2; ++i) {
+                const Person person{.id = i, .name = std::format("W{}", i), .age = 30};
+                ASSERT_TRUE(people.insert(person).execute().has_value());
+            }
+            this->seed("INSERT INTO StockEntry (warehouse_id, sku, qty) VALUES (1, 10, 5), (1, 20, 7), (2, 10, 9)");
+        }
+
+        // Selects every row and matches the key in C++ rather than in a WHERE clause.
+        // Filtering with f<^^StockEntry::warehouse>() would compare the FK MEMBER rather
+        // than its "warehouse_id" column — an unrelated gap in the WHERE layer (nothing
+        // in the tree filters on an FK member today), and leaning on it here would make
+        // this test fail for a reason unrelated to the key binding it exists to check.
+        // The tables hold three rows, so the scan costs nothing.
+        static auto qty_of(int warehouse_id, int sku) -> int {
+            storm::QuerySet<StockEntry, ConnType> qs;
+            auto                                  rows = qs.select().execute();
+            if (!rows.has_value()) {
+                return -1;
+            }
+            for (const StockEntry& row : rows.value()) {
+                if (row.warehouse.id == warehouse_id && row.sku == sku) {
+                    return row.qty;
+                }
+            }
+            return -1;
+        }
+    };
+} // namespace
+
+TYPED_TEST_SUITE(StockEntryTest, DatabaseTypes);
+
+TYPED_TEST(StockEntryTest, DeleteByFkCompositeKey) {
+    storm::QuerySet<StockEntry, TypeParam> qs;
+    const StockEntry                       target{.warehouse = {.id = 1}, .sku = 20};
+    ASSERT_TRUE(qs.erase(target).execute().has_value());
+
+    EXPECT_EQ(this->qty_of(1, 20), -1) << "the full-key row is deleted";
+    EXPECT_EQ(this->qty_of(1, 10), 5) << "same warehouse, different sku survives";
+    EXPECT_EQ(this->qty_of(2, 10), 9) << "same sku, different warehouse survives";
+}
+
+TYPED_TEST(StockEntryTest, UpdateByFkCompositeKey) {
+    storm::QuerySet<StockEntry, TypeParam> qs;
+    const StockEntry                       updated{.warehouse = {.id = 2}, .sku = 10, .qty = 900};
+    ASSERT_TRUE(qs.update(updated).execute().has_value());
+
+    EXPECT_EQ(this->qty_of(2, 10), 900);
+    EXPECT_EQ(this->qty_of(1, 10), 5) << "the sku part alone must not match";
+}
+
+TYPED_TEST(StockEntryTest, DeleteBatchByFkCompositeKey) {
+    storm::QuerySet<StockEntry, TypeParam> qs;
+    const std::vector<StockEntry>          targets{
+                     {.warehouse = {.id = 1}, .sku = 10},
+                     {.warehouse = {.id = 2}, .sku = 10},
+    };
+    ASSERT_TRUE(qs.erase(std::span<const StockEntry>(targets)).execute().has_value());
+
+    EXPECT_EQ(this->qty_of(1, 10), -1);
+    EXPECT_EQ(this->qty_of(2, 10), -1);
+    EXPECT_EQ(this->qty_of(1, 20), 7) << "unlisted key survives";
+}
+
+// ── Chunking: a batch that crosses the shrunken chunk boundary ───────────────
+// The 999-variable ceiling is spent N params per row, so a 2-part key chunks at
+// 399 rows rather than 799. 900 rows forces the max-chunk statement to run
+// twice plus a remainder.
+
+namespace {
+    template <typename ConnType> class LargeBatchTest : public CompositePkFixture<OrderLine, ConnType> {
+      public:
+        static constexpr int ROWS = 900;
+
+        auto on_after_setup(const std::shared_ptr<ConnType>& /*conn*/) -> void override {
+            std::string sql = "INSERT INTO OrderLine (order_id, product_id, quantity, note) VALUES ";
+            for (int i = 0; i < ROWS; ++i) {
+                if (i > 0) {
+                    sql += ", ";
+                }
+                sql += std::format("({}, {}, {}, 'n')", i, i * 2, i);
+            }
+            this->seed(sql);
+        }
+
+        // Keys (i, 2i) for i in [from, ROWS).
+        static auto keys_from(int from) -> std::vector<OrderLine> {
+            std::vector<OrderLine> targets;
+            targets.reserve(static_cast<std::size_t>(ROWS - from));
+            for (int i = from; i < ROWS; ++i) {
+                targets.push_back({.order_id = i, .product_id = i * 2});
+            }
+            return targets;
+        }
+    };
+} // namespace
+
+TYPED_TEST_SUITE(LargeBatchTest, DatabaseTypes);
+
+TYPED_TEST(LargeBatchTest, ChunkedDeleteSpansMultipleChunks) {
+    const std::vector<OrderLine>          targets = LargeBatchTest<TypeParam>::keys_from(0);
+    storm::QuerySet<OrderLine, TypeParam> qs;
+    ASSERT_TRUE(qs.erase(std::span<const OrderLine>(targets)).execute().has_value());
+    EXPECT_EQ(this->row_count(), 0) << "every key across every chunk is deleted";
+}
+
+// The same batch minus one key: the survivor proves the chunked path deletes the
+// keys it was given rather than everything it touched.
+TYPED_TEST(LargeBatchTest, ChunkedDeleteLeavesUnlistedKeys) {
+    const std::vector<OrderLine>          targets = LargeBatchTest<TypeParam>::keys_from(1);
+    storm::QuerySet<OrderLine, TypeParam> qs;
+    ASSERT_TRUE(qs.erase(std::span<const OrderLine>(targets)).execute().has_value());
+    EXPECT_EQ(this->row_count(), 1) << "the one unlisted key survives";
+}
+
+TYPED_TEST(LargeBatchTest, ChunkedUpdateSpansMultipleChunks) {
+    std::vector<OrderLine> updates = LargeBatchTest<TypeParam>::keys_from(0);
+    for (OrderLine& row : updates) {
+        row.quantity = 1000 + row.order_id;
+        row.note     = "u";
+    }
+    storm::QuerySet<OrderLine, TypeParam> qs;
+    ASSERT_TRUE(qs.update(std::span<const OrderLine>(updates)).execute().has_value());
+
+    using storm::orm::where::f;
+    storm::QuerySet<OrderLine, TypeParam> check;
+    auto                                  updated = check.where(f<^^OrderLine::quantity>() >= 1000).count().execute();
+    ASSERT_TRUE(updated.has_value());
+    EXPECT_EQ(updated.value(), LargeBatchTest<TypeParam>::ROWS);
+}
+
+// ── Single-PK regression ─────────────────────────────────────────────────────
+// Person is the long-standing CRUD fixture. Its UPDATE/DELETE behaviour must be
+// unchanged by the composite widening.
+
+namespace {
+    template <typename ConnType> class SinglePkRegressionTest : public StormTestFixture<Person, ConnType> {
+      public:
+        auto on_after_setup(const std::shared_ptr<ConnType>& /*conn*/) -> void override {
+            storm::QuerySet<Person, ConnType> qs;
+            for (int i = 1; i <= 3; ++i) {
+                const Person person{.id = i, .name = std::format("P{}", i), .age = 20 + i};
+                ASSERT_TRUE(qs.insert(person).execute().has_value());
+            }
+        }
+
+        static auto age_of(int person_id) -> int {
+            using storm::orm::where::f;
+            storm::QuerySet<Person, ConnType> qs;
+            auto                              rows = qs.where(f<^^Person::id>() == person_id).select().execute();
+            if (!rows.has_value() || rows.value().empty()) {
+                return -1;
+            }
+            return rows.value().begin()->age;
+        }
+    };
+} // namespace
+
+TYPED_TEST_SUITE(SinglePkRegressionTest, DatabaseTypes);
+
+TYPED_TEST(SinglePkRegressionTest, SingleDeleteStillWorks) {
+    storm::QuerySet<Person, TypeParam> qs;
+    const Person                       target{.id = 2};
+    ASSERT_TRUE(qs.erase(target).execute().has_value());
+    EXPECT_EQ(this->age_of(2), -1);
+    EXPECT_EQ(this->age_of(1), 21);
+}
+
+TYPED_TEST(SinglePkRegressionTest, SingleUpdateStillWorks) {
+    storm::QuerySet<Person, TypeParam> qs;
+    const Person                       updated{.id = 3, .name = "P3", .age = 99};
+    ASSERT_TRUE(qs.update(updated).execute().has_value());
+    EXPECT_EQ(this->age_of(3), 99);
+    EXPECT_EQ(this->age_of(1), 21);
+}
+
+TYPED_TEST(SinglePkRegressionTest, BatchDeleteStillWorks) {
+    storm::QuerySet<Person, TypeParam> qs;
+    const std::vector<Person>          targets{{.id = 1}, {.id = 3}};
+    ASSERT_TRUE(qs.erase(std::span<const Person>(targets)).execute().has_value());
+    EXPECT_EQ(this->age_of(1), -1);
+    EXPECT_EQ(this->age_of(3), -1);
+    EXPECT_EQ(this->age_of(2), 22);
+}
+
+// NOLINTEND(readability-implicit-bool-conversion)

--- a/tests/crud/test_composite_pk_models.h
+++ b/tests/crud/test_composite_pk_models.h
@@ -1,0 +1,60 @@
+#ifndef STORM_TESTS_TEST_COMPOSITE_PK_MODELS_H
+#define STORM_TESTS_TEST_COMPOSITE_PK_MODELS_H
+
+/**
+ * @file test_composite_pk_models.h
+ * @brief Composite-PK model fixtures shared by the #501 UPDATE/DELETE tests.
+ *
+ * IMPORTANT: like test_models.h, this header names storm:: types and must only
+ * be included AFTER `import storm;` (NOSONAR cpp:S954 at the include site).
+ *
+ * Split across two test TUs: test_composite_pk_sql.cpp (compile-time gates and
+ * SQL text) and test_composite_pk_crud.cpp (live execution on both backends).
+ */
+
+// Canonical 2-part composite key, both parts int.
+struct OrderLine {
+    [[= storm::primary_part]] int order_id{};
+    [[= storm::primary_part]] int product_id{};
+    int quantity{};
+    std::string note;
+};
+
+// Mixed-type parts (int + std::string): proves the bind path dispatches per
+// part type rather than assuming an integer key, and that a TEXT part is
+// compared correctly in the WHERE clause.
+struct Inventory {
+    [[= storm::primary_part]] int warehouse{};
+    [[= storm::primary_part]] std::string sku;
+    int on_hand{};
+};
+
+// Three parts, mixed widths — the AND-join and the row-value list must not be
+// arity-limited, and the consteval sizers must stay exact at N=3.
+struct Ledger {
+    [[= storm::primary_part]] int region{};
+    [[= storm::primary_part]] std::string account;
+    [[= storm::primary_part]] std::int64_t period{};
+    double balance{};
+};
+
+// Single-PK control. Every SQL assertion on this model must be byte-identical
+// to what Storm emitted before composite support.
+struct Widget {
+    [[= storm::primary]] int id{};
+    std::string name;
+    int weight{};
+};
+
+// The canonical association-table shape: a composite key whose parts are FKs.
+// Exercises the `is_fk_field` branch of bind_one_pk_part (an FK part binds the
+// REFERENCED row's key, not the whole object) and the "<name>_id" column naming
+// in the WHERE clause — emitting the bare member would name a column that does
+// not exist. `Person` comes from test_models.h.
+struct StockEntry {
+    [[= storm::primary_part]][[= storm::fk<>]] Person warehouse;
+    [[= storm::primary_part]] int sku{};
+    int qty{};
+};
+
+#endif // STORM_TESTS_TEST_COMPOSITE_PK_MODELS_H

--- a/tests/crud/test_composite_pk_sql.cpp
+++ b/tests/crud/test_composite_pk_sql.cpp
@@ -1,0 +1,217 @@
+#include <gtest/gtest.h>
+#include <meta>
+
+#include "test_db_helpers.h"
+
+import storm;
+import std;
+// UpdateGrammar / EraseGrammar are not re-exported by `storm` — same direct
+// import the m2m and reverse-FK SET-gate assertions use.
+import storm_orm_statements_update_grammar;
+import storm_orm_statements_erase_grammar;
+
+#include "test_models.h" // NOSONAR cpp:S954 — Person, the FK target of StockEntry
+
+// Must follow test_models.h: StockEntry's FK part names Person.
+#include "test_composite_pk_models.h" // NOSONAR cpp:S954
+
+// ── #501: composite PK — compile-time gates and generated SQL text ───────────
+// Step 2 of #90, on top of #500 (annotation + DDL). Widens the by-key WHERE
+// clause from "pk = ?" to "a = ? AND b = ?", with the bind arithmetic and the
+// consteval sizing that follow from it.
+//
+// Three distinct things change; this TU pins the two static ones, and
+// test_composite_pk_crud.cpp drives the third against live backends:
+//   (1) SQL TEXT — one column name becomes N, AND-joined; the bulk DELETE IN
+//       list becomes a row-value list "(a,b) IN ((?,?),(?,?))".
+//   (2) THE SET-TARGET GATE — is_settable_member must exclude EVERY PK member,
+//       not just the first, or a composite PK column becomes writable.
+//   (3) BIND ARITHMETIC — N values per key, bound after the SET values.
+//
+// INSERT stays out of scope (#502).
+
+// NOLINTBEGIN(readability-implicit-bool-conversion)
+
+namespace {
+
+    using storm::orm::statements::EraseGrammar;
+    using storm::orm::statements::UpdateGrammar;
+    using storm::orm::statements::UpsertGrammar;
+
+    // ── (2) SET-target gate: every PK member is excluded ──────────────────────
+    // update_grammar.cppm's is_settable_member() used `Member != primary_key_`,
+    // which excludes only the FIRST PK member. On a composite model that leaves
+    // every other part writable — `UPDATE ... SET product_id=? WHERE order_id=?
+    // AND product_id=?` would rewrite part of the very key it matches on.
+    //
+    // Asserted on the gate predicate directly rather than as `!requires` on the
+    // public update<>() call: that API is loosely constrained, so a bad member
+    // would hard-error instead of yielding false.
+
+    static_assert(
+            !UpdateGrammar<OrderLine>::is_settable_member<^^OrderLine::order_id>(),
+            "the FIRST part of a composite PK must not be a SET target"
+    );
+    static_assert(
+            !UpdateGrammar<OrderLine>::is_settable_member<^^OrderLine::product_id>(),
+            "EVERY part of a composite PK must be excluded from SET, not just the first"
+    );
+    static_assert(
+            UpdateGrammar<OrderLine>::is_settable_member<^^OrderLine::quantity>(),
+            "a non-key column is still a valid SET target"
+    );
+    static_assert(
+            !UpdateGrammar<Ledger>::is_settable_member<^^Ledger::period>(),
+            "the LAST part of a 3-part composite PK must be excluded from SET"
+    );
+    static_assert(
+            UpdateGrammar<Ledger>::is_settable_member<^^Ledger::balance>(),
+            "a non-key column of a 3-part-key model is a valid SET target"
+    );
+    // Single-PK behaviour unchanged.
+    static_assert(
+            !UpdateGrammar<Widget>::is_settable_member<^^Widget::id>(), "a single primary key is not a SET target"
+    );
+    static_assert(
+            UpdateGrammar<Widget>::is_settable_member<^^Widget::name>(), "a single-PK model's plain column is settable"
+    );
+
+    // The same widening is required in upsert_grammar.cppm, which carries its own
+    // copy of the gate (the issue's DoD names it explicitly). ON CONFLICT
+    // targeting a composite key is #503; excluding the key parts from the SET
+    // list is this issue's half of it.
+    static_assert(
+            !UpsertGrammar<OrderLine>::is_settable_member<^^OrderLine::product_id>(),
+            "upsert's SET gate must exclude every PK member too"
+    );
+    static_assert(
+            UpsertGrammar<OrderLine>::is_settable_member<^^OrderLine::quantity>(),
+            "upsert's SET gate still accepts a non-key column"
+    );
+
+    template <typename T> auto single_delete_sql() -> std::string {
+        return std::string(EraseGrammar<T>::build_single_delete_sql_array());
+    }
+
+    // Connection-free: the statement text is derived purely from reflection, so the
+    // shape can be asserted for any row count without a live database. Asserted through
+    // EraseGrammar rather than EraseStatement — the grammar is where the text is built,
+    // and EraseStatement is at the cpp:S1448 method ceiling.
+    template <typename T> auto bulk_delete_sql(std::size_t rows) -> std::string {
+        return EraseGrammar<T>::bulk_delete_sql_for(rows);
+    }
+
+} // namespace
+
+// ── (1) SQL text: DELETE ─────────────────────────────────────────────────────
+// The single-row DELETE WHERE clause is AND-joined across the key, in
+// DECLARATION order (the same order primary_key_members_ holds and the bind
+// loop follows).
+
+TEST(CompositePkDeleteSql, SingleRowWhereIsAndJoined) {
+    EXPECT_EQ(single_delete_sql<OrderLine>(), "DELETE FROM OrderLine WHERE order_id = ? AND product_id = ?");
+}
+
+TEST(CompositePkDeleteSql, ThreePartWhereIsAndJoinedInDeclarationOrder) {
+    EXPECT_EQ(single_delete_sql<Ledger>(), "DELETE FROM Ledger WHERE region = ? AND account = ? AND period = ?");
+}
+
+// The single-PK DELETE text must be byte-identical to before this issue.
+TEST(CompositePkDeleteSql, SinglePkTextIsByteIdentical) {
+    EXPECT_EQ(single_delete_sql<Widget>(), "DELETE FROM Widget WHERE id = ?");
+}
+
+// Bulk DELETE uses a row-value IN list for a composite key: the single-PK
+// "id IN (?,?,?)" becomes "(a,b) IN ((?,?),(?,?),(?,?))". Both SQLite (>= 3.15;
+// the project floor is 3.35) and PostgreSQL accept this form, and the execution
+// tests in test_composite_pk_crud.cpp prove it against live backends.
+TEST(CompositePkDeleteSql, BulkUsesRowValueInList) {
+    EXPECT_EQ(
+            bulk_delete_sql<OrderLine>(3), "DELETE FROM OrderLine WHERE (order_id, product_id) IN ((?,?),(?,?),(?,?))"
+    );
+}
+
+TEST(CompositePkDeleteSql, BulkThreePartRowValueInList) {
+    EXPECT_EQ(bulk_delete_sql<Ledger>(2), "DELETE FROM Ledger WHERE (region, account, period) IN ((?,?,?),(?,?,?))");
+}
+
+TEST(CompositePkDeleteSql, BulkSinglePkInListIsByteIdentical) {
+    EXPECT_EQ(bulk_delete_sql<Widget>(3), "DELETE FROM Widget WHERE id IN (?,?,?)");
+}
+
+// The grammar builds a genuine one-element IN list for count == 1; it is
+// EraseStatement::get_bulk_delete_sql that short-circuits a one-object batch to the
+// single-row form, so this pins the grammar's own shape rather than that fast path.
+TEST(CompositePkDeleteSql, BulkOfOneIsAOneElementList) {
+    EXPECT_EQ(bulk_delete_sql<OrderLine>(1), "DELETE FROM OrderLine WHERE (order_id, product_id) IN ((?,?))");
+    EXPECT_EQ(bulk_delete_sql<Widget>(1), "DELETE FROM Widget WHERE id IN (?)");
+}
+
+// An FK part's COLUMN is "<name>_id", so the key clause must name that. Emitting the
+// bare member would produce a WHERE over a column that does not exist, and the
+// statement would fail at prepare time on both backends. A composite key over FKs is
+// the canonical association-table case, not an exotic one — the same reason #500
+// asserts this for the DDL.
+TEST(CompositePkDeleteSql, FkKeyPartUsesColumnNameNotIdentifier) {
+    EXPECT_EQ(single_delete_sql<StockEntry>(), "DELETE FROM StockEntry WHERE warehouse_id = ? AND sku = ?");
+}
+
+TEST(CompositePkDeleteSql, FkKeyPartBulkUsesColumnName) {
+    EXPECT_EQ(bulk_delete_sql<StockEntry>(2), "DELETE FROM StockEntry WHERE (warehouse_id, sku) IN ((?,?),(?,?))");
+}
+
+// ── (1) SQL text: UPDATE ─────────────────────────────────────────────────────
+// SET excludes every key part; WHERE is AND-joined across all of them.
+
+TEST(CompositePkUpdateSql, SetExcludesEveryKeyPartAndWhereIsAndJoined) {
+    EXPECT_EQ(
+            UpdateGrammar<OrderLine>::update_sql_string,
+            "UPDATE OrderLine SET quantity=?, note=? WHERE order_id = ? AND product_id = ?"
+    );
+}
+
+TEST(CompositePkUpdateSql, ThreePartKeyUpdate) {
+    EXPECT_EQ(
+            UpdateGrammar<Ledger>::update_sql_string,
+            "UPDATE Ledger SET balance=? WHERE region = ? AND account = ? AND period = ?"
+    );
+}
+
+TEST(CompositePkUpdateSql, SinglePkTextIsByteIdentical) {
+    EXPECT_EQ(UpdateGrammar<Widget>::update_sql_string, "UPDATE Widget SET name=?, weight=? WHERE id = ?");
+}
+
+// FK key parts name their "_id" column in the UPDATE WHERE clause too, and stay out
+// of the SET list like any other key part.
+TEST(CompositePkUpdateSql, FkKeyPartUsesColumnNameNotIdentifier) {
+    EXPECT_EQ(
+            UpdateGrammar<StockEntry>::update_sql_string,
+            "UPDATE StockEntry SET qty=? WHERE warehouse_id = ? AND sku = ?"
+    );
+}
+
+static_assert(
+        !UpdateGrammar<StockEntry>::is_settable_member<^^StockEntry::warehouse>(),
+        "an FK part of a composite key is not a SET target"
+);
+
+// ── Chunking: the parameter budget shrinks by the key width ──────────────────
+// The 999-variable ceiling is spent N params per row for an N-part key, so the
+// effective chunk size is MAX_CHUNK_SIZE/N, not MAX_CHUNK_SIZE.
+
+namespace {
+    template <typename T> constexpr std::size_t chunk_rows = EraseGrammar<T>::MAX_CHUNK_ROWS;
+} // namespace
+
+TEST(CompositePkChunking, RowCapacityShrinksWithKeyWidth) {
+    EXPECT_EQ(chunk_rows<Widget>, 799U) << "single-PK chunking is unchanged";
+    EXPECT_EQ(chunk_rows<OrderLine>, 799U / 2) << "a 2-part key costs 2 parameters per row";
+    EXPECT_EQ(chunk_rows<Ledger>, 799U / 3) << "a 3-part key costs 3 parameters per row";
+}
+
+TEST(CompositePkChunking, RowCapacityStaysWithinTheParameterBudget) {
+    EXPECT_LE(chunk_rows<OrderLine> * 2U, 999U);
+    EXPECT_LE(chunk_rows<Ledger> * 3U, 999U);
+}
+
+// NOLINTEND(readability-implicit-bool-conversion)


### PR DESCRIPTION
Step 2 of #90, on top of #500 (annotation + `CREATE TABLE` DDL). Widens the by-key `WHERE`
from `pk = ?` to `a = ? AND b = ?` for UPDATE-by-object and DELETE-by-object, with the bind
arithmetic and consteval sizing that follow.

## What changed

**SQL text.** The clause writer/sizer pair (`append_pk_where_clause` / `pk_where_clause_size`)
are free functions in `base.cppm` taking the PK member array as a parameter — not
`BaseStatement` methods, since that class is inherited by every statement type and
`SchemaStatement` already sits at the S1448 ceiling. Parts go through `append_column_name`
(#422), so an FK part emits `warehouse_id` rather than a column that doesn't exist.

Bulk DELETE uses a **row-value IN list**, `(a, b) IN ((?,?),(?,?))` — standard SQL (PG always,
SQLite ≥ 3.15 vs this project's 3.35 floor), verified against both live backends including
untyped `PQprepare` inference. The per-column form `a IN (…) AND b IN (…)` is **wrong**: it
matches the parts' cross product and would delete keys that were never listed. There's a test
with deliberately crossing keys pinning exactly that.

**Bind arithmetic.** `bind_pk_values` binds all N parts via an index sequence with a
compile-time `param_index + Is` offset — each part may be a different type (`int` +
`std::string` is the canonical shape), so dispatch is per-part at compile time. `bind_pk_at`
now takes `param_index` by reference, which removes the old one-parameter-per-row stride.

**SET-target gate.** `is_settable_member` in **both** `update_grammar` and `upsert_grammar` now
tests `is_pk_member` instead of `!= primary_key_`. The old test excluded only the FIRST part,
leaving `SET b=? WHERE a=? AND b=?` — rewriting the key it matches on — legal on a composite
model. `bind_field_at_index` gains a **separate** `SkipAllPK` flag rather than widening
`SkipPK`: INSERT passes `SkipPK` too and composite INSERT is #502, so widening it would
silently change INSERT's bind order.

**Chunking.** `MAX_CHUNK_ROWS = 799/N`, since each row now costs N parameters against the 999
ceiling. Single-PK models keep the historical 799.

The consteval DELETE grammar moved to a new `erase_grammar.cppm` leaf (mirroring
`update_grammar.cppm`, #434) to keep `erase.cppm` under the file-size limit. Its
`append_row_placeholder_list` is shared by the consteval max-chunk builder **and** the runtime
per-count builder, so the two cannot drift into disagreeing placeholder counts.

## Verification

- **2596/2596 tests pass** on SQLite and PostgreSQL. Tests were written first and confirmed
  failing (the first failure was `product_id` being a legal SET target — the exact defect).
- **Single-PK SQL is byte-identical**, regression-asserted for both DELETE and UPDATE.
- **100% line coverage**; clang-format, clang-tidy, and the full pre-commit gate all green.
- **No performance regression.** 8 interleaved rounds against `develop` (flags verified
  `-O3 -DNDEBUG` on both sides) give deltas scattered −0.87%…+1.25% at cv 1.1–2.2%, well under
  the 5% gate.

  Worth noting: the *first* measurement leaned uniformly positive at small-N UPDATE
  (+1.4…+2.7%). That turned out to be a real cost I had introduced — a `[&]{…}()` lambda plus a
  dead per-part `++param_index` in `bind_one_pk_part`. Flattening both removed it, consistent
  with the project's recorded flat-code-vs-lambda finding. The scattered numbers above are
  post-fix.

New coverage spans 2- and 3-part keys, mixed-type parts (`int` + `std::string`), FK key parts
(the association-table shape), partial-key non-matches, empty batches, crossing batch keys, and
chunk-boundary-crossing batches.

## Out of scope

INSERT (#502), upsert `ON CONFLICT` targets (#503), composite FKs and JOIN (#504).

Also spotted and filed rather than fixed here: **#511** — `is_unlisted_auto_update` is the one
SET-clause gate that doesn't exclude PK members. Pre-existing, narrow (needs a `time_point` PK
carrying `auto_update`, a shape no in-tree model has), and the fix has a breaking option worth
deciding on its own.

Closes #501

🤖 Generated with [Claude Code](https://claude.com/claude-code)
