### PR TITLE
feat(505): add PrimaryKeyType<T> compile-time check on primary-key type

### DIFF
--- a/docs/guide/reference/FIELD_TYPES.md
+++ b/docs/guide/reference/FIELD_TYPES.md
@@ -649,3 +649,46 @@ aggregates sum/min/max several columns, e.g. `SUM(a + b)`) and is the `requires`
 `QuerySet::sum/avg/min/max`. A string/BLOB/enum/UUID/temporal/`bool` field is a **compile error**
 at the aggregate call site, not a silent coercion. `count()` / `count_distinct()` are unconstrained
 — `COUNT` is type-agnostic and accepts any column.
+
+## Primary Key Type Validation (`PrimaryKeyType`) (#505)
+
+`storm::orm::statements::PrimaryKeyType<T>` is the compile-time gate on the type of `T`'s
+primary-key member (the field annotated `storm::primary` / `storm::primary_autoincrement`).
+**Supported primary-key types: `short`, `int`, `long`, `long long`**, and their fixed-width
+spellings (`std::int16_t`, `std::int32_t`, `std::int64_t`, …). A `uint64_t` (or
+`unsigned long` / `unsigned long long`) primary key is
+accepted only when explicitly annotated `storm::signed_storage`; `storm::full_unsigned` is
+rejected even though it is a storage annotation, because it stores as zero-padded `TEXT`,
+which would silently misread through every hardcoded-`int64` primary-key extraction site
+(`select.cppm`, `join.cppm`, `insert.cppm`).
+
+Rejected, each for a specific reason:
+- **`bool`** — integral, so a naive `std::is_integral_v` check would admit it, but a
+  two-valued primary key is nonsense. Same carve-out `NumericAggregateable` makes (#475).
+- **`char` / `signed char`** — a 1-byte identity is a pathological primary key; not in the
+  accepted width list.
+- **Unsigned types without `storm::signed_storage`** — a bare `uint64_t` primary key is
+  already a compile error via `ModelStorageAnnotated` (#436); this concept additionally
+  rejects `full_unsigned` specifically as a primary-key type (see above).
+- **`std::optional<T>`** — a nullable primary key is meaningless; rejected outright, unlike
+  `ValidForeignKey`/`is_unsigned64_member`, which unwrap `std::optional` before checking.
+- **Text and `storm::UUID`** — not supported as a primary key today. This is a "not yet, not
+  a never": `storm::UUID` already works as an ordinary column everywhere (DDL, extraction,
+  WHERE/`IN`) except as a primary key, where the same hardcoded-`int64` sites block it.
+  Tracked as a follow-up (#507) to route those sites through the type-generic
+  `bind_value_by_type` path `erase.cppm` already uses.
+
+```cpp
+template <typename T>
+concept PrimaryKeyType = /* T's primary-key member's type is in the allowed set above */;
+```
+
+`PrimaryKeyType<T>` is ANDed into `BaseStatement<T>`'s constraint list alongside
+`ModelWithPrimaryKey<T>`. `QuerySet<T>` itself only requires `Entity<T>` (it must stay
+usable without a primary key), so a model with an unsupported primary-key type — `bool`,
+`std::optional<int>`, a bare `unsigned int`, `std::string`, `storm::UUID` — compiles as a
+bare `QuerySet<T>` but fails at the first call that instantiates a statement
+(`select()`, `insert()`, `join()`, …), naming `T` and `PrimaryKeyType` in the "constraints
+not satisfied" diagnostic trail. This replaces the previous behavior of failing
+inconsistently — sometimes at runtime with no mention of the primary key at all, sometimes
+at compile time deep inside `select.cppm` / `join.cppm` / `insert.cppm`.

--- a/src/orm/statements/base.cppm
+++ b/src/orm/statements/base.cppm
@@ -237,6 +237,76 @@ export namespace storm::orm::statements {
     template <typename T>
     concept ModelWithPrimaryKey = meta::has_primary_key(^^T);
 
+    namespace meta {
+        // True iff `member`'s (dealiased) type is a signed integral type admitted as a
+        // primary key (#505) — DECIDED 2026-07-22: short/int/long/long long and their
+        // fixed-width spellings (std::int16_t, std::int32_t, std::int64_t, ...); NOT
+        // char/signed char (a 1-byte identity is pathological) or bool (integral, but
+        // a two-valued PK is nonsense — same carve-out NumericAggregateable makes,
+        // #475). std::optional<T> is rejected outright — a nullable primary key is
+        // meaningless, so unlike is_unsigned64_member this does NOT unwrap optional
+        // first. A bare 64-bit unsigned type is rejected unless
+        // annotated storm::signed_storage: that annotation routes through the same
+        // bind_int64/extract_int64 path every hardcoded-int64 PK site already uses
+        // (select.cppm, join.cppm, insert.cppm); storm::full_unsigned stores as
+        // zero-padded TEXT and would silently misread through those same sites, so it
+        // stays rejected even though it is an explicit storage annotation.
+        consteval auto is_primary_key_typed_member(std::meta::info member) -> bool {
+            const std::meta::info t = std::meta::dealias(std::meta::type_of(member));
+            if (t == ^^bool) {
+                return false;
+            }
+            if (t == ^^short || t == ^^int || t == ^^long || t == ^^long long) {
+                return true;
+            }
+            if (t == ^^unsigned long || t == ^^unsigned long long) {
+                return meta::has_signed_storage_attr(member);
+            }
+            return false;
+        }
+    } // namespace meta
+
+    // Concept: T's SINGLE primary-key member (storm::primary / primary_autoincrement) has
+    // a type admitted as a primary key (#505). Scoped to the single-column case only —
+    // a composite key (one or more storm::primary_part members, #500) is exempted
+    // entirely and returns true unconditionally, for two reasons: (1) issue #505 was
+    // decided before composite PKs existed in this codebase, so the accepted-type set
+    // was never scoped against composite parts; (2) an FK-typed composite part (e.g.
+    // StockEntry::warehouse in tests/crud/test_composite_pk_models.h) binds via the
+    // REFERENCED row's key (meta::is_fk_field routing in bind_one_pk_part), not its own
+    // declared type, so "the member's type" is not even the right question for that part
+    // — and a plain non-FK TEXT part (e.g. Inventory::sku, same file) is an already-shipped,
+    // already-tested composite-key shape. Composite-PK type constraints are their own
+    // unscoped follow-up, not a silent widening of this concept's contract.
+    //
+    // ANDed alongside ModelWithPrimaryKey on BaseStatement's constraint list — a model
+    // with NO primary key already fails that sibling concept, so the loop here always
+    // finds a match when both concepts are evaluated together on a single-PK model.
+    // Checked directly on the member from nonstatic_data_members_of(^^T) (BMI-safe,
+    // #262), matching the sibling model-policy concepts (ModelStorageAnnotated,
+    // ModelFkPoliciesValid, ...).
+    //
+    // A failing BaseStatement<T> instantiation names both T and PrimaryKeyType in the
+    // "constraints not satisfied" / "because 'T' does not satisfy 'PrimaryKeyType'"
+    // diagnostic trail (matching every sibling concept here — none of them name the
+    // specific member either). A static_assert with a dynamic message naming the PK
+    // member was tried and rejected: static_assert failure inside a concept's consteval
+    // lambda is a hard compile error during constraint checking, not a SFINAE-friendly
+    // false, so it would break every negative `!PrimaryKeyType<Bad>` usage (including
+    // the tests) instead of merely gating BaseStatement.
+    template <typename T>
+    concept PrimaryKeyType = []() consteval {
+        for (auto m : std::meta::nonstatic_data_members_of(^^T, std::meta::access_context::unchecked())) {
+            if (meta::is_primary_part_member(m)) {
+                return true; // composite key: type constraint out of scope for #505
+            }
+            if (meta::is_primary_member(m)) {
+                return meta::is_primary_key_typed_member(m);
+            }
+        }
+        return true; // no PK member: ModelWithPrimaryKey<T> is the concept that rejects this
+    }();
+
     // A field type is a valid FK target iff its referenced entity (optional-unwrapped)
     // has a primary key. Names the boundary find_fk_primary_key relies on and that
     // FKFieldOf did not previously enforce at the call site (#474). Single-level: it
@@ -605,7 +675,7 @@ export namespace storm::orm::statements {
 
     // Shared reflection utilities for all statement types
     template <typename T>
-        requires storm::meta::Entity<T> && ModelWithPrimaryKey<T> && ModelStorageAnnotated<T> &&
+        requires storm::meta::Entity<T> && ModelWithPrimaryKey<T> && PrimaryKeyType<T> && ModelStorageAnnotated<T> &&
                  ModelFkPoliciesValid<T> && ModelAnnotationsValid<T> && ModelMaxLengthValid<T> &&
                  ModelPrimaryKeyValid<T>
     class BaseStatement {

--- a/src/orm/statements/base.cppm
+++ b/src/orm/statements/base.cppm
@@ -268,7 +268,7 @@ export namespace storm::orm::statements {
 
     // Concept: T's SINGLE primary-key member (storm::primary / primary_autoincrement) has
     // a type admitted as a primary key (#505). Scoped to the single-column case only —
-    // a composite key (one or more storm::primary_part members, #500) is exempted
+    // a composite key (two or more storm::primary_part members, #500) is exempted
     // entirely and returns true unconditionally, for two reasons: (1) issue #505 was
     // decided before composite PKs existed in this codebase, so the accepted-type set
     // was never scoped against composite parts; (2) an FK-typed composite part (e.g.

--- a/tests/schema/test_primary_key_type.cpp
+++ b/tests/schema/test_primary_key_type.cpp
@@ -1,0 +1,163 @@
+#include <gtest/gtest.h>
+#include <meta>
+
+#include "test_db_helpers.h"
+
+import storm;
+import std;
+
+#include "test_models.h" // NOSONAR cpp:S954
+
+// Tests for the PrimaryKeyType<T> concept (#505): a compile-time gate on the type
+// of a model's primary-key member. Independent of #90 (composite PK); found while
+// scoping it. DECIDED 2026-07-22: the allowed set is every signed integral type
+// except bool — short/int/long/long long and their fixed-width spellings. Rejected:
+// bool, std::optional<T>, unsigned types (unless storm::signed_storage), and
+// text/UUID (storm::UUID PKs are a "not yet" — filed as #507).
+
+// ============================================================================
+// Test models (local to this TU)
+// ============================================================================
+
+namespace {
+
+    // ---- Accepted: signed integral widths ----
+    struct PkShort {
+        [[= storm::primary]] short id{};
+    };
+    struct PkInt {
+        [[= storm::primary]] int id{};
+    };
+    struct PkLong {
+        [[= storm::primary]] long id{};
+    };
+    struct PkLongLong {
+        [[= storm::primary]] long long id{};
+    };
+    struct PkInt16 {
+        [[= storm::primary]] std::int16_t id{};
+    };
+    struct PkInt32 {
+        [[= storm::primary]] std::int32_t id{};
+    };
+    struct PkInt64 {
+        [[= storm::primary]] std::int64_t id{};
+    };
+    struct PkPrimaryAutoincrement {
+        [[= storm::primary_autoincrement]] int id{};
+    };
+    // A uint64_t PK explicitly annotated signed_storage is admitted — it binds and
+    // extracts through the same int64 path as any other signed field (#436).
+    struct PkUint64SignedStorage {
+        [[ = storm::primary, = storm::signed_storage ]] std::uint64_t id{};
+    };
+
+    // ---- Rejected: bool ----
+    struct PkBool {
+        [[= storm::primary]] bool id{};
+    };
+
+    // ---- Rejected: char (a 1-byte identity is pathological; not in the width list) ----
+    struct PkChar {
+        [[= storm::primary]] char id{};
+    };
+
+    // ---- Rejected: nullable primary key ----
+    struct PkOptionalInt {
+        [[= storm::primary]] std::optional<int> id{};
+    };
+
+    // ---- Rejected: unsigned without signed_storage ----
+    // (unsigned short/int are not gated by ModelStorageAnnotated at all, so they
+    // reach PrimaryKeyType — reject them here since they aren't in the decided set.)
+    struct PkUnsignedInt {
+        [[= storm::primary]] unsigned int id{};
+    };
+    // full_unsigned stores as zero-padded 20-char TEXT, which breaks every
+    // extract_int64 site a PK is read through — reject even though it is annotated.
+    struct PkUint64FullUnsigned {
+        [[ = storm::primary, = storm::full_unsigned ]] std::uint64_t id{};
+    };
+
+    // ---- Rejected: text ----
+    struct PkText {
+        [[= storm::primary]] std::string id{};
+    };
+
+    // ---- Rejected: UUID (not yet — a "not never", see #507) ----
+    struct PkUuid {
+        [[= storm::primary]] storm::UUID id{};
+    };
+
+} // namespace
+
+// ============================================================================
+// Compile-time concept gate — PrimaryKeyType<T>
+// ============================================================================
+
+// PrimaryKeyType<T> is the model-boundary concept: true iff T's primary-key member
+// has a type in the decided allowed set. It is one of the concepts BaseStatement<T>
+// (and thus QuerySet<T>) requires, so a bad model fails to instantiate with a clear
+// constraint violation. These static_asserts pin the contract on the GATE predicate
+// itself (mirrors ModelMaxLengthValid in test_max_length.cpp), not on a downstream
+// public call.
+
+static_assert(storm::orm::statements::PrimaryKeyType<PkShort>, "short PK must be accepted");
+static_assert(storm::orm::statements::PrimaryKeyType<PkInt>, "int PK must be accepted");
+static_assert(storm::orm::statements::PrimaryKeyType<PkLong>, "long PK must be accepted");
+static_assert(storm::orm::statements::PrimaryKeyType<PkLongLong>, "long long PK must be accepted");
+static_assert(storm::orm::statements::PrimaryKeyType<PkInt16>, "std::int16_t PK must be accepted");
+static_assert(storm::orm::statements::PrimaryKeyType<PkInt32>, "std::int32_t PK must be accepted");
+static_assert(storm::orm::statements::PrimaryKeyType<PkInt64>, "std::int64_t PK must be accepted");
+static_assert(
+        storm::orm::statements::PrimaryKeyType<PkPrimaryAutoincrement>, "primary_autoincrement int PK must be accepted"
+);
+static_assert(
+        storm::orm::statements::PrimaryKeyType<PkUint64SignedStorage>,
+        "uint64_t PK annotated signed_storage must be accepted"
+);
+
+static_assert(!storm::orm::statements::PrimaryKeyType<PkBool>, "bool PK must be rejected");
+static_assert(!storm::orm::statements::PrimaryKeyType<PkChar>, "char PK must be rejected");
+static_assert(!storm::orm::statements::PrimaryKeyType<PkOptionalInt>, "std::optional<int> PK must be rejected");
+static_assert(!storm::orm::statements::PrimaryKeyType<PkUnsignedInt>, "unsigned int PK must be rejected");
+static_assert(
+        !storm::orm::statements::PrimaryKeyType<PkUint64FullUnsigned>,
+        "uint64_t PK annotated full_unsigned must be rejected"
+);
+static_assert(!storm::orm::statements::PrimaryKeyType<PkText>, "std::string PK must be rejected");
+static_assert(!storm::orm::statements::PrimaryKeyType<PkUuid>, "storm::UUID PK must be rejected");
+
+// ============================================================================
+// Positive path — accepted PK types remain queryable end to end
+// ============================================================================
+
+namespace {
+    // A non-PK column keeps this out of the single-field (PK-only, non-autoincrement)
+    // INSERT edge case — a separate, pre-existing issue unrelated to #505.
+    struct PkIntWithColumn {
+        [[= storm::primary]] int id{};
+        int                      value{};
+    };
+} // namespace
+
+template <typename ConnType> class PrimaryKeyTypeAcceptedTest : public StormTestFixture<PkIntWithColumn, ConnType> {};
+TYPED_TEST_SUITE(PrimaryKeyTypeAcceptedTest, DatabaseTypes);
+
+TYPED_TEST(PrimaryKeyTypeAcceptedTest, InsertAndSelectRoundTrip) {
+    storm::QuerySet<PkIntWithColumn, TypeParam> qs;
+    auto                                        result = qs.insert(PkIntWithColumn{.id = 1, .value = 42}).execute();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+
+    auto selected = qs.select().execute();
+    ASSERT_TRUE(selected.has_value()) << selected.error().message();
+    ASSERT_EQ(selected.value().size(), 1U);
+    EXPECT_EQ(selected.value().begin()->id, 1);
+    EXPECT_EQ(selected.value().begin()->value, 42);
+}
+
+TEST(PrimaryKeyType, CompileTimeOnly) {
+    // The static_asserts above are the real test; this keeps the TU a runnable
+    // GTest target so the suite reports it.
+    SUCCEED();
+}


### PR DESCRIPTION
## Summary
- Adds `PrimaryKeyType<T>`, a compile-time gate on the type of a model's primary-key member, ANDed into `BaseStatement<T>`'s constraint list alongside `ModelWithPrimaryKey<T>`.
- Accepted: `short`/`int`/`long`/`long long` and fixed-width spellings (`std::int16_t`, `std::int32_t`, `std::int64_t`, …); `uint64_t`/`unsigned long`/`unsigned long long` only when annotated `storm::signed_storage`.
- Rejected: `bool`, `char`/`signed char`, `std::optional<T>`, unsigned without `signed_storage`, `storm::full_unsigned` (breaks the hardcoded-`int64` PK extraction sites), and text/`storm::UUID` (UUID PK support tracked as a follow-up, #507).
- Previously an unsupported PK type (e.g. `std::string`) compiled and failed inconsistently — sometimes at runtime with no mention of the primary key, sometimes deep inside `select.cppm`/`join.cppm`/`insert.cppm`.

## Test plan
- [x] New tests in `tests/schema/test_primary_key_type.cpp` written before implementation, confirmed to fail first (RED), then pass after implementing the concept (GREEN)
- [x] Negative-compile `static_assert`s target the concept predicate directly (`PrimaryKeyType<T>`), not a downstream public call, per repo convention
- [x] Positive coverage: `short`/`int`/`long`/`long long`/`int16_t`/`int32_t`/`int64_t`/`primary_autoincrement`/`uint64_t+signed_storage`
- [x] Negative coverage: `bool`, `char`, `std::optional<int>`, `unsigned int`, `uint64_t+full_unsigned`, `std::string`, `storm::UUID`
- [x] End-to-end `TYPED_TEST` insert/select round trip for an accepted PK type on both SQLite and PostgreSQL
- [x] Full test suite: 2516/2516 passing (`ctest --preset ninja-debug-sqlite`)
- [x] `ninja-debug` and `ninja-release` builds both succeed — confirms every existing model in `tests/`/`benchmarks/` still compiles unchanged
- [x] Docs updated: `docs/guide/reference/FIELD_TYPES.md` states supported PK types explicitly
- [x] Two independent `storm-code-reviewer` passes, both approved

Closes #505

🤖 Generated with [Claude Code](https://claude.com/claude-code)